### PR TITLE
ci: harden Go Windows linker setup

### DIFF
--- a/justfile
+++ b/justfile
@@ -783,12 +783,19 @@ test-go:
     coverage_out=""
     junit_out=""
     lib_dir="$NEMO_FLOW_REPO_ROOT/target/$target"
+    host_os="$(uname -s 2>/dev/null || true)"
+    is_windows=false
+    case "${RUNNER_OS:-}:${OSTYPE:-}:$host_os" in
+        Windows:*|*:msys*:*|*:win32*:*|*:*:MINGW*|*:*:MSYS*|*:*:CYGWIN*)
+            is_windows=true
+            ;;
+    esac
     cd "$NEMO_FLOW_REPO_ROOT"
     cargo build $flag -p nemo-flow-ffi
 
-    if [[ "$OSTYPE" == msys* || "$OSTYPE" == win32* ]]; then
-        export CC="${CC:-clang}"
-        export CXX="${CXX:-clang++}"
+    if [[ "$is_windows" == true ]]; then
+        export CC=clang
+        export CXX=clang++
         # Go's Windows linker checks -extldflags before deciding whether to
         # inject a GNU linker script; CGO_LDFLAGS is too late for that check.
         go_ldflags+=(-extldflags=-fuse-ld=lld)
@@ -808,12 +815,15 @@ test-go:
         coverage_out="$(prepare_artifact go-coverage.xml)"
         junit_out="$(prepare_artifact go-junit.xml)"
         go_test_cmd+=(-coverprofile=coverage.out)
-        if [[ "$OSTYPE" == msys* || "$OSTYPE" == win32* ]]; then
+        if [[ "$is_windows" == true ]]; then
             go_ldflags+=(-w)
         fi
         go install github.com/jstemmer/go-junit-report/v2@latest
         go install github.com/boumenot/gocover-cobertura@latest
         prepend_go_bin_to_path
+    fi
+    if [[ "$is_windows" == true ]]; then
+        echo "Go Windows linker: RUNNER_OS=${RUNNER_OS:-} OSTYPE=${OSTYPE:-} uname=$host_os CC=$CC CXX=$CXX ldflags=${go_ldflags[*]:-}"
     fi
     if [[ ${#go_ldflags[@]} -gt 0 ]]; then
         go_test_cmd+=("-ldflags=${go_ldflags[*]}")


### PR DESCRIPTION
#### Overview

Harden the Go binding CI recipe so Windows jobs reliably select the clang/lld linker path when GitHub-hosted runner shell metadata changes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Detect Windows from `RUNNER_OS`, `OSTYPE`, or `uname -s` instead of relying only on `OSTYPE`.
- Force the Windows Go CGO linker to clang/clang++ and keep the existing `-fuse-ld=lld` behavior so Go does not fall back to MinGW GCC for the MSVC-built FFI library.
- Emit the selected Windows linker settings in CI logs to make future failures easier to diagnose.

#### Where should the reviewer start?

Start with `justfile`, specifically the `test-go` recipe's Windows detection and linker setup.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows platform detection in the build system to check multiple environment variables for more reliable identification.
  * Reorganized Windows-specific build configurations for better maintainability.
  * Refined CI build process conditional logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->