### PR TITLE
ci: authenticate Cargo Artifactory index fetch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ variables:
   NEMO_FLOW_CI_DEBIAN_VERSION: "trixie"
   NEMO_FLOW_CI_JUST_VERSION: "1.40.0"
   NEMO_FLOW_CI_NODE_VERSION: "24"
+  NEMO_FLOW_CI_PYTHON_VERSION: "3.11"
   NEMO_FLOW_CI_RUST_VERSION: "1.93.0"
   NEMO_FLOW_CI_UV_VERSION: "0.9.28"
   NEMO_FLOW_CI_GITHUB_REPOSITORY: "NVIDIA/NeMo-Flow"
@@ -218,11 +219,12 @@ publish:artifactory:cargo:
     - job: collect:github-artifacts
       artifacts: true
   before_script:
-    - apt-get update -qq && apt-get install -y --no-install-recommends ca-certificates curl nodejs python3 && rm -rf /var/lib/apt/lists/*
+    - apt-get update -qq && apt-get install -y --no-install-recommends ca-certificates curl git nodejs && rm -rf /var/lib/apt/lists/*
     - cargo install just --version "${NEMO_FLOW_CI_JUST_VERSION}" --locked
     - curl -LsSf https://astral.sh/uv/install.sh -o /tmp/install-uv.sh
     - UV_VERSION="${NEMO_FLOW_CI_UV_VERSION}" sh /tmp/install-uv.sh
     - export PATH="${HOME}/.cargo/bin:${HOME}/.local/bin:${PATH}"
+    - uv python install "${NEMO_FLOW_CI_PYTHON_VERSION}"
     - rustc --version
     - just --version
     - uv --version
@@ -240,13 +242,14 @@ publish:artifactory:cargo:
       fi
 
       version="$(
-        python3 - <<'PY'
+        uv run --no-project python - <<'PY'
       import json
       from pathlib import Path
 
       print(json.loads(Path("collected/github-run.json").read_text()).get("tag", ""))
       PY
       )"
+
       if [ -z "$version" ]; then
         echo "Error: failed to extract package version from collected GitHub tag metadata." >&2
         exit 1
@@ -256,16 +259,44 @@ publish:artifactory:cargo:
 
       cargo_home="${CARGO_HOME:-${HOME}/.cargo}"
       mkdir -p "$cargo_home"
+
+      # Cargo fetches this Artifactory registry as an authenticated Git index.
+      git_credential_url="$(
+        uv run --no-project python - <<'PY'
+      import os
+      from urllib.parse import quote, urlsplit, urlunsplit
+
+      url = os.environ["NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL"]
+      user = quote(os.environ["NEMO_FLOW_CI_ARTIFACTORY_USER"], safe="")
+      password = quote(os.environ["NEMO_FLOW_CI_ARTIFACTORY_KEY"], safe="")
+      parts = urlsplit(url)
+      if not parts.scheme or not parts.netloc:
+          raise SystemExit("NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL must be an absolute URL")
+      print(urlunsplit((parts.scheme, f"{user}:{password}@{parts.netloc}", parts.path, parts.query, parts.fragment)))
+      PY
+      )"
+
+      git config --global credential.helper "store --file=${HOME}/.git-credentials"
+      git config --global credential.useHttpPath true
+      printf '%s\n' "$git_credential_url" > "${HOME}/.git-credentials"
+      chmod 600 "${HOME}/.git-credentials"
+
       cargo_auth="Basic $(printf '%s:%s' "${NEMO_FLOW_CI_ARTIFACTORY_USER}" "${NEMO_FLOW_CI_ARTIFACTORY_KEY}" | base64 | tr -d '\n')"
+
       cat > "${cargo_home}/config.toml" <<EOF
       [registries.artifactory]
       index = "${NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL}"
       credential-provider = "cargo:token"
+
+      [net]
+      git-fetch-with-cli = true
       EOF
+
       cat > "${cargo_home}/credentials.toml" <<EOF
       [registries.artifactory]
       token = "${cargo_auth}"
       EOF
+
       chmod 600 "${cargo_home}/credentials.toml"
 
       for crate in nemo-flow nemo-flow-adaptive nemo-flow-ffi; do


### PR DESCRIPTION
#### Overview

Fix the scheduled Cargo Artifactory publish job so Cargo can authenticate both the registry index fetch and the publish request.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `NEMO_FLOW_CI_PYTHON_VERSION` and use uv-managed Python 3.11 for the Cargo publish job's inline metadata parsing.
- Remove the apt-installed `python3` dependency from the Cargo publish job.
- Install `git`, configure Cargo to fetch the Artifactory registry index with the Git CLI, and write a scoped Git credential entry from the existing Artifactory CI secrets.
- Keep the existing Cargo registry token for the publish request itself.

#### Where should the reviewer start?

Start with `.gitlab-ci.yml`, especially the `publish:artifactory:cargo` job credential setup.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration to strengthen the Cargo package publishing process with improved dependency management
  * Upgraded Artifactory credential handling with more secure credential configuration and git integration capabilities
  * Optimized build environment setup for increased reliability, consistency, and automated version tracking across publishing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->