### PR TITLE
chore: keep OpenClaw dependency in lockstep

### DIFF
--- a/.github/workflows/ci_openclaw.yml
+++ b/.github/workflows/ci_openclaw.yml
@@ -76,7 +76,7 @@ jobs:
           if [ "${{ inputs.ref_type }}" = "tag" ]; then
             version="${{ inputs.ref_name }}"
           else
-            version="${version}-${sha}"
+            version="${version}+${sha}"
           fi
           printf 'NEMO_FLOW_PACKAGE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
 

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -58,7 +58,7 @@
     "openclaw": ">=2026.5.6"
   },
   "dependencies": {
-    "nemo-flow-node": ">0.1.0 <1.0.0"
+    "nemo-flow-node": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.0",

--- a/justfile
+++ b/justfile
@@ -313,6 +313,75 @@ try {
 NODE
 }
 
+set_npm_package_dependency_version() {
+    local pkg_path="$1"
+    local lock_path="${2:-}"
+    local lock_package_path="$3"
+    local dependency_name="$4"
+    local version="$5"
+
+    node - "$pkg_path" "$lock_path" "$lock_package_path" "$dependency_name" "$version" <<'NODE'
+const fs = require('fs');
+const [pkgPath, lockPath, lockPackagePath, dependencyName, version] = process.argv.slice(2);
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+function writeJson(path, value) {
+  fs.writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+}
+
+function requireDependency(container, label) {
+  if (
+    !container.dependencies ||
+    !Object.prototype.hasOwnProperty.call(container.dependencies, dependencyName)
+  ) {
+    throw new Error(`${label} missing dependencies["${dependencyName}"]`);
+  }
+}
+
+try {
+  const manifest = readJson(pkgPath);
+  requireDependency(manifest, pkgPath);
+  const manifestChanged = manifest.dependencies[dependencyName] !== version;
+
+  let lock = null;
+  let lockChanged = false;
+  if (lockPath) {
+    lock = readJson(lockPath);
+    if (!lock.packages) {
+      throw new Error(`${lockPath} missing packages`);
+    }
+    const packageEntry = lock.packages[lockPackagePath];
+    if (!packageEntry) {
+      throw new Error(`${lockPath} missing packages["${lockPackagePath}"]`);
+    }
+    requireDependency(packageEntry, `${lockPath} packages["${lockPackagePath}"]`);
+    lockChanged = packageEntry.dependencies[dependencyName] !== version;
+  }
+
+  manifest.dependencies[dependencyName] = version;
+  if (lock) {
+    lock.packages[lockPackagePath].dependencies[dependencyName] = version;
+  }
+
+  if (manifestChanged) {
+    writeJson(pkgPath, manifest);
+  }
+
+  if (lockPath) {
+    if (lockChanged) {
+      writeJson(lockPath, lock);
+    }
+  }
+} catch (error) {
+  console.error(`Error updating package dependency: ${error.message}`);
+  process.exit(1);
+}
+NODE
+}
+
 read_workspace_version() {
     local python_executable=""
     python_executable="$(uv_python_executable)"
@@ -441,6 +510,7 @@ set_node_package_versions() {
     local version="$1"
     set_npm_package_version crates/node/package.json package-lock.json "$version" crates/node
     set_npm_package_version integrations/openclaw/package.json package-lock.json "$version" integrations/openclaw
+    set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-flow-node "$version"
 }
 
 set_node_package_version() {
@@ -992,10 +1062,12 @@ package-node:
         package_version="${version}+${sha}"
         echo "Non-release build: appending commit hash to version"
         set_npm_package_version crates/node/package.json package-lock.json "$package_version" crates/node
+        set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-flow-node "$package_version"
     else
         package_version="{{ ref_name }}"
         echo "Using explicit version {{ ref_name }}"
         set_npm_package_version crates/node/package.json package-lock.json "$package_version" crates/node
+        set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-flow-node "$package_version"
     fi
     build_args=(build)
     if is_true "{{ ci }}" && [[ "$(uname -s)" == "Linux" ]]; then
@@ -1028,11 +1100,15 @@ package-openclaw:
     if [[ -z "{{ ref_name }}" ]]; then
         sha="$(head_git_sha)"
         version="$(read_npm_package_version integrations/openclaw/package.json)"
+        package_version="${version}+${sha}"
         echo "Non-release build: appending commit hash to version"
-        set_npm_package_version integrations/openclaw/package.json package-lock.json "${version}-${sha}" integrations/openclaw
+        set_npm_package_version integrations/openclaw/package.json package-lock.json "$package_version" integrations/openclaw
+        set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-flow-node "$package_version"
     else
+        package_version="{{ ref_name }}"
         echo "Using explicit version {{ ref_name }}"
-        set_npm_package_version integrations/openclaw/package.json package-lock.json "{{ ref_name }}" integrations/openclaw
+        set_npm_package_version integrations/openclaw/package.json package-lock.json "$package_version" integrations/openclaw
+        set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-flow-node "$package_version"
     fi
     npm install --workspace=nemo-flow-openclaw --ignore-scripts
     npm pack --workspace=nemo-flow-openclaw --pack-destination "$package_dir"

--- a/package-lock.json
+++ b/package-lock.json
@@ -838,7 +838,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nemo-flow-node": ">0.1.0 <1.0.0"
+        "nemo-flow-node": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^20.19.0",


### PR DESCRIPTION
#### Overview

Keep the OpenClaw plugin package dependency on `nemo-flow-node` aligned with the package version emitted by repository versioning and packaging workflows.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Change `nemo-flow-openclaw` to depend on the exact checked-in `nemo-flow-node` version.
- Add a `justfile` helper that updates package dependency versions in both `package.json` and `package-lock.json`.
- Wire the dependency update into `set-version`, `package-node`, and `package-openclaw` so prerelease package builds keep the Node and OpenClaw versions together.
- Align OpenClaw non-tag CI package version suffixing with the Node package workflow.

Validation run:

- `just set-version 0.2.0-alpha.20260514`, verified OpenClaw's `nemo-flow-node` dependency updated without dependency success logs, then restored with `just set-version 0.2.0`.
- `npm install --workspace=nemo-flow-node --ignore-scripts`
- `npm install --workspace=nemo-flow-openclaw --ignore-scripts`
- `npm run typecheck --workspace=nemo-flow-openclaw`
- `npm run pack:check --workspace=nemo-flow-openclaw`
- `just --list`
- `git diff --check`
- Commit-time pre-commit hooks passed for the staged files.

#### Where should the reviewer start?

Start with `justfile`, especially the new package dependency version helper and its calls from `set_node_package_versions`, `package-node`, and `package-openclaw`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refined OpenClaw package versioning format for improved clarity
  * Pinned nemo-flow-node dependency to a stable version for enhanced reliability
  * Improved build and packaging tooling to ensure consistent dependency alignment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->