### PR TITLE
fix: add OpenClaw npm provenance metadata

### DIFF
--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "description": "NeMo Flow-authored observability plugin for OpenClaw.",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NVIDIA/NeMo-Flow",
+    "directory": "integrations/openclaw"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/integrations/openclaw/scripts/check-pack-payload.mjs
+++ b/integrations/openclaw/scripts/check-pack-payload.mjs
@@ -88,6 +88,15 @@ const packedFiles = new Set(packInfo.files.map((file) => normalizePackagePath(fi
 const packageJson = JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8"));
 const declaredFiles = new Set(packageJson.files ?? []);
 
+assert(
+  packageJson.repository?.url === "https://github.com/NVIDIA/NeMo-Flow",
+  'package repository.url must match the GitHub Actions provenance source repository',
+);
+assert(
+  packageJson.repository?.directory === "integrations/openclaw",
+  "package repository.directory must identify the OpenClaw workspace",
+);
+
 for (const entry of declaredFiles) {
   assert(
     !(entry.startsWith("src/") && entry.includes("*")),


### PR DESCRIPTION
#### Overview

Fix the OpenClaw npm publish failure by declaring repository metadata that matches GitHub Actions provenance for the `nemo-flow-openclaw` package.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Added `repository` metadata to `integrations/openclaw/package.json` with the NVIDIA/NeMo-Flow source repository and OpenClaw workspace directory.
- Extended the OpenClaw pack payload check to require the provenance-sensitive repository URL and package directory before publish.
- Validated with `npm run pack:check --workspace=nemo-flow-openclaw`, `uv run pre-commit run --files integrations/openclaw/package.json integrations/openclaw/scripts/check-pack-payload.mjs`, and `just --set ci true test-openclaw`.
- `uv run pre-commit run --all-files` completed all remaining hooks except the unrelated local `ty` unresolved imports for `deepagents.create_deep_agent` and `deepagents.backends` in `python/tests/integrations/deepagents/test_deepagents_integration.py`.

#### Where should the reviewer start?

Start with `integrations/openclaw/package.json`, then check the new guard in `integrations/openclaw/scripts/check-pack-payload.mjs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: https://github.com/NVIDIA/NeMo-Flow/actions/runs/25895241662/job/76109056996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to properly reference the repository location.
  * Strengthened build validation to ensure package configuration consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/114)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->