### PR TITLE
chore(docs-build): allow prerelease docs builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
-
 env:
   NEMO_FLOW_CI_RUST_VERSION: "1.93.0"
   NEMO_FLOW_CI_NODE_VERSION: "24"

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -257,6 +257,11 @@ jobs:
         working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}/crates/node
         run: npm ci --ignore-scripts
 
+      - name: Materialize Main Branch For Versioned Docs
+        if: ${{ inputs.ref_type == 'tag' }}
+        working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
+        run: git fetch --force origin +refs/heads/main:refs/heads/main
+
       - name: Check Documentation Links
         working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
         env:

--- a/scripts/docs/postprocess_sphinx_multiversion.py
+++ b/scripts/docs/postprocess_sphinx_multiversion.py
@@ -8,8 +8,11 @@ import re
 import sys
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
+
 PATCH_RELEASE_DIR = re.compile(r"^(?:v)?(\d+)\.(\d+)\.(\d+)$")
 MINOR_RELEASE_DIR = re.compile(r"^(?:v)?(\d+)\.(\d+)$")
+PRERELEASE_DIR = re.compile(r"^(?:v)?\d+\.\d+\.\d+-(?:alpha|beta|rc)\.\d+$")
 INDEX_HTML = "index.html"
 
 
@@ -27,6 +30,21 @@ def parse_minor_release_key(name: str) -> tuple[int, int] | None:
         return None
     major, minor = match.groups()
     return (int(major), int(minor))
+
+
+def parse_prerelease_version(name: str) -> Version | None:
+    if PRERELEASE_DIR.fullmatch(name) is None:
+        return None
+
+    try:
+        parsed = Version(name.lstrip("v"))
+    except InvalidVersion:
+        return None
+
+    if parsed.is_prerelease:
+        return parsed
+
+    return None
 
 
 def iter_version_directories(build_dir: Path):
@@ -68,16 +86,39 @@ def latest_stable_version(build_dir: Path) -> str | None:
     if not candidates:
         return None
 
-    candidates.sort(reverse=True)
+    candidates.sort(key=lambda entry: entry[0], reverse=True)
     return candidates[0][1]
 
 
+def latest_prerelease_version(build_dir: Path) -> str | None:
+    candidates: list[tuple[Version, Path]] = []
+
+    for child in iter_version_directories(build_dir):
+        version = parse_prerelease_version(child.name)
+        if version is not None:
+            candidates.append((version, child))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda entry: entry[0], reverse=True)
+    latest = candidates[0][1]
+    if (latest / INDEX_HTML).exists():
+        return latest.name
+
+    return None
+
+
 def resolve_default_version(build_dir: Path) -> str | None:
-    # Prefer the newest stable release for the site root redirect, but fall
-    # back to `main` when no release directories were built.
+    # Prefer the newest stable release for the site root redirect. Prereleases
+    # can be the default only when the most recent included prerelease was built.
     stable = latest_stable_version(build_dir)
     if stable is not None:
         return stable
+
+    prerelease = latest_prerelease_version(build_dir)
+    if prerelease is not None:
+        return prerelease
 
     if (build_dir / "main" / INDEX_HTML).exists():
         return "main"


### PR DESCRIPTION
#### Overview

Allows prerelease documentation builds

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Ensure the main branch exists for tagged builds.
- Add support for prerelease versions in multi-version docs build

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #2 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prerelease documentation builds are supported with intelligent default-version selection and improved version ordering.
* **Improvements**
  * Documentation now falls back to the latest prerelease when no stable release is selected, and verifies available index pages.
* **Chore**
  * CI documentation job adds a conditional step for tag-triggered runs to ensure the correct repo ref is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->