### PR TITLE
feat: Integrate security guardrails for agent calls

### DIFF
--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -48,21 +48,21 @@ impl IntoResponse for CliError {
     fn into_response(self) -> Response {
         let message = self.to_string();
         let guardrail_reason = self.guardrail_rejection_reason().map(ToOwned::to_owned);
-        let status = if guardrail_reason.is_some() {
-            StatusCode::FORBIDDEN
-        } else {
-            match &self {
-                Self::InvalidPayload(_) => StatusCode::BAD_REQUEST,
-                Self::Upstream(_) => StatusCode::BAD_GATEWAY,
-                Self::GuardrailRejected(_)
-                | Self::Http(_)
+        let status = match (guardrail_reason.is_some(), self) {
+            (true, _) => StatusCode::FORBIDDEN,
+            (false, Self::InvalidPayload(_)) => StatusCode::BAD_REQUEST,
+            (false, Self::Upstream(_)) => StatusCode::BAD_GATEWAY,
+            (
+                false,
+                Self::Http(_)
                 | Self::Io(_)
                 | Self::Install(_)
                 | Self::Config(_)
                 | Self::Launch(_)
                 | Self::Flow(_)
-                | Self::OpenInference(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            }
+                | Self::OpenInference(_),
+            ) => StatusCode::INTERNAL_SERVER_ERROR,
+            (false, _) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         let error_type = if guardrail_reason.is_some() {
             "nemo_flow_guardrail_rejected"

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -4,10 +4,13 @@
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use serde_json::json;
+use nemo_flow::error::FlowError;
+use serde_json::{Map, Value, json};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CliError {
+    #[error("guardrail rejected: {0}")]
+    GuardrailRejected(String),
     #[error("invalid hook payload: {0}")]
     InvalidPayload(String),
     #[error("gateway upstream error: {0}")]
@@ -28,28 +31,53 @@ pub(crate) enum CliError {
     OpenInference(#[from] nemo_flow::observability::openinference::OpenInferenceError),
 }
 
+impl CliError {
+    pub(crate) fn guardrail_rejection_reason(&self) -> Option<&str> {
+        match self {
+            Self::GuardrailRejected(reason) => Some(reason),
+            Self::Flow(FlowError::GuardrailRejected(reason)) => Some(reason),
+            _ => None,
+        }
+    }
+}
+
 impl IntoResponse for CliError {
     // Maps gateway errors into a compact JSON HTTP response. Bad hook payloads are client errors,
     // upstream gateway failures are bad gateway responses, and local install/config/runtime faults
     // remain internal errors so callers do not mistake them for agent policy decisions.
     fn into_response(self) -> Response {
         let message = self.to_string();
-        let status = match &self {
-            Self::InvalidPayload(_) => StatusCode::BAD_REQUEST,
-            Self::Upstream(_) => StatusCode::BAD_GATEWAY,
-            Self::Http(_)
-            | Self::Io(_)
-            | Self::Install(_)
-            | Self::Config(_)
-            | Self::Launch(_)
-            | Self::Flow(_)
-            | Self::OpenInference(_) => StatusCode::INTERNAL_SERVER_ERROR,
-        };
-        let body = Json(json!({
-            "error": {
-                "message": message,
-                "type": "nemo_flow_gateway_error"
+        let guardrail_reason = self.guardrail_rejection_reason().map(ToOwned::to_owned);
+        let status = if guardrail_reason.is_some() {
+            StatusCode::FORBIDDEN
+        } else {
+            match &self {
+                Self::InvalidPayload(_) => StatusCode::BAD_REQUEST,
+                Self::Upstream(_) => StatusCode::BAD_GATEWAY,
+                Self::GuardrailRejected(_)
+                | Self::Http(_)
+                | Self::Io(_)
+                | Self::Install(_)
+                | Self::Config(_)
+                | Self::Launch(_)
+                | Self::Flow(_)
+                | Self::OpenInference(_) => StatusCode::INTERNAL_SERVER_ERROR,
             }
+        };
+        let error_type = if guardrail_reason.is_some() {
+            "nemo_flow_guardrail_rejected"
+        } else {
+            "nemo_flow_gateway_error"
+        };
+        let mut error = Map::from_iter([
+            ("message".to_string(), json!(message)),
+            ("type".to_string(), json!(error_type)),
+        ]);
+        if let Some(reason) = guardrail_reason {
+            error.insert("reason".to_string(), json!(reason));
+        }
+        let body = Json(json!({
+            "error": Value::Object(error)
         }));
         (status, body).into_response()
     }

--- a/crates/cli/src/gateway.rs
+++ b/crates/cli/src/gateway.rs
@@ -766,7 +766,7 @@ fn translate_runtime_error(error: FlowError, upstream_error: &UpstreamErrorSlot)
         return CliError::Upstream(upstream);
     }
     match error {
-        FlowError::GuardrailRejected(reason) => CliError::InvalidPayload(reason),
+        FlowError::GuardrailRejected(reason) => CliError::GuardrailRejected(reason),
         other => CliError::InvalidPayload(other.to_string()),
     }
 }

--- a/crates/cli/src/installer.rs
+++ b/crates/cli/src/installer.rs
@@ -158,6 +158,9 @@ async fn handle_hook_forward_response(
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             if !status.is_success() {
+                if let Some(reason) = guardrail_rejection_reason(&body) {
+                    return Err(CliError::GuardrailRejected(reason));
+                }
                 eprintln!("nemo-flow hook forward failed with HTTP {status}");
                 if fail_closed {
                     return Err(CliError::Install(format!(
@@ -180,6 +183,20 @@ async fn handle_hook_forward_response(
             }
         }
     }
+}
+
+fn guardrail_rejection_reason(body: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(body).ok()?;
+    let error = value.get("error")?;
+    (error.get("type").and_then(Value::as_str) == Some("nemo_flow_guardrail_rejected"))
+        .then(|| {
+            error
+                .get("reason")
+                .and_then(Value::as_str)
+                .or_else(|| error.get("message").and_then(Value::as_str))
+                .map(ToOwned::to_owned)
+        })
+        .flatten()
 }
 
 // Chooses the gateway URL for hook-forward. Hermes prefers the runtime environment URL because

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -34,8 +34,13 @@ async fn main() -> ExitCode {
     match run().await {
         Ok(code) => code,
         Err(error) => {
+            let exit_code = if error.guardrail_rejection_reason().is_some() {
+                ExitCode::from(2)
+            } else {
+                ExitCode::FAILURE
+            };
             eprintln!("{error}");
-            ExitCode::FAILURE
+            exit_code
         }
     }
 }

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -18,6 +18,7 @@ use nemo_flow::api::scope::{
 };
 use nemo_flow::api::tool::{
     ToolCallEndParams, ToolCallParams, ToolHandle, tool_call, tool_call_end,
+    tool_conditional_execution,
 };
 use serde_json::{Map, Value, json};
 use tokio::sync::Mutex;
@@ -1439,6 +1440,7 @@ impl Session {
         } else {
             event.arguments
         };
+        tool_conditional_execution(event.tool_name.as_str(), &arguments)?;
         let metadata = tool_correlation_metadata(
             event.metadata,
             owner.status,

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -409,6 +409,28 @@ fn cli_hook_forward_reports_http_failure_when_fail_closed() {
 }
 
 #[test]
+fn cli_hook_forward_exits_two_for_guardrail_rejection() {
+    let (server_url, received) = spawn_single_request_server(
+        403,
+        r#"{"error":{"message":"guardrail rejected: blocked by policy","type":"nemo_flow_guardrail_rejected","reason":"blocked by policy"}}"#,
+    );
+    let mut child = Command::new(gateway_bin())
+        .args(["hook-forward", "codex", "--gateway-url", &server_url])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(b"{}").unwrap();
+    let output = child.wait_with_output().unwrap();
+    let request = received.recv().unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(request.contains("POST /hooks/codex HTTP/1.1"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("blocked by policy"));
+}
+
+#[test]
 fn cli_hook_forward_reports_transport_failure_when_fail_closed() {
     let mut child = Command::new(gateway_bin())
         .args([

--- a/crates/cli/tests/coverage/server_tests.rs
+++ b/crates/cli/tests/coverage/server_tests.rs
@@ -12,6 +12,9 @@ use axum::response::IntoResponse;
 use bytes::Bytes;
 use futures_util::stream;
 use http_body_util::BodyExt;
+use nemo_flow::api::registry::{
+    deregister_tool_conditional_execution_guardrail, register_tool_conditional_execution_guardrail,
+};
 use nemo_flow::plugin::{
     ConfigDiagnostic, Plugin, PluginRegistration, PluginRegistrationContext, deregister_plugin,
     register_plugin,
@@ -29,6 +32,14 @@ static PLUGIN_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(
 const GENERIC_TEST_PLUGIN_KIND: &str = "cli-test-generic-plugin";
 static GENERIC_TEST_PLUGIN_REGISTRATIONS: AtomicUsize = AtomicUsize::new(0);
 static GENERIC_TEST_PLUGIN_DEREGISTRATIONS: AtomicUsize = AtomicUsize::new(0);
+
+struct ToolGuardrailCleanup(&'static str);
+
+impl Drop for ToolGuardrailCleanup {
+    fn drop(&mut self) {
+        let _ = deregister_tool_conditional_execution_guardrail(self.0);
+    }
+}
 
 fn test_http_client() -> reqwest::Client {
     crate::tls::install_rustls_crypto_provider();
@@ -468,6 +479,50 @@ async fn cursor_hook_returns_cursor_permission_fields() {
     assert_eq!(body["permission"], json!("allow"));
     assert!(body.get("user_message").is_none());
     assert!(body.get("agent_message").is_none());
+}
+
+#[tokio::test]
+async fn pre_tool_hook_rejects_when_conditional_guardrail_blocks() {
+    let _guard = PLUGIN_TEST_LOCK.lock().await;
+    let _ = deregister_tool_conditional_execution_guardrail("cli-pre-tool-blocker");
+    const BLOCKED_TEST_TOOL: &str = "Nmf137BlockedTool";
+    register_tool_conditional_execution_guardrail(
+        "cli-pre-tool-blocker",
+        1,
+        Box::new(|name, _args| {
+            Ok((name == BLOCKED_TEST_TOOL).then(|| "blocked by policy".to_string()))
+        }),
+    )
+    .unwrap();
+    let _cleanup = ToolGuardrailCleanup("cli-pre-tool-blocker");
+
+    let app = router(test_config());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/hooks/claude-code")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "session_id": "guardrail-session",
+                        "hook_event_name": "PreToolUse",
+                        "tool_use_id": "tool-1",
+                        "tool_name": BLOCKED_TEST_TOOL,
+                        "tool_input": { "command": "rm -rf /tmp/demo" }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["error"]["type"], json!("nemo_flow_guardrail_rejected"));
+    assert_eq!(body["error"]["reason"], json!("blocked by policy"));
 }
 
 #[tokio::test]

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -5,6 +5,11 @@
   "activation": {
     "onStartup": true
   },
+  "contracts": {
+    "agentToolCallMiddleware": [
+      "pi"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/integrations/openclaw/src/hook-replay/tool.ts
+++ b/integrations/openclaw/src/hook-replay/tool.ts
@@ -7,10 +7,41 @@
  * Tool payloads can be large or sensitive, so this module applies capture policy
  * before exporting arguments/results while keeping enough metadata for debugging.
  */
-import type { PluginHookAfterToolCallEvent, PluginHookToolContext } from "../openclaw-hook-types.js";
+import type {
+  PluginHookAfterToolCallEvent,
+  PluginHookBeforeToolCallEvent,
+  PluginHookToolContext,
+} from "../openclaw-hook-types.js";
 import { blockedToolDetails, emitMark, errorToJson, toJsonRecord, toJsonValue } from "./marks.js";
 import { ensureSession, type SessionManager } from "./session.js";
 import { nowMicros, startMicrosFromDuration } from "./correlation.js";
+
+/** Run NeMo Flow tool conditional-execution guardrails before OpenClaw executes a tool. */
+export async function guardBeforeToolCall(
+  manager: SessionManager,
+  event: PluginHookBeforeToolCallEvent,
+  ctx: PluginHookToolContext,
+): Promise<void> {
+  const session = ensureSession(manager, {
+    sessionId: ctx.sessionId,
+    sessionKey: ctx.sessionKey,
+    runId: event.runId ?? ctx.runId,
+    agentId: ctx.agentId,
+    source: "lazy_session",
+  });
+
+  if (!session) {
+    return;
+  }
+
+  const previousStack = manager.nf.currentScopeStack();
+  try {
+    manager.nf.setThreadScopeStack(session.stack);
+    await manager.nf.toolConditionalExecution(event.toolName, toJsonValue(event.params ?? {}));
+  } finally {
+    manager.nf.setThreadScopeStack(previousStack);
+  }
+}
 
 /** Convert one OpenClaw after_tool_call event into a NeMo Flow tool span or blocked-tool mark. */
 export function replayAfterToolCall(

--- a/integrations/openclaw/src/hook-replay/tool.ts
+++ b/integrations/openclaw/src/hook-replay/tool.ts
@@ -29,17 +29,18 @@ export async function guardBeforeToolCall(
     agentId: ctx.agentId,
     source: "lazy_session",
   });
+  const args = toJsonValue(event.params ?? {});
 
-  if (!session) {
-    return;
-  }
-
-  const previousStack = manager.nf.currentScopeStack();
-  try {
-    manager.nf.setThreadScopeStack(session.stack);
-    await manager.nf.toolConditionalExecution(event.toolName, toJsonValue(event.params ?? {}));
-  } finally {
-    manager.nf.setThreadScopeStack(previousStack);
+  if (session) {
+    const previousStack = manager.nf.currentScopeStack();
+    try {
+      manager.nf.setThreadScopeStack(session.stack);
+      await manager.nf.toolConditionalExecution(event.toolName, args);
+    } finally {
+      manager.nf.setThreadScopeStack(previousStack);
+    }
+  } else {
+    await manager.nf.toolConditionalExecution(event.toolName, args);
   }
 }
 

--- a/integrations/openclaw/src/hooks-backend.ts
+++ b/integrations/openclaw/src/hooks-backend.ts
@@ -21,7 +21,7 @@ import {
   replayAgentEndMessages,
   replayPendingLlmOutputsForSession,
 } from "./hook-replay/llm.js";
-import { replayAfterToolCall } from "./hook-replay/tool.js";
+import { guardBeforeToolCall, replayAfterToolCall } from "./hook-replay/tool.js";
 import {
   createHookReplayState,
   drainSession,
@@ -41,6 +41,7 @@ import type {
   PluginHookBeforeAgentFinalizeEvent,
   PluginHookBeforeMessageWriteContext,
   PluginHookBeforeMessageWriteEvent,
+  PluginHookBeforeToolCallEvent,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookLlmInputEvent,
@@ -144,6 +145,11 @@ export class HookReplayBackend {
   /** Replay a finished OpenClaw tool call as a NeMo Flow tool span or blocked mark. */
   onAfterToolCall(event: PluginHookAfterToolCallEvent, ctx: PluginHookToolContext): void {
     replayAfterToolCall(this.sessionManager(), event, ctx);
+  }
+
+  /** Run conditional-execution guardrails before OpenClaw invokes a tool. */
+  async onBeforeToolCall(event: PluginHookBeforeToolCallEvent, ctx: PluginHookToolContext): Promise<void> {
+    await guardBeforeToolCall(this.sessionManager(), event, ctx);
   }
 
   /** Capture assistant message writes that may contain the clearest provider output. */

--- a/integrations/openclaw/src/modules.ts
+++ b/integrations/openclaw/src/modules.ts
@@ -21,7 +21,8 @@ type NemoFlowRuntimeKeys =
   | "llmCall"
   | "llmCallEnd"
   | "toolCall"
-  | "toolCallEnd";
+  | "toolCallEnd"
+  | "toolConditionalExecution";
 
 type NemoFlowPluginHostKeys = "defaultConfig" | "validate" | "initialize" | "clear";
 

--- a/integrations/openclaw/src/openclaw-hook-types.ts
+++ b/integrations/openclaw/src/openclaw-hook-types.ts
@@ -13,7 +13,7 @@ export type PluginHookAgentContext = {
   agentId?: string;
   sessionKey?: string;
   sessionId?: string;
-  workspaceDir?: string;
+  workspaceDir?: string | undefined;
   modelProviderId?: string;
   modelId?: string;
 };
@@ -25,6 +25,7 @@ export type PluginHookToolContext = {
   runId?: string;
   toolName?: string;
   toolCallId?: string;
+  workspaceDir?: string;
 };
 
 export type PluginHookSessionContext = {
@@ -97,6 +98,18 @@ export type PluginHookAfterToolCallEvent = {
   error?: string;
   durationMs?: number;
 };
+
+export type PluginHookBeforeToolCallEvent = {
+  toolName: string;
+  params?: unknown;
+  runId?: string | undefined;
+  toolCallId?: string | undefined;
+};
+
+export type PluginAgentToolCallMiddlewareContext = PluginHookToolContext &
+  PluginHookBeforeToolCallEvent & {
+    execute: (params: unknown) => Promise<unknown>;
+  };
 
 export type PluginHookSessionStartEvent = {
   sessionId: string;

--- a/integrations/openclaw/src/runtime-state.ts
+++ b/integrations/openclaw/src/runtime-state.ts
@@ -20,6 +20,7 @@ import type { NemoFlowHookBackendConfig } from "./config.js";
 import { createHealthSnapshot, type HookReplayBackendStatus } from "./health.js";
 import type { HookReplayCounters } from "./hook-replay/session.js";
 import { HookReplayBackend } from "./hooks-backend.js";
+import type { PluginAgentToolCallMiddlewareContext } from "./openclaw-hook-types.js";
 import {
   defaultNemoFlowModuleLoader,
   type ConfigDiagnostic,
@@ -32,6 +33,16 @@ const SERVICE_ID = "nemo-flow-observability";
 const LIFECYCLE_ID = "nemo-flow-observability-cleanup";
 const STATUS_METHOD = "nemoFlow.status";
 type RuntimeCleanupContext = Parameters<NonNullable<PluginRuntimeLifecycleRegistration["cleanup"]>>[0];
+type ToolCallMiddlewareOptions = {
+  runtimes?: string[];
+  priority?: number;
+};
+type ToolCallMiddlewareApi = {
+  registerAgentToolCallMiddleware?: (
+    handler: (ctx: PluginAgentToolCallMiddlewareContext) => Promise<unknown>,
+    options?: ToolCallMiddlewareOptions,
+  ) => void;
+};
 
 /** Owns one plugin runtime instance across OpenClaw service start/stop cycles. */
 export class NemoFlowRuntimeState {
@@ -171,6 +182,23 @@ export class NemoFlowRuntimeState {
   /** Stop the runtime because OpenClaw service or gateway shutdown is happening. */
   async stop(reason: string, logger?: PluginLogger): Promise<void> {
     await this.stopWithStatus(reason, logger, { state: "stopped", reason });
+  }
+
+  /** Apply conditional-execution guardrails before an OpenClaw tool call proceeds. */
+  async guardToolCall(ctx: PluginAgentToolCallMiddlewareContext): Promise<void> {
+    const backend = await this.backendForHook(ctx.workspaceDir);
+    if (!backend) {
+      return;
+    }
+    await backend.onBeforeToolCall(
+      {
+        toolName: ctx.toolName,
+        params: ctx.params,
+        runId: ctx.runId,
+        toolCallId: ctx.toolCallId,
+      },
+      ctx,
+    );
   }
 
   /** Shared stop implementation that controls the final health status. */
@@ -468,6 +496,23 @@ export function registerNemoFlowPlugin(
   );
 
   runtime.registerHooks();
+  registerToolCallMiddleware(api, runtime);
+}
+
+function registerToolCallMiddleware(api: OpenClawPluginApi, runtime: NemoFlowRuntimeState): void {
+  const register = (api as OpenClawPluginApi & ToolCallMiddlewareApi).registerAgentToolCallMiddleware;
+  if (typeof register !== "function") {
+    return;
+  }
+
+  register.call(
+    api,
+    async (ctx: PluginAgentToolCallMiddlewareContext) => {
+      await runtime.guardToolCall(ctx);
+      return await ctx.execute(ctx.params);
+    },
+    { runtimes: ["pi"], priority: 100 },
+  );
 }
 
 /** Validate the NeMo Flow plugin-host config and log diagnostics. */

--- a/integrations/openclaw/test/config.test.ts
+++ b/integrations/openclaw/test/config.test.ts
@@ -23,6 +23,7 @@ import {
   type NemoFlowRuntimeModule,
 } from "../src/modules.js";
 import { registerNemoFlowPlugin } from "../src/runtime-state.js";
+import type { PluginAgentToolCallMiddlewareContext } from "../src/openclaw-hook-types.js";
 import type { OpenClawPluginApi, PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
 import { callGatewayStatus, type TestGatewayMethodHandler } from "./gateway-status.js";
 
@@ -120,6 +121,7 @@ describe("nemo-flow OpenClaw plugin shell", () => {
     assert.equal(api.calls.lifecycle.length, 0);
     assert.equal(api.calls.gatewayMethods.length, 0);
     assert.equal(api.calls.hooks.length, 0);
+    assert.equal(api.calls.toolMiddlewares.length, 0);
   });
 
   it("returns without side effects when disabled", () => {
@@ -131,6 +133,7 @@ describe("nemo-flow OpenClaw plugin shell", () => {
     assert.equal(api.calls.lifecycle.length, 0);
     assert.equal(api.calls.gatewayMethods.length, 0);
     assert.equal(api.calls.hooks.length, 0);
+    assert.equal(api.calls.toolMiddlewares.length, 0);
     assert.deepEqual(api.messages.info, ["nemo-flow observability disabled by plugin config"]);
   });
 
@@ -143,6 +146,7 @@ describe("nemo-flow OpenClaw plugin shell", () => {
     assert.equal(api.calls.lifecycle.length, 0);
     assert.equal(api.calls.gatewayMethods.length, 0);
     assert.equal(api.calls.hooks.length, 0);
+    assert.equal(api.calls.toolMiddlewares.length, 0);
     assert.match(
       api.messages.warn[0] ?? "",
       /nemo-flow observability disabled because plugin config is invalid/,
@@ -157,6 +161,9 @@ describe("nemo-flow OpenClaw plugin shell", () => {
     assert.deepEqual(api.calls.services.map((service) => service.id), ["nemo-flow-observability"]);
     assert.deepEqual(api.calls.lifecycle.map((lifecycle) => lifecycle.id), ["nemo-flow-observability-cleanup"]);
     assert.deepEqual(api.calls.gatewayMethods.map((method) => method.method), ["nemoFlow.status"]);
+    assert.deepEqual(api.calls.toolMiddlewares.map((middleware) => middleware.options), [
+      { runtimes: ["pi"], priority: 100 },
+    ]);
     assert.deepEqual(
       api.calls.hooks.map((hook) => hook.hookName),
       [
@@ -176,6 +183,58 @@ describe("nemo-flow OpenClaw plugin shell", () => {
         "subagent_ended",
       ],
     );
+  });
+
+  it("runs tool conditional guardrails before OpenClaw tool middleware execution", async () => {
+    const modules = createModules();
+    const api = createApi();
+
+    registerPlugin(api, async () => modules);
+    const middleware = api.calls.toolMiddlewares[0];
+    assert.ok(middleware);
+
+    const result = await middleware.handler({
+      toolName: "shell",
+      params: { command: "pwd" },
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      agentId: "agent-1",
+      execute: async (params) => ({ ok: true, params }),
+    });
+
+    assert.deepEqual(result, { ok: true, params: { command: "pwd" } });
+    assert.deepEqual(modules.nf.calls.toolConditionalExecution, [
+      { name: "shell", args: { command: "pwd" } },
+    ]);
+  });
+
+  it("does not execute OpenClaw tools when conditional guardrails reject", async () => {
+    const modules = createModules();
+    modules.nf.toolConditionalExecution = async () => {
+      throw new Error("guardrail rejected: blocked by policy");
+    };
+    const api = createApi();
+    let executed = false;
+
+    registerPlugin(api, async () => modules);
+    const middleware = api.calls.toolMiddlewares[0];
+    assert.ok(middleware);
+
+    await assert.rejects(
+      () =>
+        middleware.handler({
+          toolName: "shell",
+          params: { command: "rm -rf /tmp/demo" },
+          sessionId: "session-1",
+          execute: async () => {
+            executed = true;
+            return { ok: true };
+          },
+        }),
+      /blocked by policy/,
+    );
+    assert.equal(executed, false);
   });
 
   it("uses config parsed during registration when service starts", async () => {
@@ -551,6 +610,7 @@ function readBuiltJavaScriptFiles(directory: URL): string {
 }
 
 type HookHandler = (event: unknown, ctx: unknown) => void | Promise<void>;
+type ToolMiddlewareHandler = (ctx: PluginAgentToolCallMiddlewareContext) => Promise<unknown>;
 
 type TestApi = {
   id: string;
@@ -563,6 +623,10 @@ type TestApi = {
   registerService: (service: Parameters<OpenClawPluginApi["registerService"]>[0]) => void;
   registerRuntimeLifecycle: (lifecycle: Parameters<OpenClawPluginApi["registerRuntimeLifecycle"]>[0]) => void;
   on: (hookName: string, handler: HookHandler) => void;
+  registerAgentToolCallMiddleware: (
+    handler: ToolMiddlewareHandler,
+    options?: { runtimes?: string[]; priority?: number },
+  ) => void;
   registerGatewayMethod: (
     method: string,
     handler: TestGatewayMethodHandler,
@@ -576,6 +640,10 @@ type TestApi = {
       handler: TestGatewayMethodHandler;
     }>;
     hooks: Array<{ hookName: string; handler: HookHandler }>;
+    toolMiddlewares: Array<{
+      handler: ToolMiddlewareHandler;
+      options?: { runtimes?: string[]; priority?: number };
+    }>;
   };
   messages: {
     info: string[];
@@ -593,6 +661,7 @@ function createApi(params: {
     lifecycle: [],
     gatewayMethods: [],
     hooks: [],
+    toolMiddlewares: [],
   };
   const logger: PluginLogger = {
     info: (message) => messages.info.push(message),
@@ -614,6 +683,8 @@ function createApi(params: {
     registerService: (service) => calls.services.push(service),
     registerRuntimeLifecycle: (lifecycle) => calls.lifecycle.push(lifecycle),
     on: (hookName: string, handler: HookHandler) => calls.hooks.push({ hookName, handler }),
+    registerAgentToolCallMiddleware: (handler, options) =>
+      calls.toolMiddlewares.push(options === undefined ? { handler } : { handler, options }),
     registerGatewayMethod: (method, handler) => calls.gatewayMethods.push({ method, handler }),
     calls,
     messages,
@@ -641,6 +712,7 @@ type TestPluginHost = NemoFlowModules["pluginHost"] & {
 type TestNemoFlowRuntime = NemoFlowModules["nf"] & {
   calls: {
     event: Array<{ name: string; handle: unknown; data: unknown }>;
+    toolConditionalExecution: Array<{ name: string; args: unknown }>;
   };
 };
 
@@ -682,6 +754,7 @@ function createModules(params: {
 function createNemoFlowRuntime(): TestNemoFlowRuntime {
   const calls: TestNemoFlowRuntime["calls"] = {
     event: [],
+    toolConditionalExecution: [],
   };
 
   return {
@@ -697,5 +770,8 @@ function createNemoFlowRuntime(): TestNemoFlowRuntime {
     llmCallEnd: () => {},
     toolCall: () => ({} as unknown as ReturnType<NemoFlowRuntimeModule["toolCall"]>),
     toolCallEnd: () => {},
+    toolConditionalExecution: async (name, args) => {
+      calls.toolConditionalExecution.push({ name, args });
+    },
   };
 }

--- a/integrations/openclaw/test/failure-model.test.ts
+++ b/integrations/openclaw/test/failure-model.test.ts
@@ -76,6 +76,7 @@ function createThrowingLlmRuntime(): NemoFlowRuntimeModule {
     llmCallEnd: () => {},
     toolCall: () => ({} as unknown as ReturnType<NemoFlowRuntimeModule["toolCall"]>),
     toolCallEnd: () => {},
+    toolConditionalExecution: async () => {},
   };
 }
 

--- a/integrations/openclaw/test/hooks-backend.test.ts
+++ b/integrations/openclaw/test/hooks-backend.test.ts
@@ -338,6 +338,7 @@ type TestNemoFlowRuntime = NemoFlowRuntimeModule & {
     popScope: Array<{ handle: unknown; output: unknown }>;
     event: Array<{ name: string; handle: unknown; data: unknown }>;
     setThreadScopeStack: unknown[];
+    toolConditionalExecution: Array<{ name: string; args: unknown }>;
   };
 };
 
@@ -380,6 +381,7 @@ function createNemoFlowRuntime(): TestNemoFlowRuntime {
     popScope: [],
     event: [],
     setThreadScopeStack: [],
+    toolConditionalExecution: [],
   };
 
   return {
@@ -400,5 +402,8 @@ function createNemoFlowRuntime(): TestNemoFlowRuntime {
     llmCallEnd: () => {},
     toolCall: () => ({} as unknown as ReturnType<NemoFlowRuntimeModule["toolCall"]>),
     toolCallEnd: () => {},
+    toolConditionalExecution: async (name, args) => {
+      calls.toolConditionalExecution.push({ name, args });
+    },
   };
 }

--- a/integrations/openclaw/test/llm-replay.test.ts
+++ b/integrations/openclaw/test/llm-replay.test.ts
@@ -802,6 +802,7 @@ type TestNemoFlowRuntime = NemoFlowRuntimeModule & {
     llmCallEnd: Array<{ handle: unknown; response: unknown; data: unknown; timestamp: number | null | undefined }>;
     toolCall: Array<{ name: string; args: unknown }>;
     toolCallEnd: Array<{ handle: unknown; result: unknown; data: unknown }>;
+    toolConditionalExecution: Array<{ name: string; args: unknown }>;
   };
 };
 
@@ -841,6 +842,7 @@ function createNemoFlowRuntime(): TestNemoFlowRuntime {
     llmCallEnd: [],
     toolCall: [],
     toolCallEnd: [],
+    toolConditionalExecution: [],
   };
 
   return {
@@ -869,6 +871,9 @@ function createNemoFlowRuntime(): TestNemoFlowRuntime {
       return handle as unknown as ReturnType<NemoFlowRuntimeModule["toolCall"]>;
     },
     toolCallEnd: (handle, result, data) => calls.toolCallEnd.push({ handle, result, data }),
+    toolConditionalExecution: async (name, args) => {
+      calls.toolConditionalExecution.push({ name, args });
+    },
   };
 }
 

--- a/integrations/openclaw/test/tool-replay.test.ts
+++ b/integrations/openclaw/test/tool-replay.test.ts
@@ -150,6 +150,7 @@ type TestNemoFlowRuntime = NemoFlowRuntimeModule & {
     llmCallEnd: Array<{ handle: unknown; response: unknown }>;
     toolCall: Array<{ name: string; args: unknown; data: unknown }>;
     toolCallEnd: Array<{ handle: unknown; result: unknown; data: unknown }>;
+    toolConditionalExecution: Array<{ name: string; args: unknown }>;
   };
 };
 
@@ -189,6 +190,7 @@ function createNemoFlowRuntime(): TestNemoFlowRuntime {
     llmCallEnd: [],
     toolCall: [],
     toolCallEnd: [],
+    toolConditionalExecution: [],
   };
 
   return {
@@ -216,5 +218,8 @@ function createNemoFlowRuntime(): TestNemoFlowRuntime {
       return handle as unknown as ReturnType<NemoFlowRuntimeModule["toolCall"]>;
     },
     toolCallEnd: (handle, result, data) => calls.toolCallEnd.push({ handle, result, data }),
+    toolConditionalExecution: async (name, args) => {
+      calls.toolConditionalExecution.push({ name, args });
+    },
   };
 }

--- a/integrations/openclaw/test/tool-replay.test.ts
+++ b/integrations/openclaw/test/tool-replay.test.ts
@@ -138,6 +138,18 @@ describe("Tool replay", () => {
     assert.equal(nf.calls.toolCall.length, 0);
     assert.ok(nf.calls.event.some((event) => event.name === "openclaw.tool_blocked"));
   });
+
+  it("runs tool guardrails even when no session key is available", async () => {
+    const nf = createNemoFlowRuntime();
+    const backend = createBackend(nf);
+
+    await backend.onBeforeToolCall({ toolName: "shell", params: { command: "pwd" } }, {});
+
+    assert.deepEqual(nf.calls.toolConditionalExecution, [
+      { name: "shell", args: { command: "pwd" } },
+    ]);
+    assert.equal(nf.calls.setThreadScopeStack.length, 0);
+  });
 });
 
 type TestNemoFlowRuntime = NemoFlowRuntimeModule & {


### PR DESCRIPTION
## Summary

- Run tool conditional-execution guardrails before CLI coding-agent tool spans are emitted.
- Preserve LLM guardrail rejection semantics at the CLI gateway boundary with an explicit policy rejection response.
- Return hook-forward process exit code 2 for explicit guardrail rejections while preserving fail-open behavior for generic delivery failures.
- Register OpenClaw Pi tool-call middleware so NeMo Flow calls `toolConditionalExecution` before OpenClaw executes a tool.

## Validation

- `cargo test -p nemo-flow-cli guardrail -- --nocapture`
- `cargo test -p nemo-flow-cli`
- `npm run typecheck --workspace=nemo-flow-openclaw`
- `npm test --workspace=nemo-flow-openclaw`
- `git diff --check`
- pre-commit: cargo fmt, cargo clippy, cargo check, JSON/link/header checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool conditional-execution guards run before tool calls; OpenClaw integration registers middleware and exposes related plugin contracts/types.

* **Bug Fixes**
  * Guardrail rejections now surface as explicit 403 responses with typed error + reason and cause the CLI to exit with code 2.
  * Gateway and hook-forward flows detect and propagate guardrail rejection reasons instead of treating them as generic HTTP failures.

* **Tests**
  * Added and expanded tests for guardrail rejection handling and tool-guard middleware behavior.

Closes NMF-137

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->