### PR TITLE
ci: add metadata standardization and workspace publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ concurrency:
 env:
   NEMO_FLOW_CI_RUST_VERSION: "1.93.0"
   NEMO_FLOW_CI_NODE_VERSION: "24"
+  NEMO_FLOW_CI_JUST_VERSION: "1.47.1"
 
 jobs:
 
@@ -121,6 +122,14 @@ jobs:
           cache: false
           toolchain: ${{ env.NEMO_FLOW_CI_RUST_VERSION }}
 
+      - uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
+        with:
+          tool: just@${{ env.NEMO_FLOW_CI_JUST_VERSION }}
+
+      - name: Stamp Cargo release version
+        working-directory: ${{ github.workspace }}/NeMo-Flow
+        run: just --set ref_name "${{ github.ref_name }}" stamp-cargo-release-version
+
       - name: Authenticate to crates.io with trusted publishing
         if: ${{ vars.NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING == 'true' }}
         id: crates-io-auth
@@ -131,14 +140,14 @@ jobs:
         working-directory: ${{ github.workspace }}/NeMo-Flow
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-        run: cargo publish -p nemo-flow -p nemo-flow-adaptive -p nemo-flow-ffi --no-verify
+        run: cargo publish --workspace --no-verify
 
       - name: Publish to crates.io with registry token
         if: ${{ vars.NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING != 'true' }}
         working-directory: ${{ github.workspace }}/NeMo-Flow
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p nemo-flow -p nemo-flow-adaptive -p nemo-flow-ffi --no-verify
+        run: cargo publish --workspace --no-verify
 
   publish-python:
     name: Publish / PyPI
@@ -184,7 +193,6 @@ jobs:
           path: .
 
       - name: Download WASM artifact
-        if: false
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wasm-bundler
@@ -214,7 +222,6 @@ jobs:
           npm publish ./combined/package --access public --tag "${NEMO_FLOW_NPM_DIST_TAG}"
 
       - name: Publish WASM package to npm
-        if: false
         run: |
           set -e
           for pkg in wasm-package/*.tgz; do

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  NEMO_FLOW_CI_DEFAULT_PYTHON_VER: "3.11"
   NEMO_FLOW_CI_RUST_VERSION: "1.93.0"
   NEMO_FLOW_CI_NODE_VERSION: "24"
+  NEMO_FLOW_CI_UV_VERSION: "0.9.28"
   NEMO_FLOW_CI_JUST_VERSION: "1.47.1"
 
 jobs:
@@ -121,6 +123,17 @@ jobs:
         with:
           cache: false
           toolchain: ${{ env.NEMO_FLOW_CI_RUST_VERSION }}
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+        with:
+          version: ${{ env.NEMO_FLOW_CI_UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: ${{ github.workspace }}/NeMo-Flow/uv.lock
+
+      - name: Install managed Python
+        run: |
+          set -e
+          UV_PYTHON_DOWNLOADS=manual uv python install --managed-python ${{ env.NEMO_FLOW_CI_DEFAULT_PYTHON_VER }}
 
       - uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -202,7 +202,8 @@ The release pipeline then:
    - `package-wasm` packs the npm WASM package.
 4. Publishes packages from the top-level workflow after the reusable packaging
    jobs complete:
-   - `publish-rust` runs `cargo publish --workspace --no-verify`
+   - `publish-rust` stamps Cargo workspace versions from the release tag, then
+     runs `cargo publish --workspace --no-verify`
      through either trusted publishing or `CARGO_REGISTRY_TOKEN`, depending on
      `NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING`
    - `publish-python` uploads the wheel artifacts to PyPI and uses one of two

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -1,7 +1,27 @@
 {
   "name": "nemo-flow-node",
   "version": "0.1.0",
-  "description": "NeMo Flow Node.js bindings via napi-rs",
+  "description": "Node.js bindings for the NeMo Flow agent runtime.",
+  "keywords": [
+    "agents",
+    "ai",
+    "llm",
+    "middleware",
+    "nemo-flow",
+    "observability",
+    "runtime",
+    "tools"
+  ],
+  "homepage": "https://github.com/NVIDIA/NeMo-Flow#readme",
+  "bugs": {
+    "url": "https://github.com/NVIDIA/NeMo-Flow/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NVIDIA/NeMo-Flow.git",
+    "directory": "crates/node"
+  },
+  "author": "NVIDIA Corporation & Affiliates",
   "main": "index.js",
   "types": "index.d.ts",
   "exports": {

--- a/crates/wasm/scripts/prepare_pkg.mjs
+++ b/crates/wasm/scripts/prepare_pkg.mjs
@@ -15,6 +15,21 @@ const rootJsFiles = ['index.js'];
 const jsWrapperFiles = ['typed.js', 'plugin.js', 'adaptive.js'];
 const typeWrapperFiles = ['typed.d.ts', 'plugin.d.ts', 'adaptive.d.ts'];
 const wrapperFiles = [...rootJsFiles, ...jsWrapperFiles, ...typeWrapperFiles];
+const packageMetadata = {
+  description: 'WebAssembly bindings for the NeMo Flow agent runtime.',
+  keywords: ['agents', 'ai', 'llm', 'middleware', 'nemo-flow', 'observability', 'runtime', 'tools', 'wasm'],
+  homepage: 'https://github.com/NVIDIA/NeMo-Flow#readme',
+  bugs: {
+    url: 'https://github.com/NVIDIA/NeMo-Flow/issues',
+  },
+  repository: {
+    type: 'git',
+    url: 'git+https://github.com/NVIDIA/NeMo-Flow.git',
+    directory: 'crates/wasm',
+  },
+  author: 'NVIDIA Corporation & Affiliates',
+  license: 'Apache-2.0',
+};
 
 // Wrapper sources refer to the crate-local dev layout; published files need to
 // point at the package-local wasm entrypoint inside pkg/.
@@ -54,6 +69,8 @@ function updatePackageManifest(manifest) {
   const manifestPath = path.join(pkgDir, 'package.json');
   const existingFiles = Array.isArray(manifest.files) ? manifest.files : [];
   const rootTypes = 'nemo_flow_wasm.d.ts';
+
+  Object.assign(manifest, packageMetadata);
 
   // wasm-pack generates a restrictive files allowlist, so the copied helper
   // wrappers must be added here or npm pack/publish will drop them.

--- a/justfile
+++ b/justfile
@@ -269,8 +269,10 @@ PY
 
 set_cargo_workspace_versions() {
     local version="$1"
+    local python_executable=""
+    python_executable="$(uv_python_executable)"
 
-    python3 - "$version" <<'PY'
+    "$python_executable" - "$version" <<'PY'
 from pathlib import Path
 import re
 import sys
@@ -341,7 +343,7 @@ PY
     metadata_file="$(mktemp)"
     trap 'rm -f "$metadata_file"' RETURN
     cargo metadata --no-deps --format-version 1 > "$metadata_file"
-    python3 - "$version" "$metadata_file" <<'PY'
+    "$python_executable" - "$version" "$metadata_file" <<'PY'
 import json
 import sys
 from pathlib import Path

--- a/justfile
+++ b/justfile
@@ -267,6 +267,106 @@ print(match.group(1))
 PY
 }
 
+set_cargo_workspace_versions() {
+    local version="$1"
+
+    python3 - "$version" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+version = sys.argv[1]
+if version.startswith("v"):
+    raise SystemExit("Release tags must not start with 'v'; use raw SemVer such as 0.1.0")
+if not re.fullmatch(r"\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?", version):
+    raise SystemExit(f"Unsupported release tag '{version}'; use 0.1.0 or prereleases like 0.1.0-rc.1")
+
+path = Path("Cargo.toml")
+text = path.read_text()
+section = ""
+output = []
+changed = []
+found_workspace_version = False
+local_dependencies = ("nemo-flow", "nemo-flow-adaptive", "nemo-flow-ffi")
+found_dependencies = set()
+
+for line in text.splitlines(keepends=True):
+    section_match = re.match(r"^\s*\[([^\]]+)\]\s*(?:#.*)?$", line)
+    if section_match:
+        section = section_match.group(1)
+
+    updated = line
+    if section == "workspace.package":
+        updated, count = re.subn(
+            r'^(version\s*=\s*")([^"]+)(".*)$',
+            rf"\g<1>{version}\g<3>",
+            line,
+        )
+        if count == 1:
+            found_workspace_version = True
+            if updated != line:
+                changed.append("workspace.package.version")
+    elif section == "workspace.dependencies":
+        for dependency in local_dependencies:
+            updated, count = re.subn(
+                rf"^({re.escape(dependency)}\s*=\s*\{{[^}}]*\bversion\s*=\s*\")([^\"]+)(\".*)$",
+                rf"\g<1>{version}\g<3>",
+                updated,
+            )
+            if count == 1:
+                found_dependencies.add(dependency)
+                if updated != line:
+                    changed.append(f"workspace.dependencies.{dependency}.version")
+                break
+
+    output.append(updated)
+
+missing = []
+if not found_workspace_version:
+    missing.append("workspace.package.version")
+for dependency in local_dependencies:
+    if dependency not in found_dependencies:
+        missing.append(f"workspace.dependencies.{dependency}.version")
+if missing:
+    raise SystemExit(f"Failed to find expected Cargo version fields: {', '.join(missing)}")
+
+path.write_text("".join(output))
+if changed:
+    print(f"Cargo.toml stamped for {version}: {', '.join(changed)}")
+else:
+    print(f"Cargo.toml already stamped for {version}")
+PY
+
+    local metadata_file=""
+    metadata_file="$(mktemp)"
+    trap 'rm -f "$metadata_file"' RETURN
+    cargo metadata --no-deps --format-version 1 > "$metadata_file"
+    python3 - "$version" "$metadata_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+version = sys.argv[1]
+metadata = json.loads(Path(sys.argv[2]).read_text())
+workspace_members = set(metadata["workspace_members"])
+mismatched = []
+checked = 0
+
+for package in metadata["packages"]:
+    if package["id"] not in workspace_members or not package["name"].startswith("nemo-flow"):
+        continue
+    checked += 1
+    if package["version"] != version:
+        mismatched.append(f"{package['name']}={package['version']}")
+
+if checked == 0:
+    raise SystemExit("Cargo metadata did not include any nemo-flow workspace packages")
+if mismatched:
+    raise SystemExit(f"Cargo workspace packages do not all resolve to {version}: {', '.join(mismatched)}")
+print(f"Cargo metadata resolves {checked} nemo-flow workspace packages to {version}")
+PY
+}
+
 set_python_package_versions() {
     local version="$1"
     local python_executable=""
@@ -729,6 +829,17 @@ test-wasm:
 
 # --set [output_dir=<path>] [ci=true|false]
 test-all: test-rust test-python test-go test-node test-wasm
+
+# --set ref_name=<version>
+stamp-cargo-release-version:
+    #!/usr/bin/env bash
+    {{ bash_helpers }}
+    if [[ -z "{{ ref_name }}" ]]; then
+        echo "Error: ref_name is required for stamp-cargo-release-version" >&2
+        exit 1
+    fi
+    cd "$NEMO_FLOW_REPO_ROOT"
+    set_cargo_workspace_versions "{{ ref_name }}"
 
 # --set [output_dir=<path>] [ref_name=<name>]
 package-node:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,39 @@ build-backend = "maturin"
 [project]
 name = "nemo-flow"
 dynamic = ["version"]
+description = "Python bindings for the NeMo Flow agent runtime."
+readme = "python/nemo_flow/README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [
+    { name = "NVIDIA Corporation & Affiliates" },
+]
+keywords = [
+    "agents",
+    "ai",
+    "llm",
+    "middleware",
+    "nemo-flow",
+    "observability",
+    "runtime",
+    "tools",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
+]
+
+[project.urls]
+Documentation = "https://nvidia.github.io/NeMo-Flow/"
+Homepage = "https://github.com/NVIDIA/NeMo-Flow"
+Issues = "https://github.com/NVIDIA/NeMo-Flow/issues"
+Repository = "https://github.com/NVIDIA/NeMo-Flow"
 
 [tool.maturin]
 manifest-path = "crates/python/Cargo.toml"


### PR DESCRIPTION
* **New Features**
  * Automated version stamping for Rust workspace releases from git tags
  * WASM package publishing to npm is now enabled in CI/CD

* **Chores**
  * Enhanced package metadata across all published packages (descriptions, keywords, licensing information, and repository links)
  * Improved CI/CD release workflow with tool version pinning and Python environment setup

* **Documentation**
  * Updated release playbook to document new pre-publish versioning step
