### PR TITLE
ci: use cargo env token for artifactory publish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -264,9 +264,10 @@ publish:artifactory:cargo:
       [registries]
       artifactory = { index = "sparse+${NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL}" }
       EOF
+      export CARGO_REGISTRIES_ARTIFACTORY_TOKEN="${NEMO_FLOW_CI_ARTIFACTORY_KEY}"
 
       for crate in nemo-flow nemo-flow-adaptive nemo-flow-ffi; do
-        cargo publish --package "$crate" --registry artifactory --token "${NEMO_FLOW_CI_ARTIFACTORY_KEY}" --allow-dirty
+        cargo publish --package "$crate" --registry artifactory --allow-dirty
       done
 
 publish:artifactory:npm:


### PR DESCRIPTION
#### Overview

Fix the scheduled Cargo Artifactory publish job after Cargo 1.93 rejected the deprecated command-line token path for the private sparse registry. The job now exposes the existing Artifactory key through Cargo's per-registry token environment variable before publishing.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Export `CARGO_REGISTRIES_ARTIFACTORY_TOKEN` from `NEMO_FLOW_CI_ARTIFACTORY_KEY` in `publish:artifactory:cargo`.
- Remove the deprecated `cargo publish --token` flag so Cargo reads the Artifactory token through its registry credential environment path.
- Keep the existing Artifactory sparse registry configuration unchanged.

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".gitlab-ci.yml"); puts "yaml-ok"'`
- Extracted the `publish:artifactory:cargo` script block and checked it with `bash -n`
- `git diff --check`
- Commit-time pre-commit hooks passed for `.gitlab-ci.yml`

#### Where should the reviewer start?

Start with `.gitlab-ci.yml`, specifically the `publish:artifactory:cargo` job lines that configure the Cargo registry token and invoke `cargo publish`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for internal credential handling. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->