### PR TITLE
ci: fix GitLab npm artifactory publish config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -246,8 +246,6 @@ publish:artifactory:npm:
       npm_auth="$(printf '%s:%s' "${NEMO_FLOW_CI_ARTIFACTORY_USER}" "${NEMO_FLOW_CI_ARTIFACTORY_KEY}" | base64 | tr -d '\n')"
       npm config set registry "$registry_url"
       npm config set "${registry_key}:_auth" "$npm_auth"
-      npm config set "${registry_key}:email" "ci@nvidia.com"
-      npm config set "${registry_key}:always-auth" "true"
 
       npm publish --tag dev collected/node/consolidated/package
       for package_path in collected/wasm/*.tgz; do


### PR DESCRIPTION
#### Overview

Fix the GitLab `publish:artifactory:npm` job for npm 11 / Node 24 by removing legacy npm config writes that are no longer accepted.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Remove registry-scoped `email` and `always-auth` writes from the Artifactory npm publish setup.
- Keep the Artifactory registry and registry-scoped `_auth` configuration used by `npm publish`.
- Validation: reproduced npm 11 rejecting `always-auth`, verified the remaining npm config commands with npm 11.11.0, ran `git diff --check`, and commit hooks passed.

#### Where should the reviewer start?

`.gitlab-ci.yml`, in the `publish:artifactory:npm` job.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm registry authentication configuration in the CI/CD pipeline to use base64-encoded credentials for improved security during artifact publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->