### PR TITLE
ci: fix auto PR labeler

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -32,7 +32,7 @@ changelog:
         - test
     - title: 📝 Documentation Updates
       labels:
-        - doc
+        - docs
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Apply size, breaking, type, and language labels
         env:

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -154,11 +154,12 @@ jobs:
           done
 
           for label in "${remove_labels[@]}"; do
-            gh issue edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label"
+            gh api --method DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/${label}" >/dev/null
           done
 
           for label in "${add_labels[@]}"; do
-            gh issue edit "$PR_NUMBER" --repo "$REPO" --add-label "$label"
+            gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/labels" \
+              --field "labels[]=$label" >/dev/null
           done
 
           printf 'Changed lines: %s\n' "$changed_lines"

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -38,7 +38,7 @@ jobs:
           set -euo pipefail
 
           size_labels=("size:XS" "size:S" "size:M" "size:L" "size:XL" "size:XXL")
-          classifier_labels=("build" "chore" "ci" "doc" "feat" "fix" "perf" "refactor" "revert" "style" "test")
+          classifier_labels=("build" "chore" "ci" "docs" "feat" "fix" "perf" "refactor" "revert" "style" "test")
           lang_labels=("lang:go" "lang:js" "lang:python" "lang:rust")
           controlled_labels=("${size_labels[@]}" "${classifier_labels[@]}" "${lang_labels[@]}")
 
@@ -112,13 +112,10 @@ jobs:
 
           title_lower="${PR_TITLE,,}"
           classifier_label=""
-          title_pattern='^(build|chore|ci|doc|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?(!)?:'
-          breaking_pattern='^(build|chore|ci|doc|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!:'
+          title_pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?(!)?:'
+          breaking_pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!:'
           if [[ "$title_lower" =~ $title_pattern ]]; then
             classifier_label="${BASH_REMATCH[1]}"
-            if [[ "$classifier_label" == "docs" ]]; then
-              classifier_label="doc"
-            fi
             desired_labels+=("$classifier_label")
           fi
           if [[ "$PR_TITLE" =~ $breaking_pattern ]]; then


### PR DESCRIPTION
#### Overview

Fix PR auto-labeler by aligning checks with actual labels.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Remove checks for `doc` and just rely on `docs`

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #3 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pull request labeling standardized to use the "docs" label convention and title matching updated accordingly.
  * Release changelog mapping updated to categorize "docs" under Documentation Updates.
  * Automated workflow permissions expanded to allow write access for reliable label updates.
  * Label add/remove handling simplified for more consistent and reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->