### PR TITLE
ci: add cli draft release assets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -337,7 +337,7 @@ jobs:
           merge-multiple: true
           path: release-assets/
 
-      - name: Verify CLI release assets and generate checksums
+      - name: Generate CLI release checksums
         run: |
           set -euo pipefail
 
@@ -349,22 +349,6 @@ jobs:
             "nemo-flow-cli-x86_64-pc-windows-msvc-${version}.exe"
             "nemo-flow-cli-aarch64-pc-windows-msvc-${version}.exe"
           )
-
-          for asset in "${expected_assets[@]}"; do
-            if [ ! -f "release-assets/${asset}" ]; then
-              echo "Error: expected CLI release asset release-assets/${asset}" >&2
-              exit 1
-            fi
-          done
-
-          shopt -s nullglob
-          downloaded_assets=(release-assets/*)
-          if ((${#downloaded_assets[@]} != ${#expected_assets[@]})); then
-            echo "Error: unexpected CLI release asset set" >&2
-            printf 'Downloaded assets:\n' >&2
-            printf '  %s\n' "${downloaded_assets[@]}" >&2
-            exit 1
-          fi
 
           (
             cd release-assets
@@ -388,18 +372,7 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
           overwrite_files: true
           fail_on_unmatched_files: true
-          files: |
-            release-assets/nemo-flow-cli-x86_64-unknown-linux-musl-${{ github.ref_name }}
-            release-assets/nemo-flow-cli-x86_64-unknown-linux-musl-${{ github.ref_name }}.sha256
-            release-assets/nemo-flow-cli-aarch64-unknown-linux-musl-${{ github.ref_name }}
-            release-assets/nemo-flow-cli-aarch64-unknown-linux-musl-${{ github.ref_name }}.sha256
-            release-assets/nemo-flow-cli-aarch64-apple-darwin-${{ github.ref_name }}
-            release-assets/nemo-flow-cli-aarch64-apple-darwin-${{ github.ref_name }}.sha256
-            release-assets/nemo-flow-cli-x86_64-pc-windows-msvc-${{ github.ref_name }}.exe
-            release-assets/nemo-flow-cli-x86_64-pc-windows-msvc-${{ github.ref_name }}.exe.sha256
-            release-assets/nemo-flow-cli-aarch64-pc-windows-msvc-${{ github.ref_name }}.exe
-            release-assets/nemo-flow-cli-aarch64-pc-windows-msvc-${{ github.ref_name }}.exe.sha256
-            release-assets/SHA256SUMS
+          files: release-assets/*
 
   publish-rust:
     name: Publish (crates.io)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -337,26 +337,69 @@ jobs:
           merge-multiple: true
           path: release-assets/
 
-      - name: Verify CLI release assets
+      - name: Verify CLI release assets and generate checksums
         run: |
           set -euo pipefail
+
+          version="${{ github.ref_name }}"
+          expected_assets=(
+            "nemo-flow-cli-x86_64-unknown-linux-musl-${version}"
+            "nemo-flow-cli-aarch64-unknown-linux-musl-${version}"
+            "nemo-flow-cli-aarch64-apple-darwin-${version}"
+            "nemo-flow-cli-x86_64-pc-windows-msvc-${version}.exe"
+            "nemo-flow-cli-aarch64-pc-windows-msvc-${version}.exe"
+          )
+
+          for asset in "${expected_assets[@]}"; do
+            if [ ! -f "release-assets/${asset}" ]; then
+              echo "Error: expected CLI release asset release-assets/${asset}" >&2
+              exit 1
+            fi
+          done
+
           shopt -s nullglob
-          assets=(release-assets/*)
-          if ((${#assets[@]} == 0)); then
-            echo "Error: no CLI release assets were downloaded" >&2
+          downloaded_assets=(release-assets/*)
+          if ((${#downloaded_assets[@]} != ${#expected_assets[@]})); then
+            echo "Error: unexpected CLI release asset set" >&2
+            printf 'Downloaded assets:\n' >&2
+            printf '  %s\n' "${downloaded_assets[@]}" >&2
             exit 1
           fi
-          printf 'CLI release assets:\n'
-          printf '  %s\n' "${assets[@]}"
 
-      - name: Upload CLI assets to draft GitHub Release
+          (
+            cd release-assets
+            sha256sum "${expected_assets[@]}" > SHA256SUMS
+            sha256sum --check SHA256SUMS
+
+            while read -r digest filename; do
+              printf '%s  %s\n' "$digest" "$filename" > "${filename}.sha256"
+            done < SHA256SUMS
+          )
+
+          printf 'CLI release assets:\n'
+          printf '  release-assets/%s\n' "${expected_assets[@]}"
+          printf '  release-assets/%s.sha256\n' "${expected_assets[@]}"
+          printf '  release-assets/SHA256SUMS\n'
+
+      - name: Upload CLI assets and checksums to draft GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           draft: true
           prerelease: ${{ contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
           overwrite_files: true
           fail_on_unmatched_files: true
-          files: release-assets/*
+          files: |
+            release-assets/nemo-flow-cli-x86_64-unknown-linux-musl-${{ github.ref_name }}
+            release-assets/nemo-flow-cli-x86_64-unknown-linux-musl-${{ github.ref_name }}.sha256
+            release-assets/nemo-flow-cli-aarch64-unknown-linux-musl-${{ github.ref_name }}
+            release-assets/nemo-flow-cli-aarch64-unknown-linux-musl-${{ github.ref_name }}.sha256
+            release-assets/nemo-flow-cli-aarch64-apple-darwin-${{ github.ref_name }}
+            release-assets/nemo-flow-cli-aarch64-apple-darwin-${{ github.ref_name }}.sha256
+            release-assets/nemo-flow-cli-x86_64-pc-windows-msvc-${{ github.ref_name }}.exe
+            release-assets/nemo-flow-cli-x86_64-pc-windows-msvc-${{ github.ref_name }}.exe.sha256
+            release-assets/nemo-flow-cli-aarch64-pc-windows-msvc-${{ github.ref_name }}.exe
+            release-assets/nemo-flow-cli-aarch64-pc-windows-msvc-${{ github.ref_name }}.exe.sha256
+            release-assets/SHA256SUMS
 
   publish-rust:
     name: Publish (crates.io)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -321,6 +321,43 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 
+  release-cli-artifacts:
+    name: Release CLI Artifacts
+    needs: [prepare, ci_required]
+    if: ${{ needs.prepare.outputs.publish_packages == 'true' && needs.ci_required.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Download CLI binary artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: cli-*
+          merge-multiple: true
+          path: release-assets/
+
+      - name: Verify CLI release assets
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(release-assets/*)
+          if ((${#assets[@]} == 0)); then
+            echo "Error: no CLI release assets were downloaded" >&2
+            exit 1
+          fi
+          printf 'CLI release assets:\n'
+          printf '  %s\n' "${assets[@]}"
+
+      - name: Upload CLI assets to draft GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          files: release-assets/*
+
   publish-rust:
     name: Publish (crates.io)
     needs: [prepare, ci_required]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -341,29 +341,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          version="${{ github.ref_name }}"
-          expected_assets=(
-            "nemo-flow-cli-x86_64-unknown-linux-musl-${version}"
-            "nemo-flow-cli-aarch64-unknown-linux-musl-${version}"
-            "nemo-flow-cli-aarch64-apple-darwin-${version}"
-            "nemo-flow-cli-x86_64-pc-windows-msvc-${version}.exe"
-            "nemo-flow-cli-aarch64-pc-windows-msvc-${version}.exe"
-          )
-
           (
             cd release-assets
-            sha256sum "${expected_assets[@]}" > SHA256SUMS
+            cli_assets=(nemo-flow-cli-*)
+            sha256sum "${cli_assets[@]}" > SHA256SUMS
             sha256sum --check SHA256SUMS
 
             while read -r digest filename; do
               printf '%s  %s\n' "$digest" "$filename" > "${filename}.sha256"
             done < SHA256SUMS
-          )
 
-          printf 'CLI release assets:\n'
-          printf '  release-assets/%s\n' "${expected_assets[@]}"
-          printf '  release-assets/%s.sha256\n' "${expected_assets[@]}"
-          printf '  release-assets/SHA256SUMS\n'
+            printf 'CLI release assets:\n'
+            printf '  release-assets/%s\n' *
+          )
 
       - name: Upload CLI assets and checksums to draft GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -167,14 +167,19 @@ jobs:
         include:
           - platform: linux-amd64
             runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
           - platform: linux-arm64
             runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
           - platform: macos-arm64
             runner: macos-15
+            target: aarch64-apple-darwin
           - platform: windows-amd64
             runner: windows-2022
+            target: x86_64-pc-windows-msvc
           - platform: windows-arm64
             runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
 
     steps:
       - name: Checkout
@@ -188,6 +193,7 @@ jobs:
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
+          target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -197,27 +203,42 @@ jobs:
           cache-bin: false
           save-if: false
 
+      - name: Install musl tools
+        if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-musl') || startsWith(matrix.target, 'aarch64-unknown-linux-musl') }}
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
       - name: Build CLI release binary
         working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
         run: |
           set -e
-          cargo build --release -p nemo-flow-cli
+          cargo build --release --target "${{ matrix.target }}" -p nemo-flow-cli
 
       - name: Stage CLI binary artifact
         working-directory: ${{ env.NEMO_FLOW_CI_WORKSPACE }}
         run: |
           set -euo pipefail
+          target="${{ matrix.target }}"
+          version="${{ github.ref_name }}"
+          if [ "${{ github.ref_type }}" != "tag" ]; then
+            version="dev-${GIT_COMMIT::8}"
+          fi
           binary="nemo-flow"
+          asset="nemo-flow-cli-${target}-${version}"
           if [ "${{ runner.os }}" = "Windows" ]; then
             binary="${binary}.exe"
+            asset="${asset}.exe"
           fi
-          source="${NEMO_FLOW_CI_WORKSPACE}/target/release/${binary}"
+          source="${NEMO_FLOW_CI_WORKSPACE}/target/${target}/release/${binary}"
           if [ ! -f "$source" ]; then
             echo "Error: expected CLI binary at ${source}" >&2
             exit 1
           fi
+          rm -rf "${NEMO_FLOW_CI_WORKSPACE_TMP}/cli"
           mkdir -p "${NEMO_FLOW_CI_WORKSPACE_TMP}/cli"
-          cp "$source" "${NEMO_FLOW_CI_WORKSPACE_TMP}/cli/${binary}"
+          cp "$source" "${NEMO_FLOW_CI_WORKSPACE_TMP}/cli/${asset}"
 
       - name: Upload CLI binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "nemo-flow"
 path = "src/main.rs"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ target }-{ version }{ archive-suffix }"
+pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ target }-{ version }{ binary-ext }"
 pkg-fmt = "bin"
 
 [lints]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,10 @@ description = "Coding-agent gateway CLI for NeMo Flow observability."
 name = "nemo-flow"
 path = "src/main.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ target }-{ version }{ archive-suffix }"
+pkg-fmt = "bin"
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
#### Overview

Adds cargo-binstall-compatible direct CLI binary assets for non-alpha release tags, with Linux release binaries built against musl for wider compatibility. The draft release upload also publishes SHA-256 checksums for the direct binaries. Documentation changes were left out because they are handled in a separate PR.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `[package.metadata.binstall]` metadata to `nemo-flow-cli` using the direct binary asset URL pattern expected by cargo-binstall.
- Updates the Rust package workflow to build `nemo-flow-cli` for the five release targets, using musl targets for Linux.
- Stages release assets as `nemo-flow-cli-<target>-<version>[.exe]` direct binaries.
- Adds a top-level release asset upload job gated by the existing non-alpha publish policy, with draft GitHub Release uploads via `softprops/action-gh-release`.
- Generates `SHA256SUMS` from downloaded `nemo-flow-cli-*` assets, verifies it locally, creates one `.sha256` sidecar per CLI binary, and uploads the resulting `release-assets/*` set.
- Marks beta and rc tags as GitHub prereleases while leaving alpha tags skipped by the existing publish gate.

Validation:
- `ruby -e 'require "yaml"; [".github/workflows/ci.yaml", ".github/workflows/ci_rust.yml"].each { |f| YAML.load_file(f) }; puts "workflow-yaml-ok"'`
- `cargo metadata --no-deps --format-version 1 >/dev/null`
- `git diff --check -- .github/workflows/ci.yaml .github/workflows/ci_rust.yml crates/cli/Cargo.toml`
- `uv run pre-commit run --files .github/workflows/ci.yaml .github/workflows/ci_rust.yml crates/cli/Cargo.toml`
- `uv run pre-commit run --files .github/workflows/ci.yaml`
- `cargo build --release --target aarch64-apple-darwin -p nemo-flow-cli`

#### Where should the reviewer start?

Start with `.github/workflows/ci_rust.yml` for the target-specific CLI binary packaging path, then `.github/workflows/ci.yaml` for the draft release upload and checksum generation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated publishing of platform-specific CLI binaries to draft releases, including generation of overall and per-file SHA256 checksums.
  * Release uploads automatically mark prereleases for beta/RC refs and fail on unexpected/missing files to ensure release integrity.
  * Expanded cross-platform build matrix to produce musl, macOS, and Windows artifacts with explicit target handling and versioned artifact names.
  * Added packaging metadata to support binstall-style distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->