### PR TITLE
fix: emit LLM start before execution intercepts

### DIFF
--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use bitflags::bitflags;
 use chrono::{DateTime, Utc};
@@ -301,18 +300,6 @@ fn emit_llm_start(
     Ok(())
 }
 
-fn emit_llm_start_once(
-    start_emitted: &Arc<AtomicBool>,
-    handle: &LlmHandle,
-    request: &LlmRequest,
-    annotated_request: Option<Arc<AnnotatedLlmRequest>>,
-) -> Result<()> {
-    if start_emitted.swap(true, Ordering::SeqCst) {
-        return Ok(());
-    }
-    emit_llm_start(handle, request, annotated_request)
-}
-
 /// Start a manual LLM lifecycle span.
 ///
 /// This emits an LLM-start event after applying sanitize-request guardrails to
@@ -560,21 +547,7 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
             .model_name_opt(model_name)
             .build(),
     )?;
-    let start_emitted = Arc::new(AtomicBool::new(false));
-    let fallback_request = intercepted_request.clone();
-    let execution_handle = handle.clone();
-    let execution_annotated_request = annotated_request.clone();
-    let execution_start_emitted = start_emitted.clone();
-    let instrumented_func: LlmExecutionNextFn = Arc::new(move |request| {
-        let next = func.clone();
-        let handle = execution_handle.clone();
-        let annotated_request = execution_annotated_request.clone();
-        let start_emitted = execution_start_emitted.clone();
-        Box::pin(async move {
-            emit_llm_start_once(&start_emitted, &handle, &request, annotated_request)?;
-            next(request).await
-        })
-    });
+    emit_llm_start(&handle, &intercepted_request, annotated_request.clone())?;
 
     let execution = {
         let scope_stack = current_scope_stack();
@@ -585,17 +558,11 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
         let state = context
             .read()
             .map_err(|error| FlowError::Internal(error.to_string()))?;
-        state.llm_build_execution_chain(&name, instrumented_func, &scope_locals)
+        state.llm_build_execution_chain(&name, func, &scope_locals)
     };
 
     match execution(intercepted_request).await {
         Ok(response) => {
-            emit_llm_start_once(
-                &start_emitted,
-                &handle,
-                &fallback_request,
-                annotated_request.clone(),
-            )?;
             let annotated_response = response_codec
                 .as_ref()
                 .and_then(|codec| codec.decode_response(&response).ok())
@@ -612,12 +579,6 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
             Ok(response)
         }
         Err(error) => {
-            let _ = emit_llm_start_once(
-                &start_emitted,
-                &handle,
-                &fallback_request,
-                annotated_request,
-            );
             let _ = emit_llm_end_without_output(&handle, metadata);
             Err(error)
         }
@@ -717,21 +678,7 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
             .model_name_opt(model_name)
             .build(),
     )?;
-    let start_emitted = Arc::new(AtomicBool::new(false));
-    let fallback_request = intercepted_request.clone();
-    let execution_handle = handle.clone();
-    let execution_annotated_request = annotated_request.clone();
-    let execution_start_emitted = start_emitted.clone();
-    let instrumented_func: LlmStreamExecutionNextFn = Arc::new(move |request| {
-        let next = func.clone();
-        let handle = execution_handle.clone();
-        let annotated_request = execution_annotated_request.clone();
-        let start_emitted = execution_start_emitted.clone();
-        Box::pin(async move {
-            emit_llm_start_once(&start_emitted, &handle, &request, annotated_request)?;
-            next(request).await
-        })
-    });
+    emit_llm_start(&handle, &intercepted_request, annotated_request)?;
 
     let execution = {
         let scope_stack = current_scope_stack();
@@ -743,17 +690,11 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
         let state = context
             .read()
             .map_err(|error| FlowError::Internal(error.to_string()))?;
-        state.llm_stream_build_execution_chain(&name, instrumented_func, &scope_locals)
+        state.llm_stream_build_execution_chain(&name, func, &scope_locals)
     };
 
     match execution(intercepted_request).await {
         Ok(raw_stream) => {
-            emit_llm_start_once(
-                &start_emitted,
-                &handle,
-                &fallback_request,
-                annotated_request.clone(),
-            )?;
             let wrapper = LlmStreamWrapper::new(
                 raw_stream,
                 handle,
@@ -766,12 +707,6 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
             Ok(Box::pin(wrapper) as LlmJsonStream)
         }
         Err(error) => {
-            let _ = emit_llm_start_once(
-                &start_emitted,
-                &handle,
-                &fallback_request,
-                annotated_request,
-            );
             let _ = emit_llm_end_without_output(&handle, metadata);
             Err(error)
         }

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -13,23 +13,30 @@
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
+use futures::StreamExt;
 use nemo_flow::api::event::{Event, ScopeCategory};
 use nemo_flow::api::llm::LlmRequest;
-use nemo_flow::api::llm::{LlmCallExecuteParams, llm_call_execute, llm_request_intercepts};
+use nemo_flow::api::llm::{
+    LlmCallExecuteParams, LlmStreamCallExecuteParams, llm_call_execute, llm_request_intercepts,
+    llm_stream_call_execute,
+};
 use nemo_flow::api::registry::{
     deregister_llm_conditional_execution_guardrail, deregister_llm_execution_intercept,
-    deregister_llm_request_intercept, deregister_tool_conditional_execution_guardrail,
-    deregister_tool_execution_intercept, deregister_tool_request_intercept,
-    deregister_tool_sanitize_request_guardrail, deregister_tool_sanitize_response_guardrail,
-    register_llm_conditional_execution_guardrail, register_llm_execution_intercept,
-    register_llm_request_intercept, register_tool_conditional_execution_guardrail,
+    deregister_llm_request_intercept, deregister_llm_stream_execution_intercept,
+    deregister_tool_conditional_execution_guardrail, deregister_tool_execution_intercept,
+    deregister_tool_request_intercept, deregister_tool_sanitize_request_guardrail,
+    deregister_tool_sanitize_response_guardrail, register_llm_conditional_execution_guardrail,
+    register_llm_execution_intercept, register_llm_request_intercept,
+    register_llm_stream_execution_intercept, register_tool_conditional_execution_guardrail,
     register_tool_execution_intercept, register_tool_request_intercept,
     register_tool_sanitize_request_guardrail, register_tool_sanitize_response_guardrail,
     scope_register_tool_execution_intercept, scope_register_tool_sanitize_request_guardrail,
 };
 use nemo_flow::api::runtime::NemoFlowContextState;
 use nemo_flow::api::runtime::global_context;
-use nemo_flow::api::runtime::{LlmExecutionNextFn, ToolExecutionNextFn};
+use nemo_flow::api::runtime::{
+    LlmExecutionNextFn, LlmJsonStream, LlmStreamExecutionNextFn, ToolExecutionNextFn,
+};
 use nemo_flow::api::runtime::{create_scope_stack, set_thread_scope_stack};
 use nemo_flow::api::scope::{ScopeHandle, ScopeType};
 use nemo_flow::api::scope::{pop_scope, push_scope};
@@ -1858,6 +1865,227 @@ async fn test_llm_execution_intercept_chain() {
 
     // Cleanup
     deregister_llm_execution_intercept("llm_exec_1").unwrap();
+}
+
+/// LLM start is emitted after request intercepts and before execution intercepts,
+/// even when an execution intercept replaces the callback.
+#[tokio::test]
+async fn test_llm_start_emits_before_short_circuit_execution_intercept() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let ec = events.clone();
+    register_subscriber(
+        "llm_short_circuit_start_observer",
+        Arc::new(move |e: &Event| {
+            ec.lock().unwrap().push(e.clone());
+        }),
+    )
+    .unwrap();
+
+    register_llm_request_intercept(
+        "llm_short_circuit_request",
+        1,
+        false,
+        Box::new(|_name, mut req, annotated| {
+            req.content
+                .as_object_mut()
+                .unwrap()
+                .insert("phase".into(), json!("request"));
+            Ok((req, annotated))
+        }),
+    )
+    .unwrap();
+
+    let events_for_intercept = events.clone();
+    register_llm_execution_intercept(
+        "llm_short_circuit_exec",
+        1,
+        Arc::new(move |_name, mut req, _next| {
+            let events = events_for_intercept.clone();
+            Box::pin(async move {
+                req.content
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("phase".into(), json!("execution"));
+                let start_emitted = {
+                    let captured = events.lock().unwrap();
+                    captured
+                        .iter()
+                        .any(|e| is_scope_event(e, ScopeType::Llm, ScopeCategory::Start))
+                };
+                assert!(
+                    start_emitted,
+                    "LLM start should be emitted before execution intercepts run"
+                );
+                Ok(json!({"response": "short-circuited"}))
+            })
+        }),
+    )
+    .unwrap();
+
+    let original_called = Arc::new(AtomicBool::new(false));
+    let oc = original_called.clone();
+    let func: LlmExecutionNextFn = Arc::new(move |_req| {
+        oc.store(true, Ordering::SeqCst);
+        Box::pin(async move { Ok(json!({"response": "original"})) })
+    });
+
+    let request = LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({"prompt": "hello"}),
+    };
+
+    let result = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("llm")
+            .request(request)
+            .func(func)
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result["response"], "short-circuited");
+    assert!(
+        !original_called.load(Ordering::SeqCst),
+        "Original callable should not be invoked"
+    );
+
+    let captured = events.lock().unwrap();
+    let llm_events = captured
+        .iter()
+        .filter(|e| e.scope_type() == Some(ScopeType::Llm))
+        .collect::<Vec<_>>();
+    assert_eq!(llm_events.len(), 2);
+    assert_eq!(llm_events[0].scope_category(), Some(ScopeCategory::Start));
+    assert_eq!(
+        llm_events[0].input().unwrap()["content"]["phase"],
+        json!("request")
+    );
+    assert_eq!(llm_events[1].scope_category(), Some(ScopeCategory::End));
+    drop(captured);
+
+    deregister_llm_execution_intercept("llm_short_circuit_exec").unwrap();
+    deregister_llm_request_intercept("llm_short_circuit_request").unwrap();
+    deregister_subscriber("llm_short_circuit_start_observer").unwrap();
+}
+
+/// Streaming LLM start follows the same pre-execution ordering as non-streaming
+/// calls when a stream execution intercept replaces the callback.
+#[tokio::test]
+async fn test_llm_stream_start_emits_before_short_circuit_execution_intercept() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let ec = events.clone();
+    register_subscriber(
+        "llm_stream_short_circuit_start_observer",
+        Arc::new(move |e: &Event| {
+            ec.lock().unwrap().push(e.clone());
+        }),
+    )
+    .unwrap();
+
+    register_llm_request_intercept(
+        "llm_stream_short_circuit_request",
+        1,
+        false,
+        Box::new(|_name, mut req, annotated| {
+            req.content
+                .as_object_mut()
+                .unwrap()
+                .insert("phase".into(), json!("request"));
+            Ok((req, annotated))
+        }),
+    )
+    .unwrap();
+
+    let events_for_intercept = events.clone();
+    register_llm_stream_execution_intercept(
+        "llm_stream_short_circuit_exec",
+        1,
+        Arc::new(move |_name, mut req, _next| {
+            let events = events_for_intercept.clone();
+            Box::pin(async move {
+                req.content
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("phase".into(), json!("execution"));
+                let start_emitted = {
+                    let captured = events.lock().unwrap();
+                    captured
+                        .iter()
+                        .any(|e| is_scope_event(e, ScopeType::Llm, ScopeCategory::Start))
+                };
+                assert!(
+                    start_emitted,
+                    "LLM stream start should be emitted before execution intercepts run"
+                );
+                let stream = tokio_stream::iter(vec![Ok(json!({"chunk": "short-circuited"}))]);
+                Ok(Box::pin(stream) as LlmJsonStream)
+            })
+        }),
+    )
+    .unwrap();
+
+    let original_called = Arc::new(AtomicBool::new(false));
+    let oc = original_called.clone();
+    let func: LlmStreamExecutionNextFn = Arc::new(move |_req| {
+        oc.store(true, Ordering::SeqCst);
+        Box::pin(async move {
+            let stream = tokio_stream::iter(vec![Ok(json!({"chunk": "original"}))]);
+            Ok(Box::pin(stream) as LlmJsonStream)
+        })
+    });
+
+    let request = LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({"prompt": "hello"}),
+    };
+
+    let mut stream = llm_stream_call_execute(
+        LlmStreamCallExecuteParams::builder()
+            .name("llm-stream")
+            .request(request)
+            .func(func)
+            .collector(Box::new(|_chunk| Ok(())))
+            .finalizer(Box::new(|| json!({"response": "stream-complete"})))
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    while let Some(chunk) = stream.next().await {
+        chunk.unwrap();
+    }
+
+    assert!(
+        !original_called.load(Ordering::SeqCst),
+        "Original stream callable should not be invoked"
+    );
+
+    let captured = events.lock().unwrap();
+    let llm_events = captured
+        .iter()
+        .filter(|e| e.scope_type() == Some(ScopeType::Llm))
+        .collect::<Vec<_>>();
+    assert_eq!(llm_events.len(), 2);
+    assert_eq!(llm_events[0].scope_category(), Some(ScopeCategory::Start));
+    assert_eq!(
+        llm_events[0].input().unwrap()["content"]["phase"],
+        json!("request")
+    );
+    assert_eq!(llm_events[1].scope_category(), Some(ScopeCategory::End));
+    drop(captured);
+
+    deregister_llm_stream_execution_intercept("llm_stream_short_circuit_exec").unwrap();
+    deregister_llm_request_intercept("llm_stream_short_circuit_request").unwrap();
+    deregister_subscriber("llm_stream_short_circuit_start_observer").unwrap();
 }
 
 // =========================================================================


### PR DESCRIPTION
#### Overview

Move managed LLM start emission to immediately after request intercepts so terminal execution intercepts that skip `next` still run inside an already-open LLM lifecycle span.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Emit non-streaming and streaming `llm_call` start events after request intercepts and handle creation, before execution intercept chains are built and invoked.
- Remove the lazy `next`-based LLM start emission and fallback start path that could record the start after a replacement execution intercept returned.
- Add non-streaming and streaming regression tests for execution intercepts that skip `next`, verifying start is emitted before the intercept body runs and that matching end events still follow.

Validation:

- `cargo fmt --check`
- `cargo test -p nemo-flow`
- `just test-rust`
- `cargo clippy --workspace --all-targets -- -D warnings`

#### Where should the reviewer start?

Start with `crates/core/src/api/llm.rs` for the lifecycle ordering change, then review `crates/core/tests/integration/middleware_tests.rs` for the short-circuit execution intercept regressions.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured LLM start events are consistently emitted at the beginning of execution for both standard and streaming calls, improving observability and event tracking reliability.

* **Tests**
  * Added integration tests validating proper event ordering and execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->