### PR TITLE
ci(publishing): fix publishing commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,14 +131,14 @@ jobs:
         working-directory: ${{ github.workspace }}/NeMo-Flow
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-        run: cargo publish --workspace --no-verify
+        run: cargo publish -p nemo-flow -p nemo-flow-adaptive -p nemo-flow-ffi --no-verify
 
       - name: Publish to crates.io with registry token
         if: ${{ vars.NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING != 'true' }}
         working-directory: ${{ github.workspace }}/NeMo-Flow
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --workspace --no-verify
+        run: cargo publish -p nemo-flow -p nemo-flow-adaptive -p nemo-flow-ffi --no-verify
 
   publish-python:
     name: Publish / PyPI
@@ -159,7 +159,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI with trusted publishing
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   publish-npm:
     name: Publish / npm
@@ -211,7 +211,7 @@ jobs:
           unzip -q ./consolidated.zip -d combined
           echo "Platform binaries included:"
           ls -la combined/package/*.node
-          npm publish combined/package --access public --tag "${NEMO_FLOW_NPM_DIST_TAG}"
+          npm publish ./combined/package --access public --tag "${NEMO_FLOW_NPM_DIST_TAG}"
 
       - name: Publish WASM package to npm
         if: false

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -1,0 +1,20 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# nemo-flow-ffi
+
+`nemo-flow-ffi` provides the C-compatible ABI layer for NeMo Flow.
+
+It exposes the Rust runtime through exported `nemo_flow_*` symbols and a
+generated C header so downstream native bindings can call into the shared
+runtime contract.
+
+Use this crate when building language bindings or native integrations that need
+the raw C ABI. The repository-maintained Go binding consumes this surface.
+
+For project-level documentation, start with:
+
+- the repo root `README.md`
+- `docs/troubleshooting/troubleshooting-guide.md`

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# nemo-flow-node
+
+`nemo-flow-node` is the Rust native extension crate behind the NeMo Flow Node.js
+package.
+
+It uses napi-rs to expose NeMo Flow runtime scopes, tool and LLM lifecycle
+helpers, middleware, subscribers, typed helpers, plugin helpers, and adaptive
+runtime helpers to JavaScript and TypeScript.
+
+Most Node.js users should install the npm package rather than depend on this
+crate directly:
+
+```bash
+npm install nemo-flow-node
+```
+
+For project-level documentation, start with:
+
+- the repo root `README.md`
+- `docs/getting-started/nodejs.md`
+- `docs/reference/api/nodejs/index.md`

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -1,0 +1,20 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# nemo-flow-wasm
+
+`nemo-flow-wasm` provides the WebAssembly binding crate for NeMo Flow.
+
+It uses wasm-bindgen to expose the shared runtime contract to JavaScript
+environments that consume the generated WebAssembly package.
+
+Most JavaScript users should consume the generated npm package rather than
+depend on this crate directly.
+
+For project-level documentation, start with:
+
+- the repo root `README.md`
+- `docs/getting-started/installation.md`
+- `crates/wasm/package.json`


### PR DESCRIPTION
#### Overview

- Add README.md to all crates
- Bump python publishing action
- Explicitly use relative directory for NPM

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Where should the reviewer start?

- ci.yaml for the bulk changes
- Cursory glance of README.md for each crate

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #10 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added README documentation for FFI, Node.js, and WebAssembly binding crates, describing their purpose and directing users to relevant resources.

* **Chores**
  * Updated CI/CD publishing workflows to refine package distribution across platforms and registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->