### PR TITLE
chore: address Sonar scan findings

### DIFF
--- a/crates/cli/tests/coverage/server_tests.rs
+++ b/crates/cli/tests/coverage/server_tests.rs
@@ -531,7 +531,7 @@ async fn pre_tool_hook_rejects_when_conditional_guardrail_blocks() {
     register_tool_conditional_execution_guardrail(
         "cli-pre-tool-blocker",
         1,
-        Box::new(|name, _args| {
+        Arc::new(|name, _args| {
             Ok((name == BLOCKED_TEST_TOOL).then(|| "blocked by policy".to_string()))
         }),
     )

--- a/crates/core/src/plugins/nemo_guardrails/plugin_component.rs
+++ b/crates/core/src/plugins/nemo_guardrails/plugin_component.rs
@@ -660,119 +660,157 @@ fn validate_config_shape(
     policy: &ConfigPolicy,
     config: &NeMoGuardrailsConfig,
 ) {
-    let has_config_path = config.config_path.is_some();
-    let has_config_yaml = config.config_yaml.is_some();
-    let has_colang_content = config.colang_content.is_some();
-    let has_remote_config_id = config
-        .remote
-        .as_ref()
-        .and_then(|remote| remote.config_id.as_ref())
-        .is_some();
-    let has_remote_config_ids = config
-        .remote
-        .as_ref()
-        .map(|remote| !remote.config_ids.is_empty())
-        .unwrap_or(false);
+    let flags = ConfigShapeFlags::from(config);
 
     match config.mode.as_str() {
-        "local" => {
-            if has_config_path == has_config_yaml {
-                push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "nemo_guardrails.invalid_config_source",
-                    Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                    None,
-                    "exactly one of config_path or config_yaml is required in local mode"
-                        .to_string(),
-                );
-            }
-
-            if has_colang_content && !has_config_yaml {
-                push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "nemo_guardrails.unsupported_value",
-                    Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                    Some("colang_content".to_string()),
-                    "colang_content can only be used with config_yaml".to_string(),
-                );
-            }
-
-            if config.remote.is_some() {
-                push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "nemo_guardrails.unsupported_value",
-                    Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                    Some("remote".to_string()),
-                    "remote backend settings cannot be used when mode is 'local'".to_string(),
-                );
-            }
-        }
-        "remote" => {
-            if has_config_path || has_config_yaml || has_colang_content {
-                push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "nemo_guardrails.invalid_config_source",
-                    Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                    None,
-                    "remote mode uses remote config identity and cannot include config_path, config_yaml, or colang_content".to_string(),
-                );
-            }
-
-            if config.local.is_some() {
-                push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "nemo_guardrails.unsupported_value",
-                    Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                    Some("local".to_string()),
-                    "local backend settings cannot be used when mode is 'remote'".to_string(),
-                );
-            }
-
-            match &config.remote {
-                Some(remote)
-                    if remote
-                        .endpoint
-                        .as_ref()
-                        .is_some_and(|value| !value.trim().is_empty()) => {}
-                _ => push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "nemo_guardrails.unsupported_value",
-                    Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                    Some("remote.endpoint".to_string()),
-                    "remote.endpoint is required when mode is 'remote'".to_string(),
-                ),
-            }
-
-            if has_remote_config_id && has_remote_config_ids {
-                push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "nemo_guardrails.unsupported_value",
-                    Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                    Some("remote".to_string()),
-                    "remote.config_id and remote.config_ids cannot be used together".to_string(),
-                );
-            }
-
-            if !(has_remote_config_id || has_remote_config_ids) {
-                push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "nemo_guardrails.invalid_config_source",
-                    Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                    None,
-                    "remote mode requires remote.config_id or remote.config_ids".to_string(),
-                );
-            }
-        }
+        "local" => validate_local_config_shape(diagnostics, policy, config, &flags),
+        "remote" => validate_remote_config_shape(diagnostics, policy, config, &flags),
         _ => {}
     }
+}
+
+struct ConfigShapeFlags {
+    has_config_path: bool,
+    has_config_yaml: bool,
+    has_colang_content: bool,
+    has_remote_config_id: bool,
+    has_remote_config_ids: bool,
+}
+
+impl From<&NeMoGuardrailsConfig> for ConfigShapeFlags {
+    fn from(config: &NeMoGuardrailsConfig) -> Self {
+        Self {
+            has_config_path: config.config_path.is_some(),
+            has_config_yaml: config.config_yaml.is_some(),
+            has_colang_content: config.colang_content.is_some(),
+            has_remote_config_id: config
+                .remote
+                .as_ref()
+                .and_then(|remote| remote.config_id.as_ref())
+                .is_some(),
+            has_remote_config_ids: config
+                .remote
+                .as_ref()
+                .map(|remote| !remote.config_ids.is_empty())
+                .unwrap_or(false),
+        }
+    }
+}
+
+fn validate_local_config_shape(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    config: &NeMoGuardrailsConfig,
+    flags: &ConfigShapeFlags,
+) {
+    if flags.has_config_path == flags.has_config_yaml {
+        push_config_shape_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "nemo_guardrails.invalid_config_source",
+            None,
+            "exactly one of config_path or config_yaml is required in local mode",
+        );
+    }
+
+    if flags.has_colang_content && !flags.has_config_yaml {
+        push_config_shape_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "nemo_guardrails.unsupported_value",
+            Some("colang_content"),
+            "colang_content can only be used with config_yaml",
+        );
+    }
+
+    if config.remote.is_some() {
+        push_config_shape_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "nemo_guardrails.unsupported_value",
+            Some("remote"),
+            "remote backend settings cannot be used when mode is 'local'",
+        );
+    }
+}
+
+fn validate_remote_config_shape(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    config: &NeMoGuardrailsConfig,
+    flags: &ConfigShapeFlags,
+) {
+    if flags.has_config_path || flags.has_config_yaml || flags.has_colang_content {
+        push_config_shape_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "nemo_guardrails.invalid_config_source",
+            None,
+            "remote mode uses remote config identity and cannot include config_path, config_yaml, or colang_content",
+        );
+    }
+
+    if config.local.is_some() {
+        push_config_shape_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "nemo_guardrails.unsupported_value",
+            Some("local"),
+            "local backend settings cannot be used when mode is 'remote'",
+        );
+    }
+
+    match &config.remote {
+        Some(remote)
+            if remote
+                .endpoint
+                .as_ref()
+                .is_some_and(|value| !value.trim().is_empty()) => {}
+        _ => push_config_shape_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "nemo_guardrails.unsupported_value",
+            Some("remote.endpoint"),
+            "remote.endpoint is required when mode is 'remote'",
+        ),
+    }
+
+    if flags.has_remote_config_id && flags.has_remote_config_ids {
+        push_config_shape_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "nemo_guardrails.unsupported_value",
+            Some("remote"),
+            "remote.config_id and remote.config_ids cannot be used together",
+        );
+    }
+
+    if !(flags.has_remote_config_id || flags.has_remote_config_ids) {
+        push_config_shape_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "nemo_guardrails.invalid_config_source",
+            None,
+            "remote mode requires remote.config_id or remote.config_ids",
+        );
+    }
+}
+
+fn push_config_shape_diag(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    behavior: UnsupportedBehavior,
+    code: &str,
+    field: Option<&str>,
+    message: &str,
+) {
+    push_policy_diag(
+        diagnostics,
+        behavior,
+        code,
+        Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
+        field.map(str::to_string),
+        message.to_string(),
+    );
 }
 
 fn validate_codec_requirements(

--- a/crates/node/tests/scope_tests.mjs
+++ b/crates/node/tests/scope_tests.mjs
@@ -259,7 +259,7 @@ describe('Subscribers', () => {
       assert.ok(typeof captured.uuid === 'string');
       assert.ok(typeof captured.timestamp === 'string');
       assert.ok(typeof captured.kind === 'string');
-      assert.equal(JSON.parse(JSON.stringify(captured)).kind, captured.kind);
+      assert.equal(structuredClone(captured).kind, captured.kind);
     } finally {
       deregisterSubscriber('node_prop_collector');
     }

--- a/go/nemo_flow/scope_test.go
+++ b/go/nemo_flow/scope_test.go
@@ -11,7 +11,10 @@ import (
 	"time"
 )
 
-const pushScopeFailed = "PushScope failed: %v"
+const (
+	pushScopeFailed = "PushScope failed: %v"
+	emitEventFailed = "EmitEvent failed: %v"
+)
 
 type scopeTypeContract struct {
 	seenScope bool
@@ -144,7 +147,7 @@ func TestEventJSONHelpers(t *testing.T) {
 	defer DeregisterSubscriber(subscriberName)
 
 	if err := EmitEvent("go_json_mark", WithEventData(json.RawMessage(`{"ok":true}`))); err != nil {
-		t.Fatalf("EmitEvent failed: %v", err)
+		t.Fatalf(emitEventFailed, err)
 	}
 
 	select {
@@ -357,7 +360,7 @@ func TestAllScopeTypes(t *testing.T) {
 func TestEmitEvent(t *testing.T) {
 	err := EmitEvent("my_mark")
 	if err != nil {
-		t.Fatalf("EmitEvent failed: %v", err)
+		t.Fatalf(emitEventFailed, err)
 	}
 }
 
@@ -531,7 +534,7 @@ func TestEventScopeTypeMatchesEventFamily(t *testing.T) {
 	}
 
 	if err := EmitEvent("scope_type_mark"); err != nil {
-		t.Fatalf("EmitEvent failed: %v", err)
+		t.Fatalf(emitEventFailed, err)
 	}
 
 	if err := PopScope(child); err != nil {


### PR DESCRIPTION
#### Overview

Address the current Sonar scan findings by tightening the reported test and Guardrails validation code, and include the small CLI coverage-test API update needed to keep Rust validation green.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replaced the Node subscriber-event deep clone test with `structuredClone`.
- Deduplicated the repeated Go `EmitEvent failed: %v` test literal.
- Split NeMo Guardrails config-shape validation into focused mode-specific helpers backed by shared shape flags and diagnostic creation.
- Updated the CLI coverage test conditional guardrail callback from `Box` to `Arc` to match the current registry API and unblock Rust validation.

Validation:

- `cargo test -p nemo-flow nemo_guardrails`
- `just test-go`
- `just test-node`
- `just test-rust`
- commit hooks: cargo fmt, cargo clippy, cargo check, go fmt/vet, node prettier check

#### Where should the reviewer start?

Start with `crates/core/src/plugins/nemo_guardrails/plugin_component.rs`, where the Sonar cognitive-complexity issue is resolved without changing diagnostic messages.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test implementations across multiple components for consistency and clarity.

* **Refactor**
  * Improved internal configuration validation logic with a cleaner, flag-driven approach for better maintainability.

* **Chores**
  * Internal code improvements and standardization of error handling patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->