### PR TITLE
ci: fix Codecov ignore paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -110,17 +110,17 @@ github_checks:
 
 ignore:
   - "**/examples/**"
-  - "**/third_party/**"
+  - "third_party/"
   - "**/tests/**"
   - "**/tests-js/**"
   # The Node binding currently reports JS package coverage separately; exclude the
   # native Rust bridge until we have direct Rust-side coverage for this crate.
-  - "**/crates/node/src/**"
-  - "**/crates/node/coverage/**"
-  - "**/target/**"
+  - "crates/node/src/"
+  - "crates/node/coverage/"
+  - "target/"
   - "**/*.d.ts"
   - "**/*.pyi"
-  - "**/python/nemo_flow/lib_native*.dylib.dSYM/**"
+  - "python/nemo_flow/lib_native*.dylib.dSYM/**"
   # WebAssembly Rust wrappers are covered through wasm-pack execution and
   # reported through generated package JavaScript coverage.
-  - "**/crates/wasm/src/**/*.rs"
+  - "crates/wasm/src/"


### PR DESCRIPTION
#### Overview

Update Codecov ignore patterns so repo-root coverage paths are excluded correctly.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace root-level Codecov globs that compiled with a leading directory requirement.
- Use folder-prefix ignores for Node native bridge coverage, WebAssembly Rust source coverage, third-party files, target artifacts, and Python dSYM output.
- Preserve the existing WebAssembly wrapper coverage reporting path.

#### Where should the reviewer start?

Start with `codecov.yml`, especially the `ignore` section. Codecov validation now compiles `crates/wasm/src/` to `^crates/wasm/src/.*`, matching the paths shown in Codecov.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to refine path exclusion patterns for improved accuracy in coverage analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->