### PR TITLE
docs: bump docs to align with 0.3

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,4 +3,3 @@
 
 branches:
   - main
-  - release/0.2

--- a/docs/about/release-notes/highlights.md
+++ b/docs/about/release-notes/highlights.md
@@ -7,32 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 This page summarizes the notable capabilities in the current release documentation set.
 
-## NeMo Flow 0.2
+## NeMo Flow 0.3
 
 This release of NeMo Flow release introduces several new components and capabilities.
 The complete changelog and release notes can be viewed on [GitHub](https://github.com/NVIDIA/NeMo-Flow/releases).
-
-### NeMo Flow CLI
-
-- Added CLI support for coding-agent harnesses, including Claude Code, Codex, Cursor, and Hermes Agent.
-- Enhanced setup and configuration workflows with guided onboarding, environment diagnostics, plugin configuration loading, and plugin editing.
-
-### Integrations
-
-- Added OpenClaw observability support through a first-party `nemo-flow-openclaw` plugin.
-- Added middleware and runtime integrations for LangChain, LangGraph, and Deep Agents. These are accessed through the Python `nemo-flow` package through extras.
-
-### Observability
-
-- Introduced a core Observability plugin that globally configures all built-in observability exporters and subscribers.
-- Added an Agent Trajectory Observability Format (ATOF) JSONL exporter for structured event output.
-- Expanded Codec support for optional annotated LLM request and response fields.
-
-### Security
-
-- Added an example NeMo Guardrails plugin.
-
-### Agent Skill Improvements
-
-- Updated Python binding test guidance for agent skills.
-- Added PR template requirements to agent contribution guidance.

--- a/docs/about/release-notes/known-issues.md
+++ b/docs/about/release-notes/known-issues.md
@@ -7,13 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 
 This page lists current limitations and support notes for the release documentation set.
 
-## NeMo Flow 0.2
+## NeMo Flow 0.3
 
-These notes apply to the NeMo Flow 0.2 Release.
+These notes apply to the NeMo Flow 0.3 Release.
 
 - Go, WebAssembly, and the raw C FFI surface are experimental and source-first.
 - Generated API pages cover Rust, Python, and Node.js. Experimental bindings do not yet have the same generated documentation depth.
 - The NeMo Flow CLI is experimental. Coding agent observability support varies due to capabilities of hooks. Any encountered problems should be filed as bugs.
+
+### Fixed issues from NeMo Flow 0.2:
+
 
 ### Fixed issues from NeMo Flow 0.1:
 - Enabled TLS support for OTLP HTTP export.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,7 +18,7 @@ Install the NeMo Flow CLI when you want the `nemo-flow` executable for
 coding-agent hook and LLM gateway observability.
 
 ```bash
-cargo install nemo-flow-cli@0.2.0
+cargo install nemo-flow-cli@0.3.0
 ```
 
 ## Python
@@ -27,7 +27,7 @@ Install the Python package when your application uses NeMo Flow through the
 Python wrapper.
 
 ```bash
-uv add nemo-flow@0.2.0
+uv add nemo-flow@0.3.0
 ```
 
 Use `uv add` from an application project that has a `pyproject.toml`; it records
@@ -50,8 +50,8 @@ npm install nemo-flow-node
 Add the Rust crates when your application uses NeMo Flow directly from Rust.
 
 ```bash
-cargo add nemo-flow@0.2.0
-cargo add nemo-flow-adaptive@0.2.0
+cargo add nemo-flow@0.3.0
+cargo add nemo-flow-adaptive@0.3.0
 ```
 
 - `nemo-flow` provides the core runtime APIs for scopes, middleware, subscribers, plugins, tool calls, and LLM calls.
@@ -68,7 +68,7 @@ Install the OpenClaw plugin through OpenClaw so OpenClaw can register and manage
 the package:
 
 ```bash
-openclaw plugins install npm:nemo-flow-openclaw@0.2.0
+openclaw plugins install npm:nemo-flow-openclaw@0.3.0
 openclaw gateway restart
 ```
 
@@ -83,7 +83,7 @@ Install the Python package with the supported framework extras when your
 application uses LangChain, LangGraph, or Deep Agents.
 
 ```bash
-uv add "nemo-flow[langchain,langgraph,deepagents]@0.2.0"
+uv add "nemo-flow[langchain,langgraph,deepagents]@0.3.0"
 ```
 
 The extras install the NeMo Flow Python package plus the dependencies needed by

--- a/docs/getting-started/python/index.md
+++ b/docs/getting-started/python/index.md
@@ -19,7 +19,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-uv add nemo-flow@0.2.0
+uv add nemo-flow@0.3.0
 ```
 
 Run `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/rust.md
+++ b/docs/getting-started/rust.md
@@ -17,8 +17,8 @@ local checkout.
 Use the published crates when you are consuming a release:
 
 ```bash
-cargo add nemo-flow@0.2.0
-cargo add nemo-flow-adaptive@0.2.0
+cargo add nemo-flow@0.3.0
+cargo add nemo-flow-adaptive@0.3.0
 cargo add serde_json
 ```
 
@@ -26,7 +26,7 @@ Install the published NeMo Flow CLI separately when you need coding-agent hook
 and LLM gateway observability:
 
 ```bash
-cargo install nemo-flow-cli@0.2.0
+cargo install nemo-flow-cli@0.3.0
 ```
 
 ### Install from the Repository
@@ -42,7 +42,7 @@ serde_json = "1"
 
 - `nemo-flow` is the core Rust runtime surface.
 - `nemo-flow-adaptive` is the companion crate for adaptive runtime primitives and Redis-backed learning components.
-- `nemo-flow-cli` is a binary crate. Use `cargo install nemo-flow-cli@0.2.0` when
+- `nemo-flow-cli` is a binary crate. Use `cargo install nemo-flow-cli@0.3.0` when
   you need the NeMo Flow CLI.
 
 ## Push a Scope and Emit a Mark

--- a/docs/integrations/openclaw-plugin.md
+++ b/docs/integrations/openclaw-plugin.md
@@ -38,7 +38,7 @@ Optional:
 Install the plugin with OpenClaw so OpenClaw can register and manage it:
 
 ```bash
-openclaw plugins install npm:nemo-flow-openclaw@0.2.0
+openclaw plugins install npm:nemo-flow-openclaw@0.3.0
 openclaw gateway restart
 ```
 
@@ -51,7 +51,7 @@ If you manage OpenClaw plugin dependencies directly in a Node.js project,
 install the package with npm:
 
 ```bash
-npm install nemo-flow-openclaw@0.2.0
+npm install nemo-flow-openclaw@0.3.0
 ```
 
 Installing with npm makes the package available to that project. Use

--- a/docs/plugins/observability/configuration.md
+++ b/docs/plugins/observability/configuration.md
@@ -75,7 +75,7 @@ transport = "http_binary"
 endpoint = "http://localhost:4318/v1/traces"
 service_name = "nemo-flow"
 service_namespace = "agent"
-service_version = "0.2.0"
+service_version = "0.3.0"
 instrumentation_scope = "nemo-flow-observability"
 timeout_millis = 3000
 
@@ -92,7 +92,7 @@ transport = "http_binary"
 endpoint = "http://localhost:6006/v1/traces"
 service_name = "nemo-flow"
 service_namespace = "agent"
-service_version = "0.2.0"
+service_version = "0.3.0"
 instrumentation_scope = "nemo-flow-openinference"
 timeout_millis = 3000
 
@@ -151,7 +151,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:4318/v1/traces",
                     service_name="nemo-flow",
                     service_namespace="agent",
-                    service_version="0.2.0",
+                    service_version="0.3.0",
                     instrumentation_scope="nemo-flow-observability",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -160,7 +160,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:6006/v1/traces",
                     service_name="nemo-flow",
                     service_namespace="agent",
-                    service_version="0.2.0",
+                    service_version="0.3.0",
                     instrumentation_scope="nemo-flow-openinference",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -211,7 +211,7 @@ await plugin.initialize({
         endpoint: "http://localhost:4318/v1/traces",
         service_name: "nemo-flow",
         service_namespace: "agent",
-        service_version: "0.2.0",
+        service_version: "0.3.0",
         instrumentation_scope: "nemo-flow-observability",
         resource_attributes: {
           "deployment.environment": "dev",
@@ -222,7 +222,7 @@ await plugin.initialize({
         endpoint: "http://localhost:6006/v1/traces",
         service_name: "nemo-flow",
         service_namespace: "agent",
-        service_version: "0.2.0",
+        service_version: "0.3.0",
         instrumentation_scope: "nemo-flow-openinference",
         resource_attributes: {
           "deployment.environment": "dev",
@@ -269,7 +269,7 @@ let component = ComponentSpec::new(ObservabilityConfig {
         endpoint: Some("http://localhost:4318/v1/traces".into()),
         service_name: "nemo-flow".into(),
         service_namespace: Some("agent".into()),
-        service_version: Some("0.2.0".into()),
+        service_version: Some("0.3.0".into()),
         instrumentation_scope: Some("nemo-flow-observability".into()),
         resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
         ..OtlpSectionConfig::default()
@@ -279,7 +279,7 @@ let component = ComponentSpec::new(ObservabilityConfig {
         endpoint: Some("http://localhost:6006/v1/traces".into()),
         service_name: "nemo-flow".into(),
         service_namespace: Some("agent".into()),
-        service_version: Some("0.2.0".into()),
+        service_version: Some("0.3.0".into()),
         instrumentation_scope: Some("nemo-flow-openinference".into()),
         resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
         ..OtlpSectionConfig::default()


### PR DESCRIPTION
#### Overview

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Align documentation to 0.3 version

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation and release notes to reflect NeMo Flow version 0.3.0
  * Updated installation guides for Rust CLI, Python, and npm packages to 0.3.0
  * Updated observability and OpenClaw plugin configuration examples to 0.3.0
  * Added NeMo Flow 0.3 release highlights and known issues sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->