### PR TITLE
ci: add CODEOWNERS approval workflow

### DIFF
--- a/.github/workflows/codeowners-approval.yml
+++ b/.github/workflows/codeowners-approval.yml
@@ -26,7 +26,6 @@ defaults:
 jobs:
   codeowners-approval:
     name: Require CODEOWNERS approvals
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codeowners-approval.yml
+++ b/.github/workflows/codeowners-approval.yml
@@ -4,16 +4,12 @@
 name: CODEOWNERS approval
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - ready_for_review
       - reopened
       - synchronize
-  pull_request_review:
-    types:
-      - submitted
-      - dismissed
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.number }}'

--- a/.github/workflows/codeowners-approval.yml
+++ b/.github/workflows/codeowners-approval.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CODEOWNERS approval
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.number }}'
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  codeowners-approval:
+    name: Require CODEOWNERS approvals
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check token configuration
+        env:
+          NEMO_FLOW_CODEOWNERS_APPROVAL_TOKEN: ${{ secrets.NEMO_FLOW_CODEOWNERS_APPROVAL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$NEMO_FLOW_CODEOWNERS_APPROVAL_TOKEN" ]]; then
+            echo "Error: NEMO_FLOW_CODEOWNERS_APPROVAL_TOKEN is required with repo and read:org permissions." >&2
+            exit 1
+          fi
+
+      - name: Check CODEOWNERS approval
+        uses: noamelf/codeowner-multi-approval-action@ab1d2dc274612ab9439b96538f30e88be2570f49 # v0.1
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          repo-name: ${{ github.repository }}
+          github-token: ${{ secrets.NEMO_FLOW_CODEOWNERS_APPROVAL_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a standalone CODEOWNERS approval workflow.
- Require all matching CODEOWNERS to approve changed files using noamelf/codeowner-multi-approval-action pinned to v0.1.
- Fail early when NEMO_FLOW_CODEOWNERS_APPROVAL_TOKEN is not configured.

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeowners-approval.yml"); puts "yaml-ok"'\n- uv run pre-commit run --files .github/workflows/codeowners-approval.yml\n\n## Notes\n- The workflow expects NEMO_FLOW_CODEOWNERS_APPROVAL_TOKEN to have repository read access plus organization Members: Read / read:org access so team CODEOWNERS can be resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CODEOWNERS approval workflow for pull requests.
  * Enforces a single in-flight run per PR and validates that an approval token is configured before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->