### PR TITLE
ci: align Fern CLI dependency pin

### DIFF
--- a/ATTRIBUTIONS-Node.md
+++ b/ATTRIBUTIONS-Node.md
@@ -17574,7 +17574,7 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.```
 
-## fern-api - 5.37.0
+## fern-api - 5.37.10
 **Repository URL**: https://github.com/fern-api/fern
 **License Type(s)**: Apache*
 ### License: https://opensource.org/licenses/

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -8,6 +8,10 @@ instances:
 
 title: NVIDIA NeMo Relay
 
+navbar-links:
+- type: github
+  value: https://github.com/NVIDIA/NeMo-Relay
+
 global-theme: nvidia
 
 experimental:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "integrations/openclaw"
       ],
       "devDependencies": {
-        "fern-api": "^5.37.0",
+        "fern-api": "5.37.10",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -3965,9 +3965,9 @@
       }
     },
     "node_modules/fern-api": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/fern-api/-/fern-api-5.37.0.tgz",
-      "integrity": "sha512-8sXxXV3M53BQKqfP98SWa/xyDfpYX4UQN24b7O55FuRjbbIqQzqU/2fOfbb7OmbyGGOmiq4p6ZGTiO2g/hyCLg==",
+      "version": "5.37.10",
+      "resolved": "https://registry.npmjs.org/fern-api/-/fern-api-5.37.10.tgz",
+      "integrity": "sha512-GQ/lrHsB2nw0ZkuUas/nWLtxd/SSwX0Sj6QFwLSMPAImeVrN/m8871EH3pXH+Ht8cuSSxHUWlEU4buPtznwavA==",
       "dev": true,
       "bin": {
         "fern": "cli.cjs"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "integrations/openclaw"
   ],
   "devDependencies": {
-    "fern-api": "^5.37.0",
+    "fern-api": "5.37.10",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
#### Overview

Align the npm-installed Fern CLI with the version pinned in `fern/fern.config.json` so source-branch docs publishing and the `docs-website` fallback publish workflow use the same Fern release. Also add a top-right GitHub link to the Fern docs site through the Fern `docs.yml` configuration.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Pins the root `fern-api` dev dependency to `5.37.10`, matching `fern/fern.config.json`.
- Refreshes `package-lock.json` to resolve `fern-api@5.37.10`.
- Updates `ATTRIBUTIONS-Node.md` for the regenerated dependency version.
- Adds a Fern `navbar-links` GitHub link pointing to `https://github.com/NVIDIA/NeMo-Relay`.

Validation:

- `npm install --package-lock-only --ignore-scripts`
- `npm ci --ignore-scripts`
- `./node_modules/.bin/fern --version` -> `5.37.10`
- `just docs`
- Commit pre-commit hooks for changed files passed.

#### Where should the reviewer start?

Start with `package.json` and `fern/fern.config.json` to verify the Fern CLI pins now match, then check `fern/docs.yml` for the GitHub navbar link.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fern-api development dependency to version 5.37.10.

* **Documentation**
  * Updated documented API attribution version to 5.37.10.
  * Added a GitHub link to the documentation site navbar for easier repository access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->