### PR TITLE
chore: bump OpenClaw node dependency to 0.3.0

### DIFF
--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -58,7 +58,7 @@
     "openclaw": ">=2026.5.12"
   },
   "dependencies": {
-    "nemo-flow-node": "0.2.0"
+    "nemo-flow-node": "0.3.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -838,7 +838,7 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nemo-flow-node": "0.2.0"
+        "nemo-flow-node": "0.3.0"
       },
       "devDependencies": {
         "@types/node": "^20.19.0",


### PR DESCRIPTION
#### Overview

Update the OpenClaw integration package metadata so its `nemo-flow-node` dependency matches the `0.3.0` package version.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Bumped `integrations/openclaw/package.json` from `nemo-flow-node` `0.2.0` to `0.3.0`.
- Updated the corresponding `package-lock.json` entry.
- Validation: parsed `integrations/openclaw/package.json` and `package-lock.json` with Node to confirm both remain valid JSON.

#### Where should the reviewer start?

`integrations/openclaw/package.json`, then the matching lockfile entry in `package-lock.json`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/113)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->