### PR TITLE
chore: prepare 0.2 code freeze

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,3 +3,4 @@
 
 branches:
   - main
+  - release/0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-flow"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-flow-adaptive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "nemo-flow",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-flow-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-flow-ffi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-flow-node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "napi",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-flow-python"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "nemo-flow",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-flow-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ exclude = [".tmp", ".uv-cache"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/NeMo-Flow"
 
 [workspace.dependencies]
-nemo-flow = { version = "0.2.0", path = "crates/core", default-features = false }
-nemo-flow-adaptive = { version = "0.2.0", path = "crates/adaptive" }
-nemo-flow-ffi = { version = "0.2.0", path = "crates/ffi" }
-nemo-flow-cli = { version = "0.2.0", path = "crates/cli" }
+nemo-flow = { version = "0.3.0", path = "crates/core", default-features = false }
+nemo-flow-adaptive = { version = "0.3.0", path = "crates/adaptive" }
+nemo-flow-ffi = { version = "0.3.0", path = "crates/ffi" }
+nemo-flow-cli = { version = "0.3.0", path = "crates/cli" }
 uuid = "=1.18.1"
 
 [workspace.lints.rust]

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-flow-node",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Node.js bindings for the NeMo Flow agent runtime.",
   "keywords": [
     "agents",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-flow-openclaw",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "NeMo Flow-authored observability plugin for OpenClaw.",
   "type": "module",
   "main": "./dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
     },
     "crates/node": {
       "name": "nemo-flow-node",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -835,7 +835,7 @@
     },
     "integrations/openclaw": {
       "name": "nemo-flow-openclaw",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "nemo-flow-node": ">0.1.0 <1.0.0"


### PR DESCRIPTION
#### Overview

Prepare the NeMo Flow `0.2.0` code freeze by cutting the release branch and moving `main` forward for post-freeze development.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Created upstream release branch `release/0.2` from `upstream/main` at `47e3414`, where the workspace version is `0.2.0`.
- Added `release/0.2` to `.github/nightly-alpha-branches.yaml` so nightly alpha tags continue for the frozen release branch.
- Ran `just set-version 0.3.0` to bump `main` package metadata and refreshed `Cargo.lock` with `cargo check --workspace`.
- Release-bound PRs for `0.2.0` should now target `release/0.2`; ongoing development PRs continue to target `main`.

Validation:

- `cargo check --workspace`
- `just set-version 0.3.0`
- `uv run python -c 'import yaml; [yaml.safe_load(open(path, encoding="utf-8")) for path in (".github/nightly-alpha-branches.yaml", ".github/workflows/nightly-alpha-tag.yaml")]'`
- `git diff --check`
- `uv run pre-commit run --files .github/nightly-alpha-branches.yaml Cargo.toml Cargo.lock crates/node/package.json integrations/openclaw/package.json package-lock.json`

Note: the Ruby YAML validation command from the freeze checklist could not be run locally because `ruby` is not installed; the Python YAML parse above covered the same files, and pre-commit `check yaml` passed.

#### Where should the reviewer start?

Start with `.github/nightly-alpha-branches.yaml` to confirm the release branch is included, then `Cargo.toml` for the `main` version bump to `0.3.0`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.3.0 across workspace and package manifests.
  * Added release/0.2 branch to nightly build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/103)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->