### PR TITLE
chore: Set minimum Node.js version to 24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Install the tools needed for the surfaces you touch. For a full repository valid
 |---|---|---|
 | Rust | Docs minimum is 1.86 or newer; the repo pins the active toolchain in `rust-toolchain.toml` | Rust core, native bindings, FFI, WebAssembly |
 | Python | 3.11 or newer | Python package, PyO3 builds, docs tooling |
-| Node.js | 20 or newer, with npm | Node.js binding, WebAssembly JS tests, generated API docs |
+| Node.js | 24 or newer, with npm | Node.js binding, WebAssembly JS tests, generated API docs |
 | Go | 1.21 or newer | Experimental Go binding |
 | `uv` | Current project workflow tool | Python environments, docs dependencies, pre-commit |
 | `just` | 1.40 or newer | Canonical build, test, docs, package task runner |

--- a/ATTRIBUTIONS-Node.md
+++ b/ATTRIBUTIONS-Node.md
@@ -13694,7 +13694,7 @@ MIT License
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE```
 
-## @types/node - 20.19.40
+## @types/node - 24.12.4
 **Repository URL**: https://github.com/DefinitelyTyped/DefinitelyTyped
 **License Type(s)**: MIT
 ### License: https://spdx.org/licenses/MIT.html
@@ -26024,7 +26024,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.```
 
-## undici-types - 6.21.0
+## undici-types - 7.16.0
 **Repository URL**: https://github.com/nodejs/undici
 **License Type(s)**: MIT
 ### License: https://spdx.org/licenses/MIT.html

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -38,7 +38,7 @@ should install it from npm rather than depend on the Rust crate directly.
 
 ## What You Get
 
-- ✅ **npm package for Node.js**: A Node.js 20 or newer package backed by a
+- ✅ **npm package for Node.js**: A Node.js 24 or newer package backed by a
   napi-rs native extension.
 - ✅ **Managed tool and LLM execution**: Helpers that emit lifecycle events and
   run middleware in a consistent order.
@@ -51,7 +51,7 @@ should install it from npm rather than depend on the Rust crate directly.
 
 ## Installation
 
-Install the npm package in a Node.js 20 or newer project:
+Install the npm package in a Node.js 24 or newer project:
 
 ```bash
 npm install nemo-relay-node

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -47,7 +47,7 @@
     }
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "napi": {
     "name": "nemo-relay",

--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -2,7 +2,7 @@
   "name": "nemo-relay-wasm",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "build:pkg": "node scripts/build_pkg.mjs",

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -11,7 +11,7 @@ Install the tooling for the binding you plan to use.
 |---|---|---|
 | Rust | 1.86 or newer | Rust builds, local workspace builds, and the Rust core runtime |
 | Python | 3.11 or newer | Python bindings, Python tests, and docs tooling |
-| Node.js | 20 or newer | Node.js bindings and generated Node.js API docs |
+| Node.js | 24 or newer | Node.js bindings and generated Node.js API docs |
 | `uv` | see [Development Setup](../contribute/development-setup.md) | Python environments, docs builds, and repository setup |
 | `just` | see [Development Setup](../contribute/development-setup.md) | Repository development, test, build, and docs task aliases |
 

--- a/docs/reference/api/nodejs/index.md
+++ b/docs/reference/api/nodejs/index.md
@@ -12,7 +12,7 @@ These pages are generated from the exported TypeScript declaration surfaces in `
 This summary lists the package identity and support status for the binding.
 
 - Package name: `nemo-relay-node`
-- Runtime requirement: Node.js `>=20`
+- Runtime requirement: Node.js `>=24`
 - Local development path: `crates/node`
 
 The Node.js binding is built with `napi-rs`. The package root exports the core

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -56,7 +56,7 @@
     "pack:check": "node scripts/check-pack-payload.mjs",
     "prepack": "npm run build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "npm run build:test && node --test \".test-dist/test/*.test.js\"",
+    "test": "npm run build:test && node --test .test-dist/test/*.test.js",
     "test:live": "npm run build:test && node scripts/test-live.mjs"
   },
   "peerDependencies": {

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -56,7 +56,7 @@
     "pack:check": "node scripts/check-pack-payload.mjs",
     "prepack": "npm run build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "npm run build:test && node --test .test-dist/test/*.test.js",
+    "test": "npm run build:test && node --test \".test-dist/test/*.test.js\"",
     "test:live": "npm run build:test && node scripts/test-live.mjs"
   },
   "peerDependencies": {

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -66,7 +66,7 @@
     "nemo-relay-node": "0.3.0"
   },
   "devDependencies": {
-    "@types/node": "^20.19.0",
+    "@types/node": "^24.0.0",
     "typescript": "^5.8.2"
   },
   "license": "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -782,6 +782,7 @@ clean:
     rm -rf \
         .coverage \
         .pytest_cache \
+        *.profraw \
         crates/**/*.profraw \
         crates/node/*.node \
         crates/node/coverage \
@@ -792,6 +793,7 @@ clean:
         crates/wasm/node_modules \
         crates/wasm/pkg-test/ \
         crates/wasm/pkg/ \
+        integrations/openclaw/*.profraw \
         integrations/openclaw/.test-dist \
         integrations/openclaw/dist \
         integrations/openclaw/node_modules \

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
       }
     },
     "crates/node": {
@@ -29,7 +29,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
       }
     },
     "crates/node/node_modules/@bcoe/v8-coverage": {
@@ -467,7 +467,7 @@
         "c8": "^11.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
       }
     },
     "crates/wasm/node_modules/@bcoe/v8-coverage": {
@@ -841,7 +841,7 @@
         "nemo-relay-node": "0.3.0"
       },
       "devDependencies": {
-        "@types/node": "^20.19.0",
+        "@types/node": "^24.0.0",
         "typescript": "^5.8.2"
       },
       "peerDependencies": {
@@ -2059,9 +2059,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2078,9 +2075,6 @@
       "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2099,9 +2093,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,9 +2110,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2138,9 +2126,6 @@
       "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2544,12 +2529,12 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
-      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/retry": {
@@ -6632,9 +6617,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nemo-relay-workspace",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "workspaces": [
     "crates/node",


### PR DESCRIPTION
#### Overview
Set minimum Node.js version to 24, since that is the version we use in CI.

<!-- Describe your pull request here -->

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

* Remove `*.profraw` files from root of the repo and `integrations/openclaw/`

#### Where should the reviewer start?

- justfile



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced local cleanup to remove profiling (.profraw) files.
  * Updated development dependency for Node type definitions.

* **Documentation**
  * Raised the documented minimum Node.js requirement to version 24 across guides and READMEs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->