### PR TITLE
docs: avoid secret-like provider key placeholder

### DIFF
--- a/patches/hermes-agent/notes.md
+++ b/patches/hermes-agent/notes.md
@@ -88,7 +88,7 @@ the project `.env` only fills in missing variables.
 mkdir -p "${HERMES_HOME:-$HOME/.hermes}"
 cat > "${HERMES_HOME:-$HOME/.hermes}/.env" <<'EOF'
 # Optional: required only for a real Anthropic-backed agent turn.
-ANTHROPIC_API_KEY=<paste-your-key-here>
+# Add provider API credentials locally if needed; do not commit them.
 HERMES_NEMO_RELAY_ENABLED=1
 HERMES_NEMO_RELAY_ACG_ENABLED=1
 HERMES_NEMO_RELAY_ATIF_DIR=${HERMES_HOME:-$HOME/.hermes}/atif


### PR DESCRIPTION
## Summary
- Replace a committed provider-key placeholder in patch notes with a non-secret instruction
- Keeps the example useful without triggering secret scanners or encouraging credentials in git

## Test Plan
- gitleaks dir . --redact
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified operator runbook setup: instruct operators to add provider API credentials locally and avoid committing them.
  * Replaced verbose example credential snippet with a concise comment directing users to supply their own keys in their environment.
  * Emphasized credential handling as a security best practice to reduce accidental exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->