### PR TITLE
ci: use GitHub-hosted Linux runners

### DIFF
--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   check:
     name: Run
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   docs:
     name: Build
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/ci_go.yml
+++ b/.github/workflows/ci_go.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         include:
           - platform: linux-amd64
-            runner: linux-amd64-cpu4
+            runner: ubuntu-latest
           - platform: linux-arm64
-            runner: linux-arm64-cpu4
+            runner: ubuntu-24.04-arm
           - platform: macos-arm64
             runner: macos-15
           - platform: windows-amd64

--- a/.github/workflows/ci_node.yml
+++ b/.github/workflows/ci_node.yml
@@ -42,9 +42,9 @@ jobs:
       matrix:
         include:
           - platform: linux-amd64
-            runner: linux-amd64-cpu4
+            runner: ubuntu-latest
           - platform: linux-arm64
-            runner: linux-arm64-cpu4
+            runner: ubuntu-24.04-arm
           - platform: macos-arm64
             runner: macos-15
           - platform: windows-amd64
@@ -109,9 +109,9 @@ jobs:
       matrix:
         include:
           - platform: linux-amd64
-            runner: linux-amd64-cpu4
+            runner: ubuntu-latest
           - platform: linux-arm64
-            runner: linux-arm64-cpu4
+            runner: ubuntu-24.04-arm
           - platform: macos-arm64
             runner: macos-15
           - platform: windows-amd64
@@ -200,7 +200,7 @@ jobs:
     name: Consolidate
     needs: [package-node]
     if: ${{ !cancelled() && needs.package-node.result == 'success' }}
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -42,9 +42,9 @@ jobs:
       matrix:
         include:
           - platform: linux-amd64
-            runner: linux-amd64-cpu4
+            runner: ubuntu-latest
           - platform: linux-arm64
-            runner: linux-arm64-cpu4
+            runner: ubuntu-24.04-arm
           - platform: macos-arm64
             runner: macos-15
           - platform: windows-amd64
@@ -136,9 +136,9 @@ jobs:
       matrix:
         include:
           - platform: linux-amd64
-            runner: linux-amd64-cpu4
+            runner: ubuntu-latest
           - platform: linux-arm64
-            runner: linux-arm64-cpu4
+            runner: ubuntu-24.04-arm
           - platform: macos-arm64
             runner: macos-15
           - platform: windows-amd64

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -43,11 +43,11 @@ jobs:
       matrix:
         include:
           - platform: linux-amd64
-            runner: linux-amd64-cpu4
+            runner: ubuntu-latest
             run_redis_tests: true
             redis_service_image: redis:7.4.7-alpine
           - platform: linux-arm64
-            runner: linux-arm64-cpu4
+            runner: ubuntu-24.04-arm
             run_redis_tests: false
             redis_service_image: ''
           - platform: macos-arm64

--- a/.github/workflows/ci_wasm.yml
+++ b/.github/workflows/ci_wasm.yml
@@ -42,9 +42,9 @@ jobs:
       matrix:
         include:
           - platform: linux-amd64
-            runner: linux-amd64-cpu4
+            runner: ubuntu-latest
           - platform: linux-arm64
-            runner: linux-arm64-cpu4
+            runner: ubuntu-24.04-arm
           - platform: macos-arm64
             runner: macos-15
           - platform: windows-amd64
@@ -103,7 +103,7 @@ jobs:
     name: Package / linux-amd64
     needs: [test-wasm]
     if: ${{ !cancelled() && needs.test-wasm.result == 'success' }}
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
#### Overview

Switch Linux CI jobs from custom runner labels to standard GitHub-hosted runner labels.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replaces `linux-amd64-cpu4` with `ubuntu-latest` across workflow jobs and Linux AMD64 matrix entries.
- Replaces `linux-arm64-cpu4` with `ubuntu-24.04-arm` across Linux ARM64 matrix entries.
- Leaves `.github/actionlint.yaml` unchanged so the existing self-hosted runner allow-list remains in place.

#### Where should the reviewer start?

Start with `.github/workflows/ci_rust.yml`, then compare the same matrix-label change across the Go, Node.js, Python, and WebAssembly workflows.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use GitHub-hosted runners for build and test jobs across all platforms (Go, Node.js, Python, Rust, and WebAssembly).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->