### PR TITLE
ci: run node consolidation after tag packaging

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -858,6 +858,7 @@ jobs:
   consolidate-node:
     name: Consolidate / Node
     needs: [package-node]
+    if: ${{ !cancelled() && needs.package-node.result == 'success' }}
     runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

- Add an explicit `consolidate-node` job condition that runs whenever `package-node` succeeds.
- Avoid GitHub Actions' implicit `success()` behavior from skipping Node package consolidation after tag packaging runs through skipped test dependencies.

## Why

Tag-triggered release CI skips language tests but still runs packaging. `package-node` already opts into that path with `!cancelled()`, but `consolidate-node` had no explicit condition. This makes the consolidation job follow the direct `package-node` result so the `npm-consolidated` artifact is produced for tagged releases.

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f) }; puts "yaml-ok"'`
- `git diff --check`
- `uv run pre-commit run --files .github/workflows/ci.yaml .github/workflows/ci_pipe.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline reliability by adding execution guards to ensure dependent build steps only proceed when prerequisites complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->