### PR TITLE
fix(banner): update launch banner to "NEMO RELAY"

### DIFF
--- a/crates/cli/src/banner.rs
+++ b/crates/cli/src/banner.rs
@@ -14,16 +14,15 @@
 
 use std::io::IsTerminal;
 
-/// Filled-block NeMo Relay figlet with a per-row right shift so the letters lean italic. Six
-/// content rows; the renderer prepends one blank row above and appends one below for spacing
-/// and the docked version tag.
+/// Filled-block NeMo Relay figlet generated with ANSI Shadow. Six content rows; the renderer
+/// prepends one blank row above and appends one below for spacing and the docked version tag.
 const BANNER_LINES: &[&str] = &[
-    "             ███╗   ██╗███████╗███╗   ███╗ ██████╗      ███████╗██╗      ██████╗ ██╗   ██╗",
-    "            ████╗  ██║██╔════╝████╗ ████║██╔═══██╗     ██╔════╝██║     ██╔═══██╗██║   ██║",
-    "           ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║     █████╗  ██║     ██║   ██║██║ █╗██║",
-    "          ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║     ██╔══╝  ██║     ██║   ██║██║██║██║",
-    "         ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝     ██║     ███████╗╚██████╔╝╚███╔███╔╝",
-    "        ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝      ╚═╝     ╚══════╝ ╚═════╝  ╚══╝╚══╝",
+    "███╗   ██╗███████╗███╗   ███╗ ██████╗     ██████╗ ███████╗██╗      █████╗ ██╗   ██╗",
+    "████╗  ██║██╔════╝████╗ ████║██╔═══██╗    ██╔══██╗██╔════╝██║     ██╔══██╗╚██╗ ██╔╝",
+    "██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║    ██████╔╝█████╗  ██║     ███████║ ╚████╔╝",
+    "██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║    ██╔══██╗██╔══╝  ██║     ██╔══██║  ╚██╔╝",
+    "██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝    ██║  ██║███████╗███████╗██║  ██║   ██║",
+    "╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝     ╚═╝  ╚═╝╚══════╝╚══════╝╚═╝  ╚═╝   ╚═╝",
 ];
 
 /// Banner geometry (visual rows including the top and bottom spacing rails).
@@ -32,7 +31,7 @@ const BOTTOM_RAIL: usize = FIGLET_ROWS + 1; // row index of the row below the fi
 const TOTAL_ROWS: usize = FIGLET_ROWS + 2; // top rail + 6 figlet rows + bottom rail
 
 /// Version tag position, measured in columns.
-const COL_END: usize = 92; // right edge below "Flow"
+const COL_END: usize = 92; // version tag dock
 
 const MIN_WIDTH: usize = 105;
 
@@ -141,15 +140,35 @@ fn build_grid(width: usize) -> Vec<Vec<char>> {
     // Empty top rail, the 6 figlet rows, and an empty bottom rail. Each cell is a single char
     // because the figlet's block and box glyphs render as one display column in target terminals.
     let mut grid = Vec::with_capacity(TOTAL_ROWS);
+    let art_width = banner_art_width();
+    let start_col = width.saturating_sub(art_width) / 2;
     grid.push(vec![' '; width]);
-    grid.extend(BANNER_LINES.iter().map(|line| padded_row(line, width)));
+    grid.extend(
+        BANNER_LINES
+            .iter()
+            .map(|line| padded_row(line, width, start_col)),
+    );
     grid.push(vec![' '; width]);
     grid
 }
 
-fn padded_row(line: &str, width: usize) -> Vec<char> {
-    let mut row: Vec<char> = line.chars().collect();
-    row.resize(width, ' ');
+fn banner_art_width() -> usize {
+    BANNER_LINES
+        .iter()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0)
+}
+
+fn padded_row(line: &str, width: usize, start_col: usize) -> Vec<char> {
+    let mut row = vec![' '; width];
+
+    for (index, ch) in line.chars().enumerate() {
+        if let Some(cell) = row.get_mut(start_col + index) {
+            *cell = ch;
+        }
+    }
+
     row
 }
 

--- a/crates/cli/tests/coverage/banner_tests.rs
+++ b/crates/cli/tests/coverage/banner_tests.rs
@@ -9,8 +9,26 @@ fn render_frame_settled_contains_figlet_glyphs() {
     // ANSI Shadow figlet uses filled blocks and box-drawing corners.
     assert!(frame.contains('█'), "frame missing figlet block glyph");
     assert!(
+        !frame.contains("_/=|") && !frame.contains("|=\\_") && !frame.contains("╔██╗██╗"),
+        "frame should not include flag columns"
+    );
+    assert!(
         frame.contains('╗') || frame.contains('╔'),
         "frame missing figlet corners"
+    );
+}
+
+#[test]
+fn figlet_rows_are_centered_as_one_block() {
+    let frame = render_frame(false);
+    let rows = frame_grid_rows(&frame);
+    let figlet_rows = &rows[1..=FIGLET_ROWS];
+    let left_edges: Vec<usize> = figlet_rows.iter().map(|row| first_art_col(row)).collect();
+    let expected_left_edge = (frame_inner_width(&frame) - banner_art_width()) / 2;
+
+    assert!(
+        left_edges.iter().all(|edge| *edge == expected_left_edge),
+        "figlet rows should share centered left edge {expected_left_edge}; got {left_edges:?}"
     );
 }
 
@@ -65,4 +83,28 @@ fn docked_frame_includes_version_tag() {
         !frame.contains('●'),
         "docked frame should not include a bullet dot before the version"
     );
+}
+
+fn frame_grid_rows(frame: &str) -> Vec<&str> {
+    frame
+        .lines()
+        .filter(|line| line.starts_with('│') && line.ends_with('│'))
+        .map(|line| line.trim_matches('│'))
+        .collect()
+}
+
+fn frame_inner_width(frame: &str) -> usize {
+    frame
+        .lines()
+        .find(|line| line.starts_with('╭'))
+        .expect("frame should include a top border")
+        .trim_matches(['╭', '╮'])
+        .chars()
+        .count()
+}
+
+fn first_art_col(row: &str) -> usize {
+    row.chars()
+        .position(|ch| !ch.is_whitespace())
+        .expect("figlet row should contain art")
 }


### PR DESCRIPTION
#### Overview

Updates the CLI welcome banner from the old Flow wordmark to a centered ANSI Shadow `NEMO RELAY` banner while preserving the existing green styling, rounded border, and docked version tag behavior.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replaces the existing banner art with ANSI Shadow-style `NEMO RELAY` text.
- Removes the experimental checkered flag columns from the banner.
- Centers the banner as a single FIGlet block so all rows share the same left edge.
- Keeps the existing plain-mode, color-mode, border, version tag, and cursor-control behavior.
- Adds a regression test that verifies the FIGlet rows are centered together as one block.

#### Where should the reviewer start?

Start with `crates/cli/src/banner.rs` for the rendering change, then review `crates/cli/tests/coverage/banner_tests.rs` for the centering regression coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the CLI banner with a new glyph layout design featuring improved visual appearance.
  * Improved horizontal centering of banner content within the display frame.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->