### PR TITLE
fix: make node lockfile check non-mutating

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
 
       - id: node-lockfile-check
         name: package-lock.json is up to date
-        entry: bash -c 'npm install --package-lock-only --ignore-scripts --audit=false --fund=false'
+        entry: bash -c 'npm ci --ignore-scripts --audit=false --fund=false --dry-run'
         language: system
         files: 'package(?:-lock)?\.json$'
         pass_filenames: false


### PR DESCRIPTION
#### Overview

Fixes the Node lockfile pre-commit check so it validates `package-lock.json` without rewriting it.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replaces `npm install --package-lock-only` with `npm ci --dry-run` for the `node-lockfile-check` hook.
- Keeps the hook’s intended behavior: fail when `package.json` and `package-lock.json` are out of sync.
- Avoids local generated-file drift in `package-lock.json` and `ATTRIBUTIONS-Node.md`.

Validation:

```text
uv run pre-commit run node-lockfile-check --all-files
uv run pre-commit run --all-files
git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency validation process for development workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->