### PR TITLE
feat: Emit guardrail scopes for conditional guardrails

### DIFF
--- a/crates/core/src/api/event.rs
+++ b/crates/core/src/api/event.rs
@@ -53,72 +53,118 @@ pub struct EventCategory(String);
 
 impl EventCategory {
     /// Top-level agent or workflow scope.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `agent`.
     pub fn agent() -> Self {
         Self("agent".into())
     }
 
     /// Generic function or application step.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `function`.
     pub fn function() -> Self {
         Self("function".into())
     }
 
     /// LLM call.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `llm`.
     pub fn llm() -> Self {
         Self("llm".into())
     }
 
     /// Tool invocation.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `tool`.
     pub fn tool() -> Self {
         Self("tool".into())
     }
 
     /// Retrieval step.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `retriever`.
     pub fn retriever() -> Self {
         Self("retriever".into())
     }
 
     /// Embedding-generation step.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `embedder`.
     pub fn embedder() -> Self {
         Self("embedder".into())
     }
 
     /// Result reranking step.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `reranker`.
     pub fn reranker() -> Self {
         Self("reranker".into())
     }
 
     /// Guardrail or validation step.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `guardrail`.
     pub fn guardrail() -> Self {
         Self("guardrail".into())
     }
 
     /// Evaluation or scoring step.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `evaluator`.
     pub fn evaluator() -> Self {
         Self("evaluator".into())
     }
 
     /// Vendor-defined custom category.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `custom`.
     pub fn custom() -> Self {
         Self("custom".into())
     }
 
     /// Unknown or unclassified work.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] with the wire value `unknown`.
     pub fn unknown() -> Self {
         Self("unknown".into())
     }
 
     /// Create a category from an arbitrary producer-provided string.
+    ///
+    /// # Parameters
+    /// - `value`: Wire category value to preserve.
+    ///
+    /// # Returns
+    /// An [`EventCategory`] containing `value`.
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
 
     /// Return the string form serialized on the wire.
+    ///
+    /// # Returns
+    /// The category value as a string slice.
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
 
     /// Convert this category to the closest legacy scope type for internal
     /// adapters that still need span-kind classification.
+    ///
+    /// # Returns
+    /// The closest matching [`ScopeType`], or [`ScopeType::Unknown`] when the
+    /// category has no legacy equivalent.
     pub fn to_scope_type(&self) -> ScopeType {
         match self.as_str() {
             "agent" => ScopeType::Agent,
@@ -211,6 +257,9 @@ pub struct CategoryProfile {
 
 impl CategoryProfile {
     /// Return true when the profile has no wire-serialized fields.
+    ///
+    /// # Returns
+    /// `true` when no profile fields would be serialized on the wire.
     pub fn is_wire_empty(&self) -> bool {
         self.model_name.is_none()
             && self.tool_call_id.is_none()
@@ -271,6 +320,16 @@ pub struct ScopeEvent {
 
 impl ScopeEvent {
     /// Construct a scope event from a base envelope and ATOF-specific fields.
+    ///
+    /// # Parameters
+    /// - `base`: Shared ATOF event envelope.
+    /// - `scope_category`: Lifecycle phase for the scope event.
+    /// - `attributes`: Scope attributes to canonicalize and attach.
+    /// - `category`: Semantic event category.
+    /// - `category_profile`: Optional category-specific profile data.
+    ///
+    /// # Returns
+    /// A [`ScopeEvent`] containing the provided fields.
     pub fn new(
         base: BaseEvent,
         scope_category: ScopeCategory,
@@ -306,6 +365,14 @@ pub struct MarkEvent {
 
 impl MarkEvent {
     /// Construct a mark event from a base envelope and optional category data.
+    ///
+    /// # Parameters
+    /// - `base`: Shared ATOF event envelope.
+    /// - `category`: Optional semantic event category.
+    /// - `category_profile`: Optional category-specific profile data.
+    ///
+    /// # Returns
+    /// A [`MarkEvent`] containing the provided fields.
     pub fn new(
         base: BaseEvent,
         category: Option<EventCategory>,
@@ -331,6 +398,9 @@ pub enum Event {
 
 impl Event {
     /// Return the ATOF event kind.
+    ///
+    /// # Returns
+    /// `"scope"` for [`Event::Scope`] and `"mark"` for [`Event::Mark`].
     pub fn kind(&self) -> &'static str {
         match self {
             Self::Scope(_) => "scope",
@@ -339,6 +409,9 @@ impl Event {
     }
 
     /// Return the lifecycle phase for scope events.
+    ///
+    /// # Returns
+    /// `Some` lifecycle phase for scope events, otherwise `None`.
     pub fn scope_category(&self) -> Option<ScopeCategory> {
         match self {
             Self::Scope(event) => Some(event.scope_category),
@@ -347,6 +420,10 @@ impl Event {
     }
 
     /// Return the semantic category if present.
+    ///
+    /// # Returns
+    /// `Some` category for scope events and categorized mark events, otherwise
+    /// `None`.
     pub fn category(&self) -> Option<&EventCategory> {
         match self {
             Self::Scope(event) => Some(&event.category),
@@ -355,6 +432,9 @@ impl Event {
     }
 
     /// Return the category-specific profile if present.
+    ///
+    /// # Returns
+    /// `Some` profile when category-specific fields are present.
     pub fn category_profile(&self) -> Option<&CategoryProfile> {
         match self {
             Self::Scope(event) => event.category_profile.as_ref(),
@@ -363,6 +443,9 @@ impl Event {
     }
 
     /// Return the mutable category-specific profile if present.
+    ///
+    /// # Returns
+    /// `Some` mutable profile when category-specific fields are present.
     pub fn category_profile_mut(&mut self) -> Option<&mut CategoryProfile> {
         match self {
             Self::Scope(event) => event.category_profile.as_mut(),
@@ -371,41 +454,65 @@ impl Event {
     }
 
     /// Return the parent scope UUID, if the event is nested under a scope.
+    ///
+    /// # Returns
+    /// `Some` parent UUID when the event has a parent scope, otherwise `None`.
     pub fn parent_uuid(&self) -> Option<Uuid> {
         self.base().parent_uuid
     }
 
     /// Return the unique event or span UUID.
+    ///
+    /// # Returns
+    /// The event UUID.
     pub fn uuid(&self) -> Uuid {
         self.base().uuid
     }
 
     /// Return the event timestamp.
+    ///
+    /// # Returns
+    /// The UTC event timestamp.
     pub fn timestamp(&self) -> &DateTime<Utc> {
         &self.base().timestamp
     }
 
     /// Return the human-readable event name.
+    ///
+    /// # Returns
+    /// The event name.
     pub fn name(&self) -> &str {
         self.base().name.as_str()
     }
 
     /// Return the optional application payload attached to the event.
+    ///
+    /// # Returns
+    /// `Some` payload when event data is present, otherwise `None`.
     pub fn data(&self) -> Option<&Json> {
         self.base().data.as_ref()
     }
 
     /// Return the optional data schema.
+    ///
+    /// # Returns
+    /// `Some` schema when the event payload declares one, otherwise `None`.
     pub fn data_schema(&self) -> Option<&DataSchema> {
         self.base().data_schema.as_ref()
     }
 
     /// Return the optional metadata attached to the event.
+    ///
+    /// # Returns
+    /// `Some` metadata when present, otherwise `None`.
     pub fn metadata(&self) -> Option<&Json> {
         self.base().metadata.as_ref()
     }
 
     /// Return attributes for scope events.
+    ///
+    /// # Returns
+    /// `Some` attributes for scope events, otherwise `None`.
     pub fn attributes(&self) -> Option<&[String]> {
         match self {
             Self::Scope(event) => Some(event.attributes.as_slice()),
@@ -414,11 +521,17 @@ impl Event {
     }
 
     /// Return the semantic scope category for scope events.
+    ///
+    /// # Returns
+    /// `Some` legacy [`ScopeType`] when the event has a category.
     pub fn scope_type(&self) -> Option<ScopeType> {
         self.category().map(EventCategory::to_scope_type)
     }
 
     /// Return the semantic input payload for start events.
+    ///
+    /// # Returns
+    /// `Some` payload for scope-start events with data, otherwise `None`.
     pub fn input(&self) -> Option<&Json> {
         match self {
             Self::Scope(event) if event.scope_category == ScopeCategory::Start => {
@@ -429,6 +542,9 @@ impl Event {
     }
 
     /// Return the semantic output payload for end events.
+    ///
+    /// # Returns
+    /// `Some` payload for scope-end events with data, otherwise `None`.
     pub fn output(&self) -> Option<&Json> {
         match self {
             Self::Scope(event) if event.scope_category == ScopeCategory::End => {
@@ -439,30 +555,45 @@ impl Event {
     }
 
     /// Return the normalized model name for LLM events.
+    ///
+    /// # Returns
+    /// `Some` model name when the event profile includes one.
     pub fn model_name(&self) -> Option<&str> {
         self.category_profile()
             .and_then(|profile| profile.model_name.as_deref())
     }
 
     /// Return the provider-specific tool-call correlation identifier.
+    ///
+    /// # Returns
+    /// `Some` tool call identifier when the event profile includes one.
     pub fn tool_call_id(&self) -> Option<&str> {
         self.category_profile()
             .and_then(|profile| profile.tool_call_id.as_deref())
     }
 
     /// Return the runtime-only annotated LLM request.
+    ///
+    /// # Returns
+    /// `Some` annotated request when the event profile includes one.
     pub fn annotated_request(&self) -> Option<&Arc<AnnotatedLlmRequest>> {
         self.category_profile()
             .and_then(|profile| profile.annotated_request.as_ref())
     }
 
     /// Return the runtime-only annotated LLM response.
+    ///
+    /// # Returns
+    /// `Some` annotated response when the event profile includes one.
     pub fn annotated_response(&self) -> Option<&Arc<AnnotatedLlmResponse>> {
         self.category_profile()
             .and_then(|profile| profile.annotated_response.as_ref())
     }
 
     /// Return true for scope-start events.
+    ///
+    /// # Returns
+    /// `true` when the event is a scope-start event.
     pub fn is_scope_start(&self) -> bool {
         matches!(
             self,
@@ -474,6 +605,9 @@ impl Event {
     }
 
     /// Return true for scope-end events.
+    ///
+    /// # Returns
+    /// `true` when the event is a scope-end event.
     pub fn is_scope_end(&self) -> bool {
         matches!(
             self,
@@ -493,6 +627,12 @@ impl Event {
 }
 
 /// Convert handle bitflags into ATOF attributes.
+///
+/// # Parameters
+/// - `attributes`: Handle-specific attribute bitflags.
+///
+/// # Returns
+/// Canonical lowercase ATOF attribute strings for the provided bitflags.
 pub fn attributes_from_handle(attributes: HandleAttributes) -> Vec<String> {
     match attributes {
         HandleAttributes::Scope(attributes) => scope_attributes_to_strings(attributes),
@@ -502,6 +642,12 @@ pub fn attributes_from_handle(attributes: HandleAttributes) -> Vec<String> {
 }
 
 /// Convert scope bitflags into ATOF attributes.
+///
+/// # Parameters
+/// - `attributes`: Scope attribute bitflags.
+///
+/// # Returns
+/// Canonical lowercase ATOF attribute strings for the provided bitflags.
 pub fn scope_attributes_to_strings(attributes: ScopeAttributes) -> Vec<String> {
     let mut values = Vec::new();
     if attributes.contains(ScopeAttributes::PARALLEL) {
@@ -514,6 +660,12 @@ pub fn scope_attributes_to_strings(attributes: ScopeAttributes) -> Vec<String> {
 }
 
 /// Convert tool bitflags into ATOF attributes.
+///
+/// # Parameters
+/// - `attributes`: Tool attribute bitflags.
+///
+/// # Returns
+/// Canonical lowercase ATOF attribute strings for the provided bitflags.
 pub fn tool_attributes_to_strings(attributes: ToolAttributes) -> Vec<String> {
     let mut values = Vec::new();
     if attributes.contains(ToolAttributes::REMOTE) {
@@ -523,6 +675,12 @@ pub fn tool_attributes_to_strings(attributes: ToolAttributes) -> Vec<String> {
 }
 
 /// Convert LLM bitflags into ATOF attributes.
+///
+/// # Parameters
+/// - `attributes`: LLM attribute bitflags.
+///
+/// # Returns
+/// Canonical lowercase ATOF attribute strings for the provided bitflags.
 pub fn llm_attributes_to_strings(attributes: LlmAttributes) -> Vec<String> {
     let mut values = Vec::new();
     if attributes.contains(LlmAttributes::STATEFUL) {
@@ -548,6 +706,17 @@ mod timestamp {
     };
     use std::fmt;
 
+    /// Serialize a UTC timestamp as RFC 3339.
+    ///
+    /// # Parameters
+    /// - `value`: Timestamp to serialize.
+    /// - `serializer`: Serde serializer receiving the string value.
+    ///
+    /// # Returns
+    /// The serializer's success value.
+    ///
+    /// # Errors
+    /// Returns any error produced by the serializer.
     pub fn serialize<S>(value: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -555,6 +724,16 @@ mod timestamp {
         serializer.serialize_str(&value.to_rfc3339())
     }
 
+    /// Deserialize a UTC timestamp from an RFC 3339 string.
+    ///
+    /// # Parameters
+    /// - `deserializer`: Serde deserializer providing the timestamp value.
+    ///
+    /// # Returns
+    /// Parsed UTC timestamp.
+    ///
+    /// # Errors
+    /// Returns a serde error when the input is not a valid RFC 3339 timestamp.
     pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: Deserializer<'de>,

--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -538,7 +538,7 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
                 metadata.clone(),
             )
         };
-        if let Some(error) = NemoFlowContextState::llm_conditional_execution_chain(
+        if let Some(error) = NemoFlowContextState::llm_conditional_execution_snapshot_chain(
             &request,
             entries,
             &subscribers,
@@ -710,7 +710,7 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
                 metadata.clone(),
             )
         };
-        if let Some(error) = NemoFlowContextState::llm_conditional_execution_chain(
+        if let Some(error) = NemoFlowContextState::llm_conditional_execution_snapshot_chain(
             &request,
             entries,
             &subscribers,
@@ -878,7 +878,7 @@ pub fn llm_conditional_execution(request: &LlmRequest) -> Result<()> {
         let subscribers = state.collect_event_subscribers(&scope_subscribers);
         (entries, subscribers, resolve_parent_uuid(None))
     };
-    if let Some(error) = NemoFlowContextState::llm_conditional_execution_chain(
+    if let Some(error) = NemoFlowContextState::llm_conditional_execution_snapshot_chain(
         request,
         entries,
         &subscribers,

--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -522,7 +522,7 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
             let scope_stack = current_scope_stack();
             let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
             let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-                &registries.llm_conditional_execution_guardrails
+                &registries.llm_conditional_execution_shared_guardrails
             });
             let scope_subscribers = scope_guard.collect_scope_local_subscribers();
             let context = global_context();
@@ -694,7 +694,7 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
             let scope_stack = current_scope_stack();
             let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
             let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-                &registries.llm_conditional_execution_guardrails
+                &registries.llm_conditional_execution_shared_guardrails
             });
             let scope_subscribers = scope_guard.collect_scope_local_subscribers();
             let context = global_context();
@@ -867,7 +867,7 @@ pub fn llm_conditional_execution(request: &LlmRequest) -> Result<()> {
         let scope_stack = current_scope_stack();
         let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
         let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-            &registries.llm_conditional_execution_guardrails
+            &registries.llm_conditional_execution_shared_guardrails
         });
         let scope_subscribers = scope_guard.collect_scope_local_subscribers();
         let context = global_context();

--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -523,11 +523,19 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
         let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
             &registries.llm_conditional_execution_guardrails
         });
+        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
         let context = global_context();
         let state = context
             .read()
             .map_err(|error| FlowError::Internal(error.to_string()))?;
-        if let Some(error) = state.llm_conditional_execution_chain(&request, &scope_locals)? {
+        let subscribers = state.collect_event_subscribers(&scope_subscribers);
+        if let Some(error) = state.llm_conditional_execution_chain(
+            &request,
+            &scope_locals,
+            &subscribers,
+            resolve_parent_uuid(parent.as_ref()),
+            metadata.clone(),
+        )? {
             drop(state);
             drop(scope_guard);
             let mut rejection_data = json!({});
@@ -680,11 +688,19 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
         let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
             &registries.llm_conditional_execution_guardrails
         });
+        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
         let context = global_context();
         let state = context
             .read()
             .map_err(|error| FlowError::Internal(error.to_string()))?;
-        if let Some(error) = state.llm_conditional_execution_chain(&request, &scope_locals)? {
+        let subscribers = state.collect_event_subscribers(&scope_subscribers);
+        if let Some(error) = state.llm_conditional_execution_chain(
+            &request,
+            &scope_locals,
+            &subscribers,
+            resolve_parent_uuid(parent.as_ref()),
+            metadata.clone(),
+        )? {
             drop(state);
             drop(scope_guard);
             let mut rejection_data = json!({});
@@ -814,7 +830,8 @@ pub fn llm_request_intercepts(name: &str, request: LlmRequest) -> Result<LlmRequ
 /// Run only the LLM conditional-execution guardrail chain.
 ///
 /// This evaluates whether an LLM call should be allowed to proceed without
-/// emitting lifecycle events or invoking request intercepts or execution.
+/// invoking request intercepts or execution. Each evaluated guardrail emits an
+/// automatic guardrail scope start/end pair for observability.
 ///
 /// # Parameters
 /// - `request`: Raw [`LlmRequest`] to validate.
@@ -828,7 +845,8 @@ pub fn llm_request_intercepts(name: &str, request: LlmRequest) -> Result<LlmRequ
 ///
 /// # Notes
 /// This helper is useful for preflight checks when the caller needs the
-/// rejection result without starting an LLM span.
+/// rejection result without starting an LLM span. Guardrail scopes are still
+/// emitted for the conditional checks themselves.
 pub fn llm_conditional_execution(request: &LlmRequest) -> Result<()> {
     ensure_runtime_owner()?;
     let scope_stack = current_scope_stack();
@@ -836,11 +854,19 @@ pub fn llm_conditional_execution(request: &LlmRequest) -> Result<()> {
     let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
         &registries.llm_conditional_execution_guardrails
     });
+    let scope_subscribers = scope_guard.collect_scope_local_subscribers();
     let context = global_context();
     let state = context
         .read()
         .map_err(|error| FlowError::Internal(error.to_string()))?;
-    if let Some(error) = state.llm_conditional_execution_chain(request, &scope_locals)? {
+    let subscribers = state.collect_event_subscribers(&scope_subscribers);
+    if let Some(error) = state.llm_conditional_execution_chain(
+        request,
+        &scope_locals,
+        &subscribers,
+        resolve_parent_uuid(None),
+        None,
+    )? {
         return Err(FlowError::GuardrailRejected(error));
     }
     Ok(())

--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -518,26 +518,33 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
     } = params;
     ensure_runtime_owner()?;
     {
-        let scope_stack = current_scope_stack();
-        let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
-        let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-            &registries.llm_conditional_execution_guardrails
-        });
-        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
-        let context = global_context();
-        let state = context
-            .read()
-            .map_err(|error| FlowError::Internal(error.to_string()))?;
-        let subscribers = state.collect_event_subscribers(&scope_subscribers);
-        if let Some(error) = state.llm_conditional_execution_chain(
+        let (entries, subscribers, parent_uuid, guardrail_metadata) = {
+            let scope_stack = current_scope_stack();
+            let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
+            let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
+                &registries.llm_conditional_execution_guardrails
+            });
+            let scope_subscribers = scope_guard.collect_scope_local_subscribers();
+            let context = global_context();
+            let state = context
+                .read()
+                .map_err(|error| FlowError::Internal(error.to_string()))?;
+            let entries = state.llm_conditional_execution_entries(&scope_locals);
+            let subscribers = state.collect_event_subscribers(&scope_subscribers);
+            (
+                entries,
+                subscribers,
+                resolve_parent_uuid(parent.as_ref()),
+                metadata.clone(),
+            )
+        };
+        if let Some(error) = NemoFlowContextState::llm_conditional_execution_chain(
             &request,
-            &scope_locals,
+            entries,
             &subscribers,
-            resolve_parent_uuid(parent.as_ref()),
-            metadata.clone(),
+            parent_uuid,
+            guardrail_metadata,
         )? {
-            drop(state);
-            drop(scope_guard);
             let mut rejection_data = json!({});
             if let Some(object) = rejection_data.as_object_mut() {
                 object.insert("rejected".into(), json!(true));
@@ -683,26 +690,33 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
     } = params;
     ensure_runtime_owner()?;
     {
-        let scope_stack = current_scope_stack();
-        let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
-        let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-            &registries.llm_conditional_execution_guardrails
-        });
-        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
-        let context = global_context();
-        let state = context
-            .read()
-            .map_err(|error| FlowError::Internal(error.to_string()))?;
-        let subscribers = state.collect_event_subscribers(&scope_subscribers);
-        if let Some(error) = state.llm_conditional_execution_chain(
+        let (entries, subscribers, parent_uuid, guardrail_metadata) = {
+            let scope_stack = current_scope_stack();
+            let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
+            let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
+                &registries.llm_conditional_execution_guardrails
+            });
+            let scope_subscribers = scope_guard.collect_scope_local_subscribers();
+            let context = global_context();
+            let state = context
+                .read()
+                .map_err(|error| FlowError::Internal(error.to_string()))?;
+            let entries = state.llm_conditional_execution_entries(&scope_locals);
+            let subscribers = state.collect_event_subscribers(&scope_subscribers);
+            (
+                entries,
+                subscribers,
+                resolve_parent_uuid(parent.as_ref()),
+                metadata.clone(),
+            )
+        };
+        if let Some(error) = NemoFlowContextState::llm_conditional_execution_chain(
             &request,
-            &scope_locals,
+            entries,
             &subscribers,
-            resolve_parent_uuid(parent.as_ref()),
-            metadata.clone(),
+            parent_uuid,
+            guardrail_metadata,
         )? {
-            drop(state);
-            drop(scope_guard);
             let mut rejection_data = json!({});
             if let Some(object) = rejection_data.as_object_mut() {
                 object.insert("rejected".into(), json!(true));
@@ -849,22 +863,26 @@ pub fn llm_request_intercepts(name: &str, request: LlmRequest) -> Result<LlmRequ
 /// emitted for the conditional checks themselves.
 pub fn llm_conditional_execution(request: &LlmRequest) -> Result<()> {
     ensure_runtime_owner()?;
-    let scope_stack = current_scope_stack();
-    let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
-    let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-        &registries.llm_conditional_execution_guardrails
-    });
-    let scope_subscribers = scope_guard.collect_scope_local_subscribers();
-    let context = global_context();
-    let state = context
-        .read()
-        .map_err(|error| FlowError::Internal(error.to_string()))?;
-    let subscribers = state.collect_event_subscribers(&scope_subscribers);
-    if let Some(error) = state.llm_conditional_execution_chain(
+    let (entries, subscribers, parent_uuid) = {
+        let scope_stack = current_scope_stack();
+        let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
+        let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
+            &registries.llm_conditional_execution_guardrails
+        });
+        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
+        let context = global_context();
+        let state = context
+            .read()
+            .map_err(|error| FlowError::Internal(error.to_string()))?;
+        let entries = state.llm_conditional_execution_entries(&scope_locals);
+        let subscribers = state.collect_event_subscribers(&scope_subscribers);
+        (entries, subscribers, resolve_parent_uuid(None))
+    };
+    if let Some(error) = NemoFlowContextState::llm_conditional_execution_chain(
         request,
-        &scope_locals,
+        entries,
         &subscribers,
-        resolve_parent_uuid(None),
+        parent_uuid,
         None,
     )? {
         return Err(FlowError::GuardrailRejected(error));

--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -522,7 +522,7 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
             let scope_stack = current_scope_stack();
             let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
             let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-                &registries.llm_conditional_execution_shared_guardrails
+                &registries.llm_conditional_execution_guardrails
             });
             let scope_subscribers = scope_guard.collect_scope_local_subscribers();
             let context = global_context();
@@ -694,7 +694,7 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
             let scope_stack = current_scope_stack();
             let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
             let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-                &registries.llm_conditional_execution_shared_guardrails
+                &registries.llm_conditional_execution_guardrails
             });
             let scope_subscribers = scope_guard.collect_scope_local_subscribers();
             let context = global_context();
@@ -867,7 +867,7 @@ pub fn llm_conditional_execution(request: &LlmRequest) -> Result<()> {
         let scope_stack = current_scope_stack();
         let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
         let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-            &registries.llm_conditional_execution_shared_guardrails
+            &registries.llm_conditional_execution_guardrails
         });
         let scope_subscribers = scope_guard.collect_scope_local_subscribers();
         let context = global_context();

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -4,6 +4,10 @@
 //! Middleware registry helpers for global and scope-local guardrails,
 //! intercepts, and subscribers.
 
+use std::sync::Arc;
+
+use crate::api::llm::LlmRequest;
+use crate::api::runtime::callbacks::{LlmConditionalSharedFn, ToolConditionalSharedFn};
 use crate::api::runtime::{
     LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn, ToolExecutionFn,
@@ -12,6 +16,7 @@ use crate::api::runtime::{
 use crate::api::runtime::{current_scope_stack, global_context};
 use crate::api::shared::ensure_runtime_owner;
 use crate::error::{FlowError, Result};
+use crate::json::Json;
 
 /// A priority-ordered request intercept registration entry.
 pub struct Intercept<F> {
@@ -37,6 +42,33 @@ pub struct GuardrailEntry<F> {
     pub priority: i32,
     /// The caller-provided guardrail callback.
     pub guardrail: F,
+}
+
+fn share_tool_conditional_guardrail(
+    guardrail: ToolConditionalFn,
+) -> (ToolConditionalFn, ToolConditionalSharedFn) {
+    let guardrail = Arc::new(guardrail);
+    let boxed_guardrail = {
+        let guardrail = guardrail.clone();
+        Box::new(move |name: &str, args: &Json| (guardrail.as_ref())(name, args))
+            as ToolConditionalFn
+    };
+    let shared_guardrail = Arc::new(move |name: &str, args: &Json| (guardrail.as_ref())(name, args))
+        as ToolConditionalSharedFn;
+    (boxed_guardrail, shared_guardrail)
+}
+
+fn share_llm_conditional_guardrail(
+    guardrail: LlmConditionalFn,
+) -> (LlmConditionalFn, LlmConditionalSharedFn) {
+    let guardrail = Arc::new(guardrail);
+    let boxed_guardrail = {
+        let guardrail = guardrail.clone();
+        Box::new(move |request: &LlmRequest| (guardrail.as_ref())(request)) as LlmConditionalFn
+    };
+    let shared_guardrail = Arc::new(move |request: &LlmRequest| (guardrail.as_ref())(request))
+        as LlmConditionalSharedFn;
+    (boxed_guardrail, shared_guardrail)
 }
 
 macro_rules! global_guardrail_registry_api {
@@ -464,16 +496,78 @@ global_guardrail_registry_api!(
     tool_sanitize_response_guardrails,
     ToolSanitizeFn
 );
-global_guardrail_registry_api!(
-    /// Register a global tool conditional-execution guardrail.
-    /// The guardrail can block tool execution before intercepts or the tool
-    /// callback run.
-    register_tool_conditional_execution_guardrail,
-    /// Deregister a global tool conditional-execution guardrail.
-    deregister_tool_conditional_execution_guardrail,
-    tool_conditional_execution_guardrails,
-    ToolConditionalFn
-);
+/// Register a global tool conditional-execution guardrail.
+/// The guardrail can block tool execution before intercepts or the tool
+/// callback run.
+///
+/// # Parameters
+/// - `name`: Unique middleware name in the global registry.
+/// - `priority`: Lower values run earlier in the chain.
+/// - `guardrail`: Guardrail callback stored under `name`.
+///
+/// # Returns
+/// A [`Result`] that is `Ok(())` when the guardrail was registered.
+///
+/// # Errors
+/// Returns [`FlowError::AlreadyExists`] when the name is already in use or an
+/// internal error if the runtime state cannot be updated.
+pub fn register_tool_conditional_execution_guardrail(
+    name: &str,
+    priority: i32,
+    guardrail: ToolConditionalFn,
+) -> Result<()> {
+    ensure_runtime_owner()?;
+    let context = global_context();
+    let mut state = context
+        .write()
+        .map_err(|error| FlowError::Internal(error.to_string()))?;
+    let (boxed_guardrail, shared_guardrail) = share_tool_conditional_guardrail(guardrail);
+    state
+        .tool_conditional_execution_guardrails
+        .register(
+            name.to_string(),
+            GuardrailEntry {
+                priority,
+                guardrail: boxed_guardrail,
+            },
+        )
+        .map_err(FlowError::AlreadyExists)?;
+    if let Err(error) = state.tool_conditional_shared_guardrails_mut().register(
+        name.to_string(),
+        GuardrailEntry {
+            priority,
+            guardrail: shared_guardrail,
+        },
+    ) {
+        state.tool_conditional_execution_guardrails.deregister(name);
+        return Err(FlowError::AlreadyExists(error));
+    }
+    Ok(())
+}
+
+/// Deregister a global tool conditional-execution guardrail.
+///
+/// # Parameters
+/// - `name`: Global middleware name to remove.
+///
+/// # Returns
+/// A [`Result`] containing `true` when a guardrail was removed and `false`
+/// when the name was not registered.
+///
+/// # Errors
+/// Returns an internal error if the runtime state cannot be updated.
+pub fn deregister_tool_conditional_execution_guardrail(name: &str) -> Result<bool> {
+    ensure_runtime_owner()?;
+    let context = global_context();
+    let mut state = context
+        .write()
+        .map_err(|error| FlowError::Internal(error.to_string()))?;
+    let removed = state.tool_conditional_execution_guardrails.deregister(name);
+    let _ = state
+        .tool_conditional_shared_guardrails_mut()
+        .deregister(name);
+    Ok(removed)
+}
 global_intercept_registry_api!(
     /// Register a global tool request intercept.
     /// Request intercepts can rewrite tool arguments before execution.
@@ -513,16 +607,78 @@ global_guardrail_registry_api!(
     llm_sanitize_response_guardrails,
     LlmSanitizeResponseFn
 );
-global_guardrail_registry_api!(
-    /// Register a global LLM conditional-execution guardrail.
-    /// The guardrail can block LLM execution before intercepts or the provider
-    /// callback run.
-    register_llm_conditional_execution_guardrail,
-    /// Deregister a global LLM conditional-execution guardrail.
-    deregister_llm_conditional_execution_guardrail,
-    llm_conditional_execution_guardrails,
-    LlmConditionalFn
-);
+/// Register a global LLM conditional-execution guardrail.
+/// The guardrail can block LLM execution before intercepts or the provider
+/// callback run.
+///
+/// # Parameters
+/// - `name`: Unique middleware name in the global registry.
+/// - `priority`: Lower values run earlier in the chain.
+/// - `guardrail`: Guardrail callback stored under `name`.
+///
+/// # Returns
+/// A [`Result`] that is `Ok(())` when the guardrail was registered.
+///
+/// # Errors
+/// Returns [`FlowError::AlreadyExists`] when the name is already in use or an
+/// internal error if the runtime state cannot be updated.
+pub fn register_llm_conditional_execution_guardrail(
+    name: &str,
+    priority: i32,
+    guardrail: LlmConditionalFn,
+) -> Result<()> {
+    ensure_runtime_owner()?;
+    let context = global_context();
+    let mut state = context
+        .write()
+        .map_err(|error| FlowError::Internal(error.to_string()))?;
+    let (boxed_guardrail, shared_guardrail) = share_llm_conditional_guardrail(guardrail);
+    state
+        .llm_conditional_execution_guardrails
+        .register(
+            name.to_string(),
+            GuardrailEntry {
+                priority,
+                guardrail: boxed_guardrail,
+            },
+        )
+        .map_err(FlowError::AlreadyExists)?;
+    if let Err(error) = state.llm_conditional_shared_guardrails_mut().register(
+        name.to_string(),
+        GuardrailEntry {
+            priority,
+            guardrail: shared_guardrail,
+        },
+    ) {
+        state.llm_conditional_execution_guardrails.deregister(name);
+        return Err(FlowError::AlreadyExists(error));
+    }
+    Ok(())
+}
+
+/// Deregister a global LLM conditional-execution guardrail.
+///
+/// # Parameters
+/// - `name`: Global middleware name to remove.
+///
+/// # Returns
+/// A [`Result`] containing `true` when a guardrail was removed and `false`
+/// when the name was not registered.
+///
+/// # Errors
+/// Returns an internal error if the runtime state cannot be updated.
+pub fn deregister_llm_conditional_execution_guardrail(name: &str) -> Result<bool> {
+    ensure_runtime_owner()?;
+    let context = global_context();
+    let mut state = context
+        .write()
+        .map_err(|error| FlowError::Internal(error.to_string()))?;
+    let removed = state.llm_conditional_execution_guardrails.deregister(name);
+    let _ = state
+        .llm_conditional_shared_guardrails_mut()
+        .deregister(name);
+    Ok(removed)
+}
 global_intercept_registry_api!(
     /// Register a global LLM request intercept.
     /// Request intercepts can rewrite or annotate the outgoing LLM request.
@@ -571,15 +727,94 @@ scope_guardrail_registry_api!(
     tool_sanitize_response_guardrails,
     ToolSanitizeFn
 );
-scope_guardrail_registry_api!(
-    /// Register a scope-local tool conditional-execution guardrail.
-    /// The guardrail can block tool execution inside the owning scope.
-    scope_register_tool_conditional_execution_guardrail,
-    /// Deregister a scope-local tool conditional-execution guardrail.
-    scope_deregister_tool_conditional_execution_guardrail,
-    tool_conditional_execution_guardrails,
-    ToolConditionalFn
-);
+/// Register a scope-local tool conditional-execution guardrail.
+/// The guardrail can block tool execution inside the owning scope.
+///
+/// # Parameters
+/// - `scope_uuid`: UUID of the active scope that owns the middleware.
+/// - `name`: Unique middleware name on the scope-local registry.
+/// - `priority`: Lower values run earlier in the chain.
+/// - `guardrail`: Guardrail callback stored under `name`.
+///
+/// # Returns
+/// A [`Result`] that is `Ok(())` when the guardrail was registered.
+///
+/// # Errors
+/// Returns [`FlowError::NotFound`] when the scope is not active,
+/// [`FlowError::AlreadyExists`] when the name is already in use on that scope,
+/// or an internal error if the runtime owner check fails.
+pub fn scope_register_tool_conditional_execution_guardrail(
+    scope_uuid: &uuid::Uuid,
+    name: &str,
+    priority: i32,
+    guardrail: ToolConditionalFn,
+) -> Result<()> {
+    ensure_runtime_owner()?;
+    let scope_stack = current_scope_stack();
+    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
+    let registries = guard
+        .local_registries_mut(scope_uuid)
+        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
+    let (boxed_guardrail, shared_guardrail) = share_tool_conditional_guardrail(guardrail);
+    registries
+        .tool_conditional_execution_guardrails
+        .register(
+            name.to_string(),
+            GuardrailEntry {
+                priority,
+                guardrail: boxed_guardrail,
+            },
+        )
+        .map_err(FlowError::AlreadyExists)?;
+    if let Err(error) = registries
+        .tool_conditional_execution_shared_guardrails
+        .register(
+            name.to_string(),
+            GuardrailEntry {
+                priority,
+                guardrail: shared_guardrail,
+            },
+        )
+    {
+        registries
+            .tool_conditional_execution_guardrails
+            .deregister(name);
+        return Err(FlowError::AlreadyExists(error));
+    }
+    Ok(())
+}
+
+/// Deregister a scope-local tool conditional-execution guardrail.
+///
+/// # Parameters
+/// - `scope_uuid`: UUID of the active scope that owns the middleware.
+/// - `name`: Scope-local middleware name to remove.
+///
+/// # Returns
+/// A [`Result`] containing `true` when a guardrail was removed and `false`
+/// when the name was not registered on that scope.
+///
+/// # Errors
+/// Returns [`FlowError::NotFound`] when the scope is not active or an internal
+/// error if the runtime owner check fails.
+pub fn scope_deregister_tool_conditional_execution_guardrail(
+    scope_uuid: &uuid::Uuid,
+    name: &str,
+) -> Result<bool> {
+    ensure_runtime_owner()?;
+    let scope_stack = current_scope_stack();
+    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
+    let registries = guard
+        .local_registries_mut(scope_uuid)
+        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
+    let removed = registries
+        .tool_conditional_execution_guardrails
+        .deregister(name);
+    let _ = registries
+        .tool_conditional_execution_shared_guardrails
+        .deregister(name);
+    Ok(removed)
+}
 scope_intercept_registry_api!(
     /// Register a scope-local tool request intercept.
     /// Request intercepts can rewrite tool arguments inside the owning scope.
@@ -620,15 +855,94 @@ scope_guardrail_registry_api!(
     llm_sanitize_response_guardrails,
     LlmSanitizeResponseFn
 );
-scope_guardrail_registry_api!(
-    /// Register a scope-local LLM conditional-execution guardrail.
-    /// The guardrail can block LLM execution inside the owning scope.
-    scope_register_llm_conditional_execution_guardrail,
-    /// Deregister a scope-local LLM conditional-execution guardrail.
-    scope_deregister_llm_conditional_execution_guardrail,
-    llm_conditional_execution_guardrails,
-    LlmConditionalFn
-);
+/// Register a scope-local LLM conditional-execution guardrail.
+/// The guardrail can block LLM execution inside the owning scope.
+///
+/// # Parameters
+/// - `scope_uuid`: UUID of the active scope that owns the middleware.
+/// - `name`: Unique middleware name on the scope-local registry.
+/// - `priority`: Lower values run earlier in the chain.
+/// - `guardrail`: Guardrail callback stored under `name`.
+///
+/// # Returns
+/// A [`Result`] that is `Ok(())` when the guardrail was registered.
+///
+/// # Errors
+/// Returns [`FlowError::NotFound`] when the scope is not active,
+/// [`FlowError::AlreadyExists`] when the name is already in use on that scope,
+/// or an internal error if the runtime owner check fails.
+pub fn scope_register_llm_conditional_execution_guardrail(
+    scope_uuid: &uuid::Uuid,
+    name: &str,
+    priority: i32,
+    guardrail: LlmConditionalFn,
+) -> Result<()> {
+    ensure_runtime_owner()?;
+    let scope_stack = current_scope_stack();
+    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
+    let registries = guard
+        .local_registries_mut(scope_uuid)
+        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
+    let (boxed_guardrail, shared_guardrail) = share_llm_conditional_guardrail(guardrail);
+    registries
+        .llm_conditional_execution_guardrails
+        .register(
+            name.to_string(),
+            GuardrailEntry {
+                priority,
+                guardrail: boxed_guardrail,
+            },
+        )
+        .map_err(FlowError::AlreadyExists)?;
+    if let Err(error) = registries
+        .llm_conditional_execution_shared_guardrails
+        .register(
+            name.to_string(),
+            GuardrailEntry {
+                priority,
+                guardrail: shared_guardrail,
+            },
+        )
+    {
+        registries
+            .llm_conditional_execution_guardrails
+            .deregister(name);
+        return Err(FlowError::AlreadyExists(error));
+    }
+    Ok(())
+}
+
+/// Deregister a scope-local LLM conditional-execution guardrail.
+///
+/// # Parameters
+/// - `scope_uuid`: UUID of the active scope that owns the middleware.
+/// - `name`: Scope-local middleware name to remove.
+///
+/// # Returns
+/// A [`Result`] containing `true` when a guardrail was removed and `false`
+/// when the name was not registered on that scope.
+///
+/// # Errors
+/// Returns [`FlowError::NotFound`] when the scope is not active or an internal
+/// error if the runtime owner check fails.
+pub fn scope_deregister_llm_conditional_execution_guardrail(
+    scope_uuid: &uuid::Uuid,
+    name: &str,
+) -> Result<bool> {
+    ensure_runtime_owner()?;
+    let scope_stack = current_scope_stack();
+    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
+    let registries = guard
+        .local_registries_mut(scope_uuid)
+        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
+    let removed = registries
+        .llm_conditional_execution_guardrails
+        .deregister(name);
+    let _ = registries
+        .llm_conditional_execution_shared_guardrails
+        .deregister(name);
+    Ok(removed)
+}
 scope_intercept_registry_api!(
     /// Register a scope-local LLM request intercept.
     /// Request intercepts can rewrite or annotate LLM requests inside the

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -32,6 +32,7 @@ pub struct ExecutionIntercept<F> {
 }
 
 /// A priority-ordered guardrail registration entry.
+#[derive(Clone)]
 pub struct GuardrailEntry<F> {
     /// Caller-provided guardrail registration name.
     pub name: String,
@@ -76,7 +77,7 @@ macro_rules! global_guardrail_registry_api {
                     GuardrailEntry {
                         name: name.to_string(),
                         priority,
-                        guardrail,
+                        guardrail: guardrail.into(),
                     },
                 )
                 .map_err(FlowError::AlreadyExists)
@@ -273,7 +274,7 @@ macro_rules! scope_guardrail_registry_api {
                     GuardrailEntry {
                         name: name.to_string(),
                         priority,
-                        guardrail,
+                        guardrail: guardrail.into(),
                     },
                 )
                 .map_err(FlowError::AlreadyExists)

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -464,65 +464,16 @@ global_guardrail_registry_api!(
     tool_sanitize_response_guardrails,
     ToolSanitizeFn
 );
-/// Register a global tool conditional-execution guardrail.
-/// The guardrail can block tool execution before intercepts or the tool
-/// callback run.
-///
-/// # Parameters
-/// - `name`: Unique middleware name in the global registry.
-/// - `priority`: Lower values run earlier in the chain.
-/// - `guardrail`: [`Arc`](std::sync::Arc)-backed guardrail callback stored
-///   under `name`.
-///
-/// # Returns
-/// A [`Result`] that is `Ok(())` when the guardrail was registered.
-///
-/// # Errors
-/// Returns [`FlowError::AlreadyExists`] when the name is already in use or an
-/// internal error if the runtime state cannot be updated.
-pub fn register_tool_conditional_execution_guardrail(
-    name: &str,
-    priority: i32,
-    guardrail: ToolConditionalFn,
-) -> Result<()> {
-    ensure_runtime_owner()?;
-    let context = global_context();
-    let mut state = context
-        .write()
-        .map_err(|error| FlowError::Internal(error.to_string()))?;
-    state
-        .tool_conditional_execution_guardrails
-        .register(
-            name.to_string(),
-            GuardrailEntry {
-                priority,
-                guardrail,
-            },
-        )
-        .map_err(FlowError::AlreadyExists)?;
-    Ok(())
-}
-
-/// Deregister a global tool conditional-execution guardrail.
-///
-/// # Parameters
-/// - `name`: Global middleware name to remove.
-///
-/// # Returns
-/// A [`Result`] containing `true` when a guardrail was removed and `false`
-/// when the name was not registered.
-///
-/// # Errors
-/// Returns an internal error if the runtime state cannot be updated.
-pub fn deregister_tool_conditional_execution_guardrail(name: &str) -> Result<bool> {
-    ensure_runtime_owner()?;
-    let context = global_context();
-    let mut state = context
-        .write()
-        .map_err(|error| FlowError::Internal(error.to_string()))?;
-    let removed = state.tool_conditional_execution_guardrails.deregister(name);
-    Ok(removed)
-}
+global_guardrail_registry_api!(
+    /// Register a global tool conditional-execution guardrail.
+    /// The guardrail can block tool execution before intercepts or the tool
+    /// callback run.
+    register_tool_conditional_execution_guardrail,
+    /// Deregister a global tool conditional-execution guardrail.
+    deregister_tool_conditional_execution_guardrail,
+    tool_conditional_execution_guardrails,
+    ToolConditionalFn
+);
 global_intercept_registry_api!(
     /// Register a global tool request intercept.
     /// Request intercepts can rewrite tool arguments before execution.
@@ -562,65 +513,16 @@ global_guardrail_registry_api!(
     llm_sanitize_response_guardrails,
     LlmSanitizeResponseFn
 );
-/// Register a global LLM conditional-execution guardrail.
-/// The guardrail can block LLM execution before intercepts or the provider
-/// callback run.
-///
-/// # Parameters
-/// - `name`: Unique middleware name in the global registry.
-/// - `priority`: Lower values run earlier in the chain.
-/// - `guardrail`: [`Arc`](std::sync::Arc)-backed guardrail callback stored
-///   under `name`.
-///
-/// # Returns
-/// A [`Result`] that is `Ok(())` when the guardrail was registered.
-///
-/// # Errors
-/// Returns [`FlowError::AlreadyExists`] when the name is already in use or an
-/// internal error if the runtime state cannot be updated.
-pub fn register_llm_conditional_execution_guardrail(
-    name: &str,
-    priority: i32,
-    guardrail: LlmConditionalFn,
-) -> Result<()> {
-    ensure_runtime_owner()?;
-    let context = global_context();
-    let mut state = context
-        .write()
-        .map_err(|error| FlowError::Internal(error.to_string()))?;
-    state
-        .llm_conditional_execution_guardrails
-        .register(
-            name.to_string(),
-            GuardrailEntry {
-                priority,
-                guardrail,
-            },
-        )
-        .map_err(FlowError::AlreadyExists)?;
-    Ok(())
-}
-
-/// Deregister a global LLM conditional-execution guardrail.
-///
-/// # Parameters
-/// - `name`: Global middleware name to remove.
-///
-/// # Returns
-/// A [`Result`] containing `true` when a guardrail was removed and `false`
-/// when the name was not registered.
-///
-/// # Errors
-/// Returns an internal error if the runtime state cannot be updated.
-pub fn deregister_llm_conditional_execution_guardrail(name: &str) -> Result<bool> {
-    ensure_runtime_owner()?;
-    let context = global_context();
-    let mut state = context
-        .write()
-        .map_err(|error| FlowError::Internal(error.to_string()))?;
-    let removed = state.llm_conditional_execution_guardrails.deregister(name);
-    Ok(removed)
-}
+global_guardrail_registry_api!(
+    /// Register a global LLM conditional-execution guardrail.
+    /// The guardrail can block LLM execution before intercepts or the provider
+    /// callback run.
+    register_llm_conditional_execution_guardrail,
+    /// Deregister a global LLM conditional-execution guardrail.
+    deregister_llm_conditional_execution_guardrail,
+    llm_conditional_execution_guardrails,
+    LlmConditionalFn
+);
 global_intercept_registry_api!(
     /// Register a global LLM request intercept.
     /// Request intercepts can rewrite or annotate the outgoing LLM request.
@@ -669,76 +571,15 @@ scope_guardrail_registry_api!(
     tool_sanitize_response_guardrails,
     ToolSanitizeFn
 );
-/// Register a scope-local tool conditional-execution guardrail.
-/// The guardrail can block tool execution inside the owning scope.
-///
-/// # Parameters
-/// - `scope_uuid`: UUID of the active scope that owns the middleware.
-/// - `name`: Unique middleware name on the scope-local registry.
-/// - `priority`: Lower values run earlier in the chain.
-/// - `guardrail`: [`Arc`](std::sync::Arc)-backed guardrail callback stored
-///   under `name`.
-///
-/// # Returns
-/// A [`Result`] that is `Ok(())` when the guardrail was registered.
-///
-/// # Errors
-/// Returns [`FlowError::NotFound`] when the scope is not active,
-/// [`FlowError::AlreadyExists`] when the name is already in use on that scope,
-/// or an internal error if the runtime owner check fails.
-pub fn scope_register_tool_conditional_execution_guardrail(
-    scope_uuid: &uuid::Uuid,
-    name: &str,
-    priority: i32,
-    guardrail: ToolConditionalFn,
-) -> Result<()> {
-    ensure_runtime_owner()?;
-    let scope_stack = current_scope_stack();
-    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
-    let registries = guard
-        .local_registries_mut(scope_uuid)
-        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
-    registries
-        .tool_conditional_execution_guardrails
-        .register(
-            name.to_string(),
-            GuardrailEntry {
-                priority,
-                guardrail,
-            },
-        )
-        .map_err(FlowError::AlreadyExists)?;
-    Ok(())
-}
-
-/// Deregister a scope-local tool conditional-execution guardrail.
-///
-/// # Parameters
-/// - `scope_uuid`: UUID of the active scope that owns the middleware.
-/// - `name`: Scope-local middleware name to remove.
-///
-/// # Returns
-/// A [`Result`] containing `true` when a guardrail was removed and `false`
-/// when the name was not registered on that scope.
-///
-/// # Errors
-/// Returns [`FlowError::NotFound`] when the scope is not active or an internal
-/// error if the runtime owner check fails.
-pub fn scope_deregister_tool_conditional_execution_guardrail(
-    scope_uuid: &uuid::Uuid,
-    name: &str,
-) -> Result<bool> {
-    ensure_runtime_owner()?;
-    let scope_stack = current_scope_stack();
-    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
-    let registries = guard
-        .local_registries_mut(scope_uuid)
-        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
-    let removed = registries
-        .tool_conditional_execution_guardrails
-        .deregister(name);
-    Ok(removed)
-}
+scope_guardrail_registry_api!(
+    /// Register a scope-local tool conditional-execution guardrail.
+    /// The guardrail can block tool execution inside the owning scope.
+    scope_register_tool_conditional_execution_guardrail,
+    /// Deregister a scope-local tool conditional-execution guardrail.
+    scope_deregister_tool_conditional_execution_guardrail,
+    tool_conditional_execution_guardrails,
+    ToolConditionalFn
+);
 scope_intercept_registry_api!(
     /// Register a scope-local tool request intercept.
     /// Request intercepts can rewrite tool arguments inside the owning scope.
@@ -779,76 +620,15 @@ scope_guardrail_registry_api!(
     llm_sanitize_response_guardrails,
     LlmSanitizeResponseFn
 );
-/// Register a scope-local LLM conditional-execution guardrail.
-/// The guardrail can block LLM execution inside the owning scope.
-///
-/// # Parameters
-/// - `scope_uuid`: UUID of the active scope that owns the middleware.
-/// - `name`: Unique middleware name on the scope-local registry.
-/// - `priority`: Lower values run earlier in the chain.
-/// - `guardrail`: [`Arc`](std::sync::Arc)-backed guardrail callback stored
-///   under `name`.
-///
-/// # Returns
-/// A [`Result`] that is `Ok(())` when the guardrail was registered.
-///
-/// # Errors
-/// Returns [`FlowError::NotFound`] when the scope is not active,
-/// [`FlowError::AlreadyExists`] when the name is already in use on that scope,
-/// or an internal error if the runtime owner check fails.
-pub fn scope_register_llm_conditional_execution_guardrail(
-    scope_uuid: &uuid::Uuid,
-    name: &str,
-    priority: i32,
-    guardrail: LlmConditionalFn,
-) -> Result<()> {
-    ensure_runtime_owner()?;
-    let scope_stack = current_scope_stack();
-    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
-    let registries = guard
-        .local_registries_mut(scope_uuid)
-        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
-    registries
-        .llm_conditional_execution_guardrails
-        .register(
-            name.to_string(),
-            GuardrailEntry {
-                priority,
-                guardrail,
-            },
-        )
-        .map_err(FlowError::AlreadyExists)?;
-    Ok(())
-}
-
-/// Deregister a scope-local LLM conditional-execution guardrail.
-///
-/// # Parameters
-/// - `scope_uuid`: UUID of the active scope that owns the middleware.
-/// - `name`: Scope-local middleware name to remove.
-///
-/// # Returns
-/// A [`Result`] containing `true` when a guardrail was removed and `false`
-/// when the name was not registered on that scope.
-///
-/// # Errors
-/// Returns [`FlowError::NotFound`] when the scope is not active or an internal
-/// error if the runtime owner check fails.
-pub fn scope_deregister_llm_conditional_execution_guardrail(
-    scope_uuid: &uuid::Uuid,
-    name: &str,
-) -> Result<bool> {
-    ensure_runtime_owner()?;
-    let scope_stack = current_scope_stack();
-    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
-    let registries = guard
-        .local_registries_mut(scope_uuid)
-        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
-    let removed = registries
-        .llm_conditional_execution_guardrails
-        .deregister(name);
-    Ok(removed)
-}
+scope_guardrail_registry_api!(
+    /// Register a scope-local LLM conditional-execution guardrail.
+    /// The guardrail can block LLM execution inside the owning scope.
+    scope_register_llm_conditional_execution_guardrail,
+    /// Deregister a scope-local LLM conditional-execution guardrail.
+    scope_deregister_llm_conditional_execution_guardrail,
+    llm_conditional_execution_guardrails,
+    LlmConditionalFn
+);
 scope_intercept_registry_api!(
     /// Register a scope-local LLM request intercept.
     /// Request intercepts can rewrite or annotate LLM requests inside the

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -33,6 +33,8 @@ pub struct ExecutionIntercept<F> {
 
 /// A priority-ordered guardrail registration entry.
 pub struct GuardrailEntry<F> {
+    /// Caller-provided guardrail registration name.
+    pub name: String,
     /// Lower values run earlier in the chain.
     pub priority: i32,
     /// The caller-provided guardrail callback.
@@ -69,7 +71,14 @@ macro_rules! global_guardrail_registry_api {
                 .map_err(|error| FlowError::Internal(error.to_string()))?;
             state
                 .$field
-                .register(name.to_string(), GuardrailEntry { priority, guardrail })
+                .register(
+                    name.to_string(),
+                    GuardrailEntry {
+                        name: name.to_string(),
+                        priority,
+                        guardrail,
+                    },
+                )
                 .map_err(FlowError::AlreadyExists)
         }
 
@@ -259,7 +268,14 @@ macro_rules! scope_guardrail_registry_api {
                 .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
             registries
                 .$field
-                .register(name.to_string(), GuardrailEntry { priority, guardrail })
+                .register(
+                    name.to_string(),
+                    GuardrailEntry {
+                        name: name.to_string(),
+                        priority,
+                        guardrail,
+                    },
+                )
                 .map_err(FlowError::AlreadyExists)
         }
 

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -32,10 +32,7 @@ pub struct ExecutionIntercept<F> {
 }
 
 /// A priority-ordered guardrail registration entry.
-#[derive(Clone)]
 pub struct GuardrailEntry<F> {
-    /// Caller-provided guardrail registration name.
-    pub name: String,
     /// Lower values run earlier in the chain.
     pub priority: i32,
     /// The caller-provided guardrail callback.
@@ -75,7 +72,6 @@ macro_rules! global_guardrail_registry_api {
                 .register(
                     name.to_string(),
                     GuardrailEntry {
-                        name: name.to_string(),
                         priority,
                         guardrail: guardrail.into(),
                     },
@@ -272,7 +268,6 @@ macro_rules! scope_guardrail_registry_api {
                 .register(
                     name.to_string(),
                     GuardrailEntry {
-                        name: name.to_string(),
                         priority,
                         guardrail: guardrail.into(),
                     },

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -4,10 +4,6 @@
 //! Middleware registry helpers for global and scope-local guardrails,
 //! intercepts, and subscribers.
 
-use std::sync::Arc;
-
-use crate::api::llm::LlmRequest;
-use crate::api::runtime::callbacks::{LlmConditionalSharedFn, ToolConditionalSharedFn};
 use crate::api::runtime::{
     LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn, ToolExecutionFn,
@@ -16,7 +12,6 @@ use crate::api::runtime::{
 use crate::api::runtime::{current_scope_stack, global_context};
 use crate::api::shared::ensure_runtime_owner;
 use crate::error::{FlowError, Result};
-use crate::json::Json;
 
 /// A priority-ordered request intercept registration entry.
 pub struct Intercept<F> {
@@ -42,33 +37,6 @@ pub struct GuardrailEntry<F> {
     pub priority: i32,
     /// The caller-provided guardrail callback.
     pub guardrail: F,
-}
-
-fn share_tool_conditional_guardrail(
-    guardrail: ToolConditionalFn,
-) -> (ToolConditionalFn, ToolConditionalSharedFn) {
-    let guardrail = Arc::new(guardrail);
-    let boxed_guardrail = {
-        let guardrail = guardrail.clone();
-        Box::new(move |name: &str, args: &Json| (guardrail.as_ref())(name, args))
-            as ToolConditionalFn
-    };
-    let shared_guardrail = Arc::new(move |name: &str, args: &Json| (guardrail.as_ref())(name, args))
-        as ToolConditionalSharedFn;
-    (boxed_guardrail, shared_guardrail)
-}
-
-fn share_llm_conditional_guardrail(
-    guardrail: LlmConditionalFn,
-) -> (LlmConditionalFn, LlmConditionalSharedFn) {
-    let guardrail = Arc::new(guardrail);
-    let boxed_guardrail = {
-        let guardrail = guardrail.clone();
-        Box::new(move |request: &LlmRequest| (guardrail.as_ref())(request)) as LlmConditionalFn
-    };
-    let shared_guardrail = Arc::new(move |request: &LlmRequest| (guardrail.as_ref())(request))
-        as LlmConditionalSharedFn;
-    (boxed_guardrail, shared_guardrail)
 }
 
 macro_rules! global_guardrail_registry_api {
@@ -503,7 +471,8 @@ global_guardrail_registry_api!(
 /// # Parameters
 /// - `name`: Unique middleware name in the global registry.
 /// - `priority`: Lower values run earlier in the chain.
-/// - `guardrail`: Guardrail callback stored under `name`.
+/// - `guardrail`: [`Arc`](std::sync::Arc)-backed guardrail callback stored
+///   under `name`.
 ///
 /// # Returns
 /// A [`Result`] that is `Ok(())` when the guardrail was registered.
@@ -521,27 +490,16 @@ pub fn register_tool_conditional_execution_guardrail(
     let mut state = context
         .write()
         .map_err(|error| FlowError::Internal(error.to_string()))?;
-    let (boxed_guardrail, shared_guardrail) = share_tool_conditional_guardrail(guardrail);
     state
         .tool_conditional_execution_guardrails
         .register(
             name.to_string(),
             GuardrailEntry {
                 priority,
-                guardrail: boxed_guardrail,
+                guardrail,
             },
         )
         .map_err(FlowError::AlreadyExists)?;
-    if let Err(error) = state.tool_conditional_shared_guardrails_mut().register(
-        name.to_string(),
-        GuardrailEntry {
-            priority,
-            guardrail: shared_guardrail,
-        },
-    ) {
-        state.tool_conditional_execution_guardrails.deregister(name);
-        return Err(FlowError::AlreadyExists(error));
-    }
     Ok(())
 }
 
@@ -563,9 +521,6 @@ pub fn deregister_tool_conditional_execution_guardrail(name: &str) -> Result<boo
         .write()
         .map_err(|error| FlowError::Internal(error.to_string()))?;
     let removed = state.tool_conditional_execution_guardrails.deregister(name);
-    let _ = state
-        .tool_conditional_shared_guardrails_mut()
-        .deregister(name);
     Ok(removed)
 }
 global_intercept_registry_api!(
@@ -614,7 +569,8 @@ global_guardrail_registry_api!(
 /// # Parameters
 /// - `name`: Unique middleware name in the global registry.
 /// - `priority`: Lower values run earlier in the chain.
-/// - `guardrail`: Guardrail callback stored under `name`.
+/// - `guardrail`: [`Arc`](std::sync::Arc)-backed guardrail callback stored
+///   under `name`.
 ///
 /// # Returns
 /// A [`Result`] that is `Ok(())` when the guardrail was registered.
@@ -632,27 +588,16 @@ pub fn register_llm_conditional_execution_guardrail(
     let mut state = context
         .write()
         .map_err(|error| FlowError::Internal(error.to_string()))?;
-    let (boxed_guardrail, shared_guardrail) = share_llm_conditional_guardrail(guardrail);
     state
         .llm_conditional_execution_guardrails
         .register(
             name.to_string(),
             GuardrailEntry {
                 priority,
-                guardrail: boxed_guardrail,
+                guardrail,
             },
         )
         .map_err(FlowError::AlreadyExists)?;
-    if let Err(error) = state.llm_conditional_shared_guardrails_mut().register(
-        name.to_string(),
-        GuardrailEntry {
-            priority,
-            guardrail: shared_guardrail,
-        },
-    ) {
-        state.llm_conditional_execution_guardrails.deregister(name);
-        return Err(FlowError::AlreadyExists(error));
-    }
     Ok(())
 }
 
@@ -674,9 +619,6 @@ pub fn deregister_llm_conditional_execution_guardrail(name: &str) -> Result<bool
         .write()
         .map_err(|error| FlowError::Internal(error.to_string()))?;
     let removed = state.llm_conditional_execution_guardrails.deregister(name);
-    let _ = state
-        .llm_conditional_shared_guardrails_mut()
-        .deregister(name);
     Ok(removed)
 }
 global_intercept_registry_api!(
@@ -734,7 +676,8 @@ scope_guardrail_registry_api!(
 /// - `scope_uuid`: UUID of the active scope that owns the middleware.
 /// - `name`: Unique middleware name on the scope-local registry.
 /// - `priority`: Lower values run earlier in the chain.
-/// - `guardrail`: Guardrail callback stored under `name`.
+/// - `guardrail`: [`Arc`](std::sync::Arc)-backed guardrail callback stored
+///   under `name`.
 ///
 /// # Returns
 /// A [`Result`] that is `Ok(())` when the guardrail was registered.
@@ -755,32 +698,16 @@ pub fn scope_register_tool_conditional_execution_guardrail(
     let registries = guard
         .local_registries_mut(scope_uuid)
         .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
-    let (boxed_guardrail, shared_guardrail) = share_tool_conditional_guardrail(guardrail);
     registries
         .tool_conditional_execution_guardrails
         .register(
             name.to_string(),
             GuardrailEntry {
                 priority,
-                guardrail: boxed_guardrail,
+                guardrail,
             },
         )
         .map_err(FlowError::AlreadyExists)?;
-    if let Err(error) = registries
-        .tool_conditional_execution_shared_guardrails
-        .register(
-            name.to_string(),
-            GuardrailEntry {
-                priority,
-                guardrail: shared_guardrail,
-            },
-        )
-    {
-        registries
-            .tool_conditional_execution_guardrails
-            .deregister(name);
-        return Err(FlowError::AlreadyExists(error));
-    }
     Ok(())
 }
 
@@ -809,9 +736,6 @@ pub fn scope_deregister_tool_conditional_execution_guardrail(
         .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
     let removed = registries
         .tool_conditional_execution_guardrails
-        .deregister(name);
-    let _ = registries
-        .tool_conditional_execution_shared_guardrails
         .deregister(name);
     Ok(removed)
 }
@@ -862,7 +786,8 @@ scope_guardrail_registry_api!(
 /// - `scope_uuid`: UUID of the active scope that owns the middleware.
 /// - `name`: Unique middleware name on the scope-local registry.
 /// - `priority`: Lower values run earlier in the chain.
-/// - `guardrail`: Guardrail callback stored under `name`.
+/// - `guardrail`: [`Arc`](std::sync::Arc)-backed guardrail callback stored
+///   under `name`.
 ///
 /// # Returns
 /// A [`Result`] that is `Ok(())` when the guardrail was registered.
@@ -883,32 +808,16 @@ pub fn scope_register_llm_conditional_execution_guardrail(
     let registries = guard
         .local_registries_mut(scope_uuid)
         .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
-    let (boxed_guardrail, shared_guardrail) = share_llm_conditional_guardrail(guardrail);
     registries
         .llm_conditional_execution_guardrails
         .register(
             name.to_string(),
             GuardrailEntry {
                 priority,
-                guardrail: boxed_guardrail,
+                guardrail,
             },
         )
         .map_err(FlowError::AlreadyExists)?;
-    if let Err(error) = registries
-        .llm_conditional_execution_shared_guardrails
-        .register(
-            name.to_string(),
-            GuardrailEntry {
-                priority,
-                guardrail: shared_guardrail,
-            },
-        )
-    {
-        registries
-            .llm_conditional_execution_guardrails
-            .deregister(name);
-        return Err(FlowError::AlreadyExists(error));
-    }
     Ok(())
 }
 
@@ -937,9 +846,6 @@ pub fn scope_deregister_llm_conditional_execution_guardrail(
         .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
     let removed = registries
         .llm_conditional_execution_guardrails
-        .deregister(name);
-    let _ = registries
-        .llm_conditional_execution_shared_guardrails
         .deregister(name);
     Ok(removed)
 }

--- a/crates/core/src/api/runtime.rs
+++ b/crates/core/src/api/runtime.rs
@@ -13,7 +13,7 @@ pub use callbacks::{
     LlmExecutionNextFn, LlmFinalizerFn, LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn,
     LlmStreamExecutionRegistryRef, LlmStreamExecutionRegistryRefs, ToolConditionalFn,
-    ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolConditionalSharedFn, ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
 };
 pub use global::global_context;
 pub use scope_stack::{

--- a/crates/core/src/api/runtime.rs
+++ b/crates/core/src/api/runtime.rs
@@ -9,11 +9,11 @@ pub mod scope_stack;
 pub mod state;
 
 pub use callbacks::{
-    EventSubscriberFn, LlmCollectorFn, LlmConditionalFn, LlmConditionalSharedFn, LlmExecutionFn,
-    LlmExecutionNextFn, LlmFinalizerFn, LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestFn,
+    EventSubscriberFn, LlmCollectorFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn,
+    LlmFinalizerFn, LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn,
     LlmStreamExecutionRegistryRef, LlmStreamExecutionRegistryRefs, ToolConditionalFn,
-    ToolConditionalSharedFn, ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
 };
 pub use global::global_context;
 pub use scope_stack::{

--- a/crates/core/src/api/runtime.rs
+++ b/crates/core/src/api/runtime.rs
@@ -9,8 +9,8 @@ pub mod scope_stack;
 pub mod state;
 
 pub use callbacks::{
-    EventSubscriberFn, LlmCollectorFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn,
-    LlmFinalizerFn, LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestFn,
+    EventSubscriberFn, LlmCollectorFn, LlmConditionalFn, LlmConditionalSharedFn, LlmExecutionFn,
+    LlmExecutionNextFn, LlmFinalizerFn, LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn,
     LlmStreamExecutionRegistryRef, LlmStreamExecutionRegistryRefs, ToolConditionalFn,
     ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,

--- a/crates/core/src/api/runtime/callbacks.rs
+++ b/crates/core/src/api/runtime/callbacks.rs
@@ -3,10 +3,10 @@
 
 //! Callback type aliases used by the runtime middleware pipeline.
 //!
-//! The public middleware registration APIs accept boxed or shared closures with
-//! the signatures defined in this module. These aliases centralize those
-//! signatures so the runtime can compose tool and LLM middleware consistently
-//! across bindings.
+//! The public middleware registration APIs accept callback closures with the
+//! signatures defined in this module. These aliases centralize those signatures
+//! so the runtime can compose tool and LLM middleware consistently across
+//! bindings.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -25,30 +25,84 @@ use crate::json::Json;
 /// Tool sanitize callbacks are used only for observability payloads. They can
 /// rewrite the JSON arguments recorded on tool-start events without changing
 /// the caller-owned request that is passed to the tool implementation.
+///
+/// # Parameters
+/// - First argument: Tool name associated with the request payload.
+/// - Second argument: JSON payload to sanitize for observability.
+///
+/// # Returns
+/// Sanitized JSON payload for the emitted event.
 pub type ToolSanitizeFn = Box<dyn Fn(&str, Json) -> Json + Send + Sync>;
 /// Decide whether a tool call is allowed to continue.
 ///
 /// The callback receives the tool name and the current argument payload. It can
 /// return `Ok(None)` to allow execution, `Ok(Some(reason))` to reject the call
 /// with a guardrail message, or an error to abort evaluation entirely.
-pub type ToolConditionalFn = Box<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
-pub(crate) type ToolConditionalSharedFn =
-    Arc<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
+///
+/// This alias is [`Arc`]-backed so the runtime can clone conditional
+/// guardrails into an evaluation snapshot and invoke them after registry locks
+/// are released.
+///
+/// # Parameters
+/// - First argument: Tool name being evaluated.
+/// - Second argument: Current tool argument payload.
+///
+/// # Returns
+/// A [`Result`] containing `Ok(None)` when execution is allowed or
+/// `Ok(Some(reason))` when the guardrail rejects the call.
+///
+/// # Errors
+/// The callback can return any [`FlowError`](crate::error::FlowError) to abort
+/// guardrail evaluation.
+pub type ToolConditionalFn = Arc<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
 /// Rewrite tool arguments before execution.
 ///
 /// Tool request intercepts run in priority order and can transform the JSON
 /// payload that is eventually passed into the tool execution callback.
+///
+/// # Parameters
+/// - First argument: Tool name associated with the request.
+/// - Second argument: JSON argument payload to transform.
+///
+/// # Returns
+/// A [`Result`] containing the transformed JSON argument payload.
+///
+/// # Errors
+/// The callback can return any [`FlowError`](crate::error::FlowError) to abort
+/// the request-intercept chain.
 pub type ToolInterceptFn = Box<dyn Fn(&str, Json) -> Result<Json> + Send + Sync>;
 /// Continuation type invoked by tool execution intercepts.
 ///
 /// Execution intercepts receive this callable as their `next` continuation and
 /// can call it with modified arguments, wrap it, or skip it entirely.
+///
+/// # Parameters
+/// - First argument: JSON argument payload to pass to the remaining execution
+///   chain.
+///
+/// # Returns
+/// A future resolving to the tool result JSON.
+///
+/// # Errors
+/// The future resolves to an error when the remaining execution chain fails.
 pub type ToolExecutionNextFn =
     Arc<dyn Fn(Json) -> Pin<Box<dyn Future<Output = Result<Json>> + Send>> + Send + Sync>;
 /// Wrap or replace tool execution.
 ///
 /// A tool execution intercept receives the tool name, the current argument
 /// payload, and the continuation representing the rest of the chain.
+///
+/// # Parameters
+/// - First argument: Tool name associated with the execution.
+/// - Second argument: Current JSON argument payload.
+/// - Third argument: Continuation for the remaining execution chain.
+///
+/// # Returns
+/// A future resolving to the tool result JSON.
+///
+/// # Errors
+/// The future resolves to an error when the intercept or remaining execution
+/// chain fails.
 pub type ToolExecutionFn = Arc<
     dyn Fn(&str, Json, ToolExecutionNextFn) -> Pin<Box<dyn Future<Output = Result<Json>> + Send>>
         + Send
@@ -60,23 +114,60 @@ pub type ToolExecutionFn = Arc<
 /// LLM request sanitizers affect the serialized request payload emitted on
 /// start events. They do not mutate the caller-owned [`LlmRequest`] unless a
 /// separate request intercept does so.
+///
+/// # Parameters
+/// - First argument: LLM request payload to sanitize for observability.
+///
+/// # Returns
+/// Sanitized [`LlmRequest`] for the emitted event.
 pub type LlmSanitizeRequestFn = Box<dyn Fn(LlmRequest) -> LlmRequest + Send + Sync>;
 /// Sanitize an LLM response before the runtime records it.
 ///
 /// These callbacks rewrite the JSON response payload captured on LLM-end
 /// events, which is useful for redaction or payload normalization.
+///
+/// # Parameters
+/// - First argument: JSON response payload to sanitize for observability.
+///
+/// # Returns
+/// Sanitized JSON response payload for the emitted event.
 pub type LlmSanitizeResponseFn = Box<dyn Fn(Json) -> Json + Send + Sync>;
 /// Decide whether an LLM call is allowed to continue.
 ///
 /// The callback receives the current [`LlmRequest`] and can allow execution,
 /// reject it with a guardrail reason, or return an error.
-pub type LlmConditionalFn = Box<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
-pub(crate) type LlmConditionalSharedFn =
-    Arc<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
+///
+/// This alias is [`Arc`]-backed so the runtime can clone conditional
+/// guardrails into an evaluation snapshot and invoke them after registry locks
+/// are released.
+///
+/// # Parameters
+/// - First argument: Current [`LlmRequest`] being evaluated.
+///
+/// # Returns
+/// A [`Result`] containing `Ok(None)` when execution is allowed or
+/// `Ok(Some(reason))` when the guardrail rejects the call.
+///
+/// # Errors
+/// The callback can return any [`FlowError`](crate::error::FlowError) to abort
+/// guardrail evaluation.
+pub type LlmConditionalFn = Arc<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
 /// Rewrite or annotate an LLM request before execution.
 ///
 /// Request intercepts can transform the wire request, attach or replace a
 /// normalized [`AnnotatedLlmRequest`], or both.
+///
+/// # Parameters
+/// - First argument: Logical provider or model family name.
+/// - Second argument: LLM request to transform.
+/// - Third argument: Optional normalized request annotation to carry forward.
+///
+/// # Returns
+/// A [`Result`] containing the transformed request and optional annotation.
+///
+/// # Errors
+/// The callback can return any [`FlowError`](crate::error::FlowError) to abort
+/// the request-intercept chain.
 pub type LlmRequestInterceptFn = Box<
     dyn Fn(
             &str,
@@ -90,12 +181,33 @@ pub type LlmRequestInterceptFn = Box<
 ///
 /// Execution intercepts use this callable to continue the non-streaming LLM
 /// pipeline after applying their own logic.
+///
+/// # Parameters
+/// - First argument: LLM request to pass to the remaining execution chain.
+///
+/// # Returns
+/// A future resolving to the provider response JSON.
+///
+/// # Errors
+/// The future resolves to an error when the remaining execution chain fails.
 pub type LlmExecutionNextFn =
     Arc<dyn Fn(LlmRequest) -> Pin<Box<dyn Future<Output = Result<Json>> + Send>> + Send + Sync>;
 /// Wrap or replace non-streaming LLM execution.
 ///
 /// A non-streaming execution intercept receives the logical provider name, the
 /// current request, and the continuation representing the rest of the chain.
+///
+/// # Parameters
+/// - First argument: Logical provider or model family name.
+/// - Second argument: Current LLM request.
+/// - Third argument: Continuation for the remaining execution chain.
+///
+/// # Returns
+/// A future resolving to the provider response JSON.
+///
+/// # Errors
+/// The future resolves to an error when the intercept or remaining execution
+/// chain fails.
 pub type LlmExecutionFn = Arc<
     dyn Fn(
             &str,
@@ -108,20 +220,53 @@ pub type LlmExecutionFn = Arc<
 /// Stream of JSON chunks produced by the managed streaming LLM pipeline.
 pub type LlmJsonStream = Pin<Box<dyn Stream<Item = Result<Json>> + Send>>;
 /// Per-chunk collector used by the streaming LLM runtime.
+///
+/// # Parameters
+/// - First argument: One JSON chunk emitted by the provider stream.
+///
+/// # Returns
+/// A [`Result`] that is `Ok(())` when the chunk was collected.
+///
+/// # Errors
+/// The callback can return any [`FlowError`](crate::error::FlowError) to abort
+/// stream processing.
 pub type LlmCollectorFn = Box<dyn FnMut(Json) -> Result<()> + Send>;
 /// Finalizer used to synthesize the aggregate streaming response payload.
+///
+/// # Parameters
+/// This callback takes no arguments.
+///
+/// # Returns
+/// Aggregate response JSON synthesized from collected stream chunks.
 pub type LlmFinalizerFn = Box<dyn FnOnce() -> Json + Send>;
 /// Scope-local registry references passed into streaming execution-chain builders.
+///
+/// # Returns
+/// A shared reference to a scope-local streaming execution registry.
 pub type LlmStreamExecutionRegistryRef<'a> = &'a crate::registry::SortedRegistry<
     crate::api::registry::ExecutionIntercept<LlmStreamExecutionFn>,
 >;
 /// Slice of scope-local streaming execution registries.
+///
+/// # Returns
+/// A borrowed slice of scope-local streaming execution registry references.
 pub type LlmStreamExecutionRegistryRefs<'a> = &'a [LlmStreamExecutionRegistryRef<'a>];
 
 /// Continuation type invoked by streaming LLM execution intercepts.
 ///
 /// This callable represents the remainder of the streaming LLM execution chain
 /// and resolves to a stream of JSON response chunks.
+///
+/// # Parameters
+/// - First argument: LLM request to pass to the remaining streaming execution
+///   chain.
+///
+/// # Returns
+/// A future resolving to a JSON chunk stream.
+///
+/// # Errors
+/// The future resolves to an error when the remaining streaming execution
+/// chain fails.
 pub type LlmStreamExecutionNextFn = Arc<
     dyn Fn(LlmRequest) -> Pin<Box<dyn Future<Output = Result<LlmJsonStream>> + Send>> + Send + Sync,
 >;
@@ -129,6 +274,18 @@ pub type LlmStreamExecutionNextFn = Arc<
 ///
 /// A streaming execution intercept can observe or modify the request before
 /// invoking the continuation, and it can also replace the returned stream.
+///
+/// # Parameters
+/// - First argument: Logical provider or model family name.
+/// - Second argument: Current LLM request.
+/// - Third argument: Continuation for the remaining streaming execution chain.
+///
+/// # Returns
+/// A future resolving to a JSON chunk stream.
+///
+/// # Errors
+/// The future resolves to an error when the intercept or remaining streaming
+/// execution chain fails.
 pub type LlmStreamExecutionFn = Arc<
     dyn Fn(
             &str,
@@ -143,4 +300,10 @@ pub type LlmStreamExecutionFn = Arc<
 ///
 /// Event subscribers are invoked for scope, tool, LLM, and mark events after
 /// the runtime has built the final event payload.
+///
+/// # Parameters
+/// - First argument: Runtime event that was just emitted.
+///
+/// # Returns
+/// `()`.
 pub type EventSubscriberFn = Arc<dyn Fn(&Event) + Send + Sync>;

--- a/crates/core/src/api/runtime/callbacks.rs
+++ b/crates/core/src/api/runtime/callbacks.rs
@@ -69,6 +69,8 @@ pub type LlmSanitizeResponseFn = Box<dyn Fn(Json) -> Json + Send + Sync>;
 /// The callback receives the current [`LlmRequest`] and can allow execution,
 /// reject it with a guardrail reason, or return an error.
 pub type LlmConditionalFn = Box<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
+/// Shared LLM conditional guardrail callback stored in registries.
+pub type LlmConditionalSharedFn = Arc<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
 /// Rewrite or annotate an LLM request before execution.
 ///
 /// Request intercepts can transform the wire request, attach or replace a

--- a/crates/core/src/api/runtime/callbacks.rs
+++ b/crates/core/src/api/runtime/callbacks.rs
@@ -32,8 +32,8 @@ pub type ToolSanitizeFn = Box<dyn Fn(&str, Json) -> Json + Send + Sync>;
 /// return `Ok(None)` to allow execution, `Ok(Some(reason))` to reject the call
 /// with a guardrail message, or an error to abort evaluation entirely.
 pub type ToolConditionalFn = Box<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
-/// Shared tool conditional guardrail callback stored in registries.
-pub type ToolConditionalSharedFn = Arc<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
+pub(crate) type ToolConditionalSharedFn =
+    Arc<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
 /// Rewrite tool arguments before execution.
 ///
 /// Tool request intercepts run in priority order and can transform the JSON
@@ -71,8 +71,8 @@ pub type LlmSanitizeResponseFn = Box<dyn Fn(Json) -> Json + Send + Sync>;
 /// The callback receives the current [`LlmRequest`] and can allow execution,
 /// reject it with a guardrail reason, or return an error.
 pub type LlmConditionalFn = Box<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
-/// Shared LLM conditional guardrail callback stored in registries.
-pub type LlmConditionalSharedFn = Arc<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
+pub(crate) type LlmConditionalSharedFn =
+    Arc<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
 /// Rewrite or annotate an LLM request before execution.
 ///
 /// Request intercepts can transform the wire request, attach or replace a

--- a/crates/core/src/api/runtime/callbacks.rs
+++ b/crates/core/src/api/runtime/callbacks.rs
@@ -32,6 +32,8 @@ pub type ToolSanitizeFn = Box<dyn Fn(&str, Json) -> Json + Send + Sync>;
 /// return `Ok(None)` to allow execution, `Ok(Some(reason))` to reject the call
 /// with a guardrail message, or an error to abort evaluation entirely.
 pub type ToolConditionalFn = Box<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
+/// Shared tool conditional guardrail callback stored in registries.
+pub type ToolConditionalSharedFn = Arc<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
 /// Rewrite tool arguments before execution.
 ///
 /// Tool request intercepts run in priority order and can transform the JSON

--- a/crates/core/src/api/runtime/scope_stack.rs
+++ b/crates/core/src/api/runtime/scope_stack.rs
@@ -312,6 +312,10 @@ pub fn set_thread_scope_stack(handle: ScopeStackHandle) {
 /// This is intended for foreign runtimes that temporarily bind a scope stack to
 /// an OS thread and need to restore the exact previous state before releasing
 /// that thread back to their scheduler.
+///
+/// # Returns
+/// A [`ThreadScopeStackBinding`] containing the current thread-local stack and
+/// explicit-binding flag.
 pub fn capture_thread_scope_stack() -> ThreadScopeStackBinding {
     let stack = THREAD_SCOPE_STACK.with(|stack| stack.borrow().clone());
     let explicit = THREAD_SCOPE_STACK_EXPLICIT.with(|flag| flag.get());
@@ -319,6 +323,12 @@ pub fn capture_thread_scope_stack() -> ThreadScopeStackBinding {
 }
 
 /// Restore a previously captured thread-local scope stack binding.
+///
+/// # Parameters
+/// - `binding`: Captured binding to restore on the current thread.
+///
+/// # Returns
+/// `()`.
 pub fn restore_thread_scope_stack(binding: ThreadScopeStackBinding) {
     THREAD_SCOPE_STACK.with(|stack| *stack.borrow_mut() = binding.stack);
     THREAD_SCOPE_STACK_EXPLICIT.with(|flag| flag.set(binding.explicit));

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -20,10 +20,10 @@ use crate::api::llm::{CreateLlmHandleParams, EndLlmHandleParams};
 use crate::api::llm::{LlmHandle, LlmRequest};
 use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
 use crate::api::runtime::callbacks::{
-    EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmRequestInterceptFn,
-    LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn,
-    LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionFn, ToolExecutionNextFn,
-    ToolInterceptFn, ToolSanitizeFn,
+    EventSubscriberFn, LlmConditionalSharedFn, LlmExecutionFn, LlmExecutionNextFn,
+    LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn,
+    LlmStreamExecutionNextFn, LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionFn,
+    ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::scope::{CreateScopeHandleParams, EndScopeHandleParams, ScopeHandle, ScopeType};
 use crate::api::tool::ToolHandle;
@@ -60,7 +60,8 @@ pub struct NemoFlowContextState {
     /// Global LLM response sanitizers applied to emitted LLM-end payloads.
     pub llm_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<LlmSanitizeResponseFn>>,
     /// Global LLM guardrails that can reject execution before the provider callback runs.
-    pub llm_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<LlmConditionalFn>>,
+    pub llm_conditional_execution_guardrails:
+        SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>,
     /// Global LLM request intercepts that can rewrite or annotate requests.
     pub llm_request_intercepts: SortedRegistry<Intercept<LlmRequestInterceptFn>>,
     /// Global non-streaming LLM execution intercepts that wrap callback execution.
@@ -530,38 +531,55 @@ impl NemoFlowContextState {
     }
 
     fn emit_guardrail_scope_start(
-        &self,
         name: &str,
         parent_uuid: Option<Uuid>,
         metadata: Option<Json>,
         input: Json,
         subscribers: &[EventSubscriberFn],
     ) -> ScopeHandle {
-        let handle = self.create_scope_handle(
-            CreateScopeHandleParams::builder()
-                .name(name)
-                .parent_uuid_opt(parent_uuid)
-                .scope_type(ScopeType::Guardrail)
-                .metadata_opt(metadata)
+        let handle = ScopeHandle::builder()
+            .name(name)
+            .scope_type(ScopeType::Guardrail)
+            .parent_uuid_opt(parent_uuid)
+            .metadata_opt(metadata)
+            .build();
+        let event = Event::Scope(ScopeEvent::new(
+            BaseEvent::builder()
+                .parent_uuid_opt(handle.parent_uuid)
+                .uuid(handle.uuid)
+                .timestamp(handle.started_at)
+                .name(handle.name.as_str())
+                .data(input)
+                .metadata_opt(handle.metadata.clone())
                 .build(),
-        );
-        let event = self.build_scope_start_event(&handle, Some(input));
+            ScopeCategory::Start,
+            scope_attributes_to_strings(handle.attributes),
+            EventCategory::from(handle.scope_type),
+            None,
+        ));
         Self::emit_event(&event, subscribers);
         handle
     }
 
     fn emit_guardrail_scope_end(
-        &self,
         handle: &ScopeHandle,
         output: Json,
         subscribers: &[EventSubscriberFn],
     ) {
-        let event = self.build_scope_end_event(
-            EndScopeHandleParams::builder()
-                .handle(handle)
+        let event = Event::Scope(ScopeEvent::new(
+            BaseEvent::builder()
+                .parent_uuid_opt(handle.parent_uuid)
+                .uuid(handle.uuid)
+                .timestamp(end_timestamp_after(handle.started_at))
+                .name(handle.name.as_str())
                 .data(output)
+                .metadata_opt(handle.metadata.clone())
                 .build(),
-        );
+            ScopeCategory::End,
+            scope_attributes_to_strings(handle.attributes),
+            EventCategory::from(handle.scope_type),
+            None,
+        ));
         Self::emit_event(&event, subscribers);
     }
 
@@ -640,7 +658,7 @@ impl NemoFlowContextState {
         let entries =
             merge_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals);
         for entry in entries {
-            let handle = self.emit_guardrail_scope_start(
+            let handle = Self::emit_guardrail_scope_start(
                 &entry.name,
                 parent_uuid,
                 metadata.clone(),
@@ -667,7 +685,7 @@ impl NemoFlowContextState {
                     "error": error.to_string(),
                 }),
             };
-            self.emit_guardrail_scope_end(&handle, output, subscribers);
+            Self::emit_guardrail_scope_end(&handle, output, subscribers);
             if let Some(error) = result? {
                 return Ok(Some(error));
             }
@@ -782,31 +800,40 @@ impl NemoFlowContextState {
         value
     }
 
-    /// Evaluate LLM conditional-execution guardrails in priority order.
+    /// Snapshot LLM conditional-execution guardrails in priority order.
     ///
     /// # Parameters
-    /// - `request`: LLM request to validate.
     /// - `scope_locals`: Scope-local conditional guardrail registries collected
     ///   from the active scope stack.
     ///
     /// # Returns
-    /// A [`Result`] containing `Ok(None)` when execution is allowed or
-    /// `Ok(Some(reason))` when a guardrail rejects the call.
-    ///
-    /// # Errors
-    /// Propagates any error returned by a guardrail callback.
-    pub fn llm_conditional_execution_chain(
+    /// Cloned guardrail entries that can be evaluated after registry locks are
+    /// released.
+    pub fn llm_conditional_execution_entries(
         &self,
+        scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>],
+    ) -> Vec<GuardrailEntry<LlmConditionalSharedFn>> {
+        merge_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals)
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Evaluate a snapshot of LLM conditional-execution guardrails in priority order.
+    ///
+    /// This function emits guardrail scope start/end events while evaluating
+    /// the provided entries. Callers should pass entries cloned from the
+    /// global and scope-local registries so subscriber callbacks run without
+    /// registry locks held.
+    pub fn llm_conditional_execution_chain(
         request: &LlmRequest,
-        scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalFn>>],
+        entries: Vec<GuardrailEntry<LlmConditionalSharedFn>>,
         subscribers: &[EventSubscriberFn],
         parent_uuid: Option<Uuid>,
         metadata: Option<Json>,
     ) -> crate::error::Result<Option<String>> {
-        let entries =
-            merge_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals);
         for entry in entries {
-            let handle = self.emit_guardrail_scope_start(
+            let handle = Self::emit_guardrail_scope_start(
                 &entry.name,
                 parent_uuid,
                 metadata.clone(),
@@ -832,7 +859,7 @@ impl NemoFlowContextState {
                     "error": error.to_string(),
                 }),
             };
-            self.emit_guardrail_scope_end(&handle, output, subscribers);
+            Self::emit_guardrail_scope_end(&handle, output, subscribers);
             if let Some(error) = result? {
                 return Ok(Some(error));
             }

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -20,10 +20,11 @@ use crate::api::llm::{CreateLlmHandleParams, EndLlmHandleParams};
 use crate::api::llm::{LlmHandle, LlmRequest};
 use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
 use crate::api::runtime::callbacks::{
-    EventSubscriberFn, LlmConditionalSharedFn, LlmExecutionFn, LlmExecutionNextFn,
-    LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn,
-    LlmStreamExecutionNextFn, LlmStreamExecutionRegistryRefs, ToolConditionalSharedFn,
-    ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
+    EventSubscriberFn, LlmConditionalFn, LlmConditionalSharedFn, LlmExecutionFn,
+    LlmExecutionNextFn, LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn,
+    LlmStreamExecutionFn, LlmStreamExecutionNextFn, LlmStreamExecutionRegistryRefs,
+    ToolConditionalFn, ToolConditionalSharedFn, ToolExecutionFn, ToolExecutionNextFn,
+    ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::scope::{CreateScopeHandleParams, EndScopeHandleParams, ScopeHandle, ScopeType};
 use crate::api::tool::ToolHandle;
@@ -39,6 +40,11 @@ use crate::registry::SortedRegistry;
 use chrono::{Duration, Utc};
 use serde_json::json;
 use uuid::Uuid;
+
+pub(crate) const TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION: &str =
+    "__nemo_flow_tool_conditional_shared_guardrails";
+pub(crate) const LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION: &str =
+    "__nemo_flow_llm_conditional_shared_guardrails";
 
 pub(crate) struct ConditionalGuardrailSnapshot<F> {
     name: String,
@@ -56,8 +62,7 @@ pub struct NemoFlowContextState {
     /// Global tool response sanitizers applied to emitted tool-end payloads.
     pub tool_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<ToolSanitizeFn>>,
     /// Global tool guardrails that can reject execution before the callback runs.
-    pub tool_conditional_execution_guardrails:
-        SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>,
+    pub tool_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<ToolConditionalFn>>,
     /// Global tool request intercepts that can rewrite arguments before execution.
     pub tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
     /// Global tool execution intercepts that wrap or replace callback execution.
@@ -67,8 +72,7 @@ pub struct NemoFlowContextState {
     /// Global LLM response sanitizers applied to emitted LLM-end payloads.
     pub llm_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<LlmSanitizeResponseFn>>,
     /// Global LLM guardrails that can reject execution before the provider callback runs.
-    pub llm_conditional_execution_guardrails:
-        SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>,
+    pub llm_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<LlmConditionalFn>>,
     /// Global LLM request intercepts that can rewrite or annotate requests.
     pub llm_request_intercepts: SortedRegistry<Intercept<LlmRequestInterceptFn>>,
     /// Global non-streaming LLM execution intercepts that wrap callback execution.
@@ -88,7 +92,7 @@ impl NemoFlowContextState {
     /// A [`NemoFlowContextState`] with empty registries, no subscribers, and no
     /// extensions.
     pub fn new() -> Self {
-        Self {
+        let mut state = Self {
             tool_sanitize_request_guardrails: SortedRegistry::new(|entry| entry.priority),
             tool_sanitize_response_guardrails: SortedRegistry::new(|entry| entry.priority),
             tool_conditional_execution_guardrails: SortedRegistry::new(|entry| entry.priority),
@@ -102,7 +106,96 @@ impl NemoFlowContextState {
             llm_stream_execution_intercepts: SortedRegistry::new(|entry| entry.priority),
             event_subscribers: HashMap::new(),
             extensions: HashMap::new(),
+        };
+        state.install_conditional_shared_registries();
+        state
+    }
+
+    fn install_conditional_shared_registries(&mut self) {
+        self.extensions.insert(
+            TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION.to_string(),
+            Box::new(
+                SortedRegistry::<GuardrailEntry<ToolConditionalSharedFn>>::new(|entry| {
+                    entry.priority
+                }),
+            ),
+        );
+        self.extensions.insert(
+            LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION.to_string(),
+            Box::new(
+                SortedRegistry::<GuardrailEntry<LlmConditionalSharedFn>>::new(|entry| {
+                    entry.priority
+                }),
+            ),
+        );
+    }
+
+    pub(crate) fn tool_conditional_shared_guardrails(
+        &self,
+    ) -> Option<&SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>> {
+        self.extensions
+            .get(TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
+            .and_then(|value| {
+                value.downcast_ref::<SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>>()
+            })
+    }
+
+    pub(crate) fn tool_conditional_shared_guardrails_mut(
+        &mut self,
+    ) -> &mut SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>> {
+        if !self
+            .extensions
+            .contains_key(TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
+        {
+            self.extensions.insert(
+                TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION.to_string(),
+                Box::new(
+                    SortedRegistry::<GuardrailEntry<ToolConditionalSharedFn>>::new(|entry| {
+                        entry.priority
+                    }),
+                ),
+            );
         }
+        self.extensions
+            .get_mut(TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
+            .and_then(|value| {
+                value.downcast_mut::<SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>>()
+            })
+            .expect("tool conditional shared guardrail registry has invalid type")
+    }
+
+    pub(crate) fn llm_conditional_shared_guardrails(
+        &self,
+    ) -> Option<&SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>> {
+        self.extensions
+            .get(LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
+            .and_then(|value| {
+                value.downcast_ref::<SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>>()
+            })
+    }
+
+    pub(crate) fn llm_conditional_shared_guardrails_mut(
+        &mut self,
+    ) -> &mut SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>> {
+        if !self
+            .extensions
+            .contains_key(LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
+        {
+            self.extensions.insert(
+                LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION.to_string(),
+                Box::new(
+                    SortedRegistry::<GuardrailEntry<LlmConditionalSharedFn>>::new(|entry| {
+                        entry.priority
+                    }),
+                ),
+            );
+        }
+        self.extensions
+            .get_mut(LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
+            .and_then(|value| {
+                value.downcast_mut::<SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>>()
+            })
+            .expect("llm conditional shared guardrail registry has invalid type")
     }
 
     /// Store an arbitrary runtime extension under `key`.
@@ -652,7 +745,12 @@ impl NemoFlowContextState {
         &self,
         scope_locals: &[&SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>],
     ) -> Vec<ConditionalGuardrailSnapshot<ToolConditionalSharedFn>> {
-        merge_named_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals)
+        let empty_global =
+            SortedRegistry::new(|entry: &GuardrailEntry<ToolConditionalSharedFn>| entry.priority);
+        let global = self
+            .tool_conditional_shared_guardrails()
+            .unwrap_or(&empty_global);
+        merge_named_guardrail_entries(global, scope_locals)
             .into_iter()
             .map(|(name, entry)| ConditionalGuardrailSnapshot {
                 name: name.to_string(),
@@ -831,7 +929,12 @@ impl NemoFlowContextState {
         &self,
         scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>],
     ) -> Vec<ConditionalGuardrailSnapshot<LlmConditionalSharedFn>> {
-        merge_named_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals)
+        let empty_global =
+            SortedRegistry::new(|entry: &GuardrailEntry<LlmConditionalSharedFn>| entry.priority);
+        let global = self
+            .llm_conditional_shared_guardrails()
+            .unwrap_or(&empty_global);
+        merge_named_guardrail_entries(global, scope_locals)
             .into_iter()
             .map(|(name, entry)| ConditionalGuardrailSnapshot {
                 name: name.to_string(),
@@ -856,7 +959,7 @@ impl NemoFlowContextState {
     pub fn llm_conditional_execution_chain(
         &self,
         request: &LlmRequest,
-        scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>],
+        scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalFn>>],
     ) -> crate::error::Result<Option<String>> {
         let entries =
             merge_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals);

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -840,13 +840,41 @@ impl NemoFlowContextState {
             .collect()
     }
 
+    /// Evaluate LLM conditional-execution guardrails in priority order.
+    ///
+    /// # Parameters
+    /// - `request`: LLM request to validate.
+    /// - `scope_locals`: Scope-local conditional guardrail registries collected
+    ///   from the active scope stack.
+    ///
+    /// # Returns
+    /// A [`Result`] containing `Ok(None)` when execution is allowed or
+    /// `Ok(Some(reason))` when a guardrail rejects the call.
+    ///
+    /// # Errors
+    /// Propagates any error returned by a guardrail callback.
+    pub fn llm_conditional_execution_chain(
+        &self,
+        request: &LlmRequest,
+        scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>],
+    ) -> crate::error::Result<Option<String>> {
+        let entries =
+            merge_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals);
+        for entry in entries {
+            if let Some(error) = (entry.guardrail)(request)? {
+                return Ok(Some(error));
+            }
+        }
+        Ok(None)
+    }
+
     /// Evaluate a snapshot of LLM conditional-execution guardrails in priority order.
     ///
     /// This function emits guardrail scope start/end events while evaluating
     /// the provided entries. Callers should pass entries snapped from the
     /// global and scope-local registries so subscriber callbacks run without
     /// registry locks held.
-    pub(crate) fn llm_conditional_execution_chain(
+    pub(crate) fn llm_conditional_execution_snapshot_chain(
         request: &LlmRequest,
         entries: Vec<ConditionalGuardrailSnapshot<LlmConditionalSharedFn>>,
         subscribers: &[EventSubscriberFn],

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -25,7 +25,7 @@ use crate::api::runtime::callbacks::{
     LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionFn, ToolExecutionNextFn,
     ToolInterceptFn, ToolSanitizeFn,
 };
-use crate::api::scope::{CreateScopeHandleParams, EndScopeHandleParams, ScopeHandle};
+use crate::api::scope::{CreateScopeHandleParams, EndScopeHandleParams, ScopeHandle, ScopeType};
 use crate::api::tool::ToolHandle;
 use crate::api::tool::{CreateToolHandleParams, EndToolHandleParams};
 use crate::codec::request::AnnotatedLlmRequest;
@@ -36,6 +36,8 @@ use crate::context::registries::{
 use crate::json::{Json, merge_json};
 use crate::registry::SortedRegistry;
 use chrono::{Duration, Utc};
+use serde_json::json;
+use uuid::Uuid;
 
 /// Process-global runtime state backing middleware and event emission.
 ///
@@ -527,6 +529,42 @@ impl NemoFlowContextState {
         ))
     }
 
+    fn emit_guardrail_scope_start(
+        &self,
+        name: &str,
+        parent_uuid: Option<Uuid>,
+        metadata: Option<Json>,
+        input: Json,
+        subscribers: &[EventSubscriberFn],
+    ) -> ScopeHandle {
+        let handle = self.create_scope_handle(
+            CreateScopeHandleParams::builder()
+                .name(name)
+                .parent_uuid_opt(parent_uuid)
+                .scope_type(ScopeType::Guardrail)
+                .metadata_opt(metadata)
+                .build(),
+        );
+        let event = self.build_scope_start_event(&handle, Some(input));
+        Self::emit_event(&event, subscribers);
+        handle
+    }
+
+    fn emit_guardrail_scope_end(
+        &self,
+        handle: &ScopeHandle,
+        output: Json,
+        subscribers: &[EventSubscriberFn],
+    ) {
+        let event = self.build_scope_end_event(
+            EndScopeHandleParams::builder()
+                .handle(handle)
+                .data(output)
+                .build(),
+        );
+        Self::emit_event(&event, subscribers);
+    }
+
     /// Run tool request sanitizers across global and scope-local registries.
     ///
     /// # Parameters
@@ -595,11 +633,42 @@ impl NemoFlowContextState {
         name: &str,
         args: &Json,
         scope_locals: &[&SortedRegistry<GuardrailEntry<ToolConditionalFn>>],
+        subscribers: &[EventSubscriberFn],
+        parent_uuid: Option<Uuid>,
+        metadata: Option<Json>,
     ) -> crate::error::Result<Option<String>> {
         let entries =
             merge_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals);
         for entry in entries {
-            if let Some(error) = (entry.guardrail)(name, args)? {
+            let handle = self.emit_guardrail_scope_start(
+                &entry.name,
+                parent_uuid,
+                metadata.clone(),
+                json!({
+                    "kind": "tool_conditional_execution",
+                    "target_name": name,
+                    "input": args,
+                }),
+                subscribers,
+            );
+            let result = (entry.guardrail)(name, args);
+            let output = match &result {
+                Ok(Some(reason)) => json!({
+                    "allowed": false,
+                    "rejected": true,
+                    "rejection_reason": reason,
+                }),
+                Ok(None) => json!({
+                    "allowed": true,
+                    "rejected": false,
+                }),
+                Err(error) => json!({
+                    "allowed": false,
+                    "error": error.to_string(),
+                }),
+            };
+            self.emit_guardrail_scope_end(&handle, output, subscribers);
+            if let Some(error) = result? {
                 return Ok(Some(error));
             }
         }
@@ -730,11 +799,41 @@ impl NemoFlowContextState {
         &self,
         request: &LlmRequest,
         scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalFn>>],
+        subscribers: &[EventSubscriberFn],
+        parent_uuid: Option<Uuid>,
+        metadata: Option<Json>,
     ) -> crate::error::Result<Option<String>> {
         let entries =
             merge_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals);
         for entry in entries {
-            if let Some(error) = (entry.guardrail)(request)? {
+            let handle = self.emit_guardrail_scope_start(
+                &entry.name,
+                parent_uuid,
+                metadata.clone(),
+                json!({
+                    "kind": "llm_conditional_execution",
+                    "input": request,
+                }),
+                subscribers,
+            );
+            let result = (entry.guardrail)(request);
+            let output = match &result {
+                Ok(Some(reason)) => json!({
+                    "allowed": false,
+                    "rejected": true,
+                    "rejection_reason": reason,
+                }),
+                Ok(None) => json!({
+                    "allowed": true,
+                    "rejected": false,
+                }),
+                Err(error) => json!({
+                    "allowed": false,
+                    "error": error.to_string(),
+                }),
+            };
+            self.emit_guardrail_scope_end(&handle, output, subscribers);
+            if let Some(error) = result? {
                 return Ok(Some(error));
             }
         }

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -20,10 +20,9 @@ use crate::api::llm::{CreateLlmHandleParams, EndLlmHandleParams};
 use crate::api::llm::{LlmHandle, LlmRequest};
 use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
 use crate::api::runtime::callbacks::{
-    EventSubscriberFn, LlmConditionalFn, LlmConditionalSharedFn, LlmExecutionFn,
-    LlmExecutionNextFn, LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn,
-    LlmStreamExecutionFn, LlmStreamExecutionNextFn, LlmStreamExecutionRegistryRefs,
-    ToolConditionalFn, ToolConditionalSharedFn, ToolExecutionFn, ToolExecutionNextFn,
+    EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmRequestInterceptFn,
+    LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn,
+    LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionFn, ToolExecutionNextFn,
     ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::scope::{CreateScopeHandleParams, EndScopeHandleParams, ScopeHandle, ScopeType};
@@ -40,11 +39,6 @@ use crate::registry::SortedRegistry;
 use chrono::{Duration, Utc};
 use serde_json::json;
 use uuid::Uuid;
-
-pub(crate) const TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION: &str =
-    "__nemo_flow_tool_conditional_shared_guardrails";
-pub(crate) const LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION: &str =
-    "__nemo_flow_llm_conditional_shared_guardrails";
 
 pub(crate) struct ConditionalGuardrailSnapshot<F> {
     name: String,
@@ -92,7 +86,7 @@ impl NemoFlowContextState {
     /// A [`NemoFlowContextState`] with empty registries, no subscribers, and no
     /// extensions.
     pub fn new() -> Self {
-        let mut state = Self {
+        Self {
             tool_sanitize_request_guardrails: SortedRegistry::new(|entry| entry.priority),
             tool_sanitize_response_guardrails: SortedRegistry::new(|entry| entry.priority),
             tool_conditional_execution_guardrails: SortedRegistry::new(|entry| entry.priority),
@@ -106,96 +100,7 @@ impl NemoFlowContextState {
             llm_stream_execution_intercepts: SortedRegistry::new(|entry| entry.priority),
             event_subscribers: HashMap::new(),
             extensions: HashMap::new(),
-        };
-        state.install_conditional_shared_registries();
-        state
-    }
-
-    fn install_conditional_shared_registries(&mut self) {
-        self.extensions.insert(
-            TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION.to_string(),
-            Box::new(
-                SortedRegistry::<GuardrailEntry<ToolConditionalSharedFn>>::new(|entry| {
-                    entry.priority
-                }),
-            ),
-        );
-        self.extensions.insert(
-            LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION.to_string(),
-            Box::new(
-                SortedRegistry::<GuardrailEntry<LlmConditionalSharedFn>>::new(|entry| {
-                    entry.priority
-                }),
-            ),
-        );
-    }
-
-    pub(crate) fn tool_conditional_shared_guardrails(
-        &self,
-    ) -> Option<&SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>> {
-        self.extensions
-            .get(TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
-            .and_then(|value| {
-                value.downcast_ref::<SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>>()
-            })
-    }
-
-    pub(crate) fn tool_conditional_shared_guardrails_mut(
-        &mut self,
-    ) -> &mut SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>> {
-        if !self
-            .extensions
-            .contains_key(TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
-        {
-            self.extensions.insert(
-                TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION.to_string(),
-                Box::new(
-                    SortedRegistry::<GuardrailEntry<ToolConditionalSharedFn>>::new(|entry| {
-                        entry.priority
-                    }),
-                ),
-            );
         }
-        self.extensions
-            .get_mut(TOOL_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
-            .and_then(|value| {
-                value.downcast_mut::<SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>>()
-            })
-            .expect("tool conditional shared guardrail registry has invalid type")
-    }
-
-    pub(crate) fn llm_conditional_shared_guardrails(
-        &self,
-    ) -> Option<&SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>> {
-        self.extensions
-            .get(LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
-            .and_then(|value| {
-                value.downcast_ref::<SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>>()
-            })
-    }
-
-    pub(crate) fn llm_conditional_shared_guardrails_mut(
-        &mut self,
-    ) -> &mut SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>> {
-        if !self
-            .extensions
-            .contains_key(LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
-        {
-            self.extensions.insert(
-                LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION.to_string(),
-                Box::new(
-                    SortedRegistry::<GuardrailEntry<LlmConditionalSharedFn>>::new(|entry| {
-                        entry.priority
-                    }),
-                ),
-            );
-        }
-        self.extensions
-            .get_mut(LLM_CONDITIONAL_SHARED_GUARDRAILS_EXTENSION)
-            .and_then(|value| {
-                value.downcast_mut::<SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>>()
-            })
-            .expect("llm conditional shared guardrail registry has invalid type")
     }
 
     /// Store an arbitrary runtime extension under `key`.
@@ -743,14 +648,9 @@ impl NemoFlowContextState {
     /// are released.
     pub(crate) fn tool_conditional_execution_entries(
         &self,
-        scope_locals: &[&SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>],
-    ) -> Vec<ConditionalGuardrailSnapshot<ToolConditionalSharedFn>> {
-        let empty_global =
-            SortedRegistry::new(|entry: &GuardrailEntry<ToolConditionalSharedFn>| entry.priority);
-        let global = self
-            .tool_conditional_shared_guardrails()
-            .unwrap_or(&empty_global);
-        merge_named_guardrail_entries(global, scope_locals)
+        scope_locals: &[&SortedRegistry<GuardrailEntry<ToolConditionalFn>>],
+    ) -> Vec<ConditionalGuardrailSnapshot<ToolConditionalFn>> {
+        merge_named_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals)
             .into_iter()
             .map(|(name, entry)| ConditionalGuardrailSnapshot {
                 name: name.to_string(),
@@ -794,11 +694,30 @@ impl NemoFlowContextState {
     /// This function emits guardrail scope start/end events while evaluating
     /// the provided entries. Callers should pass entries snapped from the
     /// global and scope-local registries so subscriber callbacks run without
-    /// registry locks held.
+    /// registry locks held. If `entries` is empty, no guardrail scopes are
+    /// emitted.
+    ///
+    /// # Parameters
+    /// - `name`: Tool name associated with the request.
+    /// - `args`: Tool arguments to validate.
+    /// - `entries`: Owned conditional guardrail snapshots to evaluate.
+    /// - `subscribers`: Event subscribers that should observe guardrail scope
+    ///   start/end events.
+    /// - `parent_uuid`: Optional parent scope UUID for emitted guardrail
+    ///   scopes.
+    /// - `metadata`: Optional metadata attached to emitted guardrail scopes.
+    ///
+    /// # Returns
+    /// A [`Result`](crate::error::Result) containing `Ok(None)` when execution
+    /// is allowed or `Ok(Some(reason))` when a guardrail rejects the call.
+    ///
+    /// # Errors
+    /// Propagates any error returned by a guardrail callback after emitting the
+    /// corresponding guardrail scope end event.
     pub(crate) fn tool_conditional_execution_snapshot_chain(
         name: &str,
         args: &Json,
-        entries: Vec<ConditionalGuardrailSnapshot<ToolConditionalSharedFn>>,
+        entries: Vec<ConditionalGuardrailSnapshot<ToolConditionalFn>>,
         subscribers: &[EventSubscriberFn],
         parent_uuid: Option<Uuid>,
         metadata: Option<Json>,
@@ -957,14 +876,9 @@ impl NemoFlowContextState {
     /// are released.
     pub(crate) fn llm_conditional_execution_entries(
         &self,
-        scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>],
-    ) -> Vec<ConditionalGuardrailSnapshot<LlmConditionalSharedFn>> {
-        let empty_global =
-            SortedRegistry::new(|entry: &GuardrailEntry<LlmConditionalSharedFn>| entry.priority);
-        let global = self
-            .llm_conditional_shared_guardrails()
-            .unwrap_or(&empty_global);
-        merge_named_guardrail_entries(global, scope_locals)
+        scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalFn>>],
+    ) -> Vec<ConditionalGuardrailSnapshot<LlmConditionalFn>> {
+        merge_named_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals)
             .into_iter()
             .map(|(name, entry)| ConditionalGuardrailSnapshot {
                 name: name.to_string(),
@@ -1006,10 +920,28 @@ impl NemoFlowContextState {
     /// This function emits guardrail scope start/end events while evaluating
     /// the provided entries. Callers should pass entries snapped from the
     /// global and scope-local registries so subscriber callbacks run without
-    /// registry locks held.
+    /// registry locks held. If `entries` is empty, no guardrail scopes are
+    /// emitted.
+    ///
+    /// # Parameters
+    /// - `request`: LLM request to validate.
+    /// - `entries`: Owned conditional guardrail snapshots to evaluate.
+    /// - `subscribers`: Event subscribers that should observe guardrail scope
+    ///   start/end events.
+    /// - `parent_uuid`: Optional parent scope UUID for emitted guardrail
+    ///   scopes.
+    /// - `metadata`: Optional metadata attached to emitted guardrail scopes.
+    ///
+    /// # Returns
+    /// A [`Result`](crate::error::Result) containing `Ok(None)` when execution
+    /// is allowed or `Ok(Some(reason))` when a guardrail rejects the call.
+    ///
+    /// # Errors
+    /// Propagates any error returned by a guardrail callback after emitting the
+    /// corresponding guardrail scope end event.
     pub(crate) fn llm_conditional_execution_snapshot_chain(
         request: &LlmRequest,
-        entries: Vec<ConditionalGuardrailSnapshot<LlmConditionalSharedFn>>,
+        entries: Vec<ConditionalGuardrailSnapshot<LlmConditionalFn>>,
         subscribers: &[EventSubscriberFn],
         parent_uuid: Option<Uuid>,
         metadata: Option<Json>,

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -759,13 +759,43 @@ impl NemoFlowContextState {
             .collect()
     }
 
+    /// Evaluate tool conditional-execution guardrails in priority order.
+    ///
+    /// # Parameters
+    /// - `name`: Tool name associated with the request.
+    /// - `args`: Tool arguments to validate.
+    /// - `scope_locals`: Scope-local conditional guardrail registries collected
+    ///   from the active scope stack.
+    ///
+    /// # Returns
+    /// A [`Result`] containing `Ok(None)` when execution is allowed or
+    /// `Ok(Some(reason))` when a guardrail rejects the call.
+    ///
+    /// # Errors
+    /// Propagates any error returned by a guardrail callback.
+    pub fn tool_conditional_execution_chain(
+        &self,
+        name: &str,
+        args: &Json,
+        scope_locals: &[&SortedRegistry<GuardrailEntry<ToolConditionalFn>>],
+    ) -> crate::error::Result<Option<String>> {
+        let entries =
+            merge_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals);
+        for entry in entries {
+            if let Some(error) = (entry.guardrail)(name, args)? {
+                return Ok(Some(error));
+            }
+        }
+        Ok(None)
+    }
+
     /// Evaluate a snapshot of tool conditional-execution guardrails in priority order.
     ///
     /// This function emits guardrail scope start/end events while evaluating
     /// the provided entries. Callers should pass entries snapped from the
     /// global and scope-local registries so subscriber callbacks run without
     /// registry locks held.
-    pub(crate) fn tool_conditional_execution_chain(
+    pub(crate) fn tool_conditional_execution_snapshot_chain(
         name: &str,
         args: &Json,
         entries: Vec<ConditionalGuardrailSnapshot<ToolConditionalSharedFn>>,

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -695,7 +695,8 @@ impl NemoFlowContextState {
     /// the provided entries. Callers should pass entries snapped from the
     /// global and scope-local registries so subscriber callbacks run without
     /// registry locks held. If `entries` is empty, no guardrail scopes are
-    /// emitted.
+    /// emitted. Guardrail start events identify the guardrail and target but
+    /// intentionally omit raw tool arguments from their event data.
     ///
     /// # Parameters
     /// - `name`: Tool name associated with the request.
@@ -730,7 +731,6 @@ impl NemoFlowContextState {
                 json!({
                     "kind": "tool_conditional_execution",
                     "target_name": name,
-                    "input": args,
                 }),
                 subscribers,
             );
@@ -921,7 +921,8 @@ impl NemoFlowContextState {
     /// the provided entries. Callers should pass entries snapped from the
     /// global and scope-local registries so subscriber callbacks run without
     /// registry locks held. If `entries` is empty, no guardrail scopes are
-    /// emitted.
+    /// emitted. Guardrail start events identify the guardrail but intentionally
+    /// omit raw LLM requests from their event data.
     ///
     /// # Parameters
     /// - `request`: LLM request to validate.
@@ -953,7 +954,6 @@ impl NemoFlowContextState {
                 metadata.clone(),
                 json!({
                     "kind": "llm_conditional_execution",
-                    "input": request,
                 }),
                 subscribers,
             );

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -22,8 +22,8 @@ use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
 use crate::api::runtime::callbacks::{
     EventSubscriberFn, LlmConditionalSharedFn, LlmExecutionFn, LlmExecutionNextFn,
     LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn,
-    LlmStreamExecutionNextFn, LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionFn,
-    ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
+    LlmStreamExecutionNextFn, LlmStreamExecutionRegistryRefs, ToolConditionalSharedFn,
+    ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::scope::{CreateScopeHandleParams, EndScopeHandleParams, ScopeHandle, ScopeType};
 use crate::api::tool::ToolHandle;
@@ -50,7 +50,8 @@ pub struct NemoFlowContextState {
     /// Global tool response sanitizers applied to emitted tool-end payloads.
     pub tool_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<ToolSanitizeFn>>,
     /// Global tool guardrails that can reject execution before the callback runs.
-    pub tool_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<ToolConditionalFn>>,
+    pub tool_conditional_execution_guardrails:
+        SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>,
     /// Global tool request intercepts that can rewrite arguments before execution.
     pub tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
     /// Global tool execution intercepts that wrap or replace callback execution.
@@ -632,31 +633,39 @@ impl NemoFlowContextState {
         value
     }
 
-    /// Evaluate tool conditional-execution guardrails in priority order.
+    /// Snapshot tool conditional-execution guardrails in priority order.
     ///
     /// # Parameters
-    /// - `name`: Tool name associated with the request.
-    /// - `args`: Tool arguments to validate.
     /// - `scope_locals`: Scope-local conditional guardrail registries collected
     ///   from the active scope stack.
     ///
     /// # Returns
-    /// A [`Result`] containing `Ok(None)` when execution is allowed or
-    /// `Ok(Some(reason))` when a guardrail rejects the call.
-    ///
-    /// # Errors
-    /// Propagates any error returned by a guardrail callback.
-    pub fn tool_conditional_execution_chain(
+    /// Cloned guardrail entries that can be evaluated after registry locks are
+    /// released.
+    pub fn tool_conditional_execution_entries(
         &self,
+        scope_locals: &[&SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>],
+    ) -> Vec<GuardrailEntry<ToolConditionalSharedFn>> {
+        merge_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals)
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Evaluate a snapshot of tool conditional-execution guardrails in priority order.
+    ///
+    /// This function emits guardrail scope start/end events while evaluating
+    /// the provided entries. Callers should pass entries cloned from the
+    /// global and scope-local registries so subscriber callbacks run without
+    /// registry locks held.
+    pub fn tool_conditional_execution_chain(
         name: &str,
         args: &Json,
-        scope_locals: &[&SortedRegistry<GuardrailEntry<ToolConditionalFn>>],
+        entries: Vec<GuardrailEntry<ToolConditionalSharedFn>>,
         subscribers: &[EventSubscriberFn],
         parent_uuid: Option<Uuid>,
         metadata: Option<Json>,
     ) -> crate::error::Result<Option<String>> {
-        let entries =
-            merge_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals);
         for entry in entries {
             let handle = Self::emit_guardrail_scope_start(
                 &entry.name,

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -32,12 +32,18 @@ use crate::codec::request::AnnotatedLlmRequest;
 use crate::codec::response::AnnotatedLlmResponse;
 use crate::context::registries::{
     merge_execution_intercept_callables, merge_guardrail_entries, merge_intercept_entries,
+    merge_named_guardrail_entries,
 };
 use crate::json::{Json, merge_json};
 use crate::registry::SortedRegistry;
 use chrono::{Duration, Utc};
 use serde_json::json;
 use uuid::Uuid;
+
+pub(crate) struct ConditionalGuardrailSnapshot<F> {
+    name: String,
+    guardrail: F,
+}
 
 /// Process-global runtime state backing middleware and event emission.
 ///
@@ -640,28 +646,31 @@ impl NemoFlowContextState {
     ///   from the active scope stack.
     ///
     /// # Returns
-    /// Cloned guardrail entries that can be evaluated after registry locks are
-    /// released.
-    pub fn tool_conditional_execution_entries(
+    /// Owned guardrail snapshots that can be evaluated after registry locks
+    /// are released.
+    pub(crate) fn tool_conditional_execution_entries(
         &self,
         scope_locals: &[&SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>],
-    ) -> Vec<GuardrailEntry<ToolConditionalSharedFn>> {
-        merge_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals)
+    ) -> Vec<ConditionalGuardrailSnapshot<ToolConditionalSharedFn>> {
+        merge_named_guardrail_entries(&self.tool_conditional_execution_guardrails, scope_locals)
             .into_iter()
-            .cloned()
+            .map(|(name, entry)| ConditionalGuardrailSnapshot {
+                name: name.to_string(),
+                guardrail: entry.guardrail.clone(),
+            })
             .collect()
     }
 
     /// Evaluate a snapshot of tool conditional-execution guardrails in priority order.
     ///
     /// This function emits guardrail scope start/end events while evaluating
-    /// the provided entries. Callers should pass entries cloned from the
+    /// the provided entries. Callers should pass entries snapped from the
     /// global and scope-local registries so subscriber callbacks run without
     /// registry locks held.
-    pub fn tool_conditional_execution_chain(
+    pub(crate) fn tool_conditional_execution_chain(
         name: &str,
         args: &Json,
-        entries: Vec<GuardrailEntry<ToolConditionalSharedFn>>,
+        entries: Vec<ConditionalGuardrailSnapshot<ToolConditionalSharedFn>>,
         subscribers: &[EventSubscriberFn],
         parent_uuid: Option<Uuid>,
         metadata: Option<Json>,
@@ -816,27 +825,30 @@ impl NemoFlowContextState {
     ///   from the active scope stack.
     ///
     /// # Returns
-    /// Cloned guardrail entries that can be evaluated after registry locks are
-    /// released.
-    pub fn llm_conditional_execution_entries(
+    /// Owned guardrail snapshots that can be evaluated after registry locks
+    /// are released.
+    pub(crate) fn llm_conditional_execution_entries(
         &self,
         scope_locals: &[&SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>],
-    ) -> Vec<GuardrailEntry<LlmConditionalSharedFn>> {
-        merge_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals)
+    ) -> Vec<ConditionalGuardrailSnapshot<LlmConditionalSharedFn>> {
+        merge_named_guardrail_entries(&self.llm_conditional_execution_guardrails, scope_locals)
             .into_iter()
-            .cloned()
+            .map(|(name, entry)| ConditionalGuardrailSnapshot {
+                name: name.to_string(),
+                guardrail: entry.guardrail.clone(),
+            })
             .collect()
     }
 
     /// Evaluate a snapshot of LLM conditional-execution guardrails in priority order.
     ///
     /// This function emits guardrail scope start/end events while evaluating
-    /// the provided entries. Callers should pass entries cloned from the
+    /// the provided entries. Callers should pass entries snapped from the
     /// global and scope-local registries so subscriber callbacks run without
     /// registry locks held.
-    pub fn llm_conditional_execution_chain(
+    pub(crate) fn llm_conditional_execution_chain(
         request: &LlmRequest,
-        entries: Vec<GuardrailEntry<LlmConditionalSharedFn>>,
+        entries: Vec<ConditionalGuardrailSnapshot<LlmConditionalSharedFn>>,
         subscribers: &[EventSubscriberFn],
         parent_uuid: Option<Uuid>,
         metadata: Option<Json>,

--- a/crates/core/src/api/tool.rs
+++ b/crates/core/src/api/tool.rs
@@ -383,7 +383,7 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<Json> {
                 metadata.clone(),
             )
         };
-        if let Some(error) = NemoFlowContextState::tool_conditional_execution_chain(
+        if let Some(error) = NemoFlowContextState::tool_conditional_execution_snapshot_chain(
             &name,
             &args,
             entries,
@@ -530,7 +530,7 @@ pub fn tool_conditional_execution(name: &str, args: &Json) -> Result<()> {
         let subscribers = state.collect_event_subscribers(&scope_subscribers);
         (entries, subscribers, resolve_parent_uuid(None))
     };
-    if let Some(error) = NemoFlowContextState::tool_conditional_execution_chain(
+    if let Some(error) = NemoFlowContextState::tool_conditional_execution_snapshot_chain(
         name,
         args,
         entries,

--- a/crates/core/src/api/tool.rs
+++ b/crates/core/src/api/tool.rs
@@ -367,7 +367,7 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<Json> {
             let scope_stack = current_scope_stack();
             let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
             let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-                &registries.tool_conditional_execution_guardrails
+                &registries.tool_conditional_execution_shared_guardrails
             });
             let scope_subscribers = scope_guard.collect_scope_local_subscribers();
             let context = global_context();
@@ -519,7 +519,7 @@ pub fn tool_conditional_execution(name: &str, args: &Json) -> Result<()> {
         let scope_stack = current_scope_stack();
         let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
         let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-            &registries.tool_conditional_execution_guardrails
+            &registries.tool_conditional_execution_shared_guardrails
         });
         let scope_subscribers = scope_guard.collect_scope_local_subscribers();
         let context = global_context();

--- a/crates/core/src/api/tool.rs
+++ b/crates/core/src/api/tool.rs
@@ -363,27 +363,34 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<Json> {
     } = params;
     ensure_runtime_owner()?;
     {
-        let scope_stack = current_scope_stack();
-        let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
-        let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-            &registries.tool_conditional_execution_guardrails
-        });
-        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
-        let context = global_context();
-        let state = context
-            .read()
-            .map_err(|error| FlowError::Internal(error.to_string()))?;
-        let subscribers = state.collect_event_subscribers(&scope_subscribers);
-        if let Some(error) = state.tool_conditional_execution_chain(
+        let (entries, subscribers, parent_uuid, guardrail_metadata) = {
+            let scope_stack = current_scope_stack();
+            let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
+            let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
+                &registries.tool_conditional_execution_guardrails
+            });
+            let scope_subscribers = scope_guard.collect_scope_local_subscribers();
+            let context = global_context();
+            let state = context
+                .read()
+                .map_err(|error| FlowError::Internal(error.to_string()))?;
+            let entries = state.tool_conditional_execution_entries(&scope_locals);
+            let subscribers = state.collect_event_subscribers(&scope_subscribers);
+            (
+                entries,
+                subscribers,
+                resolve_parent_uuid(parent.as_ref()),
+                metadata.clone(),
+            )
+        };
+        if let Some(error) = NemoFlowContextState::tool_conditional_execution_chain(
             &name,
             &args,
-            &scope_locals,
+            entries,
             &subscribers,
-            resolve_parent_uuid(parent.as_ref()),
-            metadata.clone(),
+            parent_uuid,
+            guardrail_metadata,
         )? {
-            drop(state);
-            drop(scope_guard);
             let mut rejection_data = json!({});
             if let Some(object) = rejection_data.as_object_mut() {
                 object.insert("rejected".into(), json!(true));
@@ -508,23 +515,27 @@ pub fn tool_request_intercepts(name: &str, args: Json) -> Result<Json> {
 /// emitted for the conditional checks themselves.
 pub fn tool_conditional_execution(name: &str, args: &Json) -> Result<()> {
     ensure_runtime_owner()?;
-    let scope_stack = current_scope_stack();
-    let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
-    let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-        &registries.tool_conditional_execution_guardrails
-    });
-    let scope_subscribers = scope_guard.collect_scope_local_subscribers();
-    let context = global_context();
-    let state = context
-        .read()
-        .map_err(|error| FlowError::Internal(error.to_string()))?;
-    let subscribers = state.collect_event_subscribers(&scope_subscribers);
-    if let Some(error) = state.tool_conditional_execution_chain(
+    let (entries, subscribers, parent_uuid) = {
+        let scope_stack = current_scope_stack();
+        let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
+        let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
+            &registries.tool_conditional_execution_guardrails
+        });
+        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
+        let context = global_context();
+        let state = context
+            .read()
+            .map_err(|error| FlowError::Internal(error.to_string()))?;
+        let entries = state.tool_conditional_execution_entries(&scope_locals);
+        let subscribers = state.collect_event_subscribers(&scope_subscribers);
+        (entries, subscribers, resolve_parent_uuid(None))
+    };
+    if let Some(error) = NemoFlowContextState::tool_conditional_execution_chain(
         name,
         args,
-        &scope_locals,
+        entries,
         &subscribers,
-        resolve_parent_uuid(None),
+        parent_uuid,
         None,
     )? {
         return Err(FlowError::GuardrailRejected(error));

--- a/crates/core/src/api/tool.rs
+++ b/crates/core/src/api/tool.rs
@@ -367,7 +367,7 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<Json> {
             let scope_stack = current_scope_stack();
             let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
             let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-                &registries.tool_conditional_execution_shared_guardrails
+                &registries.tool_conditional_execution_guardrails
             });
             let scope_subscribers = scope_guard.collect_scope_local_subscribers();
             let context = global_context();
@@ -519,7 +519,7 @@ pub fn tool_conditional_execution(name: &str, args: &Json) -> Result<()> {
         let scope_stack = current_scope_stack();
         let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
         let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
-            &registries.tool_conditional_execution_shared_guardrails
+            &registries.tool_conditional_execution_guardrails
         });
         let scope_subscribers = scope_guard.collect_scope_local_subscribers();
         let context = global_context();

--- a/crates/core/src/api/tool.rs
+++ b/crates/core/src/api/tool.rs
@@ -368,11 +368,20 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<Json> {
         let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
             &registries.tool_conditional_execution_guardrails
         });
+        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
         let context = global_context();
         let state = context
             .read()
             .map_err(|error| FlowError::Internal(error.to_string()))?;
-        if let Some(error) = state.tool_conditional_execution_chain(&name, &args, &scope_locals)? {
+        let subscribers = state.collect_event_subscribers(&scope_subscribers);
+        if let Some(error) = state.tool_conditional_execution_chain(
+            &name,
+            &args,
+            &scope_locals,
+            &subscribers,
+            resolve_parent_uuid(parent.as_ref()),
+            metadata.clone(),
+        )? {
             drop(state);
             drop(scope_guard);
             let mut rejection_data = json!({});
@@ -479,7 +488,8 @@ pub fn tool_request_intercepts(name: &str, args: Json) -> Result<Json> {
 /// Run only the tool conditional-execution guardrail chain.
 ///
 /// This evaluates whether a tool call should be allowed to proceed without
-/// emitting lifecycle events or invoking request intercepts or execution.
+/// invoking request intercepts or execution. Each evaluated guardrail emits an
+/// automatic guardrail scope start/end pair for observability.
 ///
 /// # Parameters
 /// - `name`: Tool name used when resolving the guardrail chain.
@@ -494,7 +504,8 @@ pub fn tool_request_intercepts(name: &str, args: Json) -> Result<Json> {
 ///
 /// # Notes
 /// This helper is useful for preflight checks when the caller needs the
-/// rejection result without starting a tool span.
+/// rejection result without starting a tool span. Guardrail scopes are still
+/// emitted for the conditional checks themselves.
 pub fn tool_conditional_execution(name: &str, args: &Json) -> Result<()> {
     ensure_runtime_owner()?;
     let scope_stack = current_scope_stack();
@@ -502,11 +513,20 @@ pub fn tool_conditional_execution(name: &str, args: &Json) -> Result<()> {
     let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
         &registries.tool_conditional_execution_guardrails
     });
+    let scope_subscribers = scope_guard.collect_scope_local_subscribers();
     let context = global_context();
     let state = context
         .read()
         .map_err(|error| FlowError::Internal(error.to_string()))?;
-    if let Some(error) = state.tool_conditional_execution_chain(name, args, &scope_locals)? {
+    let subscribers = state.collect_event_subscribers(&scope_subscribers);
+    if let Some(error) = state.tool_conditional_execution_chain(
+        name,
+        args,
+        &scope_locals,
+        &subscribers,
+        resolve_parent_uuid(None),
+        None,
+    )? {
         return Err(FlowError::GuardrailRejected(error));
     }
     Ok(())

--- a/crates/core/src/codec/anthropic.rs
+++ b/crates/core/src/codec/anthropic.rs
@@ -577,7 +577,7 @@ impl LlmCodec for AnthropicMessagesCodec {
 /// for a non-streaming request (`{id, type, role, model, content, stop_reason, stop_sequence,
 /// usage}`). Once finalized, the assembled JSON can be fed back through
 /// [`AnthropicMessagesCodec::decode_response`] to produce an
-/// [`AnnotatedLlmResponse`](crate::codec::response::AnnotatedLlmResponse) — meaning streaming and
+/// [`AnnotatedLlmResponse`] — meaning streaming and
 /// non-streaming Anthropic requests converge on the same observability output.
 ///
 /// Internal state lives behind `Arc<Mutex<...>>` so the `&self`-produced collector and finalizer

--- a/crates/core/src/codec/openai_chat.rs
+++ b/crates/core/src/codec/openai_chat.rs
@@ -425,7 +425,7 @@ fn overlay_generation_params(
 /// non-streaming request (`{id, object, created, model, choices: [{message, finish_reason}],
 /// usage}`). Once finalized, the assembled JSON can be fed back through
 /// [`OpenAIChatCodec::decode_response`] to produce the canonical
-/// [`AnnotatedLlmResponse`](crate::codec::response::AnnotatedLlmResponse).
+/// [`AnnotatedLlmResponse`].
 ///
 /// # Strategy
 ///

--- a/crates/core/src/codec/streaming.rs
+++ b/crates/core/src/codec/streaming.rs
@@ -3,19 +3,20 @@
 
 //! Streaming response codecs for the managed LLM execution pipeline.
 //!
-//! [`LlmResponseCodec`] (in [`crate::codec::traits`]) decodes a complete provider response into a
+//! [`crate::codec::traits::LlmResponseCodec`] decodes a complete provider response into a
 //! normalized [`AnnotatedLlmResponse`]. For streaming providers, the analogous job is to:
 //!
 //! 1. consume per-chunk events as they arrive on a streaming HTTP response, and
 //! 2. assemble a single non-streaming-shape JSON payload at end of stream.
 //!
-//! Once assembled, the payload can be fed back through the matching [`LlmResponseCodec`] to produce
-//! an [`AnnotatedLlmResponse`] — meaning streaming and non-streaming requests converge on the same
-//! observability output without per-route shape duplication.
+//! Once assembled, the payload can be fed back through the matching
+//! [`crate::codec::traits::LlmResponseCodec`] to produce an [`AnnotatedLlmResponse`] — meaning
+//! streaming and non-streaming requests converge on the same observability output without
+//! per-route shape duplication.
 //!
 //! [`StreamingCodec`] is the trait that bundles the two functions
-//! ([`LlmCollectorFn`](crate::api::runtime::LlmCollectorFn),
-//! [`LlmFinalizerFn`](crate::api::runtime::LlmFinalizerFn)) used by
+//! ([`LlmCollectorFn`],
+//! [`LlmFinalizerFn`]) used by
 //! [`crate::api::llm::llm_stream_call_execute`]. Each provider supplies one impl whose internal
 //! state holds whatever incremental information is needed to materialize the final payload.
 //!

--- a/crates/core/src/config_editor.rs
+++ b/crates/core/src/config_editor.rs
@@ -4,7 +4,7 @@
 //! Typed configuration editor metadata.
 //!
 //! This module provides a small compile-time reflection surface for interactive
-//! configuration editors. Config structs use [`editor_config!`] to expose
+//! configuration editors. Config structs use `editor_config!` to expose
 //! ordered field metadata without making editor UIs depend on JSON Schema.
 
 use serde_json::Value as Json;

--- a/crates/core/src/context/registries.rs
+++ b/crates/core/src/context/registries.rs
@@ -10,10 +10,10 @@
 use std::collections::HashMap;
 
 use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
+use crate::api::runtime::callbacks::{LlmConditionalSharedFn, ToolConditionalSharedFn};
 use crate::api::runtime::{
-    EventSubscriberFn, LlmConditionalSharedFn, LlmExecutionFn, LlmRequestInterceptFn,
-    LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalSharedFn,
-    ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
+    EventSubscriberFn, LlmExecutionFn, LlmRequestInterceptFn, LlmSanitizeRequestFn,
+    LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::registry::SortedRegistry;
 
@@ -104,6 +104,20 @@ pub fn merge_guardrail_entries<'a, F>(
         all.extend(registry.sorted_values());
     }
     all.sort_by_key(|entry| entry.priority);
+    all
+}
+
+/// Merge named global and scope-local guardrail entries in priority order.
+pub(crate) fn merge_named_guardrail_entries<'a, F>(
+    global: &'a SortedRegistry<GuardrailEntry<F>>,
+    scope_locals: &'a [&'a SortedRegistry<GuardrailEntry<F>>],
+) -> Vec<(&'a str, &'a GuardrailEntry<F>)> {
+    let mut all = Vec::new();
+    all.extend(global.sorted_entries());
+    for registry in scope_locals {
+        all.extend(registry.sorted_entries());
+    }
+    all.sort_by_key(|(_, entry)| entry.priority);
     all
 }
 

--- a/crates/core/src/context/registries.rs
+++ b/crates/core/src/context/registries.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
 use crate::api::runtime::{
     EventSubscriberFn, LlmConditionalSharedFn, LlmExecutionFn, LlmRequestInterceptFn,
-    LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
+    LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalSharedFn,
     ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::registry::SortedRegistry;
@@ -29,7 +29,8 @@ pub struct ScopeLocalRegistries {
     /// Tool response sanitizers applied to emitted tool-end payloads.
     pub tool_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<ToolSanitizeFn>>,
     /// Tool guardrails that can reject execution before the callback runs.
-    pub tool_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<ToolConditionalFn>>,
+    pub tool_conditional_execution_guardrails:
+        SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>,
     /// Tool request intercepts that can rewrite arguments before execution.
     pub tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
     /// Tool execution intercepts that wrap or replace callback execution.

--- a/crates/core/src/context/registries.rs
+++ b/crates/core/src/context/registries.rs
@@ -10,12 +10,10 @@
 use std::collections::HashMap;
 
 use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
-use crate::api::runtime::callbacks::{
-    LlmConditionalFn, LlmConditionalSharedFn, ToolConditionalFn, ToolConditionalSharedFn,
-};
 use crate::api::runtime::{
-    EventSubscriberFn, LlmExecutionFn, LlmRequestInterceptFn, LlmSanitizeRequestFn,
-    LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
+    EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn,
+    LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
+    ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::registry::SortedRegistry;
 
@@ -32,9 +30,6 @@ pub struct ScopeLocalRegistries {
     pub tool_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<ToolSanitizeFn>>,
     /// Tool guardrails that can reject execution before the callback runs.
     pub tool_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<ToolConditionalFn>>,
-    /// Cloneable tool guardrails used by lock-free event-emitting evaluation.
-    pub(crate) tool_conditional_execution_shared_guardrails:
-        SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>,
     /// Tool request intercepts that can rewrite arguments before execution.
     pub tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
     /// Tool execution intercepts that wrap or replace callback execution.
@@ -45,9 +40,6 @@ pub struct ScopeLocalRegistries {
     pub llm_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<LlmSanitizeResponseFn>>,
     /// LLM guardrails that can reject execution before the provider callback runs.
     pub llm_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<LlmConditionalFn>>,
-    /// Cloneable LLM guardrails used by lock-free event-emitting evaluation.
-    pub(crate) llm_conditional_execution_shared_guardrails:
-        SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>,
     /// LLM request intercepts that can rewrite or annotate requests.
     pub llm_request_intercepts: SortedRegistry<Intercept<LlmRequestInterceptFn>>,
     /// Non-streaming LLM execution intercepts that wrap callback execution.
@@ -69,17 +61,11 @@ impl ScopeLocalRegistries {
             tool_sanitize_request_guardrails: SortedRegistry::new(|entry| entry.priority),
             tool_sanitize_response_guardrails: SortedRegistry::new(|entry| entry.priority),
             tool_conditional_execution_guardrails: SortedRegistry::new(|entry| entry.priority),
-            tool_conditional_execution_shared_guardrails: SortedRegistry::new(|entry| {
-                entry.priority
-            }),
             tool_request_intercepts: SortedRegistry::new(|entry| entry.priority),
             tool_execution_intercepts: SortedRegistry::new(|entry| entry.priority),
             llm_sanitize_request_guardrails: SortedRegistry::new(|entry| entry.priority),
             llm_sanitize_response_guardrails: SortedRegistry::new(|entry| entry.priority),
             llm_conditional_execution_guardrails: SortedRegistry::new(|entry| entry.priority),
-            llm_conditional_execution_shared_guardrails: SortedRegistry::new(|entry| {
-                entry.priority
-            }),
             llm_request_intercepts: SortedRegistry::new(|entry| entry.priority),
             llm_execution_intercepts: SortedRegistry::new(|entry| entry.priority),
             llm_stream_execution_intercepts: SortedRegistry::new(|entry| entry.priority),
@@ -120,6 +106,13 @@ pub fn merge_guardrail_entries<'a, F>(
 }
 
 /// Merge named global and scope-local guardrail entries in priority order.
+///
+/// # Parameters
+/// - `global`: Process-global guardrail registry.
+/// - `scope_locals`: Scope-local registries collected from active scopes.
+///
+/// # Returns
+/// A vector of `(name, guardrail entry)` pairs sorted by ascending priority.
 pub(crate) fn merge_named_guardrail_entries<'a, F>(
     global: &'a SortedRegistry<GuardrailEntry<F>>,
     scope_locals: &'a [&'a SortedRegistry<GuardrailEntry<F>>],

--- a/crates/core/src/context/registries.rs
+++ b/crates/core/src/context/registries.rs
@@ -10,7 +10,9 @@
 use std::collections::HashMap;
 
 use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
-use crate::api::runtime::callbacks::{LlmConditionalSharedFn, ToolConditionalSharedFn};
+use crate::api::runtime::callbacks::{
+    LlmConditionalFn, LlmConditionalSharedFn, ToolConditionalFn, ToolConditionalSharedFn,
+};
 use crate::api::runtime::{
     EventSubscriberFn, LlmExecutionFn, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
@@ -29,7 +31,9 @@ pub struct ScopeLocalRegistries {
     /// Tool response sanitizers applied to emitted tool-end payloads.
     pub tool_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<ToolSanitizeFn>>,
     /// Tool guardrails that can reject execution before the callback runs.
-    pub tool_conditional_execution_guardrails:
+    pub tool_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<ToolConditionalFn>>,
+    /// Cloneable tool guardrails used by lock-free event-emitting evaluation.
+    pub(crate) tool_conditional_execution_shared_guardrails:
         SortedRegistry<GuardrailEntry<ToolConditionalSharedFn>>,
     /// Tool request intercepts that can rewrite arguments before execution.
     pub tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
@@ -40,7 +44,9 @@ pub struct ScopeLocalRegistries {
     /// LLM response sanitizers applied to emitted LLM-end payloads.
     pub llm_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<LlmSanitizeResponseFn>>,
     /// LLM guardrails that can reject execution before the provider callback runs.
-    pub llm_conditional_execution_guardrails:
+    pub llm_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<LlmConditionalFn>>,
+    /// Cloneable LLM guardrails used by lock-free event-emitting evaluation.
+    pub(crate) llm_conditional_execution_shared_guardrails:
         SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>,
     /// LLM request intercepts that can rewrite or annotate requests.
     pub llm_request_intercepts: SortedRegistry<Intercept<LlmRequestInterceptFn>>,
@@ -63,11 +69,17 @@ impl ScopeLocalRegistries {
             tool_sanitize_request_guardrails: SortedRegistry::new(|entry| entry.priority),
             tool_sanitize_response_guardrails: SortedRegistry::new(|entry| entry.priority),
             tool_conditional_execution_guardrails: SortedRegistry::new(|entry| entry.priority),
+            tool_conditional_execution_shared_guardrails: SortedRegistry::new(|entry| {
+                entry.priority
+            }),
             tool_request_intercepts: SortedRegistry::new(|entry| entry.priority),
             tool_execution_intercepts: SortedRegistry::new(|entry| entry.priority),
             llm_sanitize_request_guardrails: SortedRegistry::new(|entry| entry.priority),
             llm_sanitize_response_guardrails: SortedRegistry::new(|entry| entry.priority),
             llm_conditional_execution_guardrails: SortedRegistry::new(|entry| entry.priority),
+            llm_conditional_execution_shared_guardrails: SortedRegistry::new(|entry| {
+                entry.priority
+            }),
             llm_request_intercepts: SortedRegistry::new(|entry| entry.priority),
             llm_execution_intercepts: SortedRegistry::new(|entry| entry.priority),
             llm_stream_execution_intercepts: SortedRegistry::new(|entry| entry.priority),

--- a/crates/core/src/context/registries.rs
+++ b/crates/core/src/context/registries.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 use crate::api::registry::{ExecutionIntercept, GuardrailEntry, Intercept};
 use crate::api::runtime::{
-    EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn,
+    EventSubscriberFn, LlmConditionalSharedFn, LlmExecutionFn, LlmRequestInterceptFn,
     LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
     ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
@@ -39,7 +39,8 @@ pub struct ScopeLocalRegistries {
     /// LLM response sanitizers applied to emitted LLM-end payloads.
     pub llm_sanitize_response_guardrails: SortedRegistry<GuardrailEntry<LlmSanitizeResponseFn>>,
     /// LLM guardrails that can reject execution before the provider callback runs.
-    pub llm_conditional_execution_guardrails: SortedRegistry<GuardrailEntry<LlmConditionalFn>>,
+    pub llm_conditional_execution_guardrails:
+        SortedRegistry<GuardrailEntry<LlmConditionalSharedFn>>,
     /// LLM request intercepts that can rewrite or annotate requests.
     pub llm_request_intercepts: SortedRegistry<Intercept<LlmRequestInterceptFn>>,
     /// Non-streaming LLM execution intercepts that wrap callback execution.

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -120,6 +120,18 @@ impl<T> SortedRegistry<T> {
             .collect()
     }
 
+    /// Return named entries sorted by priority (ascending).
+    ///
+    /// # Returns
+    /// A newly allocated [`Vec`] of `(name, entry)` pairs ordered from lowest
+    /// priority to highest priority.
+    pub(crate) fn sorted_entries(&self) -> Vec<(&str, &T)> {
+        self.sorted_keys
+            .iter()
+            .filter_map(|key| self.entries.get(key).map(|entry| (key.as_str(), entry)))
+            .collect()
+    }
+
     /// Return a shared reference to an entry by name.
     ///
     /// # Parameters

--- a/crates/core/tests/integration/api_surface_tests.rs
+++ b/crates/core/tests/integration/api_surface_tests.rs
@@ -359,7 +359,7 @@ fn test_global_registry_and_subscriber_wrappers_cover_success_and_duplicates() {
     register_tool_conditional_execution_guardrail(
         "tool-conditional",
         1,
-        Box::new(|_name, _args| Ok(None)),
+        Arc::new(|_name, _args| Ok(None)),
     )
     .unwrap();
     assert!(deregister_tool_conditional_execution_guardrail("tool-conditional").unwrap());
@@ -391,7 +391,7 @@ fn test_global_registry_and_subscriber_wrappers_cover_success_and_duplicates() {
     register_llm_conditional_execution_guardrail(
         "llm-conditional",
         1,
-        Box::new(|_request| Ok(None)),
+        Arc::new(|_request| Ok(None)),
     )
     .unwrap();
     assert!(deregister_llm_conditional_execution_guardrail("llm-conditional").unwrap());
@@ -487,7 +487,7 @@ fn test_scope_registry_and_subscriber_wrappers_cover_success_duplicates_and_miss
         &scope.uuid,
         "tool-conditional",
         1,
-        Box::new(|_name, _args| Ok(None)),
+        Arc::new(|_name, _args| Ok(None)),
     )
     .unwrap();
     assert!(
@@ -542,7 +542,7 @@ fn test_scope_registry_and_subscriber_wrappers_cover_success_duplicates_and_miss
         &scope.uuid,
         "llm-conditional",
         1,
-        Box::new(|_request| Ok(None)),
+        Arc::new(|_request| Ok(None)),
     )
     .unwrap();
     assert!(
@@ -733,7 +733,7 @@ async fn test_tool_api_emits_sanitized_events_and_covers_error_paths() {
     register_tool_conditional_execution_guardrail(
         "tool-reject",
         1,
-        Box::new(|_name, _args| Ok(Some("tool denied".into()))),
+        Arc::new(|_name, _args| Ok(Some("tool denied".into()))),
     )
     .unwrap();
     assert!(matches!(
@@ -896,7 +896,7 @@ async fn test_llm_api_emits_sanitized_events_and_covers_error_paths() {
     register_llm_conditional_execution_guardrail(
         "llm-reject",
         1,
-        Box::new(|_request| Ok(Some("llm denied".into()))),
+        Arc::new(|_request| Ok(Some("llm denied".into()))),
     )
     .unwrap();
     assert!(matches!(
@@ -1039,7 +1039,7 @@ async fn test_llm_stream_api_covers_success_rejection_and_execution_error_paths(
     register_llm_conditional_execution_guardrail(
         "llm-stream-reject",
         1,
-        Box::new(|_request| Ok(Some("stream denied".into()))),
+        Arc::new(|_request| Ok(Some("stream denied".into()))),
     )
     .unwrap();
     let reject_collector: Box<dyn FnMut(Json) -> Result<()> + Send> = Box::new(|_chunk| Ok(()));

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -676,6 +676,97 @@ async fn test_conditional_guardrail_allows() {
     deregister_tool_conditional_execution_guardrail("allower").unwrap();
 }
 
+/// Conditional tool guardrails emit Guardrail scope start/end pairs for allow
+/// and reject decisions.
+#[tokio::test]
+async fn test_tool_conditional_guardrail_emits_guardrail_scope() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = events.clone();
+    register_subscriber(
+        "tool_guardrail_scope_capture",
+        Arc::new(move |event| {
+            captured.lock().unwrap().push(event.clone());
+        }),
+    )
+    .unwrap();
+
+    register_tool_conditional_execution_guardrail("tool_scope_allow", 1, Box::new(|_, _| Ok(None)))
+        .unwrap();
+    register_tool_conditional_execution_guardrail(
+        "tool_scope_reject",
+        2,
+        Box::new(|_, _| Ok(Some("blocked by tool guardrail".to_string()))),
+    )
+    .unwrap();
+
+    let func: ToolExecutionNextFn = Arc::new(|args| Box::pin(async move { Ok(args) }));
+    let allowed = tool_call_execute(
+        nemo_flow::api::tool::ToolCallExecuteParams::builder()
+            .name("safe_tool")
+            .args(json!({"safe": true}))
+            .func(func.clone())
+            .build(),
+    )
+    .await;
+    assert!(allowed.is_err(), "second guardrail should reject");
+
+    deregister_tool_conditional_execution_guardrail("tool_scope_reject").unwrap();
+    let allowed = tool_call_execute(
+        nemo_flow::api::tool::ToolCallExecuteParams::builder()
+            .name("safe_tool")
+            .args(json!({"safe": true}))
+            .func(func)
+            .build(),
+    )
+    .await;
+    assert!(allowed.is_ok());
+
+    deregister_tool_conditional_execution_guardrail("tool_scope_allow").unwrap();
+    deregister_subscriber("tool_guardrail_scope_capture").unwrap();
+
+    let events = events.lock().unwrap();
+    let guardrail_events = events
+        .iter()
+        .filter(|event| event.scope_type() == Some(ScopeType::Guardrail))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        guardrail_events
+            .iter()
+            .filter(|event| event.scope_category() == Some(ScopeCategory::Start))
+            .count(),
+        3
+    );
+    assert_eq!(
+        guardrail_events
+            .iter()
+            .filter(|event| event.scope_category() == Some(ScopeCategory::End))
+            .count(),
+        3
+    );
+    assert!(guardrail_events.iter().any(|event| {
+        event.name() == "tool_scope_allow"
+            && event.scope_category() == Some(ScopeCategory::End)
+            && event
+                .data()
+                .and_then(|data| data.get("allowed"))
+                .and_then(|value| value.as_bool())
+                == Some(true)
+    }));
+    assert!(guardrail_events.iter().any(|event| {
+        event.name() == "tool_scope_reject"
+            && event.scope_category() == Some(ScopeCategory::End)
+            && event
+                .data()
+                .and_then(|data| data.get("rejection_reason"))
+                .and_then(|value| value.as_str())
+                == Some("blocked by tool guardrail")
+    }));
+}
+
 /// Multiple conditional guardrails: first allows, second rejects.
 /// The second one should reject (first rejection wins).
 #[tokio::test]
@@ -1771,6 +1862,103 @@ async fn test_llm_conditional_guardrail_rejects() {
 
     // Cleanup
     deregister_llm_conditional_execution_guardrail("llm_gate").unwrap();
+}
+
+/// Conditional LLM guardrails emit Guardrail scope start/end pairs for allow
+/// and reject decisions.
+#[tokio::test]
+async fn test_llm_conditional_guardrail_emits_guardrail_scope() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = events.clone();
+    register_subscriber(
+        "llm_guardrail_scope_capture",
+        Arc::new(move |event| {
+            captured.lock().unwrap().push(event.clone());
+        }),
+    )
+    .unwrap();
+
+    register_llm_conditional_execution_guardrail("llm_scope_allow", 1, Box::new(|_| Ok(None)))
+        .unwrap();
+    register_llm_conditional_execution_guardrail(
+        "llm_scope_reject",
+        2,
+        Box::new(|_| Ok(Some("blocked by llm guardrail".to_string()))),
+    )
+    .unwrap();
+
+    let func: LlmExecutionNextFn =
+        Arc::new(|_req| Box::pin(async move { Ok(json!({"response": "ok"})) }));
+    let request = LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({"prompt": "hello"}),
+    };
+
+    let rejected = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("test_llm")
+            .request(request.clone())
+            .func(func.clone())
+            .build(),
+    )
+    .await;
+    assert!(rejected.is_err());
+
+    deregister_llm_conditional_execution_guardrail("llm_scope_reject").unwrap();
+    let allowed = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("test_llm")
+            .request(request)
+            .func(func)
+            .build(),
+    )
+    .await;
+    assert!(allowed.is_ok());
+
+    deregister_llm_conditional_execution_guardrail("llm_scope_allow").unwrap();
+    deregister_subscriber("llm_guardrail_scope_capture").unwrap();
+
+    let events = events.lock().unwrap();
+    let guardrail_events = events
+        .iter()
+        .filter(|event| event.scope_type() == Some(ScopeType::Guardrail))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        guardrail_events
+            .iter()
+            .filter(|event| event.scope_category() == Some(ScopeCategory::Start))
+            .count(),
+        3
+    );
+    assert_eq!(
+        guardrail_events
+            .iter()
+            .filter(|event| event.scope_category() == Some(ScopeCategory::End))
+            .count(),
+        3
+    );
+    assert!(guardrail_events.iter().any(|event| {
+        event.name() == "llm_scope_allow"
+            && event.scope_category() == Some(ScopeCategory::End)
+            && event
+                .data()
+                .and_then(|data| data.get("allowed"))
+                .and_then(|value| value.as_bool())
+                == Some(true)
+    }));
+    assert!(guardrail_events.iter().any(|event| {
+        event.name() == "llm_scope_reject"
+            && event.scope_category() == Some(ScopeCategory::End)
+            && event
+                .data()
+                .and_then(|data| data.get("rejection_reason"))
+                .and_then(|value| value.as_str())
+                == Some("blocked by llm guardrail")
+    }));
 }
 
 /// LLM request intercept transforms the request.

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -621,7 +621,7 @@ async fn test_conditional_guardrail_rejects() {
     register_tool_conditional_execution_guardrail(
         "rejector",
         1,
-        Box::new(|_name, _args| Ok(Some("not allowed".to_string()))),
+        Arc::new(|_name, _args| Ok(Some("not allowed".to_string()))),
     )
     .unwrap();
 
@@ -655,7 +655,7 @@ async fn test_conditional_guardrail_allows() {
     reset_global();
     setup_isolated_thread();
 
-    register_tool_conditional_execution_guardrail("allower", 1, Box::new(|_name, _args| Ok(None)))
+    register_tool_conditional_execution_guardrail("allower", 1, Arc::new(|_name, _args| Ok(None)))
         .unwrap();
 
     let func: ToolExecutionNextFn = Arc::new(|args| Box::pin(async move { Ok(args) }));
@@ -694,14 +694,15 @@ async fn test_tool_conditional_guardrail_emits_guardrail_scope() {
     )
     .unwrap();
 
-    register_tool_conditional_execution_guardrail("tool_scope_allow", 1, Box::new(|_, _| Ok(None)))
+    register_tool_conditional_execution_guardrail("tool_scope_allow", 1, Arc::new(|_, _| Ok(None)))
         .unwrap();
     register_tool_conditional_execution_guardrail(
         "tool_scope_reject",
         2,
-        Box::new(|_, _| Ok(Some("blocked by tool guardrail".to_string()))),
+        Arc::new(|_, _| Ok(Some("blocked by tool guardrail".to_string()))),
     )
     .unwrap();
+    assert!(global_context().read().unwrap().extensions.is_empty());
 
     let func: ToolExecutionNextFn = Arc::new(|args| Box::pin(async move { Ok(args) }));
     let allowed = tool_call_execute(
@@ -775,13 +776,13 @@ async fn test_conditional_guardrail_first_rejection_wins() {
     reset_global();
     setup_isolated_thread();
 
-    register_tool_conditional_execution_guardrail("allows", 1, Box::new(|_name, _args| Ok(None)))
+    register_tool_conditional_execution_guardrail("allows", 1, Arc::new(|_name, _args| Ok(None)))
         .unwrap();
 
     register_tool_conditional_execution_guardrail(
         "rejects",
         2,
-        Box::new(|_name, _args| Ok(Some("blocked by second".to_string()))),
+        Arc::new(|_name, _args| Ok(Some("blocked by second".to_string()))),
     )
     .unwrap();
 
@@ -819,7 +820,7 @@ async fn test_conditional_guardrail_tool_name_filtering() {
     register_tool_conditional_execution_guardrail(
         "name_filter",
         1,
-        Box::new(|name, _args| {
+        Arc::new(|name, _args| {
             if name == "dangerous_tool" {
                 Ok(Some("dangerous_tool is forbidden".to_string()))
             } else {
@@ -1175,7 +1176,7 @@ async fn test_conditional_rejection_prevents_intercepts() {
     register_tool_conditional_execution_guardrail(
         "gate",
         1,
-        Box::new(|_name, _args| Ok(Some("blocked".to_string()))),
+        Arc::new(|_name, _args| Ok(Some("blocked".to_string()))),
     )
     .unwrap();
 
@@ -1226,7 +1227,7 @@ async fn test_conditional_rejection_prevents_execution() {
     register_tool_conditional_execution_guardrail(
         "gate2",
         1,
-        Box::new(|_name, _args| Ok(Some("no execution".to_string()))),
+        Arc::new(|_name, _args| Ok(Some("no execution".to_string()))),
     )
     .unwrap();
 
@@ -1614,7 +1615,7 @@ async fn test_full_pipeline_integration() {
     register_tool_conditional_execution_guardrail(
         "conditional",
         1,
-        Box::new(move |_name, _args| {
+        Arc::new(move |_name, _args| {
             o3.lock().unwrap().push("conditional".into());
             Ok(None) // Allow
         }),
@@ -1831,7 +1832,7 @@ async fn test_llm_conditional_guardrail_rejects() {
     register_llm_conditional_execution_guardrail(
         "llm_gate",
         1,
-        Box::new(|_req| Ok(Some("LLM call rejected".to_string()))),
+        Arc::new(|_req| Ok(Some("LLM call rejected".to_string()))),
     )
     .unwrap();
 
@@ -1882,12 +1883,12 @@ async fn test_llm_conditional_guardrail_emits_guardrail_scope() {
     )
     .unwrap();
 
-    register_llm_conditional_execution_guardrail("llm_scope_allow", 1, Box::new(|_| Ok(None)))
+    register_llm_conditional_execution_guardrail("llm_scope_allow", 1, Arc::new(|_| Ok(None)))
         .unwrap();
     register_llm_conditional_execution_guardrail(
         "llm_scope_reject",
         2,
-        Box::new(|_| Ok(Some("blocked by llm guardrail".to_string()))),
+        Arc::new(|_| Ok(Some("blocked by llm guardrail".to_string()))),
     )
     .unwrap();
 
@@ -2073,7 +2074,7 @@ fn test_standalone_conditional_execution_rejects() {
     register_tool_conditional_execution_guardrail(
         "standalone_gate",
         1,
-        Box::new(|_name, _args| Ok(Some("rejected by standalone".to_string()))),
+        Arc::new(|_name, _args| Ok(Some("rejected by standalone".to_string()))),
     )
     .unwrap();
 

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -748,6 +748,10 @@ async fn test_tool_conditional_guardrail_emits_guardrail_scope() {
             .count(),
         3
     );
+    assert!(guardrail_events.iter().all(|event| {
+        event.scope_category() != Some(ScopeCategory::Start)
+            || event.data().and_then(|data| data.get("input")).is_none()
+    }));
     assert!(guardrail_events.iter().any(|event| {
         event.name() == "tool_scope_allow"
             && event.scope_category() == Some(ScopeCategory::End)
@@ -1942,6 +1946,10 @@ async fn test_llm_conditional_guardrail_emits_guardrail_scope() {
             .count(),
         3
     );
+    assert!(guardrail_events.iter().all(|event| {
+        event.scope_category() != Some(ScopeCategory::Start)
+            || event.data().and_then(|data| data.get("input")).is_none()
+    }));
     assert!(guardrail_events.iter().any(|event| {
         event.name() == "llm_scope_allow"
             && event.scope_category() == Some(ScopeCategory::End)

--- a/crates/core/tests/integration/scope_local_tests.rs
+++ b/crates/core/tests/integration/scope_local_tests.rs
@@ -702,7 +702,7 @@ async fn test_scope_local_conditional_execution_guardrail() {
         &handle.uuid,
         "tool_blocker",
         1,
-        Box::new(|name, _args| {
+        Arc::new(|name, _args| {
             if name == "banned_tool" {
                 Ok(Some("banned_tool is not allowed in this scope".to_string()))
             } else {

--- a/crates/core/tests/unit/context_tests.rs
+++ b/crates/core/tests/unit/context_tests.rs
@@ -106,6 +106,7 @@ fn merge_helpers_preserve_global_and_scope_local_priority_order() {
         .register(
             "global".to_string(),
             GuardrailEntry {
+                name: "global".to_string(),
                 priority: 20,
                 guardrail: "global",
             },
@@ -118,6 +119,7 @@ fn merge_helpers_preserve_global_and_scope_local_priority_order() {
         .register(
             "local".to_string(),
             GuardrailEntry {
+                name: "local".to_string(),
                 priority: 5,
                 guardrail: "local",
             },

--- a/crates/core/tests/unit/context_tests.rs
+++ b/crates/core/tests/unit/context_tests.rs
@@ -201,6 +201,8 @@ fn merge_helpers_preserve_global_and_scope_local_priority_order() {
 #[test]
 fn context_state_supports_extensions_events_and_builders() {
     let mut state = NemoFlowContextState::new();
+    assert!(state.extensions.is_empty());
+
     let key = format!("ext-{}", Uuid::now_v7());
     state.set_extension(&key, vec![1_u32, 2]);
     state.get_extension_mut::<Vec<u32>>(&key).unwrap().push(3);

--- a/crates/core/tests/unit/context_tests.rs
+++ b/crates/core/tests/unit/context_tests.rs
@@ -106,7 +106,6 @@ fn merge_helpers_preserve_global_and_scope_local_priority_order() {
         .register(
             "global".to_string(),
             GuardrailEntry {
-                name: "global".to_string(),
                 priority: 20,
                 guardrail: "global",
             },
@@ -119,7 +118,6 @@ fn merge_helpers_preserve_global_and_scope_local_priority_order() {
         .register(
             "local".to_string(),
             GuardrailEntry {
-                name: "local".to_string(),
                 priority: 5,
                 guardrail: "local",
             },

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -896,7 +896,7 @@ fn test_plugin_registration_context_supports_guardrail_helpers() {
     ctx.register_tool_conditional_execution_guardrail(
         "tool_conditional",
         1,
-        Box::new(|name, _args| Ok((name == "blocked-tool").then(|| "blocked tool".to_string()))),
+        Arc::new(|name, _args| Ok((name == "blocked-tool").then(|| "blocked tool".to_string()))),
     )
     .unwrap();
     ctx.register_llm_sanitize_request_guardrail(
@@ -914,7 +914,7 @@ fn test_plugin_registration_context_supports_guardrail_helpers() {
     ctx.register_llm_conditional_execution_guardrail(
         "llm_conditional",
         1,
-        Box::new(|request| {
+        Arc::new(|request| {
             Ok((request.headers.get("blocked") == Some(&json!(true)))
                 .then(|| "blocked llm".to_string()))
         }),
@@ -1005,14 +1005,14 @@ fn test_plugin_registration_context_maps_duplicate_registration_errors() {
     ctx.register_tool_conditional_execution_guardrail(
         "tool-conditional",
         1,
-        Box::new(|_, _| Ok(None)),
+        Arc::new(|_, _| Ok(None)),
     )
     .unwrap();
     expect_registration_failed(
         ctx.register_tool_conditional_execution_guardrail(
             "tool-conditional",
             1,
-            Box::new(|_, _| Ok(None)),
+            Arc::new(|_, _| Ok(None)),
         ),
         "tool conditional execution guardrail:",
     );
@@ -1047,13 +1047,13 @@ fn test_plugin_registration_context_maps_duplicate_registration_errors() {
         "llm sanitize response guardrail:",
     );
 
-    ctx.register_llm_conditional_execution_guardrail("llm-conditional", 1, Box::new(|_| Ok(None)))
+    ctx.register_llm_conditional_execution_guardrail("llm-conditional", 1, Arc::new(|_| Ok(None)))
         .unwrap();
     expect_registration_failed(
         ctx.register_llm_conditional_execution_guardrail(
             "llm-conditional",
             1,
-            Box::new(|_| Ok(None)),
+            Arc::new(|_| Ok(None)),
         ),
         "llm conditional execution guardrail:",
     );
@@ -1164,7 +1164,7 @@ fn test_plugin_registration_context_maps_deregistration_errors() {
     ctx.register_tool_conditional_execution_guardrail(
         "tool-conditional",
         1,
-        Box::new(|_, _| Ok(None)),
+        Arc::new(|_, _| Ok(None)),
     )
     .unwrap();
     ctx.register_llm_sanitize_request_guardrail(
@@ -1179,7 +1179,7 @@ fn test_plugin_registration_context_maps_deregistration_errors() {
         Box::new(|response| response),
     )
     .unwrap();
-    ctx.register_llm_conditional_execution_guardrail("llm-conditional", 1, Box::new(|_| Ok(None)))
+    ctx.register_llm_conditional_execution_guardrail("llm-conditional", 1, Arc::new(|_| Ok(None)))
         .unwrap();
     ctx.register_llm_execution_intercept(
         "llm-exec",

--- a/crates/ffi/src/callable.rs
+++ b/crates/ffi/src/callable.rs
@@ -268,7 +268,7 @@ pub fn wrap_tool_conditional_fn(
     free_fn: NemoFlowFreeFn,
 ) -> ToolConditionalFn {
     let ud = make_user_data(user_data, free_fn);
-    Box::new(move |name: &str, args: &Json| {
+    Arc::new(move |name: &str, args: &Json| {
         clear_last_error();
         let c_name = CString::new(name).unwrap_or_default();
         let c_args = json_to_c_string(args);
@@ -685,7 +685,7 @@ pub fn wrap_llm_conditional_fn(
     free_fn: NemoFlowFreeFn,
 ) -> LlmConditionalFn {
     let ud = make_user_data(user_data, free_fn);
-    Box::new(move |request: &LlmRequest| {
+    Arc::new(move |request: &LlmRequest| {
         clear_last_error();
         let ffi_req = FfiLLMRequest(request.clone());
         let result_ptr = unsafe { cb(ud.ptr, &ffi_req) };

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -128,7 +128,7 @@ pub fn wrap_js_tool_conditional_fn(
     func: ThreadsafeFunction<(String, Json), ErrorStrategy::Fatal>,
 ) -> ToolConditionalFn {
     let func = Arc::new(func);
-    Box::new(move |name: &str, args: &Json| {
+    Arc::new(move |name: &str, args: &Json| {
         let func = func.clone();
         let name = name.to_string();
         let args = args.clone();
@@ -341,7 +341,7 @@ pub fn wrap_js_llm_conditional_fn(
     func: ThreadsafeFunction<Json, ErrorStrategy::Fatal>,
 ) -> LlmConditionalFn {
     let func = Arc::new(func);
-    Box::new(move |request: &LlmRequest| {
+    Arc::new(move |request: &LlmRequest| {
         let func = func.clone();
         let req_json = serde_json::to_value(request).unwrap_or(Json::Null);
         let (tx, rx) = std::sync::mpsc::channel();

--- a/crates/python/src/py_callable.rs
+++ b/crates/python/src/py_callable.rs
@@ -209,7 +209,7 @@ pub fn wrap_py_tool_fn(py_fn: Py<PyAny>) -> Box<dyn Fn(&str, Json) -> Json + Sen
 
 /// Wrap a Python callable `(str, Json) -> Optional[str]` for tool conditional guardrails.
 pub fn wrap_py_tool_conditional_fn(py_fn: Py<PyAny>) -> ToolConditionalFn {
-    Box::new(move |name: &str, args: &Json| {
+    Arc::new(move |name: &str, args: &Json| {
         Python::attach(|py| {
             let py_args = json_to_py(py, args).map_err(|e| {
                 FlowError::Internal(format!(
@@ -619,7 +619,7 @@ pub fn wrap_py_llm_sanitize_request_fn(
 
 /// Wrap a Python callable `(LlmRequest) -> Optional[str]` for LLM conditional guardrails.
 pub fn wrap_py_llm_conditional_fn(py_fn: Py<PyAny>) -> LlmConditionalFn {
-    Box::new(move |request: &LlmRequest| {
+    Arc::new(move |request: &LlmRequest| {
         Python::attach(|py| {
             let py_req = PyLLMRequest {
                 inner: request.clone(),

--- a/crates/wasm/src/callable.rs
+++ b/crates/wasm/src/callable.rs
@@ -177,13 +177,13 @@ pub fn wrap_js_tool_fn(func: Function) -> Box<dyn Fn(&str, Json) -> Json + Send 
 /// Wrap a JS function `(name, args) => string | null` for tool conditional guardrails.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn wrap_js_tool_conditional_fn(_func: Function) -> ToolConditionalFn {
-    Box::new(move |_name: &str, _args: &Json| Ok(None))
+    Arc::new(move |_name: &str, _args: &Json| Ok(None))
 }
 
 #[cfg(target_arch = "wasm32")]
 pub fn wrap_js_tool_conditional_fn(func: Function) -> ToolConditionalFn {
     let func = SendWrapper::new(func);
-    Box::new(move |name: &str, args: &Json| {
+    Arc::new(move |name: &str, args: &Json| {
         let js_name = JsValue::from_str(name);
         let js_args = json_to_js(args);
         let result = func
@@ -375,13 +375,13 @@ pub fn wrap_js_llm_sanitize_request_fn(
 /// Wrap a JS function for LLM conditional guardrails: `(request) => string | null`.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn wrap_js_llm_conditional_fn(_func: Function) -> LlmConditionalFn {
-    Box::new(move |_request: &LlmRequest| Ok(None))
+    Arc::new(move |_request: &LlmRequest| Ok(None))
 }
 
 #[cfg(target_arch = "wasm32")]
 pub fn wrap_js_llm_conditional_fn(func: Function) -> LlmConditionalFn {
     let func = SendWrapper::new(func);
-    Box::new(move |request: &LlmRequest| {
+    Arc::new(move |request: &LlmRequest| {
         let req_json = serde_json::to_value(request).unwrap_or(Json::Null);
         let js_req = json_to_js(&req_json);
         let result = func


### PR DESCRIPTION
#### Overview

Adds automatic Guardrail scope start/end emission around conditional guardrail evaluation for tool and LLM pipelines. The implementation keeps the public conditional guardrail registration APIs unchanged while internally snapshotting cloneable callbacks so guardrail evaluation can run after registry locks are released.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Stores conditional guardrails as cloneable shared callbacks internally and snapshots registry entries by name before evaluation.
- Emits Guardrail scope start/end pairs for managed tool execution, managed non-streaming LLM calls, managed streaming LLM calls, and standalone conditional helper paths.
- Names emitted guardrail scopes from registry keys and records allow, reject, and error outcomes in the corresponding end event data.
- Preserves existing conditional allow/reject/error behavior, rejection mark events, middleware ordering, and request/response execution flow.
- Updates FFI, Python, Node.js, and WebAssembly callable wrappers to support cloneable conditional callbacks without changing their language-level callback signatures.
- Adds Rust integration and unit coverage for guardrail scope emission, conditional callback registration, and affected API/plugin surfaces.
- Validation recorded during review: `cargo test -p nemo-flow --test middleware_integration conditional_guardrail_emits_guardrail_scope`.

#### Where should the reviewer start?

Start with `crates/core/src/api/runtime/state.rs` for the guardrail snapshot and scope-emission logic, then review `crates/core/src/api/tool.rs` and `crates/core/src/api/llm.rs` for the managed pipeline call sites. The main behavioral coverage is in `crates/core/tests/integration/middleware_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes NMF-135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guardrails now emit scope start/end events with detailed outcomes for improved observability and debugging.

* **Documentation**
  * Expanded rustdoc comments across event types and runtime APIs for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->