### PR TITLE
docs: fix versioned docs TypeScript resolution

### DIFF
--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -68,7 +68,7 @@
     "c8": "^11.0.0",
     "prettier": "^3.8.2",
     "typedoc": "^0.28.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.9.3"
   },
   "license": "Apache-2.0"
 }

--- a/justfile
+++ b/justfile
@@ -155,8 +155,23 @@ ensure_docs_dependencies() {
     npm install --ignore-scripts
 }
 
+ensure_docs_node_workspace_compat() {
+    local node_modules="$NEMO_FLOW_REPO_ROOT/crates/node/node_modules"
+    local root_node_modules="$NEMO_FLOW_REPO_ROOT/node_modules"
+
+    # Historical versioned docs builds run older docs hooks that resolve
+    # TypeDoc peers only from crates/node/node_modules. A root npm install may
+    # hoist TypeScript to root node_modules, so materialize it where those
+    # immutable release tags expect it before sphinx-multiversion copies them.
+    if [[ ! -e "$node_modules/typescript" && -d "$root_node_modules/typescript" ]]; then
+        mkdir -p "$node_modules"
+        cp -R "$root_node_modules/typescript" "$node_modules/typescript"
+    fi
+}
+
 configure_docs_environment() {
     export SPHINX_AUTODOC_RELOAD_MODULES="${SPHINX_AUTODOC_RELOAD_MODULES:-1}"
+    ensure_docs_node_workspace_compat
 }
 
 prepare_parent_dir() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
         "crates/wasm",
         "integrations/openclaw"
       ],
+      "devDependencies": {
+        "typescript": "^5.9.3"
+      },
       "engines": {
         "node": ">=20.0.0"
       }
@@ -23,7 +26,7 @@
         "c8": "^11.0.0",
         "prettier": "^3.8.2",
         "typedoc": "^0.28.0",
-        "typescript": "^5.8.2"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     "crates/node",
     "crates/wasm",
     "integrations/openclaw"
-  ]
+  ],
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
 }


### PR DESCRIPTION
#### Overview

Fix the versioned documentation build failure seen in https://github.com/NVIDIA/NeMo-Flow/actions/runs/25725031281/job/75536435325 by making TypeScript an explicit docs/tooling dependency and ensuring historical docs builds can resolve it from the Node workspace layout they expect.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `typescript` as an explicit root workspace dev dependency.
- Aligns the Node workspace TypeScript dev dependency with the locked root version.
- Adds `ensure_docs_node_workspace_compat` to materialize hoisted TypeScript under `crates/node/node_modules` before `sphinx-multiversion` copies immutable release tags.
- Documents why the compatibility helper is still required even though TypeScript is declared in package metadata.

Validation:

- `NEMO_FLOW_DOCS_DEPS_READY=1 just docs`
- Clean install-layout simulation confirmed npm still hoists TypeScript and the helper creates `crates/node/node_modules/typescript`.
- Historical docs-hook resolution smoke test confirmed `typescript` resolves when `TYPEDOC_NODE_MODULES` points at `crates/node/node_modules`.
- `uv run pre-commit run --files justfile package.json package-lock.json crates/node/package.json` passed except `lychee`, which reports existing generated Rust API links outside this change:
  - `docs/reference/api/rust/_generated/nemo-flow-adaptive/src/acg/plugin.md`
  - `docs/reference/api/rust/_generated/nemo-flow-adaptive/src/plugin_component.md`

Breaking changes: none.

#### Where should the reviewer start?

Start with `justfile`, specifically `ensure_docs_node_workspace_compat`, then check the package metadata changes in `package.json`, `crates/node/package.json`, and `package-lock.json`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript to v5.9.3
  * Improved documentation build reliability and compatibility

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/84)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->