### PR TITLE
ci: update Cargo Artifactory publishing config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -230,8 +230,8 @@ publish:artifactory:cargo:
     - |
       set -eu
 
-      if [ -z "${NEMO_FLOW_CI_ARTIFACTORY_USER:-}" ] || [ -z "${NEMO_FLOW_CI_ARTIFACTORY_KEY:-}" ] || [ -z "${NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL:-}" ]; then
-        echo "Error: uploading Cargo crates to Artifactory requires NEMO_FLOW_CI_ARTIFACTORY_USER, NEMO_FLOW_CI_ARTIFACTORY_KEY, and NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL." >&2
+      if [ -z "${NEMO_FLOW_CI_ARTIFACTORY_KEY:-}" ] || [ -z "${NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL:-}" ]; then
+        echo "Error: uploading Cargo crates to Artifactory requires NEMO_FLOW_CI_ARTIFACTORY_KEY and NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL." >&2
         exit 1
       fi
       if [ ! -f collected/github-run.json ]; then
@@ -256,20 +256,14 @@ publish:artifactory:cargo:
 
       cargo_home="${CARGO_HOME:-${HOME}/.cargo}"
       mkdir -p "$cargo_home"
-      cargo_auth="Basic $(printf '%s:%s' "${NEMO_FLOW_CI_ARTIFACTORY_USER}" "${NEMO_FLOW_CI_ARTIFACTORY_KEY}" | base64 | tr -d '\n')"
+
       cat > "${cargo_home}/config.toml" <<EOF
-      [registries.artifactory]
-      index = "${NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL}"
-      credential-provider = "cargo:token"
+      [registries]
+      artifactory = { index = "sparse+${NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL}" }
       EOF
-      cat > "${cargo_home}/credentials.toml" <<EOF
-      [registries.artifactory]
-      token = "${cargo_auth}"
-      EOF
-      chmod 600 "${cargo_home}/credentials.toml"
 
       for crate in nemo-flow nemo-flow-adaptive nemo-flow-ffi; do
-        cargo publish --package "$crate" --registry artifactory --allow-dirty
+        cargo publish --package "$crate" --registry artifactory --token "${NEMO_FLOW_CI_ARTIFACTORY_KEY}" --allow-dirty
       done
 
 publish:artifactory:npm:


### PR DESCRIPTION
#### Overview

Updates the scheduled Cargo Artifactory publish job so Cargo publishing no longer configures Git credential storage or derives a Basic auth credential from the Artifactory username and key. The job now uses the Artifactory key directly as the Cargo publish token and keeps registry configuration limited to the Artifactory sparse index.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Remove the Cargo publish job's `NEMO_FLOW_CI_ARTIFACTORY_USER` requirement.
- Remove `git_credential_url`, global Git credential helper setup, `.git-credentials` writes, and `git-fetch-with-cli` configuration from the Cargo publish path.
- Remove the now-unused Basic auth token derivation and Cargo credential-provider setting.
- Configure `~/.cargo/config.toml` with an Artifactory sparse registry entry: `sparse+${NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL}`.
- Pass `${NEMO_FLOW_CI_ARTIFACTORY_KEY}` directly to `cargo publish --token` for each Rust crate.

Validation:

- Inspected `git diff upstream/main...HEAD -- .gitlab-ci.yml`
- Confirmed the PR branch changes only `.gitlab-ci.yml`

#### Where should the reviewer start?

Start with `.gitlab-ci.yml`, specifically the `publish:artifactory:cargo` job script.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #64 #60 #59 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Cargo crate publishing configuration in CI/CD pipeline, reducing configuration complexity and credential management requirements while maintaining publishing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->