### PR TITLE
ci: set nightly tag git identity

### DIFF
--- a/.github/workflows/nightly-alpha-tag.yaml
+++ b/.github/workflows/nightly-alpha-tag.yaml
@@ -55,6 +55,8 @@ jobs:
             exit 0
           fi
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag \
             --annotate \
             --message "NeMo Flow ${version} Nightly ${tag_date}" \


### PR DESCRIPTION
## Summary

- Configure a GitHub Actions bot identity before creating the annotated nightly alpha tag.
- Keep the existing PAT-backed tag push path so tag CI is still triggered.

## Root Cause

The scheduled nightly alpha tag run failed because git tag --annotate requires a committer identity, but the runner had no local user.name or user.email configured.

## Validation

- YAML load for all workflow files
- uv run pre-commit run --files .github/workflows/nightly-alpha-tag.yaml
- git diff --check

## Breaking Changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release tagging configuration to improve consistency in nightly build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->