### PR TITLE
ci: fix CODEOWNERS groups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default ownership for repository files.
-* @nat-developers
+* @nvidia/nat-developers
 
 # Project configurations and lockfiles require dependency approver review.
-Cargo.toml @nat-dep-approvers
-Cargo.lock @nat-dep-approvers
+Cargo.toml @nvidia/nat-dep-approvers
+Cargo.lock @nvidia/nat-dep-approvers
 
-pyproject.toml @nat-dep-approvers
-uv.lock @nat-dep-approvers
+pyproject.toml @nvidia/nat-dep-approvers
+uv.lock @nvidia/nat-dep-approvers
 
-package.json @nat-dep-approvers
-package-lock.json @nat-dep-approvers
+package.json @nvidia/nat-dep-approvers
+package-lock.json @nvidia/nat-dep-approvers


### PR DESCRIPTION
#### Overview

Fixes the group names for CODEOWNERS.

Groups must start with `@nvidia/`

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

N/A

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #8 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review ownership assignments for repository files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->