### PR TITLE
ci: tighten workflow conditionals and update precommit

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -123,6 +123,7 @@ jobs:
   check:
     name: Check
     needs: [changes]
+    if: ${{ inputs.ref_type != 'tag' }}
     runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     permissions:
@@ -203,7 +204,14 @@ jobs:
   docs:
     name: Documentation
     needs: [changes, check]
-    if: ${{ (startsWith(inputs.ref_name, 'pull-request/') || inputs.ref_name == 'main' || inputs.ref_name == github.event.repository.default_branch || inputs.ref_type == 'tag') && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.docs == 'true') }}
+    if: >-
+      ${{
+        !cancelled()
+        && needs.changes.result == 'success'
+        && (inputs.ref_type == 'tag' || needs.check.result == 'success')
+        && (startsWith(inputs.ref_name, 'pull-request/') || inputs.ref_name == 'main' || inputs.ref_name == github.event.repository.default_branch || inputs.ref_type == 'tag')
+        && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.docs == 'true')
+      }}
     runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     permissions:
@@ -263,6 +271,7 @@ jobs:
         run: git fetch --force origin +refs/heads/main:refs/heads/main
 
       - name: Check Documentation Links
+        if: ${{ inputs.ref_type != 'tag' }}
         working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
         env:
           NEMO_FLOW_DOCS_DEPS_READY: "1"
@@ -291,7 +300,7 @@ jobs:
   test-rust:
     name: Test / Rust / ${{ matrix.platform }}
     needs: [changes, check]
-    if: ${{ needs.changes.outputs.run_all == 'true' || needs.changes.outputs.rust == 'true' }}
+    if: ${{ inputs.ref_type != 'tag' && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.rust == 'true') }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
@@ -416,7 +425,7 @@ jobs:
   test-go:
     name: Test / Go / ${{ matrix.platform }}
     needs: [changes, check]
-    if: ${{ needs.changes.outputs.run_all == 'true' || needs.changes.outputs.go == 'true' }}
+    if: ${{ inputs.ref_type != 'tag' && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.go == 'true') }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
@@ -483,7 +492,7 @@ jobs:
   test-node:
     name: Test / Node / ${{ matrix.platform }}
     needs: [changes, check]
-    if: ${{ needs.changes.outputs.run_all == 'true' || needs.changes.outputs.node == 'true' }}
+    if: ${{ inputs.ref_type != 'tag' && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.node == 'true') }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
@@ -548,7 +557,7 @@ jobs:
   test-python:
     name: Test / Python / ${{ matrix.platform }}
     needs: [changes, check]
-    if: ${{ needs.changes.outputs.run_all == 'true' || needs.changes.outputs.python == 'true' }}
+    if: ${{ inputs.ref_type != 'tag' && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.python == 'true') }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
@@ -640,7 +649,7 @@ jobs:
   test-wasm:
     name: Test / WASM / ${{ matrix.platform }}
     needs: [changes, check]
-    if: ${{ needs.changes.outputs.run_all == 'true' || needs.changes.outputs.wasm == 'true' }}
+    if: ${{ inputs.ref_type != 'tag' && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.wasm == 'true') }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
@@ -740,7 +749,18 @@ jobs:
   package-node:
     name: Package / Node / ${{ matrix.platform }}
     needs: [changes, test-node]
-    if: ${{ needs.changes.outputs.run_all == 'true' || needs.changes.outputs.node == 'true' }}
+    if: >-
+      ${{
+        !cancelled()
+        && needs.changes.result == 'success'
+        && (
+          inputs.ref_type == 'tag'
+          || (
+            needs.test-node.result == 'success'
+            && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.node == 'true')
+          )
+        )
+      }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
@@ -914,7 +934,18 @@ jobs:
   package-python:
     name: Package / Python / ${{ matrix.platform }}
     needs: [changes, test-python]
-    if: ${{ needs.changes.outputs.run_all == 'true' || needs.changes.outputs.python == 'true' }}
+    if: >-
+      ${{
+        !cancelled()
+        && needs.changes.result == 'success'
+        && (
+          inputs.ref_type == 'tag'
+          || (
+            needs.test-python.result == 'success'
+            && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.python == 'true')
+          )
+        )
+      }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
@@ -1029,7 +1060,18 @@ jobs:
   package-wasm:
     name: Package / WASM / linux-amd64
     needs: [changes, test-wasm]
-    if: ${{ needs.changes.outputs.run_all == 'true' || needs.changes.outputs.wasm == 'true' }}
+    if: >-
+      ${{
+        !cancelled()
+        && needs.changes.result == 'success'
+        && (
+          inputs.ref_type == 'tag'
+          || (
+            needs.test-wasm.result == 'success'
+            && (needs.changes.outputs.run_all == 'true' || needs.changes.outputs.wasm == 'true')
+          )
+        )
+      }}
     runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,30 @@ repos:
         always_run: true
         pass_filenames: false
 
+  # Lockfiles — manifest freshness
+  - repo: local
+    hooks:
+      - id: cargo-lockfile-check
+        name: Cargo.lock is up to date
+        entry: bash -c 'cargo metadata --locked --format-version 1 --no-deps >/dev/null'
+        language: system
+        files: '^(Cargo\.toml|Cargo\.lock|crates/.*/Cargo\.toml)$'
+        pass_filenames: false
+
+      - id: uv-lockfile-check
+        name: uv.lock is up to date
+        entry: uv lock --check
+        language: system
+        files: '^(pyproject\.toml|uv\.lock)$'
+        pass_filenames: false
+
+      - id: node-lockfile-check
+        name: package-lock.json is up to date
+        entry: bash -c 'cd crates/node && npm install --package-lock-only --ignore-scripts --audit=false --fund=false && git diff --exit-code -- package-lock.json'
+        language: system
+        files: '^crates/node/package(?:-lock)?\.json$'
+        pass_filenames: false
+
   # Rust — fmt + clippy + cargo-deny
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,21 +69,21 @@ repos:
     hooks:
       - id: cargo-lockfile-check
         name: Cargo.lock is up to date
-        entry: bash -c 'cargo metadata --locked --format-version 1 --no-deps >/dev/null'
+        entry: bash -c 'cargo metadata --format-version 1 --no-deps >/dev/null'
         language: system
         files: '^(Cargo\.toml|Cargo\.lock|crates/.*/Cargo\.toml)$'
         pass_filenames: false
 
       - id: uv-lockfile-check
         name: uv.lock is up to date
-        entry: uv lock --check
+        entry: uv lock
         language: system
         files: '^(pyproject\.toml|uv\.lock)$'
         pass_filenames: false
 
       - id: node-lockfile-check
         name: package-lock.json is up to date
-        entry: bash -c 'cd crates/node && npm install --package-lock-only --ignore-scripts --audit=false --fund=false && git diff --exit-code -- package-lock.json'
+        entry: bash -c 'cd crates/node && npm install --package-lock-only --ignore-scripts --audit=false --fund=false'
         language: system
         files: '^crates/node/package(?:-lock)?\.json$'
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,8 +55,14 @@ repos:
     hooks:
       - id: lychee
         name: docs markdown linkcheck
-        args: ["--no-progress", "--include-fragments"]
-        files: '^(README\.md|CONTRIBUTING\.md|docs/.*\.md)$'
+        args:
+          - --no-progress
+          - --include-fragments
+          - README.md
+          - CONTRIBUTING.md
+          - docs/**/*.md
+        always_run: true
+        pass_filenames: false
 
   # Rust — fmt + clippy + cargo-deny
   - repo: local

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -169,18 +169,19 @@ git push origin 0.1.0-rc.1
 
 Pushing a valid tag triggers [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml).
 That workflow then calls [`.github/workflows/ci_pipe.yml`](.github/workflows/ci_pipe.yml)
-for the shared build, test, docs, and packaging stages.
+for the shared release documentation and packaging stages.
 
 The release pipeline then:
 
 1. Validates the tag format in the `prepare` job.
-2. Runs repo checks, docs, and the Rust, Python, Go, Node.js, and WASM test
-   jobs.
-3. Builds publishable package artifacts with the exact tag version:
+2. Skips repo checks and the Rust, Python, Go, Node.js, and WASM test jobs.
+   Run those checks before creating and pushing the release tag.
+3. Builds and uploads the versioned GitHub Pages documentation artifact.
+4. Builds publishable package artifacts with the exact tag version:
    - `package-node` packs the npm Node.js package.
    - `package-python` builds platform wheels.
    - `package-wasm` packs the npm WASM package.
-4. Publishes packages from the top-level workflow after the reusable packaging
+5. Publishes packages from the top-level workflow after the reusable packaging
    jobs complete:
    - `publish-rust` stamps Cargo workspace versions from the release tag, then
      runs `cargo publish --package` for `nemo-flow`, `nemo-flow-adaptive`, and
@@ -194,7 +195,7 @@ The release pipeline then:
      - stable tags publish to the npm `latest` dist-tag
      - prerelease tags such as `0.1.0-rc.1` publish to the npm `next`
        dist-tag so they do not become the default upgrade target
-5. Builds and deploys the GitHub Pages docs site.
+6. Deploys the GitHub Pages docs site.
 
 The workflow boundary is split intentionally:
 

--- a/docs/resources/support-and-faqs.md
+++ b/docs/resources/support-and-faqs.md
@@ -440,7 +440,7 @@ upstream source checkouts under `third_party/`. Use the repository wrapper
 scripts when checking or applying those patches, and regenerate the patch after
 changing files inside a submodule.
 
-Refer to [Framework Integration Code Examples](../integrate-frameworks/code-examples.md#repository-utility-scripts)
+Refer to [Framework Integration Code Examples](../integrate-frameworks/code-examples.md#quickstart-apply-maintained-patches)
 and the repository root `third_party/README.md`.
 
 ### Where Are The API Docs?


### PR DESCRIPTION
## Summary

- Skip repo checks and language test jobs for tag-triggered CI runs.
- Allow documentation and packaging jobs to proceed on tag refs even when their check/test dependencies are skipped.
- Update release documentation so the described tag pipeline matches the workflow behavior.
- Fix a stale docs anchor and make the lychee pre-commit hook check the full Markdown documentation set whenever it runs.
- Add pre-commit lockfile freshness hooks for `Cargo.lock`, `uv.lock`, and `crates/node/package-lock.json`; each hook materializes the expected lockfile output so developers can commit the generated result.

## Why

Tagged release CI only needs to build documentation, package artifacts, and publish from the top-level workflow. The prior reusable pipeline treated tags as `run_all`, which scheduled checks and all language test jobs before packaging.

The lychee hook was also only checking the changed Markdown files passed by pre-commit, which allowed stale links elsewhere in the docs tree to survive until a full run. The lockfile hooks make manifest/lock drift fail through the existing pre-commit path that CI already runs, while leaving the corrected lockfile content in the working tree.

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f) }; puts "yaml-ok"'`
- `git diff --check github/main...HEAD`
- `pre-commit run lychee --all-files`
- `pre-commit run cargo-lockfile-check --all-files`
- `pre-commit run uv-lockfile-check --all-files`
- `pre-commit run node-lockfile-check --all-files`
- `pre-commit run --all-files`

## Notes

- Local `main` was fast-forwarded to `0843451` from `github/main` before rebasing this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI logic so release-tag runs focus on packaging and docs while skipping tests/checks; non-tag workflows retain full verification.
  * Added repository lockfile freshness checks and updated pre-commit link-check behavior to always run and target key docs files.

* **Documentation**
  * Updated release workflow docs to reflect the narrowed role of the reusable pipeline, new docs artifact step, and revised deploy wording.
  * Fixed a broken FAQ hyperlink.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->