### PR TITLE
chore: relax dependency codeowners review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,12 +4,9 @@
 # Default ownership for repository files.
 * @nvidia/nat-developers
 
-# Project configurations and lockfiles require dependency approver review.
-Cargo.toml @nvidia/nat-dep-approvers
+# Lockfiles and attribution files require dependency approver review.
 Cargo.lock @nvidia/nat-dep-approvers
-
-pyproject.toml @nvidia/nat-dep-approvers
 uv.lock @nvidia/nat-dep-approvers
-
-package.json @nvidia/nat-dep-approvers
 package-lock.json @nvidia/nat-dep-approvers
+
+ATTRIBUTIONS-*.md @nvidia/nat-dep-approvers


### PR DESCRIPTION
#### Overview

Relax dependency approver CODEOWNERS scope so dependency approver review is requested only for lockfile and attribution file changes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Removed dependency approver ownership from project manifest files: `Cargo.toml`, `pyproject.toml`, and `package.json`.
- Kept dependency approver ownership for lockfiles: `Cargo.lock`, `uv.lock`, and `package-lock.json`.
- Added dependency approver ownership for attribution files via `ATTRIBUTIONS-*.md`.
- Validation: `git diff --check -- .github/CODEOWNERS` passed. Commit hooks passed with `lychee` skipped after it failed on unrelated generated Rust docs links.

#### Where should the reviewer start?

Start with `.github/CODEOWNERS`; it is the only changed file.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration to refine the dependency approval process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/87)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->