### PR TITLE
fix(rust): python rust tests need isolation

### DIFF
--- a/crates/python/tests/coverage/coverage_tests.rs
+++ b/crates/python/tests/coverage/coverage_tests.rs
@@ -106,6 +106,7 @@ fn test_python_test_guard_restores_existing_runtime_env() {
         assert!(std::env::var_os("NEMO_FLOW_BINDING_KIND").is_none());
         assert!(std::env::var_os("NEMO_FLOW_RUNTIME_OWNER").is_none());
     }
+    let _lock = crate::test_support::lock_python_test();
     unsafe {
         std::env::remove_var("NEMO_FLOW_BINDING_KIND");
         std::env::remove_var("NEMO_FLOW_RUNTIME_OWNER");
@@ -134,11 +135,11 @@ fn test_python_test_guard_keeps_absent_runtime_env_absent() {
             Some("mutated-owner".into())
         );
     }
+    let _lock = crate::test_support::lock_python_test();
     unsafe {
         std::env::remove_var("NEMO_FLOW_BINDING_KIND");
         std::env::remove_var("NEMO_FLOW_RUNTIME_OWNER");
     }
-    let _lock = crate::test_support::lock_python_test();
     assert!(std::env::var_os("NEMO_FLOW_BINDING_KIND").is_none());
     assert!(std::env::var_os("NEMO_FLOW_RUNTIME_OWNER").is_none());
 }


### PR DESCRIPTION
## What changed

- Serialized the post-guard environment cleanup in the Python coverage tests with `lock_python_test()`.
- Kept the absent-runtime-owner assertion under the same mutex used by the Python test guard.

## Why

Windows Python CI was intermittently failing because the test released the Python test mutex before clearing and asserting process-wide `NEMO_FLOW_RUNTIME_OWNER` / `NEMO_FLOW_BINDING_KIND` state. Another parallel test could observe or mutate those process-wide variables in that gap.

## Validation

- `cargo test -p nemo-flow-python test_python_test_guard --lib -- --nocapture`
- Earlier local validation also passed: `cargo test -p nemo-flow-python --lib` and `just test-python`