### PR TITLE
ci: fix Codecov component paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -46,8 +46,8 @@ component_management:
     - component_id: rust_runtime
       name: Rust Runtime
       paths:
-        - "NeMo-Flow/crates/core/src"
-        - "NeMo-Flow/crates/adaptive/src"
+        - "crates/core/src"
+        - "crates/adaptive/src"
       statuses:
         - type: project
           target: 95%
@@ -57,8 +57,8 @@ component_management:
     - component_id: go_binding
       name: Go Binding
       paths:
-        - "NeMo-Flow/go/nemo_flow"
-        - "NeMo-Flow/crates/ffi/src"
+        - "go/nemo_flow"
+        - "crates/ffi/src"
       statuses:
         - type: project
           target: 95%
@@ -68,8 +68,8 @@ component_management:
     - component_id: python_binding
       name: Python Binding
       paths:
-        - "NeMo-Flow/python/nemo_flow"
-        - "NeMo-Flow/crates/python/src"
+        - "python/nemo_flow"
+        - "crates/python/src"
       statuses:
         - type: project
           target: 95%
@@ -79,7 +79,7 @@ component_management:
     - component_id: node_binding
       name: Node Binding
       paths:
-        - "NeMo-Flow/crates/node/*.js"
+        - "crates/node/*.js"
       statuses:
         - type: project
           target: 95%
@@ -89,7 +89,7 @@ component_management:
     - component_id: wasm_binding
       name: WebAssembly Binding
       paths:
-        - "NeMo-Flow/crates/wasm/wrappers/nodejs/*.js"
+        - "crates/wasm/wrappers/nodejs/*.js"
       statuses:
         - type: project
           target: 84% # cannot be any higher due to internals


### PR DESCRIPTION
#### Overview

Correct Codecov component path globs so they match repository-relative coverage paths instead of `NeMo-Flow/...`-prefixed paths.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Removed the stale `NeMo-Flow/` prefix from every `component_management.individual_components[].paths` entry.
- Left Codecov thresholds, statuses, comment layout, and ignore rules unchanged.
- Validation: `git diff --check -- codecov.yml`; Ruby YAML parse; `rg -n "NeMo-Flow/" codecov.yml` returned no matches; `uv run pre-commit run --files codecov.yml`.

#### Where should the reviewer start?

Start with `codecov.yml`, specifically the Codecov component path entries for Rust, Go, Python, Node.js, and WebAssembly.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration paths to improve monitoring consistency across runtime and binding components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->