### PR TITLE
docs: fix attribution for node

### DIFF
--- a/ATTRIBUTIONS-Node.md
+++ b/ATTRIBUTIONS-Node.md
@@ -1585,7 +1585,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***```
 
 ## nemo-flow-node - 0.1.0
-**Repository URL**: https://www.npmjs.com/package/nemo-flow-node
+**Repository URL**: https://github.com/NVIDIA/NeMo-Flow
 **License Type(s)**: Apache-2.0
 ### License: https://spdx.org/licenses/Apache-2.0.html
 ```


### PR DESCRIPTION
Fix attribution for node

Signed-off-by: Will Killian <wkillian@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated attribution reference to point to the official GitHub repository instead of the npm package page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->