### PR TITLE
docs: add build plugin skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -22,6 +22,7 @@ Use these skills for tasks such as:
 - Instrumenting tool and LLM calls
 - Choosing the current primary documentation track: Rust, Python, or Node.js
 - Tuning performance with adaptive features
+- Building reusable plugin behavior
 - Setting up observability and trace export
 - Debugging application-side NeMo Flow integrations
 

--- a/skills/nemo-flow-build-plugin/SKILL.md
+++ b/skills/nemo-flow-build-plugin/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: nemo-flow-build-plugin
+description: Build and package reusable NeMo Flow runtime behavior as a config-activated plugin with validation and rollback-safe registration
+author: NVIDIA Corporation and Affiliates
+license: Apache-2.0
+---
+
+# Build a Plugin
+
+Use this skill when a user wants to package reusable NeMo Flow runtime behavior
+behind plugin configuration.
+
+## Use This When
+
+Use this skill when the behavior should be activated by shared config and reused
+across applications, teams, or process startup paths.
+
+Common cases:
+
+- Register subscribers, guardrails, intercepts, or a small bundle of related
+  runtime behavior.
+- Validate operator-supplied config before changing runtime behavior.
+- Give reusable behavior a stable plugin `kind` and activation lifecycle.
+- Package behavior that should be enabled, disabled, or rolled out through
+  plugin config rather than repeated application startup code.
+
+## Do Not Use This When
+
+Do not build a plugin when a narrower NeMo Flow surface is enough:
+
+- One request or tenant needs temporary behavior -> use scope-local middleware.
+- The user only needs first-time scopes, tool calls, or LLM calls ->
+  `nemo-flow-instrument-calls`.
+- The user only needs to choose an exporter path ->
+  `nemo-flow-setup-observability`.
+- The behavior depends on live callables, provider clients, file handles,
+  credentials, or framework objects inside config.
+
+## Embedded Plugin Model
+
+- Plugins package reusable process-level behavior.
+- A plugin exposes a stable `kind` string and receives component-local config
+  from a shared plugin document.
+- Plugin config must be JSON-compatible across Rust, Python, Node.js, files,
+  tests, and deployment systems.
+- Validation is deterministic and side-effect free. It inspects config and
+  returns structured diagnostics before runtime behavior changes.
+- Registration runs after validation and installs real behavior through
+  `PluginContext`, such as subscribers, guardrails, request intercepts,
+  execution intercepts, or stream execution intercepts.
+- `PluginContext` gives the plugin system enough ownership to qualify runtime
+  names and roll back partial setup when activation fails.
+- Disabled components should still validate when possible so operators can find
+  config problems before rollout.
+
+## Default Path
+
+1. Decide whether a plugin is actually needed. Prefer direct instrumentation or
+   scope-local behavior when the use case is not reusable process-level
+   behavior.
+2. Pick one first runtime surface: subscriber-oriented export, sanitize
+   guardrail, conditional guardrail, request intercept, execution intercept, or
+   stream execution intercept.
+3. Choose a stable plugin `kind` and the smallest JSON-compatible config shape.
+4. Define diagnostics for missing fields, unsupported values, unknown fields,
+   unsafe config, and invalid field combinations.
+5. Validate config before initialization. Validation must not open network
+   connections, create clients, register middleware, or mutate process state.
+6. Register runtime behavior through `PluginContext`, not by hand-registering
+   global behavior inside application startup.
+7. Test activation, disabled components, validation failures, and registration
+   failure rollback.
+8. Document how to enable the plugin, what config fields are supported, and how
+   to roll back the component.
+
+## Config Shape
+
+The top-level plugin document contains `version`, `components`, and `policy`.
+Each component supplies the plugin `kind`, `enabled`, and component-local
+`config`:
+
+```json
+{
+  "version": 1,
+  "components": [
+    {
+      "kind": "redaction-policy",
+      "enabled": true,
+      "config": {
+        "preset": "strict"
+      }
+    }
+  ],
+  "policy": {
+    "unknown_component": "warn",
+    "unknown_field": "warn",
+    "unsupported_value": "error"
+  }
+}
+```
+
+Keep business logic in plugin code, not in config. Use references to secrets or
+endpoints rather than embedding sensitive values.
+
+## Binding Pointers
+
+- Python: `nemo_flow.plugin`
+- Node.js: `nemo-flow-node/plugin`
+- Rust: `nemo_flow::plugin`
+- Go, WebAssembly, and raw FFI are source-first or advanced surfaces.
+
+Use the same canonical `snake_case` config keys across bindings and files. Node
+helper functions can be `camelCase`, but plugin config objects remain
+`snake_case`.
+
+## Failure Modes To Avoid
+
+- Do not put callables, clients, credentials, framework objects, file handles,
+  or caches in plugin config.
+- Do not perform runtime registration during validation.
+- Do not skip validation for disabled components.
+- Do not register directly through global startup code when `PluginContext`
+  should own the runtime behavior.
+- Do not combine unrelated subscribers, request transforms, and policy checks
+  in the first plugin unless one config document clearly owns the bundle.
+- Do not export raw production payloads or secrets. Add telemetry sanitization
+  before data leaves the process.
+- Do not ignore partial activation failures. Roll back or surface a clear
+  diagnostic.
+
+## Validation Checklist
+
+- [ ] Stable plugin `kind` chosen.
+- [ ] Config shape is JSON-compatible and uses `snake_case`.
+- [ ] Required fields and unsupported values produce stable diagnostics.
+- [ ] Unknown fields follow the configured policy.
+- [ ] Disabled components still report config problems where possible.
+- [ ] Initialization installs behavior through `PluginContext`.
+- [ ] A forced registration failure does not leave partial runtime behavior
+      active.
+- [ ] Docs or examples show how to enable and roll back the plugin.
+
+## Use Another Skill When
+
+- You only need to wrap direct tool or LLM calls ->
+  `nemo-flow-instrument-calls`
+- You need to set up traces or exporters without packaging a plugin ->
+  `nemo-flow-setup-observability`
+- You need to debug plugin activation, missing events, or load failures ->
+  `nemo-flow-debug-runtime-integration`
+
+## Related Skills
+
+- `nemo-flow-instrument-calls`
+- `nemo-flow-setup-observability`
+- `nemo-flow-debug-runtime-integration`

--- a/skills/nemo-flow-debug-runtime-integration/SKILL.md
+++ b/skills/nemo-flow-debug-runtime-integration/SKILL.md
@@ -78,3 +78,4 @@ working.
 - `nemo-flow-start`
 - `nemo-flow-use-context-isolation`
 - `nemo-flow-tune-adaptive-config`
+- `nemo-flow-build-plugin`

--- a/skills/nemo-flow-instrument-calls/SKILL.md
+++ b/skills/nemo-flow-instrument-calls/SKILL.md
@@ -70,9 +70,12 @@ needs to run them through NeMo Flow correctly.
   `nemo-flow-debug-runtime-integration`
 - You need per-request isolation or worker-pool advice ->
   `nemo-flow-use-context-isolation`
+- You need reusable config-activated runtime behavior ->
+  `nemo-flow-build-plugin`
 
 ## Related Skills
 
 - `nemo-flow-start`
 - `nemo-flow-typed-wrappers-codecs`
 - `nemo-flow-setup-observability`
+- `nemo-flow-build-plugin`

--- a/skills/nemo-flow-setup-observability/SKILL.md
+++ b/skills/nemo-flow-setup-observability/SKILL.md
@@ -65,6 +65,8 @@ activity but has not yet decided which output they need.
 - You already know you need ATIF -> `nemo-flow-export-atif-trajectories`
 - You already know you need OTEL -> `nemo-flow-export-otel`
 - You already know you need OpenInference -> `nemo-flow-export-openinference`
+- You need to package subscriber-based export behavior as a reusable plugin ->
+  `nemo-flow-build-plugin`
 - You are debugging missing telemetry -> `nemo-flow-debug-runtime-integration`
 
 ## Related Skills
@@ -72,3 +74,4 @@ activity but has not yet decided which output they need.
 - `nemo-flow-export-atif-trajectories`
 - `nemo-flow-export-otel`
 - `nemo-flow-export-openinference`
+- `nemo-flow-build-plugin`

--- a/skills/nemo-flow-tune-adaptive-config/SKILL.md
+++ b/skills/nemo-flow-tune-adaptive-config/SKILL.md
@@ -85,3 +85,4 @@ request-specific middleware, or production trace debugging.
 - `nemo-flow-tune-performance`
 - `nemo-flow-tune-adaptive-hints`
 - `nemo-flow-debug-runtime-integration`
+- `nemo-flow-build-plugin`

--- a/skills/nemo-flow-tune-performance/SKILL.md
+++ b/skills/nemo-flow-tune-performance/SKILL.md
@@ -23,8 +23,8 @@ Do not use this skill when the application is not instrumented yet. Start with
 
 - Observe first, compare against a baseline, then enable one behavior change at
   a time.
-- Use the adaptive plugin component rather than inventing a separate optimizer
-  object or hand-registering adaptive behavior at every call site.
+- Use the adaptive plugin component rather than inventing separate tuning logic
+  or hand-registering adaptive behavior at every call site.
 - Start with in-memory state and telemetry-only behavior for local development.
 - Move to persistent state only when learned signals must survive restarts or be
   shared across workers.
@@ -71,6 +71,8 @@ Do not use this skill when the application is not instrumented yet. Start with
 - You need the exact adaptive config shape -> `nemo-flow-tune-adaptive-config`
 - You need to consume adaptive hints or scheduling guidance in app logic ->
   `nemo-flow-tune-adaptive-hints`
+- You need to build reusable plugin behavior instead of configuring the built-in
+  adaptive component -> `nemo-flow-build-plugin`
 
 ## Related Skills
 
@@ -79,3 +81,4 @@ Do not use this skill when the application is not instrumented yet. Start with
 - `nemo-flow-setup-observability`
 - `nemo-flow-tune-adaptive-config`
 - `nemo-flow-tune-adaptive-hints`
+- `nemo-flow-build-plugin`


### PR DESCRIPTION
#### Overview

Adds a public `nemo-flow-build-plugin` skill for building reusable NeMo Flow plugin behavior from configuration.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `skills/nemo-flow-build-plugin/SKILL.md` with plugin trigger guidance, default workflow, config shape, binding pointers, failure modes, and validation checklist.
- Links the new skill from related instrumentation, observability, debugging, and adaptive tuning skills.
- Removes a remaining legacy “optimizer object” phrase from the tuning skill.

#### Where should the reviewer start?

Start with `skills/nemo-flow-build-plugin/SKILL.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to the v0.3 skills improvement work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive guidance on building reusable plugin behavior as a config-activated pattern.
* Updated multiple related skill documentation files to reference the new plugin-building guidance, improving cross-skill navigation and helping users understand when to apply this pattern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Flow/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->