### PR TITLE
fix: allow docs deployment from release tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
       pages: write
       id-token: write
     environment:
-      name: github-pages
+      name: ${{ github.ref_type == 'tag' && 'github-pages-release' || 'github-pages' }}
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy GitHub Pages Site


### PR DESCRIPTION
## Summary
- keep GitHub Pages deployments from `main` on the existing `github-pages` environment
- route tag-triggered docs deployments through `github-pages-release` so release tags are not evaluated against the main-only Pages environment rule

Closes #17

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "yaml-ok"'`
- `uv run pre-commit run --files .github/workflows/ci.yaml`

## Breaking Changes
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation deployment workflow to dynamically switch between different deployment environments based on the type of build being executed. Tagged release builds now use a dedicated release environment, while regular development builds continue to use the standard environment, enabling more granular control over how documentation is deployed and maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->