### PR TITLE
feat: add ATOF JSONL exporter

### DIFF
--- a/crates/core/src/observability/atof.rs
+++ b/crates/core/src/observability/atof.rs
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! ATOF JSONL exporter support for NeMo Flow.
+//!
+//! The [`AtofExporter`] registers as an event subscriber and writes each raw
+//! NeMo Flow ATOF event as one JSON object per JSONL line.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use chrono::Utc;
+
+use crate::api::event::Event;
+use crate::api::runtime::EventSubscriberFn;
+use crate::api::subscriber::{deregister_subscriber, register_subscriber};
+use crate::error::FlowError;
+
+/// Result type for the ATOF JSONL exporter.
+pub type Result<T> = std::result::Result<T, AtofExporterError>;
+
+/// Errors produced while configuring or operating the ATOF JSONL exporter.
+#[derive(Debug, thiserror::Error)]
+pub enum AtofExporterError {
+    /// Failed to resolve the current working directory for default config.
+    #[error("failed to resolve current working directory: {0}")]
+    CurrentDirectory(std::io::Error),
+    /// Failed to open the output file.
+    #[error("failed to open ATOF output file {path:?}: {source}")]
+    OpenFile {
+        /// Output path that failed to open.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// Failed while flushing the output file.
+    #[error("failed to flush ATOF output file {path:?}: {source}")]
+    Flush {
+        /// Output path that failed to flush.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// The exporter recorded an earlier write or serialization error.
+    #[error("previous ATOF export failed for {path:?}: {message}")]
+    StoredFailure {
+        /// Output path associated with the failure.
+        path: PathBuf,
+        /// Stored failure message.
+        message: String,
+    },
+    /// The internal exporter state lock was poisoned.
+    #[error("the ATOF exporter state lock was poisoned")]
+    LockPoisoned,
+    /// Runtime subscriber registration failed.
+    #[error(transparent)]
+    Runtime(#[from] FlowError),
+}
+
+/// File write behavior for [`AtofExporter`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AtofExporterMode {
+    /// Append events to an existing file or create it if missing.
+    #[default]
+    Append,
+    /// Truncate an existing file when the exporter is created.
+    Overwrite,
+}
+
+impl AtofExporterMode {
+    /// Parse a string mode used by language bindings.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "append" => Some(Self::Append),
+            "overwrite" => Some(Self::Overwrite),
+            _ => None,
+        }
+    }
+
+    /// Return the stable string representation used by language bindings.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Append => "append",
+            Self::Overwrite => "overwrite",
+        }
+    }
+}
+
+/// Configuration for [`AtofExporter`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AtofExporterConfig {
+    /// Directory that contains the JSONL output file.
+    pub output_directory: PathBuf,
+    /// Append or overwrite behavior used when opening the file.
+    pub mode: AtofExporterMode,
+    /// Output filename.
+    pub filename: String,
+}
+
+impl Default for AtofExporterConfig {
+    fn default() -> Self {
+        Self {
+            output_directory: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            mode: AtofExporterMode::Append,
+            filename: default_filename(),
+        }
+    }
+}
+
+impl AtofExporterConfig {
+    /// Create a config with defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the output directory.
+    pub fn with_output_directory(mut self, output_directory: impl Into<PathBuf>) -> Self {
+        self.output_directory = output_directory.into();
+        self
+    }
+
+    /// Override the output mode.
+    pub fn with_mode(mut self, mode: AtofExporterMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Override the output filename.
+    pub fn with_filename(mut self, filename: impl Into<String>) -> Self {
+        self.filename = filename.into();
+        self
+    }
+
+    /// Return the full output path for this config.
+    pub fn path(&self) -> PathBuf {
+        self.output_directory.join(&self.filename)
+    }
+}
+
+struct AtofExporterState {
+    writer: BufWriter<File>,
+    last_error: Option<String>,
+}
+
+/// Filesystem-backed ATOF JSONL event exporter.
+pub struct AtofExporter {
+    path: PathBuf,
+    state: Arc<Mutex<AtofExporterState>>,
+}
+
+impl AtofExporter {
+    /// Create a new exporter from config and open its output file.
+    pub fn new(config: AtofExporterConfig) -> Result<Self> {
+        let path = config.path();
+        let file = open_file(&path, config.mode)?;
+        Ok(Self {
+            path,
+            state: Arc::new(Mutex::new(AtofExporterState {
+                writer: BufWriter::new(file),
+                last_error: None,
+            })),
+        })
+    }
+
+    /// Return the output JSONL path.
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    /// Return an event subscriber that writes one JSONL record per observed event.
+    pub fn subscriber(&self) -> EventSubscriberFn {
+        let state = Arc::clone(&self.state);
+        Arc::new(move |event: &Event| {
+            let Ok(mut state) = state.lock() else {
+                return;
+            };
+            if state.last_error.is_some() {
+                return;
+            }
+            if let Err(error) = write_event(&mut state.writer, event) {
+                state.last_error = Some(error);
+            }
+        })
+    }
+
+    /// Register this exporter globally under the given subscriber name.
+    pub fn register(&self, name: &str) -> Result<()> {
+        register_subscriber(name, self.subscriber()).map_err(Into::into)
+    }
+
+    /// Deregister a global subscriber by name.
+    pub fn deregister(&self, name: &str) -> Result<bool> {
+        deregister_subscriber(name).map_err(Into::into)
+    }
+
+    /// Flush the underlying file and report any stored write error.
+    pub fn force_flush(&self) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| AtofExporterError::LockPoisoned)?;
+        state
+            .writer
+            .flush()
+            .map_err(|source| AtofExporterError::Flush {
+                path: self.path.clone(),
+                source,
+            })?;
+        if let Some(message) = &state.last_error {
+            return Err(AtofExporterError::StoredFailure {
+                path: self.path.clone(),
+                message: message.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Shut down the exporter by flushing any buffered data.
+    pub fn shutdown(&self) -> Result<()> {
+        self.force_flush()
+    }
+}
+
+fn default_filename() -> String {
+    format!(
+        "nemo-flow-events-{}.jsonl",
+        Utc::now().format("%Y-%m-%d-%H.%M.%S")
+    )
+}
+
+fn open_file(path: &Path, mode: AtofExporterMode) -> Result<File> {
+    let mut options = OpenOptions::new();
+    options.create(true);
+    match mode {
+        AtofExporterMode::Append => {
+            options.append(true);
+        }
+        AtofExporterMode::Overwrite => {
+            options.write(true).truncate(true);
+        }
+    }
+    options
+        .open(path)
+        .map_err(|source| AtofExporterError::OpenFile {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn write_event(writer: &mut BufWriter<File>, event: &Event) -> std::result::Result<(), String> {
+    serde_json::to_writer(&mut *writer, event).map_err(|error| error.to_string())?;
+    writer.write_all(b"\n").map_err(|error| error.to_string())?;
+    writer.flush().map_err(|error| error.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[path = "../../tests/unit/observability/atof_tests.rs"]
+mod tests;

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -12,6 +12,7 @@ pub(crate) fn test_mutex() -> &'static Mutex<()> {
 }
 
 pub mod atif;
+pub mod atof;
 #[cfg(feature = "openinference")]
 pub mod openinference;
 #[cfg(feature = "otel")]

--- a/crates/core/tests/unit/observability/atof_tests.rs
+++ b/crates/core/tests/unit/observability/atof_tests.rs
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for the ATOF JSONL exporter.
+
+use super::*;
+use crate::api::event::{BaseEvent, Event, EventCategory, MarkEvent, ScopeCategory, ScopeEvent};
+use crate::api::runtime::NemoFlowContextState;
+use crate::api::runtime::global_context;
+use crate::api::scope::{EmitMarkEventParams, PopScopeParams, PushScopeParams, ScopeType};
+use serde_json::json;
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let id = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("nemo-flow-{prefix}-{id}"));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn reset_global() {
+    crate::shared_runtime::reset_runtime_owner_for_tests();
+    let context = global_context();
+    *context.write().unwrap() = NemoFlowContextState::new();
+}
+
+fn make_mark_event(name: &str) -> Event {
+    Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .uuid(Uuid::now_v7())
+            .name(name)
+            .data(json!({"step": 1}))
+            .build(),
+        None,
+        None,
+    ))
+}
+
+fn make_scope_start_event(name: &str) -> Event {
+    Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(Uuid::now_v7())
+            .name(name)
+            .data(json!({"input": true}))
+            .build(),
+        ScopeCategory::Start,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ))
+}
+
+fn read_jsonl(path: &Path) -> Vec<serde_json::Value> {
+    fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+#[test]
+fn default_config_uses_cwd_append_and_timestamped_filename() {
+    let config = AtofExporterConfig::default();
+
+    assert_eq!(config.output_directory, std::env::current_dir().unwrap());
+    assert_eq!(config.mode, AtofExporterMode::Append);
+    assert!(config.filename.starts_with("nemo-flow-events-"));
+    assert!(config.filename.ends_with(".jsonl"));
+    assert_eq!(
+        config.filename.len(),
+        "nemo-flow-events-YYYY-MM-DD-HH.MM.SS.jsonl".len()
+    );
+}
+
+#[test]
+fn append_mode_preserves_existing_lines() {
+    let dir = temp_dir("atof-append");
+    let path = dir.join("events.jsonl");
+    fs::write(&path, "{\"existing\":true}\n").unwrap();
+
+    let exporter = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&dir)
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+    (exporter.subscriber())(&make_mark_event("appended"));
+    exporter.force_flush().unwrap();
+
+    let lines = read_jsonl(&path);
+    assert_eq!(lines[0], json!({"existing": true}));
+    assert_eq!(lines[1]["kind"], "mark");
+    assert_eq!(lines[1]["name"], "appended");
+}
+
+#[test]
+fn overwrite_mode_truncates_existing_lines() {
+    let dir = temp_dir("atof-overwrite");
+    let path = dir.join("events.jsonl");
+    fs::write(&path, "{\"existing\":true}\n").unwrap();
+
+    let exporter = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&dir)
+            .with_mode(AtofExporterMode::Overwrite)
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+    (exporter.subscriber())(&make_mark_event("replacement"));
+    exporter.shutdown().unwrap();
+
+    let lines = read_jsonl(&path);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0]["kind"], "mark");
+    assert_eq!(lines[0]["name"], "replacement");
+}
+
+#[test]
+fn subscriber_writes_scope_and_mark_events_as_raw_jsonl() {
+    let dir = temp_dir("atof-shape");
+    let exporter = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&dir)
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+    let subscriber = exporter.subscriber();
+
+    subscriber(&make_scope_start_event("agent-start"));
+    subscriber(&make_mark_event("checkpoint"));
+    exporter.force_flush().unwrap();
+
+    let lines = read_jsonl(exporter.path());
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0]["kind"], "scope");
+    assert_eq!(lines[0]["scope_category"], "start");
+    assert_eq!(lines[0]["category"], "agent");
+    assert_eq!(lines[1]["kind"], "mark");
+    assert_eq!(lines[1]["data"], json!({"step": 1}));
+}
+
+#[test]
+fn register_deregister_flush_and_shutdown_work_with_runtime_events() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+    reset_global();
+
+    let dir = temp_dir("atof-runtime");
+    let exporter = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&dir)
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+    let name = format!("atof_exporter_{}", Uuid::now_v7());
+
+    exporter.register(&name).unwrap();
+    let handle = crate::api::scope::push_scope(
+        PushScopeParams::builder()
+            .name("atof_scope")
+            .scope_type(ScopeType::Agent)
+            .input(json!({"scope": true}))
+            .build(),
+    )
+    .unwrap();
+    crate::api::scope::event(
+        EmitMarkEventParams::builder()
+            .name("atof_mark")
+            .parent(&handle)
+            .data(json!({"mark": true}))
+            .build(),
+    )
+    .unwrap();
+    crate::api::scope::pop_scope(
+        PopScopeParams::builder()
+            .handle_uuid(&handle.uuid)
+            .output(json!({"done": true}))
+            .build(),
+    )
+    .unwrap();
+
+    assert!(exporter.deregister(&name).unwrap());
+    assert!(!exporter.deregister(&name).unwrap());
+    exporter.force_flush().unwrap();
+    exporter.shutdown().unwrap();
+    exporter.shutdown().unwrap();
+
+    let lines = read_jsonl(exporter.path());
+    assert_eq!(lines.len(), 3);
+    assert_eq!(lines[0]["name"], "atof_scope");
+    assert_eq!(lines[1]["name"], "atof_mark");
+    assert_eq!(lines[2]["scope_category"], "end");
+}
+
+#[test]
+fn invalid_output_path_errors_cleanly() {
+    let dir = temp_dir("atof-invalid");
+    let file_as_dir = dir.join("not-a-directory");
+    fs::write(&file_as_dir, "not a directory").unwrap();
+
+    let error = match AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&file_as_dir)
+            .with_filename("events.jsonl"),
+    ) {
+        Ok(_) => panic!("expected invalid output path error"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, AtofExporterError::OpenFile { .. }));
+}
+
+#[test]
+fn invalid_filename_errors_cleanly() {
+    let dir = temp_dir("atof-invalid-filename");
+
+    let error = match AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&dir)
+            .with_filename("missing-parent/events.jsonl"),
+    ) {
+        Ok(_) => panic!("expected invalid filename path error"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, AtofExporterError::OpenFile { .. }));
+}

--- a/crates/ffi/nemo_flow.h
+++ b/crates/ffi/nemo_flow.h
@@ -115,6 +115,11 @@ typedef int32_t NemoFlowScopeType;
 typedef struct FfiAtifExporter FfiAtifExporter;
 
 /**
+ * Opaque ATOF JSONL exporter handle.
+ */
+typedef struct FfiAtofExporter FfiAtofExporter;
+
+/**
  * Opaque handle carrying both request and response codec trait objects.
  *
  * Created by `nemo_flow_openai_chat_codec_new` (and similar constructors).
@@ -902,6 +907,64 @@ NemoFlowStatus nemo_flow_atif_exporter_export(const struct FfiAtifExporter *expo
  * `exporter` must be a valid, non-null `FfiAtifExporter` pointer.
  */
 NemoFlowStatus nemo_flow_atif_exporter_clear(const struct FfiAtifExporter *exporter);
+
+/**
+ * Creates a new filesystem-backed ATOF JSONL exporter.
+ *
+ * # Parameters
+ * - `output_directory`: Output directory path (nullable for current directory).
+ * - `mode`: `"append"` or `"overwrite"` (nullable for `"append"`).
+ * - `filename`: Output filename (nullable for generated default).
+ * - `out`: On success, receives a heap-allocated `FfiAtofExporter`.
+ *
+ * # Safety
+ * All non-null string pointers must be valid C strings. `out` must be valid.
+ */
+NemoFlowStatus nemo_flow_atof_exporter_create(const char *output_directory,
+                                              const char *mode,
+                                              const char *filename,
+                                              struct FfiAtofExporter **out);
+
+/**
+ * Registers the ATOF exporter as an event subscriber.
+ *
+ * # Safety
+ * `exporter` and `name` must be valid, non-null pointers.
+ */
+NemoFlowStatus nemo_flow_atof_exporter_register(const struct FfiAtofExporter *exporter,
+                                                const char *name);
+
+/**
+ * Deregisters the ATOF exporter subscriber.
+ *
+ * # Safety
+ * `name` must be a valid C string.
+ */
+NemoFlowStatus nemo_flow_atof_exporter_deregister(const char *name);
+
+/**
+ * Flushes the ATOF exporter output file.
+ *
+ * # Safety
+ * `exporter` must be a valid, non-null pointer.
+ */
+NemoFlowStatus nemo_flow_atof_exporter_force_flush(const struct FfiAtofExporter *exporter);
+
+/**
+ * Shuts down the ATOF exporter by flushing output.
+ *
+ * # Safety
+ * `exporter` must be a valid, non-null pointer.
+ */
+NemoFlowStatus nemo_flow_atof_exporter_shutdown(const struct FfiAtofExporter *exporter);
+
+/**
+ * Returns the ATOF exporter output path as a string.
+ *
+ * # Safety
+ * `exporter` and `out` must be valid, non-null pointers.
+ */
+NemoFlowStatus nemo_flow_atof_exporter_path(const struct FfiAtofExporter *exporter, char **out);
 
 /**
  * Creates a new OpenTelemetry subscriber.
@@ -1954,6 +2017,14 @@ void nemo_flow_scope_stack_free(struct FfiScopeStack *ptr);
  * `ptr` must be a valid pointer returned by `nemo_flow_atif_exporter_create`, or null.
  */
 void nemo_flow_atif_exporter_free(struct FfiAtifExporter *ptr);
+
+/**
+ * Free an ATOF JSONL exporter handle previously returned by `nemo_flow_atof_exporter_create`.
+ *
+ * # Safety
+ * `ptr` must be a valid pointer returned by `nemo_flow_atof_exporter_create`, or null.
+ */
+void nemo_flow_atof_exporter_free(struct FfiAtofExporter *ptr);
 
 /**
  * Free an OpenTelemetry subscriber handle previously returned by

--- a/crates/ffi/src/api/mod.rs
+++ b/crates/ffi/src/api/mod.rs
@@ -35,7 +35,7 @@ use crate::error::{
     status_from_plugin_error,
 };
 use crate::types::{
-    FfiAtifExporter, FfiCodecHandle, FfiLLMHandle, FfiOpenInferenceSubscriber,
+    FfiAtifExporter, FfiAtofExporter, FfiCodecHandle, FfiLLMHandle, FfiOpenInferenceSubscriber,
     FfiOpenTelemetrySubscriber, FfiPluginContext, FfiScopeHandle, FfiScopeStack, FfiToolHandle,
     NemoFlowScopeType,
 };

--- a/crates/ffi/src/api/observability.rs
+++ b/crates/ffi/src/api/observability.rs
@@ -2,15 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    Duration, FfiAtifExporter, FfiOpenInferenceSubscriber, FfiOpenTelemetrySubscriber,
-    NemoFlowStatus, c_char, c_str_to_string, clear_last_error, core_subscriber_api, set_last_error,
-    status_from_error, str_to_c_string, tokio_runtime,
+    Duration, FfiAtifExporter, FfiAtofExporter, FfiOpenInferenceSubscriber,
+    FfiOpenTelemetrySubscriber, NemoFlowStatus, c_char, c_str_to_string, clear_last_error,
+    core_subscriber_api, set_last_error, status_from_error, str_to_c_string, tokio_runtime,
 };
 
+type AtofExporter = nemo_flow::observability::atof::AtofExporter;
+type AtofExporterConfig = nemo_flow::observability::atof::AtofExporterConfig;
+type AtofExporterError = nemo_flow::observability::atof::AtofExporterError;
+type AtofExporterMode = nemo_flow::observability::atof::AtofExporterMode;
 type OpenTelemetryConfig = nemo_flow::observability::otel::OpenTelemetryConfig;
 type OpenTelemetrySubscriber = nemo_flow::observability::otel::OpenTelemetrySubscriber;
 type OpenInferenceConfig = nemo_flow::observability::openinference::OpenInferenceConfig;
 type OpenInferenceSubscriber = nemo_flow::observability::openinference::OpenInferenceSubscriber;
+
+fn status_from_atof_error(error: &AtofExporterError) -> NemoFlowStatus {
+    set_last_error(&error.to_string());
+    match error {
+        AtofExporterError::Runtime(error) => status_from_error(error),
+        _ => NemoFlowStatus::Internal,
+    }
+}
 
 // ---------------------------------------------------------------------------
 // ATIF exporter
@@ -176,6 +188,169 @@ pub unsafe extern "C" fn nemo_flow_atif_exporter_clear(
         return NemoFlowStatus::NullPointer;
     }
     unsafe { &*exporter }.0.clear();
+    NemoFlowStatus::Ok
+}
+
+// ---------------------------------------------------------------------------
+// ATOF JSONL exporter
+// ---------------------------------------------------------------------------
+
+/// Creates a new filesystem-backed ATOF JSONL exporter.
+///
+/// # Parameters
+/// - `output_directory`: Output directory path (nullable for current directory).
+/// - `mode`: `"append"` or `"overwrite"` (nullable for `"append"`).
+/// - `filename`: Output filename (nullable for generated default).
+/// - `out`: On success, receives a heap-allocated `FfiAtofExporter`.
+///
+/// # Safety
+/// All non-null string pointers must be valid C strings. `out` must be valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_flow_atof_exporter_create(
+    output_directory: *const c_char,
+    mode: *const c_char,
+    filename: *const c_char,
+    out: *mut *mut FfiAtofExporter,
+) -> NemoFlowStatus {
+    clear_last_error();
+    if let Err(status) = required_out_ptr(out) {
+        return status;
+    }
+
+    let output_directory = match parse_optional_string(output_directory) {
+        Ok(value) => value,
+        Err(status) => return status,
+    };
+    let mode = match parse_string_or_default(mode, "append") {
+        Ok(value) => value,
+        Err(status) => return status,
+    };
+    let filename = match parse_optional_string(filename) {
+        Ok(value) => value,
+        Err(status) => return status,
+    };
+
+    let Some(mode) = AtofExporterMode::parse(&mode) else {
+        set_last_error("ATOF exporter mode must be 'append' or 'overwrite'");
+        return NemoFlowStatus::InvalidArg;
+    };
+
+    let mut config = AtofExporterConfig::new().with_mode(mode);
+    if let Some(output_directory) = output_directory {
+        config = config.with_output_directory(output_directory);
+    }
+    if let Some(filename) = filename {
+        config = config.with_filename(filename);
+    }
+
+    match AtofExporter::new(config) {
+        Ok(exporter) => {
+            unsafe { *out = Box::into_raw(Box::new(FfiAtofExporter(exporter))) };
+            NemoFlowStatus::Ok
+        }
+        Err(error) => status_from_atof_error(&error),
+    }
+}
+
+/// Registers the ATOF exporter as an event subscriber.
+///
+/// # Safety
+/// `exporter` and `name` must be valid, non-null pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_flow_atof_exporter_register(
+    exporter: *const FfiAtofExporter,
+    name: *const c_char,
+) -> NemoFlowStatus {
+    clear_last_error();
+    if exporter.is_null() {
+        set_last_error("exporter pointer is null");
+        return NemoFlowStatus::NullPointer;
+    }
+    let name = match c_str_to_string(name) {
+        Ok(s) => s,
+        Err(status) => return status,
+    };
+    match unsafe { &*exporter }.0.register(&name) {
+        Ok(()) => NemoFlowStatus::Ok,
+        Err(error) => status_from_atof_error(&error),
+    }
+}
+
+/// Deregisters the ATOF exporter subscriber.
+///
+/// # Safety
+/// `name` must be a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_flow_atof_exporter_deregister(name: *const c_char) -> NemoFlowStatus {
+    clear_last_error();
+    let name = match c_str_to_string(name) {
+        Ok(s) => s,
+        Err(status) => return status,
+    };
+    match core_subscriber_api::deregister_subscriber(&name) {
+        Ok(_) => NemoFlowStatus::Ok,
+        Err(e) => status_from_error(&e),
+    }
+}
+
+/// Flushes the ATOF exporter output file.
+///
+/// # Safety
+/// `exporter` must be a valid, non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_flow_atof_exporter_force_flush(
+    exporter: *const FfiAtofExporter,
+) -> NemoFlowStatus {
+    clear_last_error();
+    if exporter.is_null() {
+        set_last_error("exporter pointer is null");
+        return NemoFlowStatus::NullPointer;
+    }
+    match unsafe { &*exporter }.0.force_flush() {
+        Ok(()) => NemoFlowStatus::Ok,
+        Err(error) => status_from_atof_error(&error),
+    }
+}
+
+/// Shuts down the ATOF exporter by flushing output.
+///
+/// # Safety
+/// `exporter` must be a valid, non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_flow_atof_exporter_shutdown(
+    exporter: *const FfiAtofExporter,
+) -> NemoFlowStatus {
+    clear_last_error();
+    if exporter.is_null() {
+        set_last_error("exporter pointer is null");
+        return NemoFlowStatus::NullPointer;
+    }
+    match unsafe { &*exporter }.0.shutdown() {
+        Ok(()) => NemoFlowStatus::Ok,
+        Err(error) => status_from_atof_error(&error),
+    }
+}
+
+/// Returns the ATOF exporter output path as a string.
+///
+/// # Safety
+/// `exporter` and `out` must be valid, non-null pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_flow_atof_exporter_path(
+    exporter: *const FfiAtofExporter,
+    out: *mut *mut c_char,
+) -> NemoFlowStatus {
+    clear_last_error();
+    if exporter.is_null() {
+        set_last_error("exporter pointer is null");
+        return NemoFlowStatus::NullPointer;
+    }
+    if out.is_null() {
+        set_last_error("out pointer is null");
+        return NemoFlowStatus::NullPointer;
+    }
+    let path = unsafe { &*exporter }.0.path().to_string_lossy();
+    unsafe { *out = str_to_c_string(&path) };
     NemoFlowStatus::Ok
 }
 

--- a/crates/ffi/src/types/mod.rs
+++ b/crates/ffi/src/types/mod.rs
@@ -50,6 +50,8 @@ pub struct FfiEvent(pub Event);
 pub struct FfiScopeStack(pub ScopeStackHandle);
 /// Opaque ATIF exporter handle.
 pub struct FfiAtifExporter(pub nemo_flow::observability::atif::AtifExporter);
+/// Opaque ATOF JSONL exporter handle.
+pub struct FfiAtofExporter(pub nemo_flow::observability::atof::AtofExporter);
 /// Opaque OpenTelemetry subscriber handle.
 pub struct FfiOpenTelemetrySubscriber(pub nemo_flow::observability::otel::OpenTelemetrySubscriber);
 /// Opaque OpenInference subscriber handle.
@@ -224,6 +226,17 @@ pub unsafe extern "C" fn nemo_flow_scope_stack_free(ptr: *mut FfiScopeStack) {
 /// `ptr` must be a valid pointer returned by `nemo_flow_atif_exporter_create`, or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nemo_flow_atif_exporter_free(ptr: *mut FfiAtifExporter) {
+    if !ptr.is_null() {
+        drop(unsafe { Box::from_raw(ptr) });
+    }
+}
+
+/// Free an ATOF JSONL exporter handle previously returned by `nemo_flow_atof_exporter_create`.
+///
+/// # Safety
+/// `ptr` must be a valid pointer returned by `nemo_flow_atof_exporter_create`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_flow_atof_exporter_free(ptr: *mut FfiAtofExporter) {
     if !ptr.is_null() {
         drop(unsafe { Box::from_raw(ptr) });
     }

--- a/crates/ffi/tests/integration/api_tests.rs
+++ b/crates/ffi/tests/integration/api_tests.rs
@@ -5,8 +5,10 @@
 
 use super::*;
 use std::ffi::{CStr, CString};
+use std::fs;
 use std::ptr;
 use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use nemo_flow::plugin::PluginRegistrationContext;
 use serde_json::{Value as Json, json};
@@ -16,20 +18,21 @@ use nemo_flow_ffi::callable::{NemoFlowLlmExecNextFn, NemoFlowToolExecNextFn};
 use nemo_flow_ffi::convert::nemo_flow_string_free;
 use nemo_flow_ffi::error::{NemoFlowStatus, nemo_flow_last_error, set_last_error};
 use nemo_flow_ffi::types::{
-    FfiAtifExporter, FfiEvent, FfiLLMHandle, FfiLLMRequest, FfiOpenTelemetrySubscriber,
-    FfiScopeStack, FfiToolHandle, nemo_flow_atif_exporter_free, nemo_flow_event_data,
-    nemo_flow_event_input, nemo_flow_event_metadata, nemo_flow_event_model_name,
-    nemo_flow_event_name, nemo_flow_event_output, nemo_flow_event_parent_uuid,
-    nemo_flow_event_scope_type, nemo_flow_event_timestamp, nemo_flow_event_tool_call_id,
-    nemo_flow_event_uuid, nemo_flow_llm_handle_attributes, nemo_flow_llm_handle_free,
-    nemo_flow_llm_handle_name, nemo_flow_llm_handle_parent_uuid, nemo_flow_llm_handle_uuid,
-    nemo_flow_llm_request_content, nemo_flow_llm_request_free, nemo_flow_llm_request_headers,
-    nemo_flow_llm_request_new, nemo_flow_otel_subscriber_free, nemo_flow_scope_handle_attributes,
-    nemo_flow_scope_handle_data, nemo_flow_scope_handle_free, nemo_flow_scope_handle_metadata,
-    nemo_flow_scope_handle_name, nemo_flow_scope_handle_parent_uuid,
-    nemo_flow_scope_handle_scope_type, nemo_flow_scope_handle_uuid, nemo_flow_scope_stack_free,
-    nemo_flow_tool_handle_attributes, nemo_flow_tool_handle_free, nemo_flow_tool_handle_name,
-    nemo_flow_tool_handle_parent_uuid, nemo_flow_tool_handle_uuid,
+    FfiAtifExporter, FfiAtofExporter, FfiEvent, FfiLLMHandle, FfiLLMRequest,
+    FfiOpenTelemetrySubscriber, FfiScopeStack, FfiToolHandle, nemo_flow_atif_exporter_free,
+    nemo_flow_atof_exporter_free, nemo_flow_event_data, nemo_flow_event_input,
+    nemo_flow_event_metadata, nemo_flow_event_model_name, nemo_flow_event_name,
+    nemo_flow_event_output, nemo_flow_event_parent_uuid, nemo_flow_event_scope_type,
+    nemo_flow_event_timestamp, nemo_flow_event_tool_call_id, nemo_flow_event_uuid,
+    nemo_flow_llm_handle_attributes, nemo_flow_llm_handle_free, nemo_flow_llm_handle_name,
+    nemo_flow_llm_handle_parent_uuid, nemo_flow_llm_handle_uuid, nemo_flow_llm_request_content,
+    nemo_flow_llm_request_free, nemo_flow_llm_request_headers, nemo_flow_llm_request_new,
+    nemo_flow_otel_subscriber_free, nemo_flow_scope_handle_attributes, nemo_flow_scope_handle_data,
+    nemo_flow_scope_handle_free, nemo_flow_scope_handle_metadata, nemo_flow_scope_handle_name,
+    nemo_flow_scope_handle_parent_uuid, nemo_flow_scope_handle_scope_type,
+    nemo_flow_scope_handle_uuid, nemo_flow_scope_stack_free, nemo_flow_tool_handle_attributes,
+    nemo_flow_tool_handle_free, nemo_flow_tool_handle_name, nemo_flow_tool_handle_parent_uuid,
+    nemo_flow_tool_handle_uuid,
 };
 use nemo_flow_ffi::{api, callable, types};
 
@@ -65,6 +68,16 @@ fn lock_unpoisoned<T>(mutex: &'static Mutex<T>) -> std::sync::MutexGuard<'static
 
 fn cstring(s: &str) -> CString {
     CString::new(s).unwrap()
+}
+
+fn temp_dir(prefix: &str) -> std::path::PathBuf {
+    let id = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("nemo-flow-{prefix}-{id}"));
+    fs::create_dir_all(&path).unwrap();
+    path
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -649,4 +662,103 @@ fn scope_stack_create_reports_null_pointer_errors() {
         .to_string_lossy()
         .into_owned();
     assert!(message.contains("out pointer is null"));
+}
+
+#[test]
+fn atof_exporter_writes_raw_jsonl_events() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let stack = unsafe { fresh_scope_stack() };
+    let dir = temp_dir("ffi-atof");
+    let output_directory = cstring(dir.to_str().unwrap());
+    let mode = cstring("overwrite");
+    let filename = cstring("events.jsonl");
+    let mut exporter: *mut FfiAtofExporter = ptr::null_mut();
+
+    assert_eq!(
+        unsafe {
+            api::nemo_flow_atof_exporter_create(
+                output_directory.as_ptr(),
+                mode.as_ptr(),
+                filename.as_ptr(),
+                &mut exporter,
+            )
+        },
+        NemoFlowStatus::Ok
+    );
+    assert!(!exporter.is_null());
+
+    let mut path_ptr = ptr::null_mut();
+    assert_eq!(
+        unsafe { api::nemo_flow_atof_exporter_path(exporter, &mut path_ptr) },
+        NemoFlowStatus::Ok
+    );
+    let path = unsafe { take_string(path_ptr) }.unwrap();
+    assert!(path.ends_with("events.jsonl"));
+
+    let subscriber_name = cstring("ffi_atof_exporter");
+    assert_eq!(
+        unsafe { api::nemo_flow_atof_exporter_register(exporter, subscriber_name.as_ptr()) },
+        NemoFlowStatus::Ok
+    );
+
+    let scope_name = cstring("ffi_atof_scope");
+    let input = cstring(r#"{"scope":true}"#);
+    let mut scope = ptr::null_mut();
+    assert_eq!(
+        unsafe {
+            nemo_flow_push_scope(
+                scope_name.as_ptr(),
+                NemoFlowScopeType::Agent,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                input.as_ptr(),
+                &mut scope,
+            )
+        },
+        NemoFlowStatus::Ok
+    );
+
+    let event_name = cstring("ffi_atof_mark");
+    let event_data = cstring(r#"{"step":1}"#);
+    assert_eq!(
+        unsafe { nemo_flow_event(event_name.as_ptr(), scope, event_data.as_ptr(), ptr::null()) },
+        NemoFlowStatus::Ok
+    );
+
+    let output = cstring(r#"{"done":true}"#);
+    assert_eq!(
+        unsafe { nemo_flow_pop_scope(scope, output.as_ptr()) },
+        NemoFlowStatus::Ok
+    );
+    unsafe { nemo_flow_scope_handle_free(scope) };
+
+    assert_eq!(
+        unsafe { api::nemo_flow_atof_exporter_deregister(subscriber_name.as_ptr()) },
+        NemoFlowStatus::Ok
+    );
+    assert_eq!(
+        unsafe { api::nemo_flow_atof_exporter_force_flush(exporter) },
+        NemoFlowStatus::Ok
+    );
+    assert_eq!(
+        unsafe { api::nemo_flow_atof_exporter_shutdown(exporter) },
+        NemoFlowStatus::Ok
+    );
+
+    let records = fs::read_to_string(&path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<Json>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(records.len(), 3);
+    assert_eq!(records[0]["kind"], "scope");
+    assert_eq!(records[1]["name"], "ffi_atof_mark");
+    assert_eq!(records[2]["scope_category"], "end");
+
+    unsafe {
+        nemo_flow_atof_exporter_free(exporter);
+        nemo_flow_scope_stack_free(stack);
+    }
 }

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -11,6 +11,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::ptr;
 use std::sync::Arc;
@@ -134,6 +135,30 @@ fn build_otel_config(
     }
     for (key, value) in parse_string_map(options.resource_attributes, "resourceAttributes")? {
         config = config.with_resource_attribute(key, value);
+    }
+
+    Ok(config)
+}
+
+fn build_atof_config(
+    options: Option<AtofExporterConfig>,
+) -> napi::Result<nemo_flow::observability::atof::AtofExporterConfig> {
+    let options = options.unwrap_or_default();
+    let mut config = nemo_flow::observability::atof::AtofExporterConfig::new();
+
+    if let Some(output_directory) = options.output_directory {
+        config = config.with_output_directory(PathBuf::from(output_directory));
+    }
+    if let Some(filename) = options.filename {
+        config = config.with_filename(filename);
+    }
+    if let Some(mode) = options.mode {
+        let Some(mode) = nemo_flow::observability::atof::AtofExporterMode::parse(&mode) else {
+            return Err(napi::Error::from_reason(
+                "mode must be 'append' or 'overwrite'",
+            ));
+        };
+        config = config.with_mode(mode);
     }
 
     Ok(config)
@@ -2932,6 +2957,73 @@ impl AtifExporter {
     #[napi]
     pub fn clear(&self) {
         self.inner.clear();
+    }
+}
+
+/// Mutable configuration object for `AtofExporter`.
+#[napi(object)]
+#[derive(Default)]
+pub struct AtofExporterConfig {
+    /// Output directory. Defaults to the current working directory.
+    pub output_directory: Option<String>,
+    /// `"append"` (default) or `"overwrite"`.
+    pub mode: Option<String>,
+    /// Output filename. Defaults to `nemo-flow-events-YYYY-MM-DD-HH.MM.SS.jsonl`.
+    pub filename: Option<String>,
+}
+
+/// Filesystem-backed ATOF JSONL event exporter.
+#[napi]
+pub struct AtofExporter {
+    inner: nemo_flow::observability::atof::AtofExporter,
+}
+
+#[napi]
+impl AtofExporter {
+    /// Create a new ATOF JSONL exporter from a config object.
+    #[napi(constructor)]
+    pub fn new(config: Option<AtofExporterConfig>) -> napi::Result<Self> {
+        let inner = nemo_flow::observability::atof::AtofExporter::new(build_atof_config(config)?)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    /// Return the JSONL output path.
+    #[napi(getter)]
+    pub fn path(&self) -> String {
+        self.inner.path().to_string_lossy().into_owned()
+    }
+
+    /// Register this exporter globally with the given name.
+    #[napi]
+    pub fn register(&self, name: String) -> napi::Result<()> {
+        self.inner
+            .register(&name)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
+    /// Deregister a subscriber by name.
+    #[napi]
+    pub fn deregister(&self, name: String) -> napi::Result<bool> {
+        self.inner
+            .deregister(&name)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
+    /// Flush the output file.
+    #[napi]
+    pub fn force_flush(&self) -> napi::Result<()> {
+        self.inner
+            .force_flush()
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
+    /// Shut down the exporter by flushing output.
+    #[napi]
+    pub fn shutdown(&self) -> napi::Result<()> {
+        self.inner
+            .shutdown()
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 }
 

--- a/crates/node/tests/atof_tests.mjs
+++ b/crates/node/tests/atof_tests.mjs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { AtofExporter, ScopeType, pushScope, popScope, event } = require('../index.js');
+
+function tempDir(prefix) {
+  return mkdtempSync(join(tmpdir(), `nemo-flow-${prefix}-`));
+}
+
+function lines(path) {
+  return readFileSync(path, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+describe('AtofExporter', () => {
+  it('constructs with defaults and rejects invalid mode', () => {
+    const exporter = new AtofExporter({ outputDirectory: tempDir('node-atof-defaults') });
+    assert.match(exporter.path, /nemo-flow-events-\d{4}-\d{2}-\d{2}-\d{2}\.\d{2}\.\d{2}\.jsonl$/);
+    exporter.shutdown();
+
+    assert.throws(() => new AtofExporter({ mode: 'invalid' }), /mode must be/i);
+  });
+
+  it('writes raw ATOF JSONL events and supports lifecycle methods', () => {
+    const outputDirectory = tempDir('node-atof');
+    const exporter = new AtofExporter({
+      outputDirectory,
+      mode: 'overwrite',
+      filename: 'events.jsonl',
+    });
+    const name = `node_atof_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+
+    exporter.register(name);
+    try {
+      const scope = pushScope('atof_scope', ScopeType.Agent, null, null, null, null, { scope: true });
+      event('atof_mark', scope, { step: 1 }, null);
+      popScope(scope, { done: true });
+    } finally {
+      assert.equal(exporter.deregister(name), true);
+      assert.equal(exporter.deregister(name), false);
+      exporter.forceFlush();
+      exporter.shutdown();
+    }
+
+    const records = lines(join(outputDirectory, 'events.jsonl'));
+    assert.deepEqual(
+      records.map((record) => record.kind),
+      ['scope', 'mark', 'scope'],
+    );
+    assert.equal(records[0].name, 'atof_scope');
+    assert.deepEqual(records[1].data, { step: 1 });
+    assert.equal(records[2].scope_category, 'end');
+  });
+
+  it('supports append and overwrite modes', () => {
+    const outputDirectory = tempDir('node-atof-modes');
+    const path = join(outputDirectory, 'events.jsonl');
+    writeFileSync(path, '{"existing":true}\n');
+
+    const appendExporter = new AtofExporter({ outputDirectory, filename: 'events.jsonl' });
+    appendExporter.shutdown();
+    assert.equal(readFileSync(path, 'utf8'), '{"existing":true}\n');
+
+    const overwriteExporter = new AtofExporter({
+      outputDirectory,
+      mode: 'overwrite',
+      filename: 'events.jsonl',
+    });
+    overwriteExporter.shutdown();
+    assert.equal(readFileSync(path, 'utf8'), '');
+  });
+});

--- a/crates/python/src/py_types/mod.rs
+++ b/crates/python/src/py_types/mod.rs
@@ -137,6 +137,9 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyScopeEvent>()?;
     m.add_class::<PyMarkEvent>()?;
     m.add_class::<PyAtifExporter>()?;
+    m.add_class::<PyAtofExporterMode>()?;
+    m.add_class::<PyAtofExporterConfig>()?;
+    m.add_class::<PyAtofExporter>()?;
     m.add_class::<PyOpenTelemetryConfig>()?;
     m.add_class::<PyOpenTelemetrySubscriber>()?;
     m.add_class::<PyOpenInferenceConfig>()?;

--- a/crates/python/src/py_types/observability.rs
+++ b/crates/python/src/py_types/observability.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use pyo3::prelude::*;
+use std::path::PathBuf;
 use tokio::runtime::{Handle, Runtime};
 
 use super::{
@@ -124,6 +125,133 @@ impl PyAtifExporter {
 
     pub(crate) fn __repr__(&self) -> String {
         "<AtifExporter>".to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ATOF JSONL exporter
+// ---------------------------------------------------------------------------
+
+/// File write behavior for ``AtofExporter``.
+#[pyclass(name = "AtofExporterMode", eq, eq_int, from_py_object)]
+#[derive(Clone, PartialEq)]
+pub enum PyAtofExporterMode {
+    Append = 0,
+    Overwrite = 1,
+}
+
+impl From<PyAtofExporterMode> for nemo_flow::observability::atof::AtofExporterMode {
+    fn from(value: PyAtofExporterMode) -> Self {
+        match value {
+            PyAtofExporterMode::Append => Self::Append,
+            PyAtofExporterMode::Overwrite => Self::Overwrite,
+        }
+    }
+}
+
+impl From<nemo_flow::observability::atof::AtofExporterMode> for PyAtofExporterMode {
+    fn from(value: nemo_flow::observability::atof::AtofExporterMode) -> Self {
+        match value {
+            nemo_flow::observability::atof::AtofExporterMode::Append => Self::Append,
+            nemo_flow::observability::atof::AtofExporterMode::Overwrite => Self::Overwrite,
+        }
+    }
+}
+
+/// Mutable configuration object for the filesystem-backed ATOF JSONL exporter.
+#[pyclass(name = "AtofExporterConfig")]
+pub struct PyAtofExporterConfig {
+    #[pyo3(get, set)]
+    pub(crate) output_directory: String,
+    #[pyo3(get, set)]
+    pub(crate) mode: PyAtofExporterMode,
+    #[pyo3(get, set)]
+    pub(crate) filename: String,
+}
+
+impl PyAtofExporterConfig {
+    fn to_rust_config(&self) -> nemo_flow::observability::atof::AtofExporterConfig {
+        nemo_flow::observability::atof::AtofExporterConfig::new()
+            .with_output_directory(PathBuf::from(self.output_directory.clone()))
+            .with_mode(self.mode.clone().into())
+            .with_filename(self.filename.clone())
+    }
+}
+
+#[pymethods]
+impl PyAtofExporterConfig {
+    #[new]
+    pub(crate) fn new() -> Self {
+        let config = nemo_flow::observability::atof::AtofExporterConfig::new();
+        Self {
+            output_directory: config.output_directory.to_string_lossy().into_owned(),
+            mode: config.mode.into(),
+            filename: config.filename,
+        }
+    }
+
+    pub(crate) fn __repr__(&self) -> String {
+        format!(
+            "<AtofExporterConfig output_directory={:?} filename={:?}>",
+            self.output_directory, self.filename
+        )
+    }
+}
+
+/// Filesystem-backed ATOF JSONL exporter.
+///
+/// Register the exporter under a subscriber name, run instrumented application
+/// code, then deregister and shut down the exporter to flush output.
+#[pyclass(name = "AtofExporter")]
+pub struct PyAtofExporter {
+    inner: nemo_flow::observability::atof::AtofExporter,
+}
+
+#[pymethods]
+impl PyAtofExporter {
+    #[new]
+    pub(crate) fn new(config: PyRef<'_, PyAtofExporterConfig>) -> PyResult<Self> {
+        let inner = nemo_flow::observability::atof::AtofExporter::new(config.to_rust_config())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    /// Return the JSONL output path.
+    #[getter]
+    pub(crate) fn path(&self) -> String {
+        self.inner.path().to_string_lossy().into_owned()
+    }
+
+    /// Register this exporter globally under ``name``.
+    pub(crate) fn register(&self, name: String) -> PyResult<()> {
+        self.inner
+            .register(&name)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+    }
+
+    /// Deregister a global subscriber by name.
+    pub(crate) fn deregister(&self, name: String) -> PyResult<bool> {
+        self.inner
+            .deregister(&name)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+    }
+
+    /// Flush the output file.
+    pub(crate) fn force_flush(&self) -> PyResult<()> {
+        self.inner
+            .force_flush()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+    }
+
+    /// Shut down the exporter by flushing output.
+    pub(crate) fn shutdown(&self) -> PyResult<()> {
+        self.inner
+            .shutdown()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+    }
+
+    pub(crate) fn __repr__(&self) -> String {
+        "<AtofExporter>".to_string()
     }
 }
 

--- a/crates/wasm/tests-js/types_tests.mjs
+++ b/crates/wasm/tests-js/types_tests.mjs
@@ -14,6 +14,7 @@ test('WebAssembly package exports canonical runtime classes and scope type enum 
   assert.equal(typeof wasm.OpenTelemetrySubscriber, 'function');
   assert.equal(typeof wasm.OpenInferenceSubscriber, 'function');
   assert.equal(typeof wasm.AtifExporter, 'function');
+  assert.equal(typeof wasm.AtofExporter, 'undefined');
 
   assert.equal(wasm.ScopeType.Agent, 0);
   assert.equal(wasm.ScopeType.Function, 1);

--- a/docs/about/concepts/subscribers.md
+++ b/docs/about/concepts/subscribers.md
@@ -86,6 +86,13 @@ of the canonical event stream.
 The ATIF exporter collects lifecycle events and emits trajectory artifacts for
 offline analysis, replay, or debugging.
 
+### ATOF JSONL Exporter
+
+The ATOF JSONL exporter writes the canonical event stream to a native
+filesystem path as one raw ATOF event per line. It is available for native
+Rust, Python, Node.js, Go, and C FFI use. It is not exposed in WebAssembly
+because arbitrary filesystem writes are not portable there.
+
 ### OpenTelemetry Subscriber
 
 The OpenTelemetry subscriber maps runtime events into OTLP traces for tracing

--- a/docs/export-observability-data/about.md
+++ b/docs/export-observability-data/about.md
@@ -11,8 +11,8 @@ or export agent activity to tracing, trajectory, or analysis systems.
 Observability in NeMo Flow starts with events. Scopes, marks, managed tool
 calls, managed LLM calls, middleware, and manual lifecycle APIs emit a canonical
 event stream. Subscribers consume that stream inside the process, and
-exporter-oriented subscribers translate it into formats such as ATIF,
-OpenTelemetry, and OpenInference.
+exporter-oriented subscribers write raw ATOF JSONL or translate it into formats
+such as ATIF, OpenTelemetry, and OpenInference.
 
 Use these guides to confirm what ran, where it belonged, which model or tool was
 involved, and what sanitized payload was observed across Rust, Python, and
@@ -35,10 +35,11 @@ If you have not instrumented any scopes, tools, or LLM calls yet, start with [In
 The following guides describe available tutorials and exporters:
 
 - [Basic Guide: Register a Subscriber](basic-guide.md) shows a simple subscriber lifecycle and validation workflow.
+- [Code Examples](code-examples.md#atof-jsonl-export) shows how to write raw ATOF events as JSONL.
 - [Advanced Guide: Export OpenTelemetry Data](opentelemetry.md) shows how to export generic OTLP spans.
 - [Advanced Guide: Export OpenInference Data](advanced-guide.md) shows how to configure and operate the OpenInference exporter.
 - [Advanced Guide: Export ATIF](atif.md) shows how to collect and export trajectory artifacts.
-- [Code Examples](code-examples.md) shows event shape, scope-local subscribers, ATIF export, OpenTelemetry export, and exporter selection snippets.
+- [Code Examples](code-examples.md) shows event shape, scope-local subscribers, ATOF JSONL export, ATIF export, OpenTelemetry export, and exporter selection snippets.
 
 Begin with a local subscriber so you can confirm the application emits the
 expected scope, tool, LLM, and mark events. Add exporters only after the event
@@ -48,3 +49,8 @@ For production export, register subscribers before the first instrumented
 request, use stable service identity fields, keep credentials outside source
 code, flush during graceful shutdown, and filter by `root_uuid` when analyzing
 concurrent agent runs.
+
+The filesystem-backed ATOF JSONL exporter is available on native Rust, Python,
+Node.js, Go, and C FFI surfaces. It is not exposed in WebAssembly because
+arbitrary filesystem writes are not portable across browser and hosted WASM
+environments.

--- a/docs/export-observability-data/basic-guide.md
+++ b/docs/export-observability-data/basic-guide.md
@@ -132,6 +132,7 @@ The table below compares subscriber and exporter options for common observabilit
 |---|---|
 | Custom subscriber | Consume events in process. |
 | Scope-local subscriber | Observe one request or tenant and clean up when its scope closes. |
+| ATOF JSONL exporter | Write raw ATOF events as one JSON object per line. |
 | ATIF exporter | Collect events and export ATIF v1.6 trajectories. |
 | OpenTelemetry subscriber | Export lifecycle events as OTLP spans. |
 | OpenInference subscriber | Export lifecycle events as OTLP spans with OpenInference-oriented semantics. |

--- a/docs/export-observability-data/code-examples.md
+++ b/docs/export-observability-data/code-examples.md
@@ -167,6 +167,109 @@ scope_register_subscriber(&scope.uuid, "scoped-logger", Arc::new(|event| {
 
 ::::
 
+## ATOF JSONL Export
+
+Use the ATOF JSONL exporter when you want the raw canonical event stream on
+disk. The exporter writes one ATOF event JSON object per line, opens files in
+append mode by default, and flushes after every event. WebAssembly does not
+expose this filesystem-backed exporter.
+
+::::{tab-set}
+:sync-group: language
+
+:::{tab-item} Python
+:sync: python
+
+```python
+from nemo_flow import AtofExporter, AtofExporterConfig, AtofExporterMode
+
+config = AtofExporterConfig()
+config.output_directory = "logs"
+config.mode = AtofExporterMode.Append
+config.filename = "nemo-flow-events.jsonl"
+
+exporter = AtofExporter(config)
+exporter.register("atof-jsonl")
+
+# Run instrumented application work here.
+
+exporter.deregister("atof-jsonl")
+exporter.shutdown()
+```
+:::
+
+:::{tab-item} Node.js
+:sync: node
+
+```ts
+import { AtofExporter } from 'nemo-flow-node';
+
+const exporter = new AtofExporter({
+  outputDirectory: 'logs',
+  mode: 'append',
+  filename: 'nemo-flow-events.jsonl',
+});
+
+exporter.register('atof-jsonl');
+
+// Run instrumented application work here.
+
+exporter.deregister('atof-jsonl');
+exporter.shutdown();
+```
+:::
+
+:::{tab-item} Rust
+:sync: rust
+
+```rust
+use nemo_flow::observability::atof::{
+    AtofExporter, AtofExporterConfig, AtofExporterMode,
+};
+
+let exporter = AtofExporter::new(
+    AtofExporterConfig::new()
+        .with_output_directory("logs")
+        .with_mode(AtofExporterMode::Append)
+        .with_filename("nemo-flow-events.jsonl"),
+)?;
+
+exporter.register("atof-jsonl")?;
+
+// Run instrumented application work here.
+
+exporter.deregister("atof-jsonl")?;
+exporter.shutdown()?;
+```
+:::
+
+:::{tab-item} Go
+:sync: go
+
+```go
+exporter, err := nemo_flow.NewAtofExporter(nemo_flow.AtofExporterConfig{
+    OutputDirectory: "logs",
+    Mode:            nemo_flow.AtofExporterModeAppend,
+    Filename:        "nemo-flow-events.jsonl",
+})
+if err != nil {
+    return err
+}
+defer exporter.Close()
+
+if err := exporter.Register("atof-jsonl"); err != nil {
+    return err
+}
+
+// Run instrumented application work here.
+
+_ = exporter.Deregister("atof-jsonl")
+return exporter.Shutdown()
+```
+:::
+
+::::
+
 ## ATIF Export
 
 The ATIF exporter collects lifecycle events and exports an ATIF trajectory for offline analysis, replay, or debugging.
@@ -332,6 +435,7 @@ The table below summarizes which exporter or subscriber to start with for each g
 | Subscriber / Exporter | Purpose |
 |---|---|
 | Custom subscriber | Consume events in process. |
+| ATOF JSONL exporter | Write raw ATOF events as one JSON object per line. |
 | ATIF exporter | Collect events and export ATIF v1.6 trajectories. |
 | OpenTelemetry subscriber | Export lifecycle events as OTLP spans. |
 | OpenInference subscriber | Export lifecycle events as OTLP spans with OpenInference-oriented semantics. |

--- a/go/nemo_flow/atof_test.go
+++ b/go/nemo_flow/atof_test.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nemo_flow
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewAtofExporterConfigDefaults(t *testing.T) {
+	config := NewAtofExporterConfig()
+
+	if config.Mode != AtofExporterModeAppend {
+		t.Fatalf("expected append mode default, got %q", config.Mode)
+	}
+	if config.OutputDirectory != "" {
+		t.Fatalf("expected empty output directory default override, got %q", config.OutputDirectory)
+	}
+	if config.Filename != "" {
+		t.Fatalf("expected empty filename default override, got %q", config.Filename)
+	}
+}
+
+func TestAtofExporterLifecycleWritesRawJSONL(t *testing.T) {
+	dir := t.TempDir()
+	exporter, err := NewAtofExporter(AtofExporterConfig{
+		OutputDirectory: dir,
+		Mode:            AtofExporterModeOverwrite,
+		Filename:        "events.jsonl",
+	})
+	if err != nil {
+		t.Fatalf("NewAtofExporter failed: %v", err)
+	}
+	defer exporter.Close()
+
+	path, err := exporter.Path()
+	if err != nil {
+		t.Fatalf("Path failed: %v", err)
+	}
+	if filepath.Base(path) != "events.jsonl" {
+		t.Fatalf("expected events.jsonl path, got %q", path)
+	}
+
+	name := "go_atof_" + time.Now().Format("150405.000000")
+	if err := exporter.Register(name); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	handle, err := PushScope("atof_scope", ScopeTypeAgent, WithInput(json.RawMessage(`{"scope":true}`)))
+	if err != nil {
+		t.Fatalf("PushScope failed: %v", err)
+	}
+	if err := EmitEvent("atof_mark", WithEventParent(handle), WithEventData(json.RawMessage(`{"step":1}`))); err != nil {
+		t.Fatalf("EmitEvent failed: %v", err)
+	}
+	if err := PopScope(handle, WithOutput(json.RawMessage(`{"done":true}`))); err != nil {
+		t.Fatalf("PopScope failed: %v", err)
+	}
+	if err := exporter.Deregister(name); err != nil {
+		t.Fatalf("Deregister failed: %v", err)
+	}
+	if err := exporter.Deregister(name); err != nil {
+		t.Fatalf("repeated Deregister should be safe, got: %v", err)
+	}
+	if err := exporter.ForceFlush(); err != nil {
+		t.Fatalf("ForceFlush failed: %v", err)
+	}
+	if err := exporter.Shutdown(); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+
+	records := readAtofRecords(t, path)
+	if len(records) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+	if records[0]["kind"] != "scope" || records[0]["name"] != "atof_scope" {
+		t.Fatalf("unexpected first record: %#v", records[0])
+	}
+	if records[1]["kind"] != "mark" || records[1]["name"] != "atof_mark" {
+		t.Fatalf("unexpected mark record: %#v", records[1])
+	}
+	if records[2]["scope_category"] != "end" {
+		t.Fatalf("expected end scope record, got %#v", records[2])
+	}
+}
+
+func TestAtofExporterAppendAndOverwriteModes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	if err := os.WriteFile(path, []byte("{\"existing\":true}\n"), 0o600); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+
+	appendExporter, err := NewAtofExporter(AtofExporterConfig{
+		OutputDirectory: dir,
+		Filename:        "events.jsonl",
+	})
+	if err != nil {
+		t.Fatalf("append NewAtofExporter failed: %v", err)
+	}
+	if err := appendExporter.Shutdown(); err != nil {
+		t.Fatalf("append Shutdown failed: %v", err)
+	}
+	appendExporter.Close()
+	if got := string(mustReadFile(t, path)); got != "{\"existing\":true}\n" {
+		t.Fatalf("append mode changed file: %q", got)
+	}
+
+	overwriteExporter, err := NewAtofExporter(AtofExporterConfig{
+		OutputDirectory: dir,
+		Mode:            AtofExporterModeOverwrite,
+		Filename:        "events.jsonl",
+	})
+	if err != nil {
+		t.Fatalf("overwrite NewAtofExporter failed: %v", err)
+	}
+	if err := overwriteExporter.Shutdown(); err != nil {
+		t.Fatalf("overwrite Shutdown failed: %v", err)
+	}
+	overwriteExporter.Close()
+	if got := string(mustReadFile(t, path)); got != "" {
+		t.Fatalf("overwrite mode did not truncate file: %q", got)
+	}
+}
+
+func readAtofRecords(t *testing.T, path string) []map[string]interface{} {
+	t.Helper()
+	content := strings.TrimSpace(string(mustReadFile(t, path)))
+	if content == "" {
+		return nil
+	}
+	lines := strings.Split(content, "\n")
+	records := make([]map[string]interface{}, 0, len(lines))
+	for _, line := range lines {
+		var record map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("invalid JSONL record %q: %v", line, err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return content
+}

--- a/go/nemo_flow/nemo_flow.go
+++ b/go/nemo_flow/nemo_flow.go
@@ -222,6 +222,15 @@ extern int32_t nemo_flow_atif_exporter_export(const void*, char**);
 extern int32_t nemo_flow_atif_exporter_clear(const void*);
 extern void nemo_flow_atif_exporter_free(void*);
 
+// ATOF JSONL exporter
+extern int32_t nemo_flow_atof_exporter_create(const char*, const char*, const char*, void**);
+extern int32_t nemo_flow_atof_exporter_register(const void*, const char*);
+extern int32_t nemo_flow_atof_exporter_deregister(const char*);
+extern int32_t nemo_flow_atof_exporter_force_flush(const void*);
+extern int32_t nemo_flow_atof_exporter_shutdown(const void*);
+extern int32_t nemo_flow_atof_exporter_path(const void*, char**);
+extern void nemo_flow_atof_exporter_free(void*);
+
 // OpenTelemetry subscriber
 extern int32_t nemo_flow_otel_subscriber_create(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, uint64_t, void**);
 extern int32_t nemo_flow_otel_subscriber_register(const void*, const char*);
@@ -305,6 +314,30 @@ var (
 		var ptr unsafe.Pointer
 		status := C.nemo_flow_atif_exporter_create(cSessionID, cAgentName, cAgentVersion, cModelName, &ptr)
 		return checkedValue(int32(status), &AtifExporter{ptr: ptr})
+	}
+	newAtofExporterFunc = func(config AtofExporterConfig) (*AtofExporter, error) {
+		if config.Mode == "" {
+			config.Mode = AtofExporterModeAppend
+		}
+
+		var cOutputDirectory *C.char
+		if config.OutputDirectory != "" {
+			cOutputDirectory = C.CString(config.OutputDirectory)
+			defer C.free(unsafe.Pointer(cOutputDirectory))
+		}
+
+		cMode := C.CString(string(config.Mode))
+		defer C.free(unsafe.Pointer(cMode))
+
+		var cFilename *C.char
+		if config.Filename != "" {
+			cFilename = C.CString(config.Filename)
+			defer C.free(unsafe.Pointer(cFilename))
+		}
+
+		var ptr unsafe.Pointer
+		status := C.nemo_flow_atof_exporter_create(cOutputDirectory, cMode, cFilename, &ptr)
+		return checkedValue(int32(status), &AtofExporter{ptr: ptr})
 	}
 )
 
@@ -1533,6 +1566,91 @@ func (e *AtifExporter) Clear() {
 func (e *AtifExporter) Close() {
 	if e.ptr != nil {
 		C.nemo_flow_atif_exporter_free(e.ptr)
+		e.ptr = nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ATOF JSONL Exporter
+// ---------------------------------------------------------------------------
+
+// AtofExporterMode controls how an ATOF JSONL exporter opens its output file.
+type AtofExporterMode string
+
+const (
+	// AtofExporterModeAppend appends events to an existing file.
+	AtofExporterModeAppend AtofExporterMode = "append"
+	// AtofExporterModeOverwrite truncates an existing file when the exporter is created.
+	AtofExporterModeOverwrite AtofExporterMode = "overwrite"
+)
+
+// AtofExporterConfig configures the filesystem-backed ATOF JSONL exporter.
+type AtofExporterConfig struct {
+	OutputDirectory string
+	Mode            AtofExporterMode
+	Filename        string
+}
+
+// NewAtofExporterConfig returns a config initialized with native defaults.
+func NewAtofExporterConfig() AtofExporterConfig {
+	return AtofExporterConfig{
+		Mode: AtofExporterModeAppend,
+	}
+}
+
+// AtofExporter writes raw NeMo Flow ATOF lifecycle events as JSONL.
+type AtofExporter struct {
+	ptr unsafe.Pointer
+}
+
+// NewAtofExporter creates a new filesystem-backed ATOF JSONL exporter.
+func NewAtofExporter(config AtofExporterConfig) (*AtofExporter, error) {
+	return newAtofExporterFunc(config)
+}
+
+// Path returns the JSONL output path.
+func (e *AtofExporter) Path() (string, error) {
+	var cOut *C.char
+	status := C.nemo_flow_atof_exporter_path(e.ptr, &cOut)
+	if err := checkStatus(status); err != nil {
+		return "", err
+	}
+	defer C.nemo_flow_string_free(cOut)
+	return C.GoString(cOut), nil
+}
+
+// Register registers the exporter as a global event subscriber.
+func (e *AtofExporter) Register(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	status := C.nemo_flow_atof_exporter_register(e.ptr, cName)
+	return checkStatus(status)
+}
+
+// Deregister removes the exporter subscriber by name.
+func (e *AtofExporter) Deregister(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	status := C.nemo_flow_atof_exporter_deregister(cName)
+	return checkStatus(status)
+}
+
+// ForceFlush flushes the output file.
+func (e *AtofExporter) ForceFlush() error {
+	status := C.nemo_flow_atof_exporter_force_flush(e.ptr)
+	return checkStatus(status)
+}
+
+// Shutdown flushes the output file.
+func (e *AtofExporter) Shutdown() error {
+	status := C.nemo_flow_atof_exporter_shutdown(e.ptr)
+	return checkStatus(status)
+}
+
+// Close frees the exporter handle.
+func (e *AtofExporter) Close() {
+	if e.ptr != nil {
+		C.nemo_flow_atof_exporter_free(e.ptr)
 		e.ptr = nil
 	}
 }

--- a/python/nemo_flow/__init__.py
+++ b/python/nemo_flow/__init__.py
@@ -22,7 +22,7 @@ Top-level exports also include:
   ``set_thread_scope_stack()``, and ``scope_stack_active()``
 - native runtime types such as ``ScopeHandle``, ``ToolHandle``, ``LLMHandle``,
   ``LLMRequest``, ``ScopeType``, and the lifecycle event classes
-- observability helpers such as ``AtifExporter``,
+- observability helpers such as ``AtifExporter``, ``AtofExporter``,
   ``OpenTelemetrySubscriber``, and ``OpenInferenceSubscriber``
 - JSON and callback type aliases used by middleware, typed wrappers, and
   plugin-facing configuration helpers
@@ -80,6 +80,9 @@ from nemo_flow._native import (
     AnnotatedLLMRequest,
     AnnotatedLLMResponse,
     AtifExporter,
+    AtofExporter,
+    AtofExporterConfig,
+    AtofExporterMode,
     LLMAttributes,
     LLMHandle,
     LLMRequest,
@@ -441,6 +444,9 @@ __all__ = [
     "AnnotatedLLMRequest",
     "AnnotatedLLMResponse",
     "AtifExporter",
+    "AtofExporterMode",
+    "AtofExporterConfig",
+    "AtofExporter",
     "OpenInferenceConfig",
     "OpenInferenceSubscriber",
     "OpenTelemetryConfig",

--- a/python/nemo_flow/__init__.pyi
+++ b/python/nemo_flow/__init__.pyi
@@ -46,6 +46,15 @@ from nemo_flow._native import (
     AtifExporter as AtifExporter,
 )
 from nemo_flow._native import (
+    AtofExporter as AtofExporter,
+)
+from nemo_flow._native import (
+    AtofExporterConfig as AtofExporterConfig,
+)
+from nemo_flow._native import (
+    AtofExporterMode as AtofExporterMode,
+)
+from nemo_flow._native import (
     LLMAttributes as LLMAttributes,
 )
 from nemo_flow._native import (

--- a/python/nemo_flow/_native.pyi
+++ b/python/nemo_flow/_native.pyi
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Mapping, Sequence
 from datetime import datetime
-from typing import Literal, Optional, TypeAlias
+from typing import ClassVar, Literal, Optional, TypeAlias
 
 _JsonPrimitive: TypeAlias = str | int | float | bool | None
 _JsonValue: TypeAlias = _JsonPrimitive | list["_JsonValue"] | dict[str, "_JsonValue"]
@@ -710,6 +710,46 @@ class AtifExporter:
         ...
     def clear(self) -> None:
         """Clear collected events without changing subscriber registration."""
+        ...
+
+class AtofExporterMode:
+    """File write mode for ``AtofExporter``."""
+
+    Append: ClassVar[AtofExporterMode]
+    Overwrite: ClassVar[AtofExporterMode]
+
+class AtofExporterConfig:
+    """Mutable configuration for the filesystem-backed ATOF JSONL exporter."""
+
+    output_directory: str
+    mode: AtofExporterMode
+    filename: str
+
+    def __init__(self) -> None:
+        """Create an ATOF exporter config with native defaults."""
+        ...
+
+class AtofExporter:
+    """Filesystem-backed exporter that writes raw ATOF events as JSONL."""
+
+    def __init__(self, config: AtofExporterConfig) -> None:
+        """Create an ATOF JSONL exporter from config."""
+        ...
+    @property
+    def path(self) -> str:
+        """Return the JSONL output path."""
+        ...
+    def register(self, name: str) -> None:
+        """Register the exporter under ``name``."""
+        ...
+    def deregister(self, name: str) -> bool:
+        """Deregister ``name`` and return whether it existed."""
+        ...
+    def force_flush(self) -> None:
+        """Flush the output file."""
+        ...
+    def shutdown(self) -> None:
+        """Flush the output file before shutdown."""
         ...
 
 class ScopeStack:

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -13,6 +13,9 @@ import pytest
 
 from nemo_flow import (
     AtifExporter,
+    AtofExporter,
+    AtofExporterConfig,
+    AtofExporterMode,
     JsonObject,
     LLMAttributes,
     LLMRequest,
@@ -439,6 +442,74 @@ class TestAtifExporterType:
             scope.pop(parent)
             assert exporter.deregister("py_atif_exporter") is True
             assert exporter.deregister("py_atif_exporter") is False
+
+
+class TestAtofExporterType:
+    def test_config_defaults_mutation_and_repr(self, tmp_path):
+        config = AtofExporterConfig()
+
+        assert config.mode == AtofExporterMode.Append
+        assert config.filename.startswith("nemo-flow-events-")
+        assert config.filename.endswith(".jsonl")
+        assert "AtofExporterConfig" in repr(config)
+
+        config.output_directory = str(tmp_path)
+        config.mode = AtofExporterMode.Overwrite
+        config.filename = "events.jsonl"
+
+        assert config.output_directory == str(tmp_path)
+        assert config.mode == AtofExporterMode.Overwrite
+        assert config.filename == "events.jsonl"
+
+    def test_exporter_lifecycle_writes_raw_jsonl_events(self, tmp_path):
+        config = AtofExporterConfig()
+        config.output_directory = str(tmp_path)
+        config.mode = AtofExporterMode.Overwrite
+        config.filename = "events.jsonl"
+
+        exporter = AtofExporter(config)
+        assert "<AtofExporter>" in repr(exporter)
+        assert exporter.path.endswith("events.jsonl")
+
+        subscriber_name = f"py_atof_{uuid4().hex}"
+        exporter.register(subscriber_name)
+        try:
+            handle = scope.push("atof_scope", ScopeType.Agent, input={"scope": True})
+            try:
+                scope.event("atof_mark", handle=handle, data={"step": 1})
+            finally:
+                scope.pop(handle, output={"done": True})
+        finally:
+            assert exporter.deregister(subscriber_name) is True
+            assert exporter.deregister(subscriber_name) is False
+            exporter.force_flush()
+            exporter.shutdown()
+            subscribers.deregister(subscriber_name)
+
+        lines = [json.loads(line) for line in (tmp_path / "events.jsonl").read_text().splitlines()]
+        assert [line["kind"] for line in lines] == ["scope", "mark", "scope"]
+        assert lines[0]["name"] == "atof_scope"
+        assert lines[1]["data"] == {"step": 1}
+        assert lines[2]["scope_category"] == "end"
+
+    def test_append_and_overwrite_modes(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        path.write_text('{"existing": true}\n')
+
+        append_config = AtofExporterConfig()
+        append_config.output_directory = str(tmp_path)
+        append_config.filename = "events.jsonl"
+        append_exporter = AtofExporter(append_config)
+        append_exporter.shutdown()
+        assert path.read_text().startswith('{"existing": true}\n')
+
+        overwrite_config = AtofExporterConfig()
+        overwrite_config.output_directory = str(tmp_path)
+        overwrite_config.mode = AtofExporterMode.Overwrite
+        overwrite_config.filename = "events.jsonl"
+        overwrite_exporter = AtofExporter(overwrite_config)
+        overwrite_exporter.shutdown()
+        assert path.read_text() == ""
 
 
 class TestOpenTelemetryTypes:


### PR DESCRIPTION
#### Overview

Adds a native filesystem-backed ATOF JSONL exporter that registers as a NeMo Flow event subscriber and writes one raw ATOF `Event` JSON object per line.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `nemo_flow::observability::atof::{AtofExporter, AtofExporterConfig, AtofExporterMode}` with append/overwrite modes, default current-directory output, generated UTC filenames, registration, deregistration, flush, and shutdown.
- Exposes native bindings through FFI, Python, Node.js, and Go with language-appropriate config and lifecycle APIs.
- Keeps WebAssembly unsupported for this filesystem-backed exporter and documents the native-only limitation.
- Adds core, FFI, Python, Node.js, Go, and WASM coverage for defaults, lifecycle behavior, JSONL output shape, append/overwrite behavior, and unsupported WASM surface.
- Updates observability export docs with Rust, Python, Node.js, and Go usage examples.

#### Where should the reviewer start?

Start with `crates/core/src/observability/atof.rs` for the exporter behavior, then review `crates/core/tests/unit/observability/atof_tests.rs` and the FFI/Python/Node/Go binding additions for API parity.

Validation run locally:

- `cargo fmt --all`
- `git diff --check`
- `just test-rust`
- `just test-python`
- `just test-node`
- `just test-go`
- `just test-wasm`
- `just docs`
- `cargo test -p nemo-flow observability::atof::tests -- --nocapture`
- Commit hooks passed with `lychee` skipped after it reported two unrelated generated Rust API doc links under `docs/reference/api/rust/_generated/nemo-flow-adaptive/...`; `just docs` passed.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none
