### PR TITLE
fix: add OpenClaw plugin to npm publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,6 +202,9 @@ jobs:
     if: ${{ needs.ci_check.result == 'success' && needs.ci_changes.outputs.run_openclaw == 'true' }}
     permissions:
       contents: read
+    with:
+      ref_type: ${{ github.ref_type }}
+      ref_name: ${{ github.ref_name }}
 
   ci_python:
     name: Python
@@ -294,7 +297,7 @@ jobs:
           if [[ "$publish_packages" == "true" ]]; then
             require_success "Rust" "$RUST_RESULT"
             require_success "Node.js" "$NODE_RESULT"
-            allow_success_or_skipped "OpenClaw" "$OPENCLAW_RESULT"
+            require_success "OpenClaw" "$OPENCLAW_RESULT"
             require_success "Python" "$PYTHON_RESULT"
             require_success "WebAssembly" "$WEBASSEMBLY_RESULT"
           else
@@ -439,6 +442,12 @@ jobs:
           name: wasm-bundler
           path: wasm-package/
 
+      - name: Download OpenClaw plugin artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openclaw-npm
+          path: openclaw-package/
+
       - name: Select npm dist-tag
         run: |
           set -e
@@ -455,6 +464,14 @@ jobs:
           echo "Platform binaries included:"
           ls -la combined/package/*.node
           npm publish ./combined/package --access public --tag "${NEMO_FLOW_NPM_DIST_TAG}"
+
+      - name: Publish OpenClaw plugin package to npm
+        run: |
+          set -euo pipefail
+          for pkg in ./openclaw-package/*.tgz; do
+            echo "Publishing ${pkg}..."
+            npm publish "${pkg}" --access public --tag "${NEMO_FLOW_NPM_DIST_TAG}"
+          done
 
       - name: Publish WebAssembly package to npm
         run: |

--- a/.github/workflows/ci_openclaw.yml
+++ b/.github/workflows/ci_openclaw.yml
@@ -5,6 +5,15 @@ name: OpenClaw
 
 on:
   workflow_call:
+    inputs:
+      ref_type:
+        description: 'The ref type from the triggering workflow'
+        required: true
+        type: string
+      ref_name:
+        description: 'The ref name from the triggering workflow'
+        required: true
+        type: string
 
 defaults:
   run:
@@ -14,6 +23,7 @@ env:
   GH_TOKEN: "${{ github.token }}"
   GIT_COMMIT: "${{ github.sha }}"
   NEMO_FLOW_CI_WORKSPACE: "${{ github.workspace }}"
+  NEMO_FLOW_CI_WORKSPACE_TMP: "${{ github.workspace }}/ci/tmp"
   UV_PYTHON_DOWNLOADS: never
 
 jobs:
@@ -56,3 +66,32 @@ jobs:
       - name: Run OpenClaw integration checks
         working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
         run: just --set ci true test-openclaw
+
+      - name: Derive OpenClaw package version
+        working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
+        run: |
+          set -e
+          version="$(node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("integrations/openclaw/package.json", "utf8")); if (!pkg.version) { throw new Error("integrations/openclaw/package.json missing version field"); } console.log(pkg.version);')"
+          sha="${GITHUB_SHA::8}"
+          if [ "${{ inputs.ref_type }}" = "tag" ]; then
+            version="${{ inputs.ref_name }}"
+          else
+            version="${version}-${sha}"
+          fi
+          printf 'NEMO_FLOW_PACKAGE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
+      - name: Package OpenClaw plugin
+        working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
+        run: |
+          set -euo pipefail
+          just \
+            --set output_dir "${NEMO_FLOW_CI_WORKSPACE_TMP}" \
+            --set ref_name "${NEMO_FLOW_PACKAGE_VERSION}" \
+            package-openclaw
+
+      - name: Upload OpenClaw plugin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: openclaw-npm
+          path: ${{ env.NEMO_FLOW_CI_WORKSPACE_TMP }}/openclaw/*.tgz
+          if-no-files-found: error

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,7 +1,6 @@
 {
   "name": "nemo-flow-openclaw",
   "version": "0.2.0",
-  "private": true,
   "description": "NeMo Flow-authored observability plugin for OpenClaw.",
   "type": "module",
   "main": "./dist/index.js",

--- a/justfile
+++ b/justfile
@@ -898,6 +898,7 @@ test-openclaw:
     fi
     npm run typecheck --workspace=nemo-flow-openclaw
     npm test --workspace=nemo-flow-openclaw
+    npm run pack:check --workspace=nemo-flow-openclaw
 
 # --set [output_dir=<path>] [ci=true|false]
 test-wasm:
@@ -990,6 +991,33 @@ package-node:
     packages=("$package_dir"/*.tgz)
     if ((${#packages[@]} == 0)); then
         echo "Error: No npm packages found in $package_dir"
+        exit 1
+    fi
+
+# --set [output_dir=<path>] [ref_name=<name>]
+package-openclaw:
+    #!/usr/bin/env bash
+    {{ bash_helpers }}
+    # If `ref_name` is empty, append the current short HEAD SHA to the version.
+    # If `ref_name` is set, write it as the exact package version before packing.
+    output_dir="{{ output_dir }}"
+    cd "$NEMO_FLOW_REPO_ROOT"
+    package_dir="$(prepare_package_dir openclaw)"
+    if [[ -z "{{ ref_name }}" ]]; then
+        sha="$(head_git_sha)"
+        version="$(read_npm_package_version integrations/openclaw/package.json)"
+        echo "Non-release build: appending commit hash to version"
+        set_npm_package_version integrations/openclaw/package.json package-lock.json "${version}-${sha}" integrations/openclaw
+    else
+        echo "Using explicit version {{ ref_name }}"
+        set_npm_package_version integrations/openclaw/package.json package-lock.json "{{ ref_name }}" integrations/openclaw
+    fi
+    npm install --workspace=nemo-flow-openclaw --ignore-scripts
+    npm pack --workspace=nemo-flow-openclaw --pack-destination "$package_dir"
+    shopt -s nullglob
+    packages=("$package_dir"/*.tgz)
+    if ((${#packages[@]} == 0)); then
+        echo "Error: No OpenClaw npm packages found in $package_dir"
         exit 1
     fi
 


### PR DESCRIPTION
#### Overview

Adds the OpenClaw plugin package to the npm release path so `nemo-flow-openclaw` can be published for the v0.2 user install flow.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Removes `private: true` from `integrations/openclaw/package.json`.
- Adds a `package-openclaw` release recipe that follows the existing npm package versioning pattern.
- Updates OpenClaw CI to validate the package payload and upload an npm tarball artifact.
- Updates the npm release job to require OpenClaw CI and publish the OpenClaw plugin package after `nemo-flow-node`.

Validation:
- `just --set ci true test-openclaw`
- `just --set output_dir /private/tmp/nemo-openclaw-pack-final --set ref_name 0.2.0 package-openclaw`
- `git diff --check`
- `uv run pre-commit run --all-files` passes except for existing generated Rust docs linkcheck failures unrelated to this PR.

#### Where should the reviewer start?

Start with `justfile` for the new `package-openclaw` recipe, then review `.github/workflows/ci_openclaw.yml` and `.github/workflows/ci.yaml` for artifact upload and npm publish wiring.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw is now published as npm packages to the registry.

* **Chores**
  * OpenClaw is now a required component in the publish pipeline (previously optional).
  * Enhanced validation checks for OpenClaw packages during the build process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->