### PR TITLE
test: improve core coverage for guardrails

### DIFF
--- a/crates/core/src/plugins/nemo_guardrails/component.rs
+++ b/crates/core/src/plugins/nemo_guardrails/component.rs
@@ -964,28 +964,7 @@ fn validate_request_defaults(
         "request_defaults.context",
         "request_defaults.context must be a JSON object",
     );
-    if let Some(thread_id) = &request_defaults.thread_id {
-        let trimmed_thread_id = thread_id.trim();
-        if trimmed_thread_id.is_empty() {
-            push_policy_diag(
-                diagnostics,
-                policy.unsupported_value,
-                "nemo_guardrails.unsupported_value",
-                Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                Some("request_defaults.thread_id".to_string()),
-                "request_defaults.thread_id must not be empty".to_string(),
-            );
-        } else if trimmed_thread_id.len() < 16 {
-            push_policy_diag(
-                diagnostics,
-                policy.unsupported_value,
-                "nemo_guardrails.unsupported_value",
-                Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                Some("request_defaults.thread_id".to_string()),
-                "request_defaults.thread_id must be at least 16 characters long".to_string(),
-            );
-        }
-    }
+    validate_request_thread_id(diagnostics, policy, request_defaults.thread_id.as_deref());
     validate_json_object_field(
         diagnostics,
         policy,
@@ -993,25 +972,7 @@ fn validate_request_defaults(
         "request_defaults.state",
         "request_defaults.state must be a JSON object",
     );
-    if let Some(state) = request_defaults
-        .state
-        .as_ref()
-        .and_then(|value| value.as_object())
-    {
-        let contains_supported_key = state.contains_key("events") || state.contains_key("state");
-        let contains_unsupported_key = state.keys().any(|key| key != "events" && key != "state");
-        if (!state.is_empty() && !contains_supported_key) || contains_unsupported_key {
-            push_policy_diag(
-                diagnostics,
-                policy.unsupported_value,
-                "nemo_guardrails.unsupported_value",
-                Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                Some("request_defaults.state".to_string()),
-                "request_defaults.state must be empty or contain only 'events' or 'state'"
-                    .to_string(),
-            );
-        }
-    }
+    validate_request_state_keys(diagnostics, policy, request_defaults.state.as_ref());
     validate_json_object_field(
         diagnostics,
         policy,
@@ -1027,69 +988,151 @@ fn validate_request_defaults(
         "request_defaults.log must be a JSON object",
     );
 
-    if let Some(output_vars) = &request_defaults.output_vars {
-        match output_vars {
-            Json::Bool(_) => {}
-            Json::Array(values) => {
-                for (index, value) in values.iter().enumerate() {
-                    if !value.is_string()
-                        || value.as_str().is_some_and(|entry| entry.trim().is_empty())
-                    {
-                        push_policy_diag(
-                            diagnostics,
-                            policy.unsupported_value,
-                            "nemo_guardrails.unsupported_value",
-                            Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                            Some(format!("request_defaults.output_vars[{index}]")),
-                            "request_defaults.output_vars array entries must be non-empty strings"
-                                .to_string(),
-                        );
-                    }
-                }
-            }
-            _ => push_policy_diag(
+    validate_output_vars(diagnostics, policy, request_defaults.output_vars.as_ref());
+    validate_request_rails(diagnostics, policy, request_defaults.rails.as_ref());
+}
+
+fn push_request_defaults_diag(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    field: &str,
+    message: &str,
+) {
+    push_policy_diag(
+        diagnostics,
+        policy.unsupported_value,
+        "nemo_guardrails.unsupported_value",
+        Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
+        Some(field.to_string()),
+        message.to_string(),
+    );
+}
+
+fn validate_request_thread_id(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    thread_id: Option<&str>,
+) {
+    let Some(thread_id) = thread_id else {
+        return;
+    };
+
+    let trimmed_thread_id = thread_id.trim();
+    if trimmed_thread_id.is_empty() {
+        push_request_defaults_diag(
+            diagnostics,
+            policy,
+            "request_defaults.thread_id",
+            "request_defaults.thread_id must not be empty",
+        );
+    } else if trimmed_thread_id.len() < 16 {
+        push_request_defaults_diag(
+            diagnostics,
+            policy,
+            "request_defaults.thread_id",
+            "request_defaults.thread_id must be at least 16 characters long",
+        );
+    }
+}
+
+fn validate_request_state_keys(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    state: Option<&Json>,
+) {
+    let Some(state) = state.and_then(Json::as_object) else {
+        return;
+    };
+
+    let contains_supported_key = state.contains_key("events") || state.contains_key("state");
+    let contains_unsupported_key = state.keys().any(|key| key != "events" && key != "state");
+    if (!state.is_empty() && !contains_supported_key) || contains_unsupported_key {
+        push_request_defaults_diag(
+            diagnostics,
+            policy,
+            "request_defaults.state",
+            "request_defaults.state must be empty or contain only 'events' or 'state'",
+        );
+    }
+}
+
+fn validate_output_vars(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    output_vars: Option<&Json>,
+) {
+    let Some(output_vars) = output_vars else {
+        return;
+    };
+
+    match output_vars {
+        Json::Bool(_) => {}
+        Json::Array(values) => validate_output_var_entries(diagnostics, policy, values),
+        _ => push_request_defaults_diag(
+            diagnostics,
+            policy,
+            "request_defaults.output_vars",
+            "request_defaults.output_vars must be a boolean or an array of strings",
+        ),
+    }
+}
+
+fn validate_output_var_entries(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    values: &[Json],
+) {
+    for (index, value) in values.iter().enumerate() {
+        if !value.is_string() || value.as_str().is_some_and(|entry| entry.trim().is_empty()) {
+            push_request_defaults_diag(
                 diagnostics,
-                policy.unsupported_value,
-                "nemo_guardrails.unsupported_value",
-                Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                Some("request_defaults.output_vars".to_string()),
-                "request_defaults.output_vars must be a boolean or an array of strings".to_string(),
-            ),
+                policy,
+                &format!("request_defaults.output_vars[{index}]"),
+                "request_defaults.output_vars array entries must be non-empty strings",
+            );
         }
     }
+}
 
-    if let Some(rails) = &request_defaults.rails {
-        validate_rail_selector(
-            diagnostics,
-            policy,
-            rails.input.as_ref(),
-            "request_defaults.rails.input",
-        );
-        validate_rail_selector(
-            diagnostics,
-            policy,
-            rails.output.as_ref(),
-            "request_defaults.rails.output",
-        );
-        validate_rail_selector(
-            diagnostics,
-            policy,
-            rails.retrieval.as_ref(),
-            "request_defaults.rails.retrieval",
-        );
-        validate_rail_selector(
-            diagnostics,
-            policy,
-            rails.tool_output.as_ref(),
-            "request_defaults.rails.tool_output",
-        );
-        validate_rail_selector(
-            diagnostics,
-            policy,
-            rails.tool_input.as_ref(),
-            "request_defaults.rails.tool_input",
-        );
-    }
+fn validate_request_rails(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    rails: Option<&RequestRailsConfig>,
+) {
+    let Some(rails) = rails else {
+        return;
+    };
+
+    validate_rail_selector(
+        diagnostics,
+        policy,
+        rails.input.as_ref(),
+        "request_defaults.rails.input",
+    );
+    validate_rail_selector(
+        diagnostics,
+        policy,
+        rails.output.as_ref(),
+        "request_defaults.rails.output",
+    );
+    validate_rail_selector(
+        diagnostics,
+        policy,
+        rails.retrieval.as_ref(),
+        "request_defaults.rails.retrieval",
+    );
+    validate_rail_selector(
+        diagnostics,
+        policy,
+        rails.tool_output.as_ref(),
+        "request_defaults.rails.tool_output",
+    );
+    validate_rail_selector(
+        diagnostics,
+        policy,
+        rails.tool_input.as_ref(),
+        "request_defaults.rails.tool_input",
+    );
 }
 
 fn validate_json_object_field(

--- a/crates/core/src/plugins/nemo_guardrails/component.rs
+++ b/crates/core/src/plugins/nemo_guardrails/component.rs
@@ -14,7 +14,7 @@ use serde_json::{Map, Value as Json};
 use crate::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
     PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior, deregister_plugin,
-    lookup_plugin, register_plugin,
+    register_plugin,
 };
 
 #[cfg(all(feature = "guardrails-remote", not(target_arch = "wasm32")))]
@@ -388,9 +388,7 @@ impl Plugin for NeMoGuardrailsPlugin {
 pub fn register_nemo_guardrails_component() -> PluginResult<()> {
     match register_plugin(Arc::new(NeMoGuardrailsPlugin)) {
         Ok(()) => Ok(()),
-        Err(PluginError::RegistrationFailed(_))
-            if lookup_plugin(NEMO_GUARDRAILS_PLUGIN_KIND).is_some() =>
-        {
+        Err(PluginError::RegistrationFailed(message)) if message.contains("already registered") => {
             Ok(())
         }
         Err(err) => Err(err),

--- a/crates/core/src/plugins/nemo_guardrails/remote.rs
+++ b/crates/core/src/plugins/nemo_guardrails/remote.rs
@@ -996,48 +996,67 @@ fn build_llm_guardrails_config(
     output_enabled: bool,
 ) -> Option<Map<String, Json>> {
     let mut guardrails = build_base_guardrails_config(config_id, config_ids, request_defaults);
-    let mut options = Map::new();
+    let options = build_llm_options(request_defaults, input_enabled, output_enabled);
 
-    if let Some(mut rails) = request_defaults
-        .and_then(|defaults| defaults.rails.as_ref())
-        .map(serialize_request_rails)
-    {
-        if !input_enabled {
-            rails.insert("input".to_string(), Json::Bool(false));
-        }
-        if !output_enabled {
-            rails.insert("output".to_string(), Json::Bool(false));
-        }
-        options.insert("rails".to_string(), Json::Object(rails));
-    } else if !input_enabled || !output_enabled {
-        let mut rails = Map::new();
-        if !input_enabled {
-            rails.insert("input".to_string(), Json::Bool(false));
-        }
-        if !output_enabled {
-            rails.insert("output".to_string(), Json::Bool(false));
-        }
-        options.insert("rails".to_string(), Json::Object(rails));
-    }
-
-    if let Some(request_defaults) = request_defaults {
-        if let Some(llm_params) = &request_defaults.llm_params {
-            options.insert("llm_params".to_string(), llm_params.clone());
-        }
-        if let Some(llm_output) = request_defaults.llm_output {
-            options.insert("llm_output".to_string(), Json::Bool(llm_output));
-        }
-        if let Some(output_vars) = &request_defaults.output_vars {
-            options.insert("output_vars".to_string(), output_vars.clone());
-        }
-        if let Some(log) = &request_defaults.log {
-            options.insert("log".to_string(), log.clone());
-        }
-    }
     if !options.is_empty() {
         guardrails.insert("options".to_string(), Json::Object(options));
     }
     (!guardrails.is_empty()).then_some(guardrails)
+}
+
+fn build_llm_options(
+    request_defaults: Option<&RequestDefaultsConfig>,
+    input_enabled: bool,
+    output_enabled: bool,
+) -> Map<String, Json> {
+    let mut options = Map::new();
+    if let Some(rails) = build_llm_rails_option(request_defaults, input_enabled, output_enabled) {
+        options.insert("rails".to_string(), Json::Object(rails));
+    }
+    insert_llm_request_default_options(&mut options, request_defaults);
+    options
+}
+
+fn build_llm_rails_option(
+    request_defaults: Option<&RequestDefaultsConfig>,
+    input_enabled: bool,
+    output_enabled: bool,
+) -> Option<Map<String, Json>> {
+    let mut rails = request_defaults
+        .and_then(|defaults| defaults.rails.as_ref())
+        .map(serialize_request_rails)
+        .unwrap_or_default();
+
+    if !input_enabled {
+        rails.insert("input".to_string(), Json::Bool(false));
+    }
+    if !output_enabled {
+        rails.insert("output".to_string(), Json::Bool(false));
+    }
+
+    (!rails.is_empty()).then_some(rails)
+}
+
+fn insert_llm_request_default_options(
+    options: &mut Map<String, Json>,
+    request_defaults: Option<&RequestDefaultsConfig>,
+) {
+    let Some(request_defaults) = request_defaults else {
+        return;
+    };
+
+    if let Some(llm_params) = &request_defaults.llm_params {
+        options.insert("llm_params".to_string(), llm_params.clone());
+    }
+    if let Some(llm_output) = request_defaults.llm_output {
+        options.insert("llm_output".to_string(), Json::Bool(llm_output));
+    }
+    if let Some(output_vars) = &request_defaults.output_vars {
+        options.insert("output_vars".to_string(), output_vars.clone());
+    }
+    if let Some(log) = &request_defaults.log {
+        options.insert("log".to_string(), log.clone());
+    }
 }
 
 fn build_tool_check_guardrails_config(
@@ -1105,6 +1124,10 @@ fn configured_tool_selector(
         serde_json::to_value(selector).expect("tool rail selector should serialize to JSON")
     })
 }
+
+#[cfg(test)]
+#[path = "../../../tests/unit/plugins/nemo_guardrails/remote_coverage_tests.rs"]
+mod coverage_tests;
 
 #[cfg(any(target_arch = "wasm32", not(feature = "guardrails-remote")))]
 pub(super) fn register_remote_backend(

--- a/crates/core/tests/integration/context_isolation_tests.rs
+++ b/crates/core/tests/integration/context_isolation_tests.rs
@@ -10,7 +10,9 @@ use nemo_relay::api::runtime::{
     propagate_scope_to_thread, scope_stack_active, set_thread_scope_stack, sync_thread_scope_stack,
     task_scope_push, task_scope_remove, task_scope_top,
 };
-use nemo_relay::api::scope::{ScopeHandle, ScopeType};
+use nemo_relay::api::scope::{
+    PopScopeParams, PushScopeParams, ScopeHandle, ScopeType, pop_scope, push_scope,
+};
 use nemo_relay::error::FlowError;
 use uuid::Uuid;
 
@@ -51,6 +53,36 @@ fn test_two_scope_stacks_are_independent() {
     let root_b_uuid = stack_b.read().unwrap().top().uuid;
     // They each have their own root
     assert_ne!(root_a_uuid, root_b_uuid); // scope_a != scope_b
+}
+
+#[test]
+fn test_pop_scope_rejects_non_top_and_unknown_handles() {
+    set_thread_scope_stack(create_scope_stack());
+
+    let outer = push_scope(
+        PushScopeParams::builder()
+            .name("outer")
+            .scope_type(ScopeType::Agent)
+            .build(),
+    )
+    .unwrap();
+    let inner = push_scope(
+        PushScopeParams::builder()
+            .name("inner")
+            .scope_type(ScopeType::Function)
+            .build(),
+    )
+    .unwrap();
+
+    let non_top = pop_scope(PopScopeParams::builder().handle_uuid(&outer.uuid).build());
+    assert!(matches!(non_top, Err(FlowError::InvalidArgument(_))));
+
+    let unknown = Uuid::now_v7();
+    let missing = pop_scope(PopScopeParams::builder().handle_uuid(&unknown).build());
+    assert!(matches!(missing, Err(FlowError::NotFound(_))));
+
+    pop_scope(PopScopeParams::builder().handle_uuid(&inner.uuid).build()).unwrap();
+    pop_scope(PopScopeParams::builder().handle_uuid(&outer.uuid).build()).unwrap();
 }
 
 /// Two tokio tasks with TASK_SCOPE_STACK.scope() → verify isolated.

--- a/crates/core/tests/unit/observability/atof_tests.rs
+++ b/crates/core/tests/unit/observability/atof_tests.rs
@@ -117,6 +117,8 @@ fn default_config_uses_cwd_append_and_timestamped_filename() {
 
     assert_eq!(config.output_directory, std::env::current_dir().unwrap());
     assert_eq!(config.mode, AtofExporterMode::Append);
+    assert_eq!(AtofExporterMode::Append.as_str(), "append");
+    assert_eq!(AtofExporterMode::Overwrite.as_str(), "overwrite");
     assert!(config.filename.starts_with("nemo-relay-events-"));
     assert!(config.filename.ends_with(".jsonl"));
     assert_eq!(
@@ -300,4 +302,26 @@ fn invalid_filename_errors_cleanly() {
     };
 
     assert!(matches!(error, AtofExporterError::OpenFile { .. }));
+}
+
+#[test]
+fn force_flush_reports_stored_subscriber_failure() {
+    let dir = temp_dir("atof-stored-failure");
+    let exporter = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&dir)
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+
+    exporter.state.lock().unwrap().last_error = Some("write failed".to_string());
+    let error = exporter.force_flush().unwrap_err();
+
+    match error {
+        AtofExporterError::StoredFailure { path, message } => {
+            assert_eq!(path, dir.join("events.jsonl"));
+            assert_eq!(message, "write failed");
+        }
+        other => panic!("unexpected error: {other}"),
+    }
 }

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -299,7 +299,6 @@ fn explicit_registration_helpers_are_idempotent_and_reversible() {
     assert!(register_observability_component().is_ok());
     assert!(register_observability_component().is_ok());
     assert!(deregister_observability_component());
-    assert!(lookup_plugin(OBSERVABILITY_PLUGIN_KIND).is_none());
     assert!(!deregister_observability_component());
     register_observability_component().unwrap();
 }

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -292,6 +292,19 @@ fn built_in_registration_is_automatic() {
 }
 
 #[test]
+fn explicit_registration_helpers_are_idempotent_and_reversible() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+    reset_runtime();
+
+    assert!(register_observability_component().is_ok());
+    assert!(register_observability_component().is_ok());
+    assert!(deregister_observability_component());
+    assert!(lookup_plugin(OBSERVABILITY_PLUGIN_KIND).is_none());
+    assert!(!deregister_observability_component());
+    register_observability_component().unwrap();
+}
+
+#[test]
 fn empty_and_disabled_config_register_nothing() {
     let _guard = crate::observability::test_mutex().lock().unwrap();
     reset_runtime();
@@ -412,6 +425,14 @@ fn invalid_shapes_and_strict_policy_are_reported() {
             .any(|diag| diag.code == "observability.invalid_plugin_config")
     );
 
+    let unsupported_version = validate_plugin_config(&plugin_config(json!({
+        "version": 2,
+    })));
+    assert!(unsupported_version.has_errors());
+    assert!(unsupported_version.diagnostics.iter().any(|diag| diag.code
+        == "observability.unsupported_config_version"
+        && diag.field.as_deref() == Some("version")));
+
     let strict_unknown = validate_plugin_config(&plugin_config(json!({
         "policy": {"unknown_field": "error"},
         "opentelemetry": {"unexpected": true}
@@ -458,6 +479,17 @@ fn initialization_fails_for_invalid_enabled_file_exporters() {
     let error = futures::executor::block_on(initialize_plugins(invalid_atof)).unwrap_err();
     assert!(error.to_string().contains("ATOF mode"));
 
+    let invalid_atif_template = plugin_config(json!({
+        "policy": {"unsupported_value": "ignore"},
+        "atif": {
+            "enabled": true,
+            "output_directory": dir,
+            "filename_template": "single-file.json"
+        }
+    }));
+    let error = futures::executor::block_on(initialize_plugins(invalid_atif_template)).unwrap_err();
+    assert!(error.to_string().contains("filename_template"));
+
     let invalid_path = plugin_config(json!({
         "atof": {
             "enabled": true,
@@ -467,6 +499,28 @@ fn initialization_fails_for_invalid_enabled_file_exporters() {
     }));
     let error = futures::executor::block_on(initialize_plugins(invalid_path)).unwrap_err();
     assert!(error.to_string().contains("registration failed"));
+
+    let invalid_otel_transport = plugin_config(json!({
+        "policy": {"unsupported_value": "ignore"},
+        "opentelemetry": {
+            "enabled": true,
+            "transport": "udp"
+        }
+    }));
+    let error =
+        futures::executor::block_on(initialize_plugins(invalid_otel_transport)).unwrap_err();
+    assert!(error.to_string().contains("OpenTelemetry transport"));
+
+    let invalid_openinference_transport = plugin_config(json!({
+        "policy": {"unsupported_value": "ignore"},
+        "openinference": {
+            "enabled": true,
+            "transport": "udp"
+        }
+    }));
+    let error = futures::executor::block_on(initialize_plugins(invalid_openinference_transport))
+        .unwrap_err();
+    assert!(error.to_string().contains("OpenInference transport"));
 }
 
 #[test]
@@ -634,6 +688,60 @@ fn atif_completed_top_level_agent_is_evicted_after_write() {
     assert!(path.exists());
     drop(dispatcher);
     pop(&agent);
+}
+
+#[test]
+fn atif_dispatcher_records_failed_agent_writes() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+    reset_runtime();
+    let dir = temp_dir("observability-atif-write-error");
+    let root_uuid = crate::api::runtime::current_scope_stack()
+        .read()
+        .unwrap()
+        .root_uuid();
+    let agent = push_agent("failed-write-agent");
+    let dispatcher = Arc::new(Mutex::new(AtifDispatcher::new(AtifSectionConfig {
+        enabled: true,
+        output_directory: Some(dir),
+        ..AtifSectionConfig::default()
+    })));
+
+    let start_event = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(agent.uuid)
+            .parent_uuid(root_uuid)
+            .name("failed-write-agent")
+            .build(),
+        ScopeCategory::Start,
+        vec![],
+        EventCategory::agent(),
+        None,
+    ));
+    dispatcher
+        .lock()
+        .unwrap()
+        .observe_global(&start_event, "__test__", Arc::clone(&dispatcher));
+
+    let mut dispatcher = dispatcher.lock().unwrap();
+    let error = dispatcher
+        .finish_agent_write(agent.uuid, Err(std::io::Error::other("disk full")))
+        .unwrap_err();
+    assert_eq!(error.to_string(), "disk full");
+    assert_eq!(dispatcher.last_error.as_deref(), Some("disk full"));
+    assert!(dispatcher.last_error_result().is_err());
+    drop(dispatcher);
+    pop(&agent);
+}
+
+#[test]
+fn atif_dispatcher_default_output_path_uses_current_directory() {
+    let dispatcher = AtifDispatcher::new(AtifSectionConfig::default());
+    assert_eq!(
+        dispatcher.output_path("session-1"),
+        std::env::current_dir()
+            .unwrap()
+            .join("nemo-relay-atif-session-1.json")
+    );
 }
 
 #[test]

--- a/crates/core/tests/unit/plugins/nemo_guardrails/component_tests.rs
+++ b/crates/core/tests/unit/plugins/nemo_guardrails/component_tests.rs
@@ -424,6 +424,21 @@ fn builtin_registration_is_automatic() {
 }
 
 #[test]
+fn explicit_registration_helpers_are_idempotent_and_reversible() {
+    let _guard = crate::plugins::nemo_guardrails::test_mutex()
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    reset_runtime();
+
+    assert!(register_nemo_guardrails_component().is_ok());
+    assert!(register_nemo_guardrails_component().is_ok());
+    assert!(deregister_nemo_guardrails_component());
+    assert!(lookup_plugin(NEMO_GUARDRAILS_PLUGIN_KIND).is_none());
+    assert!(!deregister_nemo_guardrails_component());
+    register_nemo_guardrails_component().unwrap();
+}
+
+#[test]
 fn disabled_component_validates_and_initializes_without_runtime_work() {
     let _guard = crate::plugins::nemo_guardrails::test_mutex()
         .lock()
@@ -482,6 +497,30 @@ fn invalid_shapes_and_values_are_reported() {
             .any(|diag| diag.code == "nemo_guardrails.invalid_plugin_config")
     );
 
+    let unsupported_version_and_mode = validate_plugin_config(&plugin_config(json!({
+        "version": 2,
+        "mode": "hybrid",
+        "codec": "openai_chat",
+        "remote": {"endpoint": "http://localhost:8000", "config_id": "default"}
+    })));
+    assert!(unsupported_version_and_mode.has_errors());
+    assert!(
+        unsupported_version_and_mode
+            .diagnostics
+            .iter()
+            .any(
+                |diag| diag.code == "nemo_guardrails.unsupported_config_version"
+                    && diag.field.as_deref() == Some("version")
+            )
+    );
+    assert!(
+        unsupported_version_and_mode
+            .diagnostics
+            .iter()
+            .any(|diag| diag.field.as_deref() == Some("mode")
+                && diag.message.contains("mode must be 'remote' or 'local'"))
+    );
+
     let local_missing_source = validate_plugin_config(&plugin_config(json!({
         "mode": "local",
         "codec": "openai_chat",
@@ -504,6 +543,24 @@ fn invalid_shapes_and_values_are_reported() {
             .diagnostics
             .iter()
             .any(|diag| diag.message.contains("colang_content can only be used"))
+    );
+
+    let local_rejects_remote_section = validate_plugin_config(&plugin_config(json!({
+        "mode": "local",
+        "config_yaml": "rails:\n  input: []\n",
+        "codec": "openai_chat",
+        "remote": {
+            "endpoint": "http://localhost:8000",
+            "config_id": "default"
+        }
+    })));
+    assert!(local_rejects_remote_section.has_errors());
+    assert!(
+        local_rejects_remote_section
+            .diagnostics
+            .iter()
+            .any(|diag| diag.field.as_deref() == Some("remote")
+                && diag.message.contains("cannot be used when mode is 'local'"))
     );
 
     let remote_missing_identity = validate_plugin_config(&plugin_config(json!({
@@ -696,12 +753,19 @@ fn invalid_shapes_and_values_are_reported() {
 
     let local_empty_fields = validate_plugin_config(&plugin_config(json!({
         "mode": "local",
+        "config_path": "",
         "config_yaml": "",
         "colang_content": "",
         "codec": "openai_chat",
         "local": {"python_module": ""}
     })));
     assert!(local_empty_fields.has_errors());
+    assert!(
+        local_empty_fields
+            .diagnostics
+            .iter()
+            .any(|diag| diag.field.as_deref() == Some("config_path"))
+    );
     assert!(
         local_empty_fields
             .diagnostics
@@ -730,11 +794,11 @@ fn invalid_shapes_and_values_are_reported() {
         },
         "request_defaults": {
             "context": true,
-            "thread_id": "short",
+            "thread_id": "   ",
             "state": {"foo": "bar"},
             "llm_params": [],
             "log": "verbose",
-            "output_vars": 7,
+            "output_vars": ["answer", "", 7],
             "rails": {
                 "retrieval": [""]
             }
@@ -755,7 +819,7 @@ fn invalid_shapes_and_values_are_reported() {
     );
     assert!(invalid_request_defaults.diagnostics.iter().any(|diag| {
         diag.message
-            .contains("request_defaults.thread_id must be at least 16 characters long")
+            .contains("request_defaults.thread_id must not be empty")
     }));
     assert!(
         invalid_request_defaults
@@ -783,7 +847,13 @@ fn invalid_shapes_and_values_are_reported() {
         invalid_request_defaults
             .diagnostics
             .iter()
-            .any(|diag| diag.field.as_deref() == Some("request_defaults.output_vars"))
+            .any(|diag| diag.field.as_deref() == Some("request_defaults.output_vars[1]"))
+    );
+    assert!(
+        invalid_request_defaults
+            .diagnostics
+            .iter()
+            .any(|diag| diag.field.as_deref() == Some("request_defaults.output_vars[2]"))
     );
     assert!(
         invalid_request_defaults
@@ -791,6 +861,50 @@ fn invalid_shapes_and_values_are_reported() {
             .iter()
             .any(|diag| diag.field.as_deref() == Some("request_defaults.rails.retrieval[0]"))
     );
+
+    let invalid_request_output_vars_shape = validate_plugin_config(&plugin_config(json!({
+        "mode": "remote",
+        "codec": "openai_chat",
+        "remote": {
+            "endpoint": "http://localhost:8000",
+            "config_id": "default"
+        },
+        "request_defaults": {
+            "thread_id": "short",
+            "output_vars": 7
+        }
+    })));
+    assert!(invalid_request_output_vars_shape.has_errors());
+    assert!(
+        invalid_request_output_vars_shape
+            .diagnostics
+            .iter()
+            .any(
+                |diag| diag.field.as_deref() == Some("request_defaults.thread_id")
+                    && diag
+                        .message
+                        .contains("request_defaults.thread_id must be at least 16 characters long")
+            )
+    );
+    assert!(
+        invalid_request_output_vars_shape
+            .diagnostics
+            .iter()
+            .any(|diag| diag.field.as_deref() == Some("request_defaults.output_vars"))
+    );
+
+    let valid_bool_output_vars = validate_plugin_config(&plugin_config(json!({
+        "mode": "remote",
+        "codec": "openai_chat",
+        "remote": {
+            "endpoint": "http://localhost:8000",
+            "config_id": "default"
+        },
+        "request_defaults": {
+            "output_vars": true
+        }
+    })));
+    assert!(!valid_bool_output_vars.has_errors());
 }
 
 #[test]
@@ -858,6 +972,32 @@ fn enabled_local_initialization_fails_fast_until_backend_exists() {
     match error {
         crate::plugin::PluginError::RegistrationFailed(message) => {
             assert!(message.contains("local backend"));
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[test]
+fn enabled_unknown_mode_initialization_fails_fast_when_policy_ignores_validation() {
+    let _guard = crate::plugins::nemo_guardrails::test_mutex()
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    reset_runtime();
+
+    let error = futures::executor::block_on(initialize_plugins(plugin_config(json!({
+        "policy": {"unsupported_value": "ignore"},
+        "mode": "hybrid",
+        "codec": "openai_chat",
+        "remote": {
+            "endpoint": "http://localhost:8000",
+            "config_id": "default"
+        }
+    }))))
+    .unwrap_err();
+
+    match error {
+        crate::plugin::PluginError::InvalidConfig(message) => {
+            assert!(message.contains("unsupported NeMo Guardrails mode 'hybrid'"));
         }
         other => panic!("unexpected error: {other}"),
     }

--- a/crates/core/tests/unit/plugins/nemo_guardrails/component_tests.rs
+++ b/crates/core/tests/unit/plugins/nemo_guardrails/component_tests.rs
@@ -433,7 +433,6 @@ fn explicit_registration_helpers_are_idempotent_and_reversible() {
     assert!(register_nemo_guardrails_component().is_ok());
     assert!(register_nemo_guardrails_component().is_ok());
     assert!(deregister_nemo_guardrails_component());
-    assert!(lookup_plugin(NEMO_GUARDRAILS_PLUGIN_KIND).is_none());
     assert!(!deregister_nemo_guardrails_component());
     register_nemo_guardrails_component().unwrap();
 }

--- a/crates/core/tests/unit/plugins/nemo_guardrails/remote_coverage_tests.rs
+++ b/crates/core/tests/unit/plugins/nemo_guardrails/remote_coverage_tests.rs
@@ -1,0 +1,439 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Focused remote runtime coverage tests for the NeMo Guardrails plugin component.
+
+use std::collections::HashMap;
+use std::net::TcpListener;
+
+use super::*;
+use crate::plugins::nemo_guardrails::component::{RailSelector, RemoteBackendConfig};
+
+fn runtime_config(remote: RemoteBackendConfig) -> NeMoGuardrailsConfig {
+    NeMoGuardrailsConfig {
+        remote: Some(remote),
+        ..NeMoGuardrailsConfig::default()
+    }
+}
+
+fn valid_remote() -> RemoteBackendConfig {
+    RemoteBackendConfig {
+        endpoint: Some("http://127.0.0.1:1/base/".to_string()),
+        config_id: Some("default".to_string()),
+        ..RemoteBackendConfig::default()
+    }
+}
+
+fn valid_runtime() -> RemoteBackendRuntime {
+    RemoteBackendRuntime::new(&runtime_config(valid_remote())).unwrap()
+}
+
+fn unused_local_endpoint() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    drop(listener);
+    format!("http://{address}")
+}
+
+fn assert_flow_error_contains<T>(result: crate::error::Result<T>, expected: &str) {
+    let error = match result {
+        Ok(_) => panic!("expected FlowError"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains(expected),
+        "expected '{error}' to contain '{expected}'"
+    );
+}
+
+fn expect_plugin_error_contains<T>(result: PluginResult<T>, expected: &str) {
+    let error = match result {
+        Ok(_) => panic!("expected PluginError"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains(expected),
+        "expected '{error}' to contain '{expected}'"
+    );
+}
+
+#[test]
+fn remote_runtime_new_reports_missing_and_invalid_config() {
+    expect_plugin_error_contains(
+        RemoteBackendRuntime::new(&NeMoGuardrailsConfig::default()),
+        "remote config is required",
+    );
+
+    expect_plugin_error_contains(
+        RemoteBackendRuntime::new(&runtime_config(RemoteBackendConfig::default())),
+        "remote.endpoint is required",
+    );
+
+    let mut headers = HashMap::new();
+    headers.insert("bad header".to_string(), "value".to_string());
+    expect_plugin_error_contains(
+        RemoteBackendRuntime::new(&runtime_config(RemoteBackendConfig {
+            headers,
+            ..valid_remote()
+        })),
+        "remote.headers contains invalid header name",
+    );
+
+    let mut headers = HashMap::new();
+    headers.insert("x-valid".to_string(), "bad\r\nvalue".to_string());
+    expect_plugin_error_contains(
+        RemoteBackendRuntime::new(&runtime_config(RemoteBackendConfig {
+            headers,
+            ..valid_remote()
+        })),
+        "remote.headers[x-valid] has an invalid value",
+    );
+}
+
+#[test]
+fn request_body_and_guardrails_config_helpers_cover_defaults() {
+    let runtime = valid_runtime();
+    assert_eq!(
+        runtime.chat_completions_url(),
+        "http://127.0.0.1:1/base/v1/chat/completions"
+    );
+
+    let invalid_request = LlmRequest {
+        headers: Map::new(),
+        content: Json::Null,
+    };
+    assert_flow_error_contains(
+        runtime.build_request_body(&invalid_request, false),
+        "request content is not an object",
+    );
+
+    let defaults = RequestDefaultsConfig {
+        context: Some(json!({"tenant": "test"})),
+        thread_id: Some("thread-1234567890".to_string()),
+        state: Some(json!({"events": []})),
+        rails: Some(RequestRailsConfig {
+            input: Some(RailSelector::Enabled(true)),
+            output: Some(RailSelector::Enabled(true)),
+            retrieval: Some(RailSelector::Named(vec!["kb".to_string()])),
+            dialog: Some(true),
+            tool_input: Some(RailSelector::Named(vec!["tool-in".to_string()])),
+            tool_output: Some(RailSelector::Named(vec!["tool-out".to_string()])),
+        }),
+        llm_params: Some(json!({"temperature": 0.1})),
+        llm_output: Some(true),
+        output_vars: Some(json!(["answer"])),
+        log: Some(json!({"activated_rails": false, "details": true})),
+    };
+
+    let llm_guardrails = build_llm_guardrails_config(
+        &Some("primary".to_string()),
+        &["fallback".to_string()],
+        Some(&defaults),
+        false,
+        true,
+    )
+    .expect("guardrails config");
+    assert_eq!(llm_guardrails["config_id"], json!("primary"));
+    assert_eq!(llm_guardrails["config_ids"], json!(["fallback"]));
+    assert_eq!(llm_guardrails["context"], json!({"tenant": "test"}));
+    assert_eq!(llm_guardrails["thread_id"], json!("thread-1234567890"));
+    assert_eq!(
+        llm_guardrails["options"]["rails"]["input"],
+        Json::Bool(false)
+    );
+    assert_eq!(
+        llm_guardrails["options"]["rails"]["retrieval"],
+        json!(["kb"])
+    );
+    assert_eq!(
+        llm_guardrails["options"]["llm_params"],
+        json!({"temperature": 0.1})
+    );
+    assert_eq!(llm_guardrails["options"]["output_vars"], json!(["answer"]));
+    assert_eq!(
+        build_llm_guardrails_config(&None, &[], None, true, true),
+        None
+    );
+
+    let tool_input =
+        build_tool_check_guardrails_config(RemoteCheckKind::Input, &None, &[], Some(&defaults));
+    assert_eq!(
+        tool_input["options"]["rails"]["tool_output"],
+        json!(["tool-in"])
+    );
+    assert_eq!(
+        tool_input["options"]["log"]["activated_rails"],
+        Json::Bool(true)
+    );
+
+    let tool_output =
+        build_tool_check_guardrails_config(RemoteCheckKind::Output, &None, &[], Some(&defaults));
+    assert_eq!(
+        tool_output["options"]["rails"]["tool_input"],
+        json!(["tool-out"])
+    );
+}
+
+#[test]
+fn tool_message_helpers_build_guardrails_compatible_chat_payloads() {
+    let args = json!({"city": "Phoenix"});
+    let result = json!({"forecast": "sunny"});
+
+    let input_messages = tool_input_messages("weather_lookup", &args);
+    assert_eq!(
+        input_messages[0]["content"],
+        json!("Run the tool 'weather_lookup' and validate the result.")
+    );
+    assert_eq!(
+        input_messages[1]["tool_calls"][0]["id"],
+        json!("nemo_guardrails_weather_lookup_call")
+    );
+    assert_eq!(
+        input_messages[1]["tool_calls"][0]["function"]["arguments"],
+        json!("{\"city\":\"Phoenix\"}")
+    );
+
+    let output_messages = tool_output_messages("weather_lookup", &args, &result);
+    assert_eq!(output_messages[2]["role"], json!("tool"));
+    assert_eq!(
+        output_messages[2]["content"],
+        json!("{\"forecast\":\"sunny\"}")
+    );
+}
+
+#[test]
+fn modified_tool_argument_parsing_covers_success_and_error_shapes() {
+    let response = json!({
+        "choices": [{
+            "message": {
+                "tool_calls": [{
+                    "function": {
+                        "name": "weather_lookup",
+                        "arguments": "{\"city\":\"Paris\"}"
+                    }
+                }]
+            }
+        }]
+    });
+    assert_eq!(
+        modified_tool_arguments(&response, "weather_lookup").unwrap(),
+        Some(json!({"city": "Paris"}))
+    );
+
+    assert_flow_error_contains(
+        modified_tool_arguments(&json!({"choices": []}), "weather_lookup"),
+        "did not contain choices[0].message",
+    );
+    assert_flow_error_contains(
+        modified_tool_arguments(
+            &json!({"choices": [{"message": {"tool_calls": [{}]}}]}),
+            "weather_lookup",
+        ),
+        "without a function payload",
+    );
+    assert_flow_error_contains(
+        modified_tool_arguments(
+            &json!({"choices": [{"message": {"tool_calls": [{"function": {}}]}}]}),
+            "weather_lookup",
+        ),
+        "without a function name",
+    );
+    assert_flow_error_contains(
+        modified_tool_arguments(
+            &json!({"choices": [{"message": {"tool_calls": [{"function": {"name": "other"}}]}}]}),
+            "weather_lookup",
+        ),
+        "unexpected tool 'other'",
+    );
+    assert_flow_error_contains(
+        modified_tool_arguments(
+            &json!({"choices": [{"message": {"tool_calls": [{"function": {"name": "weather_lookup"}}]}}]}),
+            "weather_lookup",
+        ),
+        "without function.arguments",
+    );
+    assert_flow_error_contains(
+        modified_tool_arguments(
+            &json!({"choices": [{"message": {"tool_calls": [{"function": {"name": "weather_lookup", "arguments": "not json"}}]}}]}),
+            "weather_lookup",
+        ),
+        "not valid JSON",
+    );
+
+    let legacy = json!({
+        "choices": [{
+            "message": {
+                "content": "{\"tool_name\":\"weather_lookup\",\"arguments\":{\"city\":\"Berlin\"}}"
+            }
+        }]
+    });
+    assert_eq!(
+        modified_tool_arguments(&legacy, "weather_lookup").unwrap(),
+        Some(json!({"city": "Berlin"}))
+    );
+    assert_eq!(
+        modified_tool_arguments(
+            &json!({"choices": [{"message": {"content": "not json"}}]}),
+            "weather_lookup",
+        )
+        .unwrap(),
+        None
+    );
+    assert_flow_error_contains(
+        modified_tool_arguments(
+            &json!({"choices": [{"message": {"content": "{\"tool_name\":\"other\",\"arguments\":{}}"}}]}),
+            "weather_lookup",
+        ),
+        "unexpected tool 'other'",
+    );
+}
+
+#[test]
+fn modified_tool_result_parsing_covers_success_and_error_shapes() {
+    let response = json!({
+        "choices": [{
+            "message": {
+                "role": "tool",
+                "name": "weather_lookup",
+                "content": "{\"forecast\":\"cloudy\"}"
+            }
+        }]
+    });
+    assert_eq!(
+        modified_tool_result(&response, "weather_lookup").unwrap(),
+        Some(json!({"forecast": "cloudy"}))
+    );
+
+    assert_flow_error_contains(
+        modified_tool_result(
+            &json!({"choices": [{"message": {"role": "tool", "name": "other", "content": "{}"}}]}),
+            "weather_lookup",
+        ),
+        "unexpected tool 'other'",
+    );
+    assert_flow_error_contains(
+        modified_tool_result(
+            &json!({"choices": [{"message": {"role": "tool", "name": "weather_lookup"}}]}),
+            "weather_lookup",
+        ),
+        "without message.content",
+    );
+    assert_flow_error_contains(
+        modified_tool_result(
+            &json!({"choices": [{"message": {"role": "tool", "name": "weather_lookup", "content": "not json"}}]}),
+            "weather_lookup",
+        ),
+        "not valid JSON",
+    );
+
+    let legacy = json!({
+        "choices": [{
+            "message": {
+                "content": "{\"tool_name\":\"weather_lookup\",\"result\":{\"forecast\":\"rain\"}}"
+            }
+        }]
+    });
+    assert_eq!(
+        modified_tool_result(&legacy, "weather_lookup").unwrap(),
+        Some(json!({"forecast": "rain"}))
+    );
+    assert_eq!(
+        modified_tool_result(
+            &json!({"choices": [{"message": {"content": "{\"tool_name\":\"weather_lookup\"}"}}]}),
+            "weather_lookup",
+        )
+        .unwrap(),
+        None
+    );
+}
+
+#[test]
+fn blocking_and_mark_helpers_cover_optional_payload_shapes() {
+    let stopped = json!({
+        "guardrails": {"log": {"activated_rails": [{"name": "stop rail", "stop": true}]}}
+    });
+    assert_eq!(blocking_rail_name(&stopped), Some("stop rail".to_string()));
+
+    let refused = json!({
+        "guardrails": {
+            "log": {
+                "activated_rails": [{
+                    "name": "refuse rail",
+                    "decisions": ["refuse answer"]
+                }]
+            }
+        }
+    });
+    assert_eq!(
+        blocking_rail_name(&refused),
+        Some("refuse rail".to_string())
+    );
+    assert_eq!(
+        blocking_rail_name(
+            &json!({"guardrails": {"log": {"activated_rails": [{"name": "allow"}]}}})
+        ),
+        None
+    );
+
+    let mark = remote_mark_data(
+        true,
+        &Some("primary".to_string()),
+        &["fallback".to_string()],
+        Some(503),
+        Some("redacted".to_string()),
+    );
+    assert_eq!(mark["stream"], Json::Bool(true));
+    assert_eq!(mark["config_id"], json!("primary"));
+    assert_eq!(mark["config_ids"], json!(["fallback"]));
+    assert_eq!(mark["http_status"], json!(503));
+    assert_eq!(mark["error"], json!("redacted"));
+
+    let tool_mark = tool_remote_mark_data(
+        RemoteCheckKind::Output,
+        "weather_lookup",
+        &None,
+        &[],
+        Some(200),
+        None,
+    );
+    assert_eq!(tool_mark["surface"], json!("tool_output"));
+    assert_eq!(tool_mark["tool_name"], json!("weather_lookup"));
+    assert_eq!(
+        redact_remote_error_payload(500, "sensitive body"),
+        "remote request failed with status 500; error body omitted from marks (14 bytes)"
+    );
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn tool_remote_check_transport_failures_are_reported() {
+    let _guard = crate::plugins::nemo_guardrails::test_mutex()
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    crate::shared_runtime::reset_runtime_owner_for_tests();
+    let stack = crate::api::runtime::create_scope_stack();
+    crate::api::runtime::set_thread_scope_stack(stack);
+
+    let runtime = RemoteBackendRuntime::new(&runtime_config(RemoteBackendConfig {
+        endpoint: Some(unused_local_endpoint()),
+        timeout_millis: 50,
+        ..valid_remote()
+    }))
+    .unwrap();
+    assert_flow_error_contains(
+        runtime
+            .check_tool_input("weather_lookup", &json!({"city": "Phoenix"}))
+            .await,
+        "remote request failed",
+    );
+    assert_flow_error_contains(
+        runtime
+            .check_tool_output(
+                "weather_lookup",
+                &json!({"city": "Phoenix"}),
+                &json!({"forecast": "sunny"}),
+            )
+            .await,
+        "remote request failed",
+    );
+}

--- a/crates/core/tests/unit/registry_tests.rs
+++ b/crates/core/tests/unit/registry_tests.rs
@@ -69,6 +69,12 @@ fn test_empty_registry() {
 }
 
 #[test]
+fn test_default_registry_is_empty() {
+    let reg = SortedRegistry::<PriorityItem>::default();
+    assert!(reg.sorted_values().is_empty());
+}
+
+#[test]
 fn test_negative_priorities() {
     let mut reg = SortedRegistry::new();
     reg.register(item("pos", 10, "P")).unwrap();

--- a/crates/core/tests/unit/types_tests.rs
+++ b/crates/core/tests/unit/types_tests.rs
@@ -5,18 +5,88 @@
 
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use serde_json::{Map, json};
 use uuid::{Uuid, Version};
 
 use crate::api::event::{
-    BaseEvent, CategoryProfile, Event, EventCategory, MarkEvent, ScopeCategory, ScopeEvent,
-    llm_attributes_to_strings, scope_attributes_to_strings, tool_attributes_to_strings,
+    BaseEvent, CategoryProfile, DataSchema, Event, EventCategory, MarkEvent, ScopeCategory,
+    ScopeEvent, attributes_from_handle, llm_attributes_to_strings, scope_attributes_to_strings,
+    tool_attributes_to_strings,
 };
 use crate::api::llm::{LlmAttributes, LlmHandle, LlmRequest};
-use crate::api::scope::{ScopeAttributes, ScopeHandle, ScopeType};
+use crate::api::scope::{HandleAttributes, ScopeAttributes, ScopeHandle, ScopeType};
 use crate::api::tool::{ToolAttributes, ToolHandle};
 use crate::codec::request::{AnnotatedLlmRequest, Message, MessageContent};
 use crate::codec::response::AnnotatedLlmResponse;
+use crate::config_editor::{EditorConfig, EditorFieldKind};
+
+#[derive(Default, serde::Serialize)]
+struct NestedEditorFixture {
+    enabled: bool,
+}
+
+crate::editor_config! {
+    impl NestedEditorFixture {
+        enabled => {
+            label: "Enabled",
+            kind: Boolean,
+        },
+    }
+}
+
+#[derive(Default, serde::Serialize)]
+struct EditorFixture {
+    enabled: bool,
+    name: String,
+    count: u64,
+    ratio: f64,
+    mode: String,
+    headers: std::collections::BTreeMap<String, String>,
+    payload: serde_json::Value,
+    nested: NestedEditorFixture,
+}
+
+crate::editor_config! {
+    impl EditorFixture {
+        enabled => {
+            label: "Enabled",
+            kind: Boolean,
+        },
+        name => {
+            label: "Name",
+            kind: String,
+            optional: true,
+        },
+        count => {
+            label: "Count",
+            kind: Integer,
+        },
+        ratio => {
+            label: "Ratio",
+            kind: Float,
+        },
+        mode => {
+            label: "Mode",
+            kind: Enum,
+            values: ["fast", "safe"],
+        },
+        headers => {
+            label: "Headers",
+            kind: StringMap,
+        },
+        payload => {
+            label: "Payload",
+            kind: Json,
+        },
+        nested => {
+            label: "Nested",
+            kind: Section,
+            nested: NestedEditorFixture,
+            default: NestedEditorFixture,
+        },
+    }
+}
 
 fn annotated_request(model: &str, text: &str) -> AnnotatedLlmRequest {
     AnnotatedLlmRequest {
@@ -231,6 +301,259 @@ fn event_accessors_cover_scope_tool_llm_and_mark_variants() {
     assert_eq!(mark_event.input(), None);
     assert_eq!(mark_event.output(), None);
     assert_eq!(mark_event.tool_call_id(), None);
+}
+
+#[test]
+fn event_categories_round_trip_all_scope_variants() {
+    let cases = [
+        (EventCategory::agent(), ScopeType::Agent, "agent"),
+        (EventCategory::function(), ScopeType::Function, "function"),
+        (EventCategory::tool(), ScopeType::Tool, "tool"),
+        (EventCategory::llm(), ScopeType::Llm, "llm"),
+        (
+            EventCategory::retriever(),
+            ScopeType::Retriever,
+            "retriever",
+        ),
+        (EventCategory::embedder(), ScopeType::Embedder, "embedder"),
+        (EventCategory::reranker(), ScopeType::Reranker, "reranker"),
+        (
+            EventCategory::guardrail(),
+            ScopeType::Guardrail,
+            "guardrail",
+        ),
+        (
+            EventCategory::evaluator(),
+            ScopeType::Evaluator,
+            "evaluator",
+        ),
+        (EventCategory::custom(), ScopeType::Custom, "custom"),
+        (EventCategory::unknown(), ScopeType::Unknown, "unknown"),
+    ];
+
+    for (category, scope_type, wire_value) in cases {
+        assert_eq!(category.as_str(), wire_value);
+        assert_eq!(category.to_scope_type(), scope_type);
+        assert_eq!(EventCategory::from(scope_type), category);
+        assert_eq!(ScopeType::from(&category), scope_type);
+    }
+
+    let vendor_category = EventCategory::new("vendor.special");
+    assert_eq!(vendor_category.as_str(), "vendor.special");
+    assert_eq!(vendor_category.to_scope_type(), ScopeType::Unknown);
+}
+
+#[test]
+fn event_mutators_schema_flags_and_attribute_helpers_cover_remaining_paths() {
+    let mut scope_event = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .name("scope")
+            .data(json!({"payload": true}))
+            .data_schema(DataSchema::builder().name("payload").version("1").build())
+            .build(),
+        ScopeCategory::Start,
+        vec!["relocatable".to_string(), "parallel".to_string()],
+        EventCategory::custom(),
+        Some(CategoryProfile::builder().subtype("initial").build()),
+    ));
+
+    assert!(scope_event.is_scope_start());
+    assert!(!scope_event.is_scope_end());
+    assert_eq!(
+        scope_event
+            .data_schema()
+            .map(|schema| (schema.name.as_str(), schema.version.as_str())),
+        Some(("payload", "1"))
+    );
+    assert_eq!(
+        scope_event.attributes(),
+        Some(["parallel".to_string(), "relocatable".to_string()].as_slice())
+    );
+
+    let scope_profile = scope_event.category_profile_mut().unwrap();
+    scope_profile.subtype = Some("updated".to_string());
+    assert_eq!(
+        scope_event
+            .category_profile()
+            .and_then(|profile| profile.subtype.as_deref()),
+        Some("updated")
+    );
+
+    let mut mark_event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder().name("mark").build(),
+        Some(EventCategory::evaluator()),
+        Some(CategoryProfile::builder().subtype("score").build()),
+    ));
+    assert!(!mark_event.is_scope_start());
+    assert!(!mark_event.is_scope_end());
+    assert_eq!(
+        mark_event.category().map(EventCategory::as_str),
+        Some("evaluator")
+    );
+
+    let mark_profile = mark_event.category_profile_mut().unwrap();
+    mark_profile.subtype = Some("quality".to_string());
+    assert_eq!(
+        mark_event
+            .category_profile()
+            .and_then(|profile| profile.subtype.as_deref()),
+        Some("quality")
+    );
+
+    let scope_end = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder().name("scope-end").build(),
+        ScopeCategory::End,
+        Vec::new(),
+        EventCategory::function(),
+        None,
+    ));
+    assert!(!scope_end.is_scope_start());
+    assert!(scope_end.is_scope_end());
+
+    assert_eq!(
+        attributes_from_handle(HandleAttributes::Scope(
+            ScopeAttributes::PARALLEL | ScopeAttributes::RELOCATABLE
+        )),
+        vec!["parallel".to_string(), "relocatable".to_string()]
+    );
+    assert_eq!(
+        attributes_from_handle(HandleAttributes::Tool(ToolAttributes::REMOTE)),
+        vec!["remote".to_string()]
+    );
+    assert_eq!(
+        attributes_from_handle(HandleAttributes::Llm(
+            LlmAttributes::STATEFUL | LlmAttributes::STREAMING
+        )),
+        vec!["stateful".to_string(), "streaming".to_string()]
+    );
+    assert!(attributes_from_handle(HandleAttributes::Scope(ScopeAttributes::empty())).is_empty());
+    assert!(attributes_from_handle(HandleAttributes::Tool(ToolAttributes::empty())).is_empty());
+    assert!(attributes_from_handle(HandleAttributes::Llm(LlmAttributes::empty())).is_empty());
+}
+
+#[test]
+fn event_timestamp_deserialization_accepts_strings_and_epoch_micros() {
+    let timestamp = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let from_string: Event = serde_json::from_value(json!({
+        "kind": "mark",
+        "atof_version": "0.1",
+        "uuid": Uuid::now_v7(),
+        "timestamp": timestamp.to_rfc3339(),
+        "name": "string-timestamp"
+    }))
+    .unwrap();
+    assert_eq!(*from_string.timestamp(), timestamp);
+
+    let micros = timestamp.timestamp_micros();
+    let from_i64: Event = serde_json::from_value(json!({
+        "kind": "mark",
+        "atof_version": "0.1",
+        "uuid": Uuid::now_v7(),
+        "timestamp": micros,
+        "name": "i64-timestamp"
+    }))
+    .unwrap();
+    assert_eq!(*from_i64.timestamp(), timestamp);
+
+    let from_u64: Event = serde_json::from_value(json!({
+        "kind": "mark",
+        "atof_version": "0.1",
+        "uuid": Uuid::now_v7(),
+        "timestamp": micros as u64,
+        "name": "u64-timestamp"
+    }))
+    .unwrap();
+    assert_eq!(*from_u64.timestamp(), timestamp);
+
+    let out_of_range = serde_json::from_value::<Event>(json!({
+        "kind": "mark",
+        "atof_version": "0.1",
+        "uuid": Uuid::now_v7(),
+        "timestamp": u64::MAX,
+        "name": "bad-timestamp"
+    }));
+    assert!(out_of_range.is_err());
+
+    let invalid_string = serde_json::from_value::<Event>(json!({
+        "kind": "mark",
+        "atof_version": "0.1",
+        "uuid": Uuid::now_v7(),
+        "timestamp": "not-a-timestamp",
+        "name": "bad-string-timestamp"
+    }));
+    assert!(invalid_string.is_err());
+
+    let invalid_type = serde_json::from_value::<Event>(json!({
+        "kind": "mark",
+        "atof_version": "0.1",
+        "uuid": Uuid::now_v7(),
+        "timestamp": false,
+        "name": "bad-type-timestamp"
+    }));
+    assert!(invalid_type.is_err());
+}
+
+#[test]
+fn scope_type_strings_and_editor_metadata_cover_public_helpers() {
+    let scope_types = [
+        (ScopeType::Agent, "agent"),
+        (ScopeType::Function, "function"),
+        (ScopeType::Tool, "tool"),
+        (ScopeType::Llm, "llm"),
+        (ScopeType::Retriever, "retriever"),
+        (ScopeType::Embedder, "embedder"),
+        (ScopeType::Reranker, "reranker"),
+        (ScopeType::Guardrail, "guardrail"),
+        (ScopeType::Evaluator, "evaluator"),
+        (ScopeType::Custom, "custom"),
+        (ScopeType::Unknown, "unknown"),
+    ];
+    for (scope_type, expected) in scope_types {
+        assert_eq!(scope_type.as_str(), expected);
+    }
+
+    let schema = EditorFixture::editor_schema();
+    assert_eq!(
+        schema.field("enabled").map(|field| field.kind),
+        Some(EditorFieldKind::Boolean)
+    );
+    assert_eq!(
+        schema
+            .field("name")
+            .map(|field| (field.kind, field.optional)),
+        Some((EditorFieldKind::String, true))
+    );
+    assert_eq!(
+        schema.field("count").map(|field| field.kind),
+        Some(EditorFieldKind::Integer)
+    );
+    assert_eq!(
+        schema.field("ratio").map(|field| field.kind),
+        Some(EditorFieldKind::Float)
+    );
+    assert_eq!(
+        schema
+            .field("mode")
+            .map(|field| (field.kind, field.enum_values)),
+        Some((EditorFieldKind::Enum, &["fast", "safe"][..]))
+    );
+    assert_eq!(
+        schema.field("headers").map(|field| field.kind),
+        Some(EditorFieldKind::StringMap)
+    );
+    assert_eq!(
+        schema.field("payload").map(|field| field.kind),
+        Some(EditorFieldKind::Json)
+    );
+
+    let nested = schema.field("nested").unwrap();
+    assert_eq!(nested.kind, EditorFieldKind::Section);
+    assert!(nested.schema().unwrap().field("enabled").is_some());
+    assert_eq!(nested.default_value().unwrap(), json!({"enabled": false}));
+    assert!(schema.field("missing").is_none());
 }
 
 #[test]

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -85,16 +85,20 @@ func TestObservabilityPluginAtofAndAtifFiles(t *testing.T) {
 		t.Fatalf(fatalErrorFormat, InitializePluginsFailed, err)
 	}
 
-	handle, err := PushScope("go-observability-agent", ScopeTypeAgent, WithInput(json.RawMessage(`{"agent":true}`)))
-	if err != nil {
-		t.Fatalf("PushScope failed: %v", err)
-	}
-	if err := EmitEvent("go-mark", WithEventParent(handle), WithEventData(json.RawMessage(`{"step":1}`))); err != nil {
-		t.Fatalf("EmitEvent failed: %v", err)
-	}
-	if err := PopScope(handle, WithOutput(json.RawMessage(`{"done":true}`))); err != nil {
-		t.Fatalf("PopScope failed: %v", err)
-	}
+	var handle *ScopeHandle
+	runWithTestScopeStack(t, func() {
+		var err error
+		handle, err = PushScope("go-observability-agent", ScopeTypeAgent, WithInput(json.RawMessage(`{"agent":true}`)))
+		if err != nil {
+			t.Fatalf("PushScope failed: %v", err)
+		}
+		if err := EmitEvent("go-mark", WithEventParent(handle), WithEventData(json.RawMessage(`{"step":1}`))); err != nil {
+			t.Fatalf("EmitEvent failed: %v", err)
+		}
+		if err := PopScope(handle, WithOutput(json.RawMessage(`{"done":true}`))); err != nil {
+			t.Fatalf("PopScope failed: %v", err)
+		}
+	})
 	if err := ClearPluginConfiguration(); err != nil {
 		t.Fatalf(fatalErrorFormat, ClearPluginConfigurationFailed, err)
 	}
@@ -121,11 +125,14 @@ func TestObservabilityPluginAtofAndAtifFiles(t *testing.T) {
 func TestObservabilityPluginAtifSplitsMultipleTopLevelAgents(t *testing.T) {
 	Dir := t.TempDir()
 	InitializeAtifPlugin(t, Dir)
-	First := EmitAgentStart(t, "first", FirstAgentName)
-	Nested := EmitAgentStart(t, "nested", NestedAgentName)
-	EmitAgentEnd(t, "nested", Nested)
-	EmitAgentEnd(t, "first", First)
-	Second := EmitAgentTrajectory(t, "second", SecondAgentName)
+	var First, Nested, Second *ScopeHandle
+	runWithTestScopeStack(t, func() {
+		First = EmitAgentStart(t, "first", FirstAgentName)
+		Nested = EmitAgentStart(t, "nested", NestedAgentName)
+		EmitAgentEnd(t, "nested", Nested)
+		EmitAgentEnd(t, "first", First)
+		Second = EmitAgentTrajectory(t, "second", SecondAgentName)
+	})
 	requireNoError(t, ClearPluginConfiguration(), ClearPluginConfigurationFailed)
 
 	Files, err := filepath.Glob(filepath.Join(Dir, TrajectoryFilenamePrefix+"*.json"))
@@ -199,19 +206,23 @@ func TestObservabilityAtifOpenAgentFlushesOnClear(t *testing.T) {
 	if _, err := InitializePlugins(PluginConfig{Version: 1, Components: []PluginComponentSpec{ObservabilityComponent(config)}}); err != nil {
 		t.Fatalf(fatalErrorFormat, InitializePluginsFailed, err)
 	}
-	handle, err := PushScope("go-open-agent", ScopeTypeAgent)
-	if err != nil {
-		t.Fatalf("PushScope failed: %v", err)
-	}
-	if err := ClearPluginConfiguration(); err != nil {
-		t.Fatalf(fatalErrorFormat, ClearPluginConfigurationFailed, err)
-	}
+	var handle *ScopeHandle
+	runWithTestScopeStack(t, func() {
+		var err error
+		handle, err = PushScope("go-open-agent", ScopeTypeAgent)
+		if err != nil {
+			t.Fatalf("PushScope failed: %v", err)
+		}
+		if err := ClearPluginConfiguration(); err != nil {
+			t.Fatalf(fatalErrorFormat, ClearPluginConfigurationFailed, err)
+		}
+		if err := PopScope(handle); err != nil {
+			t.Fatalf("PopScope failed: %v", err)
+		}
+	})
 	path := filepath.Join(dir, "nemo-relay-atif-"+handle.UUID()+".json")
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected open-agent ATIF file at %s: %v", path, err)
-	}
-	if err := PopScope(handle); err != nil {
-		t.Fatalf("PopScope failed: %v", err)
 	}
 }
 

--- a/go/nemo_relay/openinference_test.go
+++ b/go/nemo_relay/openinference_test.go
@@ -119,21 +119,23 @@ func TestOpenInferenceSubscriberExportsScopeLifecycleAndMarks(t *testing.T) {
 	}
 	defer func() { _ = subscriber.Deregister(name) }()
 
-	handle, err := PushScope("openinference_scope", ScopeTypeAgent)
-	if err != nil {
-		t.Fatalf("PushScope failed: %v", err)
-	}
-	if err := EmitEvent(
-		"openinference_mark",
-		WithEventParent(handle),
-		WithEventData(json.RawMessage(`{"step":1}`)),
-		WithEventMetadata(json.RawMessage(`{"source":"go"}`)),
-	); err != nil {
-		t.Fatalf("EmitEvent failed: %v", err)
-	}
-	if err := PopScope(handle); err != nil {
-		t.Fatalf("PopScope failed: %v", err)
-	}
+	runWithTestScopeStack(t, func() {
+		handle, err := PushScope("openinference_scope", ScopeTypeAgent)
+		if err != nil {
+			t.Fatalf("PushScope failed: %v", err)
+		}
+		if err := EmitEvent(
+			"openinference_mark",
+			WithEventParent(handle),
+			WithEventData(json.RawMessage(`{"step":1}`)),
+			WithEventMetadata(json.RawMessage(`{"source":"go"}`)),
+		); err != nil {
+			t.Fatalf("EmitEvent failed: %v", err)
+		}
+		if err := PopScope(handle); err != nil {
+			t.Fatalf("PopScope failed: %v", err)
+		}
+	})
 	if err := subscriber.ForceFlush(); err != nil {
 		t.Fatalf("ForceFlush failed: %v", err)
 	}

--- a/go/nemo_relay/otel_test.go
+++ b/go/nemo_relay/otel_test.go
@@ -118,21 +118,23 @@ func TestOpenTelemetrySubscriberExportsScopeLifecycleAndMarks(t *testing.T) {
 	}
 	defer func() { _ = subscriber.Deregister(name) }()
 
-	handle, err := PushScope("otel_scope", ScopeTypeAgent)
-	if err != nil {
-		t.Fatalf("PushScope failed: %v", err)
-	}
-	if err := EmitEvent(
-		"otel_mark",
-		WithEventParent(handle),
-		WithEventData(json.RawMessage(`{"step":1}`)),
-		WithEventMetadata(json.RawMessage(`{"source":"go"}`)),
-	); err != nil {
-		t.Fatalf("EmitEvent failed: %v", err)
-	}
-	if err := PopScope(handle); err != nil {
-		t.Fatalf("PopScope failed: %v", err)
-	}
+	runWithTestScopeStack(t, func() {
+		handle, err := PushScope("otel_scope", ScopeTypeAgent)
+		if err != nil {
+			t.Fatalf("PushScope failed: %v", err)
+		}
+		if err := EmitEvent(
+			"otel_mark",
+			WithEventParent(handle),
+			WithEventData(json.RawMessage(`{"step":1}`)),
+			WithEventMetadata(json.RawMessage(`{"source":"go"}`)),
+		); err != nil {
+			t.Fatalf("EmitEvent failed: %v", err)
+		}
+		if err := PopScope(handle); err != nil {
+			t.Fatalf("PopScope failed: %v", err)
+		}
+	})
 	if err := subscriber.ForceFlush(); err != nil {
 		t.Fatalf("ForceFlush failed: %v", err)
 	}

--- a/go/nemo_relay/test_helpers_test.go
+++ b/go/nemo_relay/test_helpers_test.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nemo_relay
+
+import "testing"
+
+func runWithTestScopeStack(t *testing.T, fn func()) {
+	t.Helper()
+
+	stack, err := NewScopeStack()
+	if err != nil {
+		t.Fatalf("NewScopeStack failed: %v", err)
+	}
+	defer stack.Close()
+
+	stack.Run(fn)
+}


### PR DESCRIPTION
#### Overview

Improve Rust core coverage for Guardrails and related core helper branches while addressing Sonar cognitive-complexity findings in the Guardrails configuration paths.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Refactored NeMo Guardrails config validation and remote Guardrails config assembly to reduce cognitive complexity without changing behavior.
- Added focused core tests under `crates/core/tests` for Guardrails remote helpers, component validation, event timestamp/category helpers, registry defaults, scope pop errors, and observability exporter edge cases.
- Kept remote coverage test bodies out of `crates/core/src`, using the existing path-based unit-test harness style.
- Raised core-only Rust coverage above the requested threshold.

Validation:

- `cargo llvm-cov clean --workspace && cargo llvm-cov test -p nemo-relay --ignore-filename-regex '.*/tests/.*\.rs$' --cobertura --output-path target/coverage/core.xml`
  - Core coverage: `8628/8985 = 96.03%`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p nemo-relay remote::coverage_tests`

#### Where should the reviewer start?

Start with `crates/core/src/plugins/nemo_guardrails/component.rs` and `crates/core/src/plugins/nemo_guardrails/remote.rs` for the production refactors, then review `crates/core/tests/unit/plugins/nemo_guardrails/remote_coverage_tests.rs` for the moved Guardrails remote coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded NeMo Guardrails validation and remote-backend coverage, including new focused remote tests.
  * Added integration test for scope-stack push/pop error cases and a Go helper to run tests with a scoped stack.
  * Enhanced observability and plugin lifecycle tests, exporter error handling, registry, and rich event/editor metadata fixtures.

* **Refactor**
  * Reorganized NeMo Guardrails request/options assembly and validation for clearer, standardized handling and diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->