### PR TITLE
ci: fix Artifactory Cargo crate publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -264,9 +264,31 @@ publish:artifactory:cargo:
       [registries]
       artifactory = { index = "sparse+${NEMO_FLOW_CI_ARTIFACTORY_CARGO_URL}" }
       EOF
-      export CARGO_REGISTRIES_ARTIFACTORY_TOKEN="${NEMO_FLOW_CI_ARTIFACTORY_KEY}"
+      export CARGO_REGISTRIES_ARTIFACTORY_TOKEN="Bearer ${NEMO_FLOW_CI_ARTIFACTORY_KEY}"
+      export NEMO_FLOW_ARTIFACTORY_CRATE_DIRS="core adaptive ffi cli"
 
-      for crate in nemo-flow nemo-flow-adaptive nemo-flow-ffi nemo-flow-sidecar; do
+      crates="$(
+        uv run --no-project python - <<'PY'
+      import os
+      import tomllib
+      from pathlib import Path
+
+      manifest = Path("Cargo.toml")
+      text = manifest.read_text()
+      for crate_dir in os.environ["NEMO_FLOW_ARTIFACTORY_CRATE_DIRS"].split():
+          before = f'path = "crates/{crate_dir}"'
+          after = f'{before}, registry = "artifactory"'
+          if after not in text:
+              text = text.replace(before, after)
+      manifest.write_text(text)
+
+      for crate_dir in os.environ["NEMO_FLOW_ARTIFACTORY_CRATE_DIRS"].split():
+          crate_manifest = Path("crates") / crate_dir / "Cargo.toml"
+          print(tomllib.loads(crate_manifest.read_text())["package"]["name"])
+      PY
+      )"
+
+      for crate in $crates; do
         cargo publish --package "$crate" --registry artifactory --allow-dirty
       done
 


### PR DESCRIPTION
#### Overview

Fix the GitLab Artifactory Cargo publish job so internal NeMo Flow crate dependencies resolve from the Artifactory registry during package verification.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Configure the Artifactory Cargo token with the expected bearer-token prefix.
- Define the Artifactory-published crate directories once and derive package names from each crate manifest.
- Temporarily add `registry = "artifactory"` to root workspace path dependencies before publishing so dependent crates resolve already-published internal packages from Artifactory instead of crates.io.
- Replace the stale `nemo-flow-sidecar` publish entry with the current `nemo-flow-cli` crate.

#### Where should the reviewer start?

Start with `.gitlab-ci.yml`, especially the `publish:artifactory:cargo` job. The key behavior is the Python snippet that rewrites workspace dependency registry metadata before the `cargo publish --registry artifactory` loop.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to enhance the crate publishing process with improved flexibility and configurability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/81)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->