### PR TITLE
docs: tolerate missing Node API docs declarations

### DIFF
--- a/scripts/docs/build_node_docs_artifacts.mjs
+++ b/scripts/docs/build_node_docs_artifacts.mjs
@@ -25,6 +25,7 @@ const MODULES = [
     deppath: './declarations/index.d',
     entryTarget: './declarations/index',
     pageName: 'runtime',
+    required: true,
     title: 'Runtime',
   },
   {
@@ -158,11 +159,12 @@ function main() {
   runCommand('npm', ['run', 'build-debug'], { cwd: nodePackageDir });
   resetGeneratedDirectories();
   ensureRequiredArtifacts(['index.js', 'index.d.ts']);
-  stageDeclarationSources();
-  writeModuleEntrypoints();
+  const modules = availableModules();
+  stageDeclarationSources(modules);
+  writeModuleEntrypoints(modules);
   writeDocsPackageManifest();
   runTypeDoc();
-  writeModulePages(readTypedocItems());
+  writeModulePages(readTypedocItems(), modules);
 }
 
 function runCommand(command, args, { cwd, env = process.env } = {}) {
@@ -196,6 +198,24 @@ function ensureRequiredArtifacts(artifacts) {
   }
 }
 
+function declarationPath(module) {
+  return path.join(nodePackageDir, module.declaration);
+}
+
+function availableModules() {
+  return MODULES.filter((module) => {
+    if (existsSync(declarationPath(module))) {
+      return true;
+    }
+    if (module.required) {
+      throw new Error(`Expected generated Node docs artifact missing: ${declarationPath(module)}`);
+    }
+
+    console.warn(`Skipping Node API docs module with no declaration artifact: ${module.declaration}`);
+    return false;
+  });
+}
+
 function normalizeDeclaration(filename, contents) {
   const normalized = filename === 'index.d.ts' ? stripInternalTestHelpers(contents) : contents;
   const rewrites = DECLARATION_REWRITES.get(filename);
@@ -225,17 +245,17 @@ function applyRewrite(filename, contents, { original, replacement }) {
   return contents.replace(original, replacement);
 }
 
-function stageDeclarationSources() {
-  for (const module of MODULES) {
-    const contents = readUtf8(path.join(nodePackageDir, module.declaration));
+function stageDeclarationSources(modules) {
+  for (const module of modules) {
+    const contents = readUtf8(declarationPath(module));
     writeUtf8(path.join(nodeDocsDeclDir, module.declaration), normalizeDeclaration(module.declaration, contents));
   }
 }
 
-function writeModuleEntrypoints() {
+function writeModuleEntrypoints(modules) {
   // TypeDoc works more predictably when each documented surface has its own
   // tiny entrypoint instead of pointing it at a directory of declarations.
-  for (const module of MODULES) {
+  for (const module of modules) {
     writeUtf8(path.join(nodeDocsSourceDir, `${module.pageName}.ts`), `export * from "${module.entryTarget}";\n`);
   }
 }
@@ -302,8 +322,8 @@ function readTypedocItems() {
   throw new Error(`Unexpected TypeDoc JSON structure in ${nodeApiJsonPath}`);
 }
 
-function writeModulePages(irObjects) {
-  const grouped = new Map(MODULES.map((module) => [module.deppath, []]));
+function writeModulePages(irObjects, modules) {
+  const grouped = new Map(modules.map((module) => [module.deppath, []]));
 
   for (const item of irObjects) {
     if (!isDocumentedNodeApiItem(item)) {
@@ -314,7 +334,7 @@ function writeModulePages(irObjects) {
     }
   }
 
-  for (const module of MODULES) {
+  for (const module of modules) {
     writeModulePage(module, grouped.get(module.deppath) ?? []);
   }
 }


### PR DESCRIPTION
#### Overview

Make the Node.js API docs artifact builder tolerate optional declaration files that are absent when sphinx-multiversion builds older release tags.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Keep the root `index.d.ts` artifact required so a broken Node package build still fails loudly.
- Filter subpath docs modules to the declaration files present in the checked-out version before staging declarations, writing TypeDoc entrypoints, and rendering generated pages.
- Log skipped optional modules, such as `observability.d.ts` in the `0.1.0` tag, instead of throwing `ENOENT` during multi-version docs builds.

Validation:

- `node --check scripts/docs/build_node_docs_artifacts.mjs`
- `just docs-github-pages`
- `SKIP=lychee git commit -s -m "docs: tolerate missing Node API docs declarations"` because the commit hook's docs markdown linkcheck failed on pre-existing generated Rust API links unrelated to this change.

#### Where should the reviewer start?

Start with `scripts/docs/build_node_docs_artifacts.mjs`, especially the new `availableModules()` filtering path and the places that now pass the filtered module list through staging, entrypoint generation, and page rendering.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Node API documentation build to dynamically validate available modules and gracefully skip missing optional ones.
  * Improved build pipeline reliability by threading computed modules list through documentation generation stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/94)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->