### PR TITLE
fix: enable TLS for OTLP HTTP export

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -102,5 +102,5 @@ path = "tests/integration/api_surface_tests.rs"
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client", "grpc-tonic"], optional = true }
+opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client", "reqwest-rustls", "grpc-tonic"], optional = true }
 tonic = { version = "0.14.1", default-features = false, optional = true }


### PR DESCRIPTION
#### Overview

Enable TLS support for NeMo Flow's native OTLP/HTTP exporter so direct HTTPS trace endpoints, including internal platform backed Datadog ingestion, work without routing through a local OpenTelemetry collector.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds the `reqwest-rustls` feature to the native `opentelemetry-otlp` dependency.

Validation:

- `cargo tree -p nemo-flow -e features -i reqwest --features otel --target x86_64-apple-darwin` confirms `reqwest/rustls-tls-native-roots` is enabled.
- `cargo test -p nemo-flow --features otel observability::otel::tests -- --nocapture`

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes NMF-112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry OTLP dependency configuration to include Rustls-based HTTP request support for improved TLS/SSL handling in non-WebAssembly environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->