### PR TITLE
chore: ignore local agent directories

### DIFF
--- a/.codex/skills
+++ b/.codex/skills
@@ -1,1 +1,0 @@
-../.agents/skills

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,1 +1,0 @@
-../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ $RECYCLE.BIN/
 .tmp/
 .planning/
 .claude/commands/
+/.codex/
+/.cursor/
 .env
 benchmarks/
 


### PR DESCRIPTION
## What changed
- Removed the tracked `.cursor/skills` symlink.
- Removed the tracked `.codex/skills` symlink.
- Added root-level `.cursor/` and `.codex/` entries to `.gitignore`.

## Why
These directories are local agent/editor state and should not be tracked in the repository.

## Validation
- `git ls-files .cursor .codex .gitignore` now only reports `.gitignore`.
- `git check-ignore -v .cursor/skills .codex/skills`
- `git diff --check`
- `uv run pre-commit run --files .gitignore`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal development configuration files.
  * Updated repository settings to exclude internal directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->