### PR TITLE
test: isolate CLI config override tests

### DIFF
--- a/crates/cli/tests/coverage/config_tests.rs
+++ b/crates/cli/tests/coverage/config_tests.rs
@@ -16,6 +16,10 @@ fn config() -> GatewayConfig {
     }
 }
 
+fn isolated_config_path(temp: &tempfile::TempDir) -> std::path::PathBuf {
+    temp.path().join("config.toml")
+}
+
 #[test]
 fn session_config_prefers_headers_and_parses_json() {
     let mut headers = HeaderMap::new();
@@ -607,7 +611,9 @@ openai_base_url = "http://file-openai"
 
 #[test]
 fn run_plugin_config_overrides_inherited_top_level_plugin_config() {
+    let temp = tempfile::tempdir().unwrap();
     let server = ServerArgs {
+        config: Some(isolated_config_path(&temp)),
         plugin_config: Some(r#"{"components":["top-level"]}"#.into()),
         ..ServerArgs::default()
     };
@@ -633,8 +639,9 @@ fn run_plugin_config_overrides_inherited_top_level_plugin_config() {
 
 #[test]
 fn server_resolution_applies_all_server_overrides() {
+    let temp = tempfile::tempdir().unwrap();
     let args = ServerArgs {
-        config: None,
+        config: Some(isolated_config_path(&temp)),
         bind: Some("127.0.0.1:0".parse().unwrap()),
         openai_base_url: Some("http://cli-openai".into()),
         anthropic_base_url: Some("http://cli-anthropic".into()),
@@ -655,9 +662,10 @@ fn server_resolution_applies_all_server_overrides() {
 
 #[test]
 fn run_resolution_applies_all_run_overrides() {
+    let temp = tempfile::tempdir().unwrap();
     let command = RunCommand {
         agent: Some(CodingAgent::Codex),
-        config: None,
+        config: Some(isolated_config_path(&temp)),
         openai_base_url: Some("http://run-openai".into()),
         anthropic_base_url: Some("http://run-anthropic".into()),
         session_metadata: Some(r#"{"team":"run"}"#.into()),


### PR DESCRIPTION
#### Overview

Isolates CLI config override unit tests from developer-level NeMo Flow configuration discovered through the normal user config path.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds a temp-scoped explicit config path helper for config tests that require no implicit user or project config discovery.
- Updates the affected override tests to use that explicit path instead of relying on ambient process configuration.

#### Where should the reviewer start?

Start with `crates/cli/tests/coverage/config_tests.rs`, especially the tests around CLI plugin config overrides.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for configuration resolution by improving test isolation and setup processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/105)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->