### PR TITLE
ci: improve workflow linting and job names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,9 +87,11 @@ jobs:
             publish_packages=true
           fi
 
-          printf 'full_ci=%s\n' "$full_ci" >> "$GITHUB_OUTPUT"
-          printf 'publish_docs=%s\n' "$publish_docs" >> "$GITHUB_OUTPUT"
-          printf 'publish_packages=%s\n' "$publish_packages" >> "$GITHUB_OUTPUT"
+          {
+            printf 'full_ci=%s\n' "$full_ci"
+            printf 'publish_docs=%s\n' "$publish_docs"
+            printf 'publish_packages=%s\n' "$publish_packages"
+          } >> "$GITHUB_OUTPUT"
 
     outputs:
       full_ci: ${{ steps.policy.outputs.full_ci }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event_name }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: '${{ github.workflow }} @ ${{ github.event_name }} @ ${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:
@@ -298,7 +298,7 @@ jobs:
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 
   publish-rust:
-    name: Publish / crates.io
+    name: Publish (crates.io)
     needs: [prepare, ci_required]
     if: ${{ needs.prepare.outputs.publish_packages == 'true' && needs.ci_required.result == 'success' }}
     runs-on: ubuntu-latest
@@ -354,7 +354,7 @@ jobs:
           done
 
   publish-python:
-    name: Publish / PyPI
+    name: Publish (PyPI)
     needs: [prepare, ci_required]
     if: ${{ needs.prepare.outputs.publish_packages == 'true' && needs.ci_required.result == 'success' }}
     runs-on: ubuntu-latest
@@ -375,7 +375,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   publish-npm:
-    name: Publish / npm
+    name: Publish (npm)
     needs: [prepare, ci_required]
     if: ${{ needs.prepare.outputs.publish_packages == 'true' && needs.ci_required.result == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_go.yml
+++ b/.github/workflows/ci_go.yml
@@ -21,8 +21,8 @@ env:
   UV_PYTHON_DOWNLOADS: never
 
 jobs:
-  test-go:
-    name: Test / ${{ matrix.platform }}
+  Test:
+    name: Test (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     continue-on-error: ${{ startsWith(matrix.platform, 'windows') }}

--- a/.github/workflows/ci_node.yml
+++ b/.github/workflows/ci_node.yml
@@ -30,8 +30,8 @@ env:
   UV_PYTHON_DOWNLOADS: never
 
 jobs:
-  test-node:
-    name: Test / ${{ matrix.platform }}
+  Test:
+    name: Test (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     continue-on-error: ${{ startsWith(matrix.platform, 'windows') }}
@@ -96,10 +96,10 @@ jobs:
           name: node-${{ matrix.platform }}
           verbose: true
 
-  package-node:
-    name: Package / ${{ matrix.platform }}
-    needs: [test-node]
-    if: ${{ !cancelled() && needs.test-node.result == 'success' }}
+  Package:
+    name: Package (${{ matrix.platform }})
+    needs: [Test]
+    if: ${{ !cancelled() && needs.Test.result == 'success' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
@@ -196,10 +196,10 @@ jobs:
           path: ${{ env.NEMO_FLOW_CI_WORKSPACE_TMP }}/npm/*.tgz
           if-no-files-found: error
 
-  consolidate-node:
+  Consolidate:
     name: Consolidate
-    needs: [package-node]
-    if: ${{ !cancelled() && needs.package-node.result == 'success' }}
+    needs: [Package]
+    if: ${{ !cancelled() && needs.Package.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -30,8 +30,8 @@ env:
   UV_PYTHON_DOWNLOADS: never
 
 jobs:
-  test-python:
-    name: Test / ${{ matrix.platform }}
+  Test:
+    name: Test (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     continue-on-error: ${{ startsWith(matrix.platform, 'windows') }}
@@ -123,10 +123,10 @@ jobs:
         working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
         run: uv cache prune --ci
 
-  package-python:
-    name: Package / ${{ matrix.platform }}
-    needs: [test-python]
-    if: ${{ !cancelled() && needs.test-python.result == 'success' }}
+  Package:
+    name: Package (${{ matrix.platform }})
+    needs: [Test]
+    if: ${{ !cancelled() && needs.Test.result == 'success' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -21,8 +21,8 @@ env:
   UV_PYTHON_DOWNLOADS: never
 
 jobs:
-  test-rust:
-    name: Test / ${{ matrix.platform }}
+  Test:
+    name: Test (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     continue-on-error: ${{ startsWith(matrix.platform, 'windows') }}

--- a/.github/workflows/ci_wasm.yml
+++ b/.github/workflows/ci_wasm.yml
@@ -30,8 +30,8 @@ env:
   UV_PYTHON_DOWNLOADS: never
 
 jobs:
-  test-wasm:
-    name: Test / ${{ matrix.platform }}
+  Test:
+    name: Test (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     continue-on-error: ${{ startsWith(matrix.platform, 'windows') }}
@@ -99,10 +99,10 @@ jobs:
           name: wasm-${{ matrix.platform }}
           verbose: true
 
-  package-wasm:
-    name: Package / linux-amd64
-    needs: [test-wasm]
-    if: ${{ !cancelled() && needs.test-wasm.result == 'success' }}
+  Package:
+    name: Package (linux-amd64)
+    needs: [Test]
+    if: ${{ !cancelled() && needs.Test.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,14 @@ repos:
         args: ["--maxkb=500"]
         exclude: '^ATTRIBUTIONS-(Rust|Python|Node)\.md$'
 
+  # GitHub Actions — workflow semantics
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        files: '^(\.github/workflows/.*\.ya?ml|\.github/actions/.*/action\.ya?ml|\.github/actionlint\.ya?ml)$'
+        pass_filenames: false
+
   # Python — ruff lint + format
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.0


### PR DESCRIPTION
#### Overview

Add actionlint to pre-commit and make CI job display names clearer in the GitHub Actions sidebar.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add the `rhysd/actionlint` pre-commit hook for workflow files, local action metadata, and `.github/actionlint.yaml` changes.
- Replace slash-separated CI job names with parenthesized labels so matrix entries render as `Test (linux-amd64)` instead of duplicate platform-only leaves.
- Remove a push-only workflow concurrency reference to `github.event.pull_request`.
- Validated with targeted actionlint/pre-commit runs and the commit-time pre-commit hooks.

#### Where should the reviewer start?

Start with `.pre-commit-config.yaml` for the new actionlint hook, then `.github/workflows/ci_node.yml` for the matrix job naming pattern applied across CI workflows.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI job names and display formats across platforms for consistency.
  * Adjusted workflow run grouping key affecting how runs are grouped for cancellation.
  * Updated artifact publish step titles to a unified format.
  * Added workflow linting via a pre-commit hook to validate workflow YAML files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->