### PR TITLE
ci: narrow language PR labels

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -70,25 +70,25 @@ jobs:
             changed_lines=$((changed_lines + additions + deletions))
 
             case "$path" in
-              *.go|go/*|*/go.mod|*/go.sum|go.mod|go.sum)
+              *.go)
                 has_go=true
                 ;;
             esac
 
             case "$path" in
-              *.cjs|*.cts|*.js|*.jsx|*.mjs|*.mts|*.ts|*.tsx|crates/node/*|*/package.json|*/package-lock.json|package.json|package-lock.json)
+              *.cjs|*.cts|*.js|*.jsx|*.mjs|*.mts|*.ts|*.tsx)
                 has_js=true
                 ;;
             esac
 
             case "$path" in
-              *.py|*.pyi|python/*|crates/python/*|pyproject.toml|uv.lock)
+              *.py|*.pyi)
                 has_python=true
                 ;;
             esac
 
             case "$path" in
-              *.rs|Cargo.toml|Cargo.lock|crates/*/Cargo.toml)
+              *.rs)
                 has_rust=true
                 ;;
             esac


### PR DESCRIPTION
## Summary
- constrain auto-applied `lang:*` labels to source file extensions
- stop README and manifest-only binding edits from receiving language labels

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-labels.yaml"); puts "yaml-ok"'`
- shell simulation for README, manifest, and source-file examples
- `uv run pre-commit run --files .github/workflows/pr-labels.yaml`

## Breaking Changes
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined PR labeling automation to identify programming languages based exclusively on source file extensions. This narrows the criteria previously used, which included ecosystem manifest files and directory structures, resulting in more selective language category label application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->