### PR TITLE
ci: install sphinx rustdoc generator

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -79,7 +79,7 @@ jobs:
 
       - uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
         with:
-          tool: just@${{ steps.ci-config.outputs.just_version }}
+          tool: just@${{ steps.ci-config.outputs.just_version }},sphinx-rustdocgen@1.0.1
 
       - name: Install Documentation Dependencies
         working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}


### PR DESCRIPTION
#### Overview

Install the Rust documentation generator required by `sphinxcontrib-rust` in the documentation CI job so `just docs-linkcheck` can generate Rust API docs before Sphinx link checking.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Added `sphinx-rustdocgen@1.0.1` to the existing `taiki-e/install-action` tool list in `.github/workflows/ci_docs.yml`.
- Kept the fix CI-scoped; the `justfile` docs recipes are unchanged.
- Pinned the generator to `1.0.1` to match the currently locked `sphinxcontrib-rust` Python package version used by the docs dependency group.
- `sphinxcontrib-rust` includes a `setup.py` install hook for building `sphinx-rustdocgen`, but `uv sync` builds and installs a wheel from the sdist rather than running `setup.py install`; wheel installation does not execute that custom install command, so CI must provide the executable explicitly.

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci_docs.yml"); puts "yaml-ok"'` passed.
- `git diff --check -- .github/workflows/ci_docs.yml` passed.
- `uv run pre-commit run --files .github/workflows/ci_docs.yml` passed.
- `NEMO_FLOW_DOCS_DEPS_READY=1 just docs-linkcheck` passed locally. Local environment already had `sphinx-rustdocgen`; the workflow change ensures CI has the same required executable before running the same command.

#### Where should the reviewer start?

Start with `.github/workflows/ci_docs.yml`, where the documentation tool install step now installs both `just` and `sphinx-rustdocgen`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated documentation CI workflow to include additional tooling for enhanced documentation generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->