### PR TITLE
ci: keep docs-only PR checks focused

### DIFF
--- a/.github/ci-path-filters.yml
+++ b/.github/ci-path-filters.yml
@@ -41,7 +41,7 @@ go:
   - 'crates/ffi/cbindgen.toml'
   - 'crates/ffi/nemo_flow.h'
   - 'crates/ffi/src/**'
-  - 'go/**'
+  - 'go/**/!(*.md)'
 
 node:
   - 'crates/node/Cargo.toml'
@@ -58,7 +58,7 @@ python:
   - 'crates/python/Cargo.toml'
   - 'crates/python/src/**'
   - 'pyproject.toml'
-  - 'python/**'
+  - 'python/**/!(*.md)'
   - 'uv.lock'
 
 wasm:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,14 @@ jobs:
     needs:
       - prepare
       - ci_required
-    if: ${{ needs.prepare.outputs.publish_docs != 'true' }}
+    if: >-
+      ${{
+        always()
+        && !cancelled()
+        && needs.prepare.result == 'success'
+        && needs.ci_required.result == 'success'
+        && needs.prepare.outputs.publish_docs != 'true'
+      }}
     permissions:
       contents: read
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@4866bb5437e913caf5bf775f57c91abd144ed391 # main


### PR DESCRIPTION
#### Overview

Narrow docs-only CI behavior for language package Markdown updates and keep the required PR-builder check from disappearing when optional language jobs are skipped.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace the broad `go/**` filter with `go/**/!(*.md)`.
- Replace the broad `python/**` filter with `python/**/!(*.md)`.
- Use non-Markdown glob patterns instead of standalone negative entries because the pinned `dorny/paths-filter` matcher ORs top-level filter entries by default.
- Add an explicit status function to the `pr-builder` job condition so expected skipped jobs, such as Rust/Node/WebAssembly in docs-only PRs, do not suppress the reusable workflow check required by branch protection.

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); YAML.load_file(".github/ci-path-filters.yml"); puts "yaml-ok"'`
- `picomatch@2.3.1` smoke test for Go/Python Markdown and non-Markdown paths
- `uv run pre-commit run --files .github/workflows/ci.yaml .github/ci-path-filters.yml`

#### Where should the reviewer start?

Start with `.github/ci-path-filters.yml` for the language Markdown filter change, then `.github/workflows/ci.yaml` for the required `pr-builder / run` check fix.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline path filters to exclude Markdown files from triggering Go and Python jobs
  * Enhanced CI workflow conditions for improved build reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->