### PR TITLE
fix: restrict crates.io publish scope

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,14 +153,22 @@ jobs:
         working-directory: ${{ github.workspace }}/NeMo-Flow
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-        run: cargo publish --workspace --no-verify --allow-dirty
+        run: |
+          set -euo pipefail
+          for package in nemo-flow nemo-flow-adaptive nemo-flow-ffi; do
+            cargo publish --package "$package" --no-verify --allow-dirty
+          done
 
       - name: Publish to crates.io with registry token
         if: ${{ vars.NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING != 'true' }}
         working-directory: ${{ github.workspace }}/NeMo-Flow
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --workspace --no-verify --allow-dirty
+        run: |
+          set -euo pipefail
+          for package in nemo-flow nemo-flow-adaptive nemo-flow-ffi; do
+            cargo publish --package "$package" --no-verify --allow-dirty
+          done
 
   publish-python:
     name: Publish / PyPI

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,7 +30,7 @@ The release pipeline publishes these package surfaces from a tag push:
 
 | Ecosystem | Published Surface |
 |---|---|
-| crates.io | `nemo-flow`, `nemo-flow-adaptive`, `nemo-flow-ffi`, `nemo-flow-node`, `nemo-flow-python`, `nemo-flow-wasm` |
+| crates.io | `nemo-flow`, `nemo-flow-adaptive`, `nemo-flow-ffi` |
 | PyPI | `nemo-flow` |
 | npm | `nemo-flow-node`, `nemo-flow-wasm` |
 | GitHub Pages | The documentation site, including the versioned docs build |
@@ -203,7 +203,8 @@ The release pipeline then:
 4. Publishes packages from the top-level workflow after the reusable packaging
    jobs complete:
    - `publish-rust` stamps Cargo workspace versions from the release tag, then
-     runs `cargo publish --workspace --no-verify`
+     runs `cargo publish --package` for `nemo-flow`, `nemo-flow-adaptive`, and
+     `nemo-flow-ffi`
      through either trusted publishing or `CARGO_REGISTRY_TOKEN`, depending on
      `NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING`
    - `publish-python` uploads the wheel artifacts to PyPI and uses one of two


### PR DESCRIPTION
## Summary
- replace workspace-wide crates.io publishing with an explicit ordered crate publish list
- publish only `nemo-flow`, `nemo-flow-adaptive`, and `nemo-flow-ffi` from release tags
- update release documentation to match the narrowed crates.io surface

Closes #19

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "yaml-ok"'`
- `uv run pre-commit run --files .github/workflows/ci.yaml RELEASING.md`

## Breaking Changes
- Binding crates are no longer published to crates.io by the release workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow for Rust crates to explicitly specify which packages are released.

* **Documentation**
  * Updated release documentation to clarify which crates are available on crates.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->