### PR TITLE
ci: require crates.io trusted publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,26 +144,13 @@ jobs:
         run: just --set ref_name "${{ github.ref_name }}" stamp-cargo-release-version
 
       - name: Authenticate to crates.io with trusted publishing
-        if: ${{ vars.NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING == 'true' }}
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       - name: Publish to crates.io with trusted publishing
-        if: ${{ vars.NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING == 'true' }}
         working-directory: ${{ github.workspace }}/NeMo-Flow
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-        run: |
-          set -euo pipefail
-          for package in nemo-flow nemo-flow-adaptive nemo-flow-ffi; do
-            cargo publish --package "$package" --no-verify --allow-dirty
-          done
-
-      - name: Publish to crates.io with registry token
-        if: ${{ vars.NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING != 'true' }}
-        working-directory: ${{ github.workspace }}/NeMo-Flow
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
           for package in nemo-flow nemo-flow-adaptive nemo-flow-ffi; do

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,16 +85,14 @@ Before you create a release tag, confirm the following:
    public API changes that belong in the release.
 3. The working tree you use for local validation is clean or disposable.
 4. Registry credentials and repository settings are in place:
-   - `CARGO_REGISTRY_TOKEN` for crates.io publishing when `NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING` is not enabled
-   - GitHub Actions `id-token: write` access for the top-level crates.io publish job when `NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING=true`
+   - GitHub Actions `id-token: write` access for the top-level crates.io publish job
+   - crates.io trusted publishers for `nemo-flow`, `nemo-flow-adaptive`, and
+     `nemo-flow-ffi` are configured for the top-level
+     [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) workflow
    - GitHub Actions `id-token: write` access is available for the top-level npm publish job
    - npm trusted publishers for `nemo-flow-node` and `nemo-flow-wasm` are configured for the top-level [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) workflow
    - GitHub Actions `id-token: write` access for the top-level PyPI publish job
-5. The repository variable `NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING` matches the
-   intended crates.io auth path for this release:
-   - `true` uses GitHub OIDC plus `rust-lang/crates-io-auth-action`
-   - `false` uses the `CARGO_REGISTRY_TOKEN` secret
-6. The GitHub Release entry is ready to become the only canonical release-notes
+5. The GitHub Release entry is ready to become the only canonical release-notes
    surface.
 
 ## Prepare The Release Commit
@@ -185,9 +183,7 @@ The release pipeline then:
    jobs complete:
    - `publish-rust` stamps Cargo workspace versions from the release tag, then
      runs `cargo publish --package` for `nemo-flow`, `nemo-flow-adaptive`, and
-     `nemo-flow-ffi`
-     through either trusted publishing or `CARGO_REGISTRY_TOKEN`, depending on
-     `NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING`
+     `nemo-flow-ffi` through trusted publishing from the top-level workflow
    - `publish-python` uploads the wheel artifacts to PyPI with trusted
      publishing from the top-level workflow
    - `publish-npm` publishes the Node.js and WASM npm packages through npm


### PR DESCRIPTION
## Summary

- Remove the `NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING` gate from the crates.io publish job.
- Delete the `CARGO_REGISTRY_TOKEN` fallback publish path.
- Update `RELEASING.md` so crates.io release prep assumes trusted publishing is configured.

## Why

crates.io trusted publishing is now the required release path, so the repository variable no longer needs to select between OIDC and a registry token fallback.

## Validation

- `rg -n "NEMO_FLOW_ENABLE_TRUSTED_PUBLISHING|Publish to crates.io with registry token|CARGO_REGISTRY_TOKEN for crates.io|through either trusted publishing" .github RELEASING.md` returned no matches
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f) }; puts "yaml-ok"'`
- `git diff --check`
- `uv run pre-commit run --files .github/workflows/ci.yaml RELEASING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Rust crate publishing workflow by consolidating to a single trusted publishing path for crate distribution
  * Updated release documentation to align with the new publishing configuration requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->