### PR TITLE
ci: align PR labels with Linear issue types

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,25 +14,25 @@ changelog:
         - breaking
     - title: ✨ New Features
       labels:
-        - feat
+        - Feature
     - title: ⚡ Improvements
       labels:
-        - perf
-        - refactor
+        - Improvement
     - title: 🐛 Bug Fixes
       labels:
-        - fix
-        - revert
+        - Bug
+    - title: ✅ Tests
+      labels:
+        - Test
+    - title: 🤖 Automation
+      labels:
+        - Automation
     - title: 🧰 Maintenance
       labels:
-        - build
-        - chore
-        - ci
-        - style
-        - test
+        - Maintenance
     - title: 📝 Documentation Updates
       labels:
-        - docs
+        - Documentation
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -39,8 +39,9 @@ jobs:
 
           size_labels=("size:XS" "size:S" "size:M" "size:L" "size:XL" "size:XXL")
           classifier_labels=("build" "chore" "ci" "docs" "feat" "fix" "perf" "refactor" "revert" "style" "test")
+          type_labels=("Automation" "Bug" "Documentation" "Feature" "Improvement" "Maintenance" "Test")
           lang_labels=("lang:go" "lang:js" "lang:python" "lang:rust")
-          controlled_labels=("${size_labels[@]}" "${classifier_labels[@]}" "${lang_labels[@]}")
+          controlled_labels=("${size_labels[@]}" "${classifier_labels[@]}" "${type_labels[@]}" "${lang_labels[@]}")
 
           contains_label() {
             local needle="$1"
@@ -111,12 +112,31 @@ jobs:
           desired_labels=("$size_label")
 
           title_lower="${PR_TITLE,,}"
-          classifier_label=""
+          type_label=""
           title_pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?(!)?:'
           breaking_pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!:'
           if [[ "$title_lower" =~ $title_pattern ]]; then
-            classifier_label="${BASH_REMATCH[1]}"
-            desired_labels+=("$classifier_label")
+            case "${BASH_REMATCH[1]}" in
+              feat)
+                type_label="Feature"
+                ;;
+              perf|refactor)
+                type_label="Improvement"
+                ;;
+              fix|revert)
+                type_label="Bug"
+                ;;
+              test)
+                type_label="Test"
+                ;;
+              docs)
+                type_label="Documentation"
+                ;;
+              build|chore|ci|style)
+                type_label="Maintenance"
+                ;;
+            esac
+            desired_labels+=("$type_label")
           fi
           if [[ "$PR_TITLE" =~ $breaking_pattern ]]; then
             desired_labels+=("breaking")


### PR DESCRIPTION
#### Overview

Align GitHub PR labeling and release grouping with the Linear issue type labels used for NMF-79.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Map conventional PR title prefixes to Linear type labels in the PR auto-labeler.
- Keep size, language, and breaking-change labels unchanged.
- Remove old conventional-commit labels from the PR labeler controlled set when they are present on PRs.
- Update release changelog categories to group by Linear type labels.

#### Where should the reviewer start?

Start with `.github/workflows/pr-labels.yaml` to review the conventional-prefix to Linear-type mapping.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to NMF-79

#### Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "yaml-ok"' .github/workflows/pr-labels.yaml .github/release.yml .github/ISSUE_TEMPLATE/01-bug.yml .github/ISSUE_TEMPLATE/02-enhancement.yml .github/ISSUE_TEMPLATE/03-documentation.yml .github/ISSUE_TEMPLATE/04-epic.yml .github/ISSUE_TEMPLATE/05-initiative.yml`
- `git diff --check`
- `uv run pre-commit run check-yaml --files .github/workflows/pr-labels.yaml .github/release.yml`
- `uv run pre-commit run actionlint --files .github/workflows/pr-labels.yaml`
- Commit hook passed with `SKIP=lychee`; the skipped `lychee` hook fails on pre-existing generated Rust API doc links outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release notes categorization system with streamlined, standardized labels (Feature, Bug Fixes, Tests, etc.).
  * Enhanced pull request labeling automation for improved consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->