### PR TITLE
feat: add guardrails plugin editor support

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ pkg-fmt = "bin"
 workspace = true
 
 [dependencies]
-nemo-relay = { workspace = true, features = ["openinference"] }
+nemo-relay = { workspace = true, features = ["guardrails-remote", "openinference"] }
 nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }
 async-stream = "0.3"
 axum = "0.8"

--- a/crates/cli/src/plugins.rs
+++ b/crates/cli/src/plugins.rs
@@ -13,9 +13,7 @@ use std::path::Path;
 use console::{Key, Term, style};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Input, Select};
-use nemo_relay::config_editor::{EditorConfig, EditorFieldKind, EditorFieldSpec};
-use nemo_relay::observability::plugin_component::ObservabilityConfig;
-use nemo_relay_adaptive::AdaptiveConfig;
+use nemo_relay::config_editor::{EditorFieldKind, EditorFieldSpec};
 use serde_json::{Value, json};
 
 use crate::config::PluginsEditCommand;
@@ -91,8 +89,7 @@ pub(crate) fn edit(command: PluginsEditCommand) -> Result<(), CliError> {
     let mut config = read_plugin_config(&path)?;
     ensure_observability_component(&mut config)?;
     ensure_adaptive_component(&mut config)?;
-    let mut observability = component_observability_config(&config)?;
-    let mut adaptive = component_adaptive_config(&config)?;
+    let mut components = editable_components(&config)?;
 
     let theme = ColorfulTheme::default();
     crate::banner::print_intro();
@@ -101,101 +98,55 @@ pub(crate) fn edit(command: PluginsEditCommand) -> Result<(), CliError> {
     println!();
     let mut selected_index = 0;
     loop {
-        let summary = observability_summary(&config, &observability);
-        let adaptive_summary = adaptive_summary(&config, &adaptive);
-        let observability_fields = ObservabilityConfig::editor_schema().fields;
-        let adaptive_fields = AdaptiveConfig::editor_schema().fields;
-        let mut items = vec![MenuItem::new(format!(
-            "Toggle Observability component [{}]",
-            status_label(component_enabled(&config))
-        ))];
-        items.extend(observability_fields.iter().map(|section| {
-            MenuItem::new(configured_label(
-                section_configured(&observability, *section),
-                format!("Edit {}", section.label),
-            ))
-        }));
-        items.push(MenuItem::new(format!(
-            "Toggle Adaptive component [{}]",
-            status_label(adaptive_component_enabled(&config))
-        )));
-        items.extend(adaptive_fields.iter().map(|field| {
-            MenuItem::new(configured_label(
-                config_field_configured(&adaptive, *field).unwrap_or(false),
-                format!("Edit Adaptive {}", field.label),
-            ))
-        }));
-        items.push(MenuItem::new(shortcut_label("Preview TOML", "p")));
-        items.push(MenuItem::new(shortcut_label(
-            format!("Save to {}", path.display()),
-            "s",
-        )));
-        items.push(MenuItem::new(shortcut_label("Cancel", "q")));
+        let (items, actions) = plugin_menu_items(&components, &path);
         println!();
-        println!("Observability: {summary}");
-        println!("Adaptive: {adaptive_summary}");
-        let observability_start_index = 1;
-        let observability_end_index = observability_start_index + observability_fields.len();
-        let adaptive_toggle_index = observability_end_index;
-        let adaptive_start_index = adaptive_toggle_index + 1;
-        let preview_index = adaptive_start_index + adaptive_fields.len();
-        let save_index = preview_index + 1;
-        let cancel_index = preview_index + 2;
+        for component in &components {
+            println!("{}: {}", component.label(), component.summary());
+        }
         let selection = prompt_menu(&theme, "plugins.toml", &items, selected_index)?;
         if let Some(selected) = menu_response_index(&selection) {
             selected_index = selected;
         }
         match selection {
-            MenuResponse::Selected(0) => {
-                let enabled = !component_enabled(&config);
-                set_component_enabled(&mut config, enabled);
-            }
-            MenuResponse::Selected(selection)
-                if (observability_start_index..observability_end_index).contains(&selection) =>
-            {
-                edit_section(
-                    &theme,
-                    &mut observability,
-                    observability_fields[selection - observability_start_index],
-                )?
-            }
-            MenuResponse::Selected(selection) if selection == adaptive_toggle_index => {
-                let enabled = !adaptive_component_enabled(&config);
-                set_adaptive_component_enabled(&mut config, enabled);
-            }
-            MenuResponse::Selected(selection)
-                if (adaptive_start_index..preview_index).contains(&selection) =>
-            {
-                edit_config_field(
-                    &theme,
-                    &mut adaptive,
-                    adaptive_fields[selection - adaptive_start_index],
-                )?
-            }
-            MenuResponse::Selected(selection) if selection == preview_index => {
-                let preview_config = config_with_components(&config, &observability, &adaptive)?;
-                print_preview(&preview_config)?;
-            }
-            MenuResponse::Selected(selection) if selection == save_index => {
-                store_observability_config(&mut config, &observability)?;
-                store_adaptive_config(&mut config, &adaptive)?;
-                validate_config(&config)?;
-                write_plugin_config(&path, &config)?;
-                print_save_success(&path);
-                return Ok(());
-            }
-            MenuResponse::Selected(selection) if selection == cancel_index => {
-                return Err(CliError::Config(
-                    "plugin edit cancelled; no config saved".into(),
-                ));
-            }
+            MenuResponse::Selected(selection) => match actions.get(selection).copied() {
+                Some(MenuAction::ToggleComponent(component_index)) => {
+                    if let Some(component) = components.get_mut(component_index) {
+                        component.toggle_enabled();
+                    }
+                }
+                Some(MenuAction::EditField {
+                    component_index,
+                    field_index,
+                }) => {
+                    if let Some(component) = components.get_mut(component_index)
+                        && let Some(field) = component.fields().get(field_index)
+                    {
+                        edit_component_field(&theme, component, *field)?;
+                    }
+                }
+                Some(MenuAction::Preview) => {
+                    let preview_config = config_with_editable_components(&config, &components)?;
+                    print_preview(&preview_config)?;
+                }
+                Some(MenuAction::Save) => {
+                    store_editable_components(&mut config, &components)?;
+                    validate_config(&config)?;
+                    write_plugin_config(&path, &config)?;
+                    print_save_success(&path);
+                    return Ok(());
+                }
+                Some(MenuAction::Cancel) | None => {
+                    return Err(CliError::Config(
+                        "plugin edit cancelled; no config saved".into(),
+                    ));
+                }
+            },
             MenuResponse::Shortcut(MenuShortcut::Preview, _) => {
-                let preview_config = config_with_components(&config, &observability, &adaptive)?;
+                let preview_config = config_with_editable_components(&config, &components)?;
                 print_preview(&preview_config)?;
             }
             MenuResponse::Shortcut(MenuShortcut::Save, _) => {
-                store_observability_config(&mut config, &observability)?;
-                store_adaptive_config(&mut config, &adaptive)?;
+                store_editable_components(&mut config, &components)?;
                 validate_config(&config)?;
                 write_plugin_config(&path, &config)?;
                 print_save_success(&path);
@@ -203,29 +154,56 @@ pub(crate) fn edit(command: PluginsEditCommand) -> Result<(), CliError> {
             }
             MenuResponse::Shortcut(MenuShortcut::Help, _) => print_editor_help(),
             MenuResponse::Shortcut(MenuShortcut::Reset | MenuShortcut::Clear, selected) => {
-                if (observability_start_index..observability_end_index).contains(&selected) {
-                    reset_config_field(
-                        &mut observability,
-                        observability_fields[selected - observability_start_index],
-                    )?;
-                } else if (adaptive_start_index..preview_index).contains(&selected) {
-                    reset_config_field(
-                        &mut adaptive,
-                        adaptive_fields[selected - adaptive_start_index],
-                    )?;
-                } else {
-                    println!(
-                        "  Select an Observability or Adaptive field, or a section field, to reset or clear."
-                    );
+                match actions.get(selected).copied() {
+                    Some(MenuAction::ToggleComponent(component_index)) => {
+                        if let Some(component) = components.get_mut(component_index) {
+                            component.set_enabled(false);
+                        }
+                    }
+                    Some(MenuAction::EditField {
+                        component_index,
+                        field_index,
+                    }) => {
+                        if let Some(component) = components.get_mut(component_index)
+                            && let Some(field) = component.fields().get(field_index)
+                        {
+                            component.reset_field(*field)?;
+                        }
+                    }
+                    _ => {
+                        println!("  Select a component or editable field to reset or clear.");
+                    }
                 }
             }
-            MenuResponse::Cancel | MenuResponse::Selected(_) => {
+            MenuResponse::Cancel => {
                 return Err(CliError::Config(
                     "plugin edit cancelled; no config saved".into(),
                 ));
             }
         }
     }
+}
+
+fn edit_component_field(
+    theme: &ColorfulTheme,
+    component: &mut EditableComponent,
+    field: EditorFieldSpec,
+) -> Result<(), CliError> {
+    match component {
+        EditableComponent::Observability(state) => {
+            edit_section(theme, &mut state.config, field)?;
+            state.mark_touched();
+        }
+        EditableComponent::Adaptive(state) => {
+            edit_config_field(theme, &mut state.config, field)?;
+            state.mark_touched();
+        }
+        EditableComponent::NemoGuardrails(state) => {
+            edit_config_field(theme, &mut state.config, field)?;
+            state.mark_touched();
+        }
+    }
+    Ok(())
 }
 
 fn menu_response_index(response: &MenuResponse) -> Option<usize> {
@@ -681,21 +659,26 @@ where
     T: SerializeConfig,
 {
     let mut value = section_field_value(config, section, field.name)?
-        .or_else(|| field.default_value())
+        .or_else(|| section_field_default(section, field))
         .unwrap_or_else(|| json!({}));
     let schema = field
         .schema()
         .ok_or_else(|| CliError::Config(format!("{} is not an editable section", field.name)))?;
+    let default = section_field_default(section, field);
     if edit_value_section(
         theme,
         &format!("{}.{}", section.name, field.name),
         &mut value,
         schema,
-        field.default_value(),
+        default,
     )? {
         store_edited_section_field(config, section, field, value)?;
     }
     Ok(())
+}
+
+fn section_field_default(section: EditorFieldSpec, field: EditorFieldSpec) -> Option<Value> {
+    default_field_value(section, field).or_else(|| field.default_value())
 }
 
 fn store_edited_config_section<T>(
@@ -796,9 +779,9 @@ fn value_field_menu_item(
 ) -> Result<MenuItem, CliError> {
     let configured = value_field_configured(value, field, default);
     let rendered = value_field_value(value, field.name)
-        .map(|value| display_value_with_default(&value, default_object_field_value(default, field)))
+        .map(|value| display_value_with_default(&value, value_field_default(default, field)))
         .or_else(|| {
-            default_object_field_value(default, field)
+            value_field_default(default, field)
                 .map(|value| format!("{} (default)", display_value(&value)))
         })
         .unwrap_or_else(|| "(default)".to_string());
@@ -837,8 +820,9 @@ fn edit_value_field(
     default: Option<&Value>,
 ) -> Result<(), CliError> {
     if field.kind == EditorFieldKind::Section {
+        let nested_default = value_field_default(default, field);
         let mut nested_value = value_field_value(value, field.name)
-            .or_else(|| field.default_value())
+            .or_else(|| nested_default.clone())
             .unwrap_or_else(|| json!({}));
         let nested_schema = field.schema().ok_or_else(|| {
             CliError::Config(format!("{} is not an editable section", field.name))
@@ -848,7 +832,7 @@ fn edit_value_field(
             &format!("{prompt}.{}", field.name),
             &mut nested_value,
             nested_schema,
-            field.default_value(),
+            nested_default,
         )? {
             store_edited_value_section(value, field, nested_value);
         }
@@ -872,10 +856,10 @@ fn edit_value_field(
             current
                 .as_ref()
                 .map(|value| {
-                    display_value_with_default(value, default_object_field_value(default, field))
+                    display_value_with_default(value, value_field_default(default, field))
                 })
                 .or_else(|| {
-                    default_object_field_value(default, field)
+                    value_field_default(default, field)
                         .map(|value| format!("{} (default)", display_value(&value)))
                 })
                 .unwrap_or_else(|| "(default)".to_string())
@@ -934,7 +918,7 @@ fn value_field_configured(value: &Value, field: EditorFieldSpec, default: Option
     if field.optional {
         return true;
     }
-    default_object_field_value(default, field)
+    value_field_default(default, field)
         .as_ref()
         .is_none_or(|default| default != &current)
 }
@@ -953,6 +937,10 @@ fn default_object_field_value(default: Option<&Value>, field: EditorFieldSpec) -
         .and_then(|object| object.get(field.name))
         .filter(|value| !value.is_null())
         .cloned()
+}
+
+fn value_field_default(default: Option<&Value>, field: EditorFieldSpec) -> Option<Value> {
+    default_object_field_value(default, field).or_else(|| field.default_value())
 }
 
 fn set_value_field(target: &mut Value, field: &str, field_value: Value) {
@@ -974,7 +962,7 @@ fn remove_value_field(target: &mut Value, field: &str) {
 }
 
 fn reset_value_field(value: &mut Value, field: EditorFieldSpec, default: Option<&Value>) {
-    if let Some(default) = default_object_field_value(default, field) {
+    if let Some(default) = value_field_default(default, field) {
         set_value_field(value, field.name, default);
     } else {
         remove_value_field(value, field.name);

--- a/crates/cli/src/plugins.rs
+++ b/crates/cli/src/plugins.rs
@@ -153,28 +153,29 @@ pub(crate) fn edit(command: PluginsEditCommand) -> Result<(), CliError> {
                 return Ok(());
             }
             MenuResponse::Shortcut(MenuShortcut::Help, _) => print_editor_help(),
-            MenuResponse::Shortcut(MenuShortcut::Reset | MenuShortcut::Clear, selected) => {
-                match actions.get(selected).copied() {
-                    Some(MenuAction::ToggleComponent(component_index)) => {
-                        if let Some(component) = components.get_mut(component_index) {
-                            component.set_enabled(false);
-                        }
-                    }
-                    Some(MenuAction::EditField {
-                        component_index,
-                        field_index,
-                    }) => {
-                        if let Some(component) = components.get_mut(component_index)
-                            && let Some(field) = component.fields().get(field_index)
-                        {
-                            component.reset_field(*field)?;
-                        }
-                    }
-                    _ => {
-                        println!("  Select a component or editable field to reset or clear.");
+            MenuResponse::Shortcut(
+                shortcut @ (MenuShortcut::Reset | MenuShortcut::Clear),
+                selected,
+            ) => match actions.get(selected).copied() {
+                Some(MenuAction::ToggleComponent(component_index)) => {
+                    if let Some(component) = components.get_mut(component_index) {
+                        apply_component_enablement_shortcut(component, shortcut);
                     }
                 }
-            }
+                Some(MenuAction::EditField {
+                    component_index,
+                    field_index,
+                }) => {
+                    if let Some(component) = components.get_mut(component_index)
+                        && let Some(field) = component.fields().get(field_index)
+                    {
+                        component.reset_field(*field)?;
+                    }
+                }
+                _ => {
+                    println!("  Select a component or editable field to reset or clear.");
+                }
+            },
             MenuResponse::Cancel => {
                 return Err(CliError::Config(
                     "plugin edit cancelled; no config saved".into(),
@@ -192,18 +193,26 @@ fn edit_component_field(
     match component {
         EditableComponent::Observability(state) => {
             edit_section(theme, &mut state.config, field)?;
-            state.mark_touched();
+            state.mark_config_touched();
         }
         EditableComponent::Adaptive(state) => {
             edit_config_field(theme, &mut state.config, field)?;
-            state.mark_touched();
+            state.mark_config_touched();
         }
         EditableComponent::NemoGuardrails(state) => {
             edit_config_field(theme, &mut state.config, field)?;
-            state.mark_touched();
+            state.mark_config_touched();
         }
     }
     Ok(())
+}
+
+fn apply_component_enablement_shortcut(component: &mut EditableComponent, shortcut: MenuShortcut) {
+    match shortcut {
+        MenuShortcut::Reset => component.reset_enabled(),
+        MenuShortcut::Clear => component.set_enabled(false),
+        _ => {}
+    }
 }
 
 fn menu_response_index(response: &MenuResponse) -> Option<usize> {

--- a/crates/cli/src/plugins/editor_model.rs
+++ b/crates/cli/src/plugins/editor_model.rs
@@ -25,8 +25,10 @@ pub(super) const POLICY_SECTION: &str = "policy";
 pub(super) struct ComponentEditorState<T> {
     pub(super) config: T,
     pub(super) enabled: bool,
+    default_enabled: bool,
     existing: bool,
     touched: bool,
+    config_touched: bool,
 }
 
 #[derive(Debug)]
@@ -77,6 +79,14 @@ impl EditableComponent {
         }
     }
 
+    pub(super) fn reset_enabled(&mut self) {
+        match self {
+            Self::Observability(state) => state.reset_enabled(),
+            Self::Adaptive(state) => state.reset_enabled(),
+            Self::NemoGuardrails(state) => state.reset_enabled(),
+        }
+    }
+
     pub(super) fn summary(&self) -> String {
         match self {
             Self::Observability(state) => observability_summary(state),
@@ -99,15 +109,15 @@ impl EditableComponent {
         match self {
             Self::Observability(state) => {
                 reset_config_field(&mut state.config, field)?;
-                state.mark_touched();
+                state.mark_config_touched();
             }
             Self::Adaptive(state) => {
                 reset_config_field(&mut state.config, field)?;
-                state.mark_touched();
+                state.mark_config_touched();
             }
             Self::NemoGuardrails(state) => {
                 reset_config_field(&mut state.config, field)?;
-                state.mark_touched();
+                state.mark_config_touched();
             }
         }
         Ok(())
@@ -216,6 +226,11 @@ impl<T> ComponentEditorState<T> {
         self.touched = true;
     }
 
+    pub(super) fn mark_config_touched(&mut self) {
+        self.config_touched = true;
+        self.mark_touched();
+    }
+
     pub(super) fn toggle_enabled(&mut self) {
         self.enabled = !self.enabled;
         self.mark_touched();
@@ -223,6 +238,11 @@ impl<T> ComponentEditorState<T> {
 
     pub(super) fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
+        self.mark_touched();
+    }
+
+    pub(super) fn reset_enabled(&mut self) {
+        self.enabled = self.default_enabled;
         self.mark_touched();
     }
 
@@ -249,16 +269,20 @@ where
         return Ok(ComponentEditorState {
             config,
             enabled: component.enabled,
+            default_enabled,
             existing: true,
             touched: false,
+            config_touched: false,
         });
     }
 
     Ok(ComponentEditorState {
         config: T::default(),
         enabled: default_enabled,
+        default_enabled,
         existing: false,
         touched: false,
+        config_touched: false,
     })
 }
 
@@ -346,7 +370,7 @@ pub(super) fn store_nemo_guardrails_state(
     config: &mut PluginConfig,
     state: &ComponentEditorState<NeMoGuardrailsConfig>,
 ) -> Result<(), CliError> {
-    if state.should_store(nemo_guardrails_configured(&state.config)) {
+    if state.should_store(state.config_touched || nemo_guardrails_configured(&state.config)) {
         store_component_editor_config(
             config,
             NEMO_GUARDRAILS_PLUGIN_KIND,

--- a/crates/cli/src/plugins/editor_model.rs
+++ b/crates/cli/src/plugins/editor_model.rs
@@ -3,9 +3,14 @@
 
 //! Testable plugin editor state helpers.
 
+use std::path::Path;
+
 use nemo_relay::config_editor::{EditorConfig, EditorFieldKind, EditorFieldSpec};
 use nemo_relay::observability::plugin_component::{OBSERVABILITY_PLUGIN_KIND, ObservabilityConfig};
 use nemo_relay::plugin::{PluginComponentSpec, PluginConfig};
+use nemo_relay::plugins::nemo_guardrails::component::{
+    NEMO_GUARDRAILS_PLUGIN_KIND, NeMoGuardrailsConfig,
+};
 use nemo_relay_adaptive::AdaptiveConfig;
 use nemo_relay_adaptive::plugin_component::ADAPTIVE_PLUGIN_KIND;
 use serde::Serialize;
@@ -15,6 +20,247 @@ use serde_json::{Map, Value, json};
 use crate::error::CliError;
 
 pub(super) const POLICY_SECTION: &str = "policy";
+
+#[derive(Debug, Clone)]
+pub(super) struct ComponentEditorState<T> {
+    pub(super) config: T,
+    pub(super) enabled: bool,
+    existing: bool,
+    touched: bool,
+}
+
+#[derive(Debug)]
+pub(super) enum EditableComponent {
+    Observability(ComponentEditorState<ObservabilityConfig>),
+    Adaptive(ComponentEditorState<AdaptiveConfig>),
+    NemoGuardrails(ComponentEditorState<NeMoGuardrailsConfig>),
+}
+
+impl EditableComponent {
+    pub(super) fn label(&self) -> &'static str {
+        match self {
+            Self::Observability(_) => "Observability",
+            Self::Adaptive(_) => "Adaptive",
+            Self::NemoGuardrails(_) => "NeMo Guardrails",
+        }
+    }
+
+    pub(super) fn fields(&self) -> &'static [EditorFieldSpec] {
+        match self {
+            Self::Observability(_) => ObservabilityConfig::editor_schema().fields,
+            Self::Adaptive(_) => AdaptiveConfig::editor_schema().fields,
+            Self::NemoGuardrails(_) => NeMoGuardrailsConfig::editor_schema().fields,
+        }
+    }
+
+    pub(super) fn enabled(&self) -> bool {
+        match self {
+            Self::Observability(state) => state.enabled,
+            Self::Adaptive(state) => state.enabled,
+            Self::NemoGuardrails(state) => state.enabled,
+        }
+    }
+
+    pub(super) fn toggle_enabled(&mut self) {
+        match self {
+            Self::Observability(state) => state.toggle_enabled(),
+            Self::Adaptive(state) => state.toggle_enabled(),
+            Self::NemoGuardrails(state) => state.toggle_enabled(),
+        }
+    }
+
+    pub(super) fn set_enabled(&mut self, enabled: bool) {
+        match self {
+            Self::Observability(state) => state.set_enabled(enabled),
+            Self::Adaptive(state) => state.set_enabled(enabled),
+            Self::NemoGuardrails(state) => state.set_enabled(enabled),
+        }
+    }
+
+    pub(super) fn summary(&self) -> String {
+        match self {
+            Self::Observability(state) => observability_summary(state),
+            Self::Adaptive(state) => adaptive_summary(state),
+            Self::NemoGuardrails(state) => nemo_guardrails_summary(state),
+        }
+    }
+
+    pub(super) fn field_configured(&self, field: EditorFieldSpec) -> bool {
+        match self {
+            Self::Observability(state) => section_configured(&state.config, field),
+            Self::Adaptive(state) => config_field_configured(&state.config, field).unwrap_or(false),
+            Self::NemoGuardrails(state) => {
+                config_field_configured(&state.config, field).unwrap_or(false)
+            }
+        }
+    }
+
+    pub(super) fn reset_field(&mut self, field: EditorFieldSpec) -> Result<(), CliError> {
+        match self {
+            Self::Observability(state) => {
+                reset_config_field(&mut state.config, field)?;
+                state.mark_touched();
+            }
+            Self::Adaptive(state) => {
+                reset_config_field(&mut state.config, field)?;
+                state.mark_touched();
+            }
+            Self::NemoGuardrails(state) => {
+                reset_config_field(&mut state.config, field)?;
+                state.mark_touched();
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn store(&self, config: &mut PluginConfig) -> Result<(), CliError> {
+        match self {
+            Self::Observability(state) => store_observability_state(config, state),
+            Self::Adaptive(state) => store_adaptive_state(config, state),
+            Self::NemoGuardrails(state) => store_nemo_guardrails_state(config, state),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum MenuAction {
+    ToggleComponent(usize),
+    EditField {
+        component_index: usize,
+        field_index: usize,
+    },
+    Preview,
+    Save,
+    Cancel,
+}
+
+pub(super) fn editable_components(
+    config: &PluginConfig,
+) -> Result<Vec<EditableComponent>, CliError> {
+    Ok(vec![
+        EditableComponent::Observability(component_observability_state(config)?),
+        EditableComponent::Adaptive(component_adaptive_state(config)?),
+        EditableComponent::NemoGuardrails(component_nemo_guardrails_state(config)?),
+    ])
+}
+
+pub(super) fn plugin_menu_items(
+    components: &[EditableComponent],
+    path: &Path,
+) -> (Vec<super::MenuItem>, Vec<MenuAction>) {
+    let mut items = Vec::new();
+    let mut actions = Vec::new();
+    for (component_index, component) in components.iter().enumerate() {
+        items.push(super::MenuItem::new(format!(
+            "Toggle {} component [{}]",
+            component.label(),
+            super::status_label(component.enabled())
+        )));
+        actions.push(MenuAction::ToggleComponent(component_index));
+
+        items.extend(component.fields().iter().map(|field| {
+            super::MenuItem::new(super::configured_label(
+                component.field_configured(*field),
+                format!("Edit {} {}", component.label(), field.label),
+            ))
+        }));
+        actions.extend(
+            component
+                .fields()
+                .iter()
+                .enumerate()
+                .map(|(field_index, _)| MenuAction::EditField {
+                    component_index,
+                    field_index,
+                }),
+        );
+    }
+
+    items.push(super::MenuItem::new(super::shortcut_label(
+        "Preview TOML",
+        "p",
+    )));
+    actions.push(MenuAction::Preview);
+    items.push(super::MenuItem::new(super::shortcut_label(
+        format!("Save to {}", path.display()),
+        "s",
+    )));
+    actions.push(MenuAction::Save);
+    items.push(super::MenuItem::new(super::shortcut_label("Cancel", "q")));
+    actions.push(MenuAction::Cancel);
+
+    (items, actions)
+}
+
+pub(super) fn config_with_editable_components(
+    config: &PluginConfig,
+    components: &[EditableComponent],
+) -> Result<PluginConfig, CliError> {
+    let mut config = config.clone();
+    store_editable_components(&mut config, components)?;
+    Ok(config)
+}
+
+pub(super) fn store_editable_components(
+    config: &mut PluginConfig,
+    components: &[EditableComponent],
+) -> Result<(), CliError> {
+    for component in components {
+        component.store(config)?;
+    }
+    Ok(())
+}
+
+impl<T> ComponentEditorState<T> {
+    pub(super) fn mark_touched(&mut self) {
+        self.touched = true;
+    }
+
+    pub(super) fn toggle_enabled(&mut self) {
+        self.enabled = !self.enabled;
+        self.mark_touched();
+    }
+
+    pub(super) fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        self.mark_touched();
+    }
+
+    pub(super) fn should_store(&self, configured: bool) -> bool {
+        self.existing || (self.touched && (self.enabled || configured))
+    }
+}
+
+fn component_editor_state<T>(
+    config: &PluginConfig,
+    kind: &str,
+    default_enabled: bool,
+) -> Result<ComponentEditorState<T>, CliError>
+where
+    T: Default + DeserializeOwned,
+{
+    if let Some(component) = config
+        .components
+        .iter()
+        .find(|component| component.kind == kind)
+    {
+        let config = serde_json::from_value(Value::Object(component.config.clone()))
+            .map_err(|error| CliError::Config(format!("invalid {kind} plugin config: {error}")))?;
+        return Ok(ComponentEditorState {
+            config,
+            enabled: component.enabled,
+            existing: true,
+            touched: false,
+        });
+    }
+
+    Ok(ComponentEditorState {
+        config: T::default(),
+        enabled: default_enabled,
+        existing: false,
+        touched: false,
+    })
+}
 
 pub(super) fn ensure_observability_component(config: &mut PluginConfig) -> Result<(), CliError> {
     if !config
@@ -46,80 +292,93 @@ pub(super) fn ensure_adaptive_component(config: &mut PluginConfig) -> Result<(),
     Ok(())
 }
 
-pub(super) fn component_enabled(config: &PluginConfig) -> bool {
-    observability_component(config)
-        .map(|component| component.enabled)
-        .unwrap_or(true)
-}
-
-pub(super) fn set_component_enabled(config: &mut PluginConfig, enabled: bool) {
-    if let Some(component) = observability_component_mut(config) {
-        component.enabled = enabled;
-    }
-}
-
-pub(super) fn adaptive_component_enabled(config: &PluginConfig) -> bool {
-    adaptive_component(config)
-        .map(|component| component.enabled)
-        .unwrap_or(false)
-}
-
-pub(super) fn set_adaptive_component_enabled(config: &mut PluginConfig, enabled: bool) {
-    if let Some(component) = adaptive_component_mut(config) {
-        component.enabled = enabled;
-    }
-}
-
-pub(super) fn component_observability_config(
+pub(super) fn component_observability_state(
     config: &PluginConfig,
-) -> Result<ObservabilityConfig, CliError> {
-    observability_component(config)
-        .map(|component| serde_json::from_value(Value::Object(component.config.clone())))
-        .transpose()
-        .map_err(|error| CliError::Config(format!("invalid observability plugin config: {error}")))?
-        .ok_or_else(|| CliError::Config("observability plugin component is missing".into()))
+) -> Result<ComponentEditorState<ObservabilityConfig>, CliError> {
+    component_editor_state(config, OBSERVABILITY_PLUGIN_KIND, true)
 }
 
-pub(super) fn component_adaptive_config(config: &PluginConfig) -> Result<AdaptiveConfig, CliError> {
-    adaptive_component(config)
-        .map(|component| serde_json::from_value(Value::Object(component.config.clone())))
-        .transpose()
-        .map_err(|error| CliError::Config(format!("invalid adaptive plugin config: {error}")))?
-        .ok_or_else(|| CliError::Config("adaptive plugin component is missing".into()))
-}
-
-pub(super) fn config_with_components(
+pub(super) fn component_adaptive_state(
     config: &PluginConfig,
-    observability: &ObservabilityConfig,
-    adaptive: &AdaptiveConfig,
-) -> Result<PluginConfig, CliError> {
-    let mut config = config.clone();
-    store_observability_config(&mut config, observability)?;
-    store_adaptive_config(&mut config, adaptive)?;
-    Ok(config)
+) -> Result<ComponentEditorState<AdaptiveConfig>, CliError> {
+    component_editor_state(config, ADAPTIVE_PLUGIN_KIND, false)
 }
 
-pub(super) fn store_observability_config(
+pub(super) fn component_nemo_guardrails_state(
+    config: &PluginConfig,
+) -> Result<ComponentEditorState<NeMoGuardrailsConfig>, CliError> {
+    component_editor_state(config, NEMO_GUARDRAILS_PLUGIN_KIND, false)
+}
+
+pub(super) fn store_observability_state(
     config: &mut PluginConfig,
-    observability: &ObservabilityConfig,
+    state: &ComponentEditorState<ObservabilityConfig>,
 ) -> Result<(), CliError> {
-    if let Some(component) = observability_component_mut(config) {
-        merge_observability_editor_config(
-            &mut component.config,
-            observability_config_map(observability)?,
+    if state.should_store(true) {
+        store_component_editor_config(
+            config,
+            OBSERVABILITY_PLUGIN_KIND,
+            state.enabled,
+            observability_config_map(&state.config)?,
+            merge_observability_editor_config,
         );
     }
     Ok(())
 }
 
-pub(super) fn store_adaptive_config(
+pub(super) fn store_adaptive_state(
     config: &mut PluginConfig,
-    adaptive: &AdaptiveConfig,
+    state: &ComponentEditorState<AdaptiveConfig>,
 ) -> Result<(), CliError> {
-    if let Some(component) = adaptive_component_mut(config) {
-        merge_adaptive_editor_config(&mut component.config, adaptive_config_map(adaptive)?);
+    if state.should_store(true) {
+        store_component_editor_config(
+            config,
+            ADAPTIVE_PLUGIN_KIND,
+            state.enabled,
+            adaptive_config_map(&state.config)?,
+            merge_adaptive_editor_config,
+        );
     }
     Ok(())
+}
+
+pub(super) fn store_nemo_guardrails_state(
+    config: &mut PluginConfig,
+    state: &ComponentEditorState<NeMoGuardrailsConfig>,
+) -> Result<(), CliError> {
+    if state.should_store(nemo_guardrails_configured(&state.config)) {
+        store_component_editor_config(
+            config,
+            NEMO_GUARDRAILS_PLUGIN_KIND,
+            state.enabled,
+            nemo_guardrails_config_map(&state.config)?,
+            merge_nemo_guardrails_editor_config,
+        );
+    }
+    Ok(())
+}
+
+fn store_component_editor_config(
+    config: &mut PluginConfig,
+    kind: &str,
+    enabled: bool,
+    edited: Map<String, Value>,
+    merge: fn(&mut Map<String, Value>, Map<String, Value>),
+) {
+    if let Some(component) = config
+        .components
+        .iter_mut()
+        .find(|component| component.kind == kind)
+    {
+        component.enabled = enabled;
+        merge(&mut component.config, edited);
+    } else {
+        config.components.push(PluginComponentSpec {
+            kind: kind.to_string(),
+            enabled,
+            config: edited,
+        });
+    }
 }
 
 pub(super) fn ensure_section<T>(config: &mut T, section: EditorFieldSpec)
@@ -379,38 +638,6 @@ where
         .and_then(|config| config.get(field.name).cloned())
 }
 
-pub(super) fn observability_component(config: &PluginConfig) -> Option<&PluginComponentSpec> {
-    config
-        .components
-        .iter()
-        .find(|component| component.kind == OBSERVABILITY_PLUGIN_KIND)
-}
-
-pub(super) fn observability_component_mut(
-    config: &mut PluginConfig,
-) -> Option<&mut PluginComponentSpec> {
-    config
-        .components
-        .iter_mut()
-        .find(|component| component.kind == OBSERVABILITY_PLUGIN_KIND)
-}
-
-pub(super) fn adaptive_component(config: &PluginConfig) -> Option<&PluginComponentSpec> {
-    config
-        .components
-        .iter()
-        .find(|component| component.kind == ADAPTIVE_PLUGIN_KIND)
-}
-
-pub(super) fn adaptive_component_mut(
-    config: &mut PluginConfig,
-) -> Option<&mut PluginComponentSpec> {
-    config
-        .components
-        .iter_mut()
-        .find(|component| component.kind == ADAPTIVE_PLUGIN_KIND)
-}
-
 pub(super) fn ensure_object(value: &mut Value) -> &mut Map<String, Value> {
     if !value.is_object() {
         *value = json!({});
@@ -445,6 +672,23 @@ pub(super) fn adaptive_config_map(config: &AdaptiveConfig) -> Result<Map<String,
     }
 }
 
+pub(super) fn nemo_guardrails_config_map(
+    config: &NeMoGuardrailsConfig,
+) -> Result<Map<String, Value>, CliError> {
+    let value = serde_json::to_value(config).map_err(serde_error)?;
+    match value {
+        Value::Object(mut map) => {
+            if is_version_one(map.get("version")) {
+                map.remove("version");
+            }
+            Ok(map)
+        }
+        _ => Err(CliError::Config(
+            "nemo_guardrails config must serialize to an object".into(),
+        )),
+    }
+}
+
 pub(super) fn merge_observability_editor_config(
     existing: &mut Map<String, Value>,
     edited: Map<String, Value>,
@@ -469,6 +713,21 @@ pub(super) fn merge_adaptive_editor_config(
         edited,
         &nested_editor_keys(AdaptiveConfig::editor_schema()),
         AdaptiveConfig::editor_schema(),
+    );
+}
+
+pub(super) fn merge_nemo_guardrails_editor_config(
+    existing: &mut Map<String, Value>,
+    edited: Map<String, Value>,
+) {
+    if is_version_one(existing.get("version")) {
+        existing.remove("version");
+    }
+    merge_known_editor_object(
+        existing,
+        edited,
+        &nested_editor_keys(NeMoGuardrailsConfig::editor_schema()),
+        NeMoGuardrailsConfig::editor_schema(),
     );
 }
 
@@ -562,24 +821,17 @@ pub(super) fn display_value(value: &Value) -> String {
     }
 }
 
-pub(super) fn observability_summary(
-    config: &PluginConfig,
-    observability: &ObservabilityConfig,
-) -> String {
+pub(super) fn observability_summary(state: &ComponentEditorState<ObservabilityConfig>) -> String {
     let enabled_sections = ObservabilityConfig::editor_schema()
         .fields
         .iter()
         .filter(|section| section.name != POLICY_SECTION)
-        .filter(|section| section_enabled(observability, **section).unwrap_or(false))
+        .filter(|section| section_enabled(&state.config, **section).unwrap_or(false))
         .map(|section| section.label)
         .collect::<Vec<_>>();
     format!(
         "component {}, sections {}",
-        if component_enabled(config) {
-            "enabled"
-        } else {
-            "disabled"
-        },
+        if state.enabled { "enabled" } else { "disabled" },
         if enabled_sections.is_empty() {
             "none".into()
         } else {
@@ -588,21 +840,46 @@ pub(super) fn observability_summary(
     )
 }
 
-pub(super) fn adaptive_summary(config: &PluginConfig, adaptive: &AdaptiveConfig) -> String {
+pub(super) fn adaptive_summary(state: &ComponentEditorState<AdaptiveConfig>) -> String {
     let configured_fields = AdaptiveConfig::editor_schema()
         .fields
         .iter()
         .filter(|field| field.name != POLICY_SECTION)
-        .filter(|field| config_field_configured(adaptive, **field).unwrap_or(false))
+        .filter(|field| config_field_configured(&state.config, **field).unwrap_or(false))
         .map(|field| field.label)
         .collect::<Vec<_>>();
     format!(
         "component {}, fields {}",
-        if adaptive_component_enabled(config) {
-            "enabled"
+        if state.enabled { "enabled" } else { "disabled" },
+        if configured_fields.is_empty() {
+            "none".into()
         } else {
-            "disabled"
-        },
+            configured_fields.join(", ")
+        }
+    )
+}
+
+pub(super) fn nemo_guardrails_configured(config: &NeMoGuardrailsConfig) -> bool {
+    NeMoGuardrailsConfig::editor_schema()
+        .fields
+        .iter()
+        .filter(|field| field.name != POLICY_SECTION)
+        .any(|field| config_field_configured(config, *field).unwrap_or(false))
+}
+
+pub(super) fn nemo_guardrails_summary(
+    state: &ComponentEditorState<NeMoGuardrailsConfig>,
+) -> String {
+    let configured_fields = NeMoGuardrailsConfig::editor_schema()
+        .fields
+        .iter()
+        .filter(|field| field.name != POLICY_SECTION)
+        .filter(|field| config_field_configured(&state.config, **field).unwrap_or(false))
+        .map(|field| field.label)
+        .collect::<Vec<_>>();
+    format!(
+        "component {}, fields {}",
+        if state.enabled { "enabled" } else { "disabled" },
         if configured_fields.is_empty() {
             "none".into()
         } else {

--- a/crates/cli/tests/coverage/plugins_tests.rs
+++ b/crates/cli/tests/coverage/plugins_tests.rs
@@ -219,16 +219,24 @@ fn component_enablement_shortcuts_clear_and_reset_differ() {
     let config = PluginConfig::default();
     let mut components = editable_components(&config).unwrap();
 
-    components[0].set_enabled(false);
-    apply_component_enablement_shortcut(&mut components[0], MenuShortcut::Reset);
-    assert!(components[0].enabled());
+    let observability = components
+        .iter_mut()
+        .find(|component| component.label() == "Observability")
+        .unwrap();
+    observability.set_enabled(false);
+    apply_component_enablement_shortcut(observability, MenuShortcut::Reset);
+    assert!(observability.enabled());
 
-    apply_component_enablement_shortcut(&mut components[0], MenuShortcut::Clear);
-    assert!(!components[0].enabled());
+    apply_component_enablement_shortcut(observability, MenuShortcut::Clear);
+    assert!(!observability.enabled());
 
-    components[1].set_enabled(true);
-    apply_component_enablement_shortcut(&mut components[1], MenuShortcut::Reset);
-    assert!(!components[1].enabled());
+    let adaptive = components
+        .iter_mut()
+        .find(|component| component.label() == "Adaptive")
+        .unwrap();
+    adaptive.set_enabled(true);
+    apply_component_enablement_shortcut(adaptive, MenuShortcut::Reset);
+    assert!(!adaptive.enabled());
 }
 
 #[test]

--- a/crates/cli/tests/coverage/plugins_tests.rs
+++ b/crates/cli/tests/coverage/plugins_tests.rs
@@ -215,6 +215,23 @@ fn plugin_menu_builds_ordered_component_actions() {
 }
 
 #[test]
+fn component_enablement_shortcuts_clear_and_reset_differ() {
+    let config = PluginConfig::default();
+    let mut components = editable_components(&config).unwrap();
+
+    components[0].set_enabled(false);
+    apply_component_enablement_shortcut(&mut components[0], MenuShortcut::Reset);
+    assert!(components[0].enabled());
+
+    apply_component_enablement_shortcut(&mut components[0], MenuShortcut::Clear);
+    assert!(!components[0].enabled());
+
+    components[1].set_enabled(true);
+    apply_component_enablement_shortcut(&mut components[1], MenuShortcut::Reset);
+    assert!(!components[1].enabled());
+}
+
+#[test]
 fn menu_response_index_tracks_selected_and_shortcut_positions() {
     assert_eq!(menu_response_index(&MenuResponse::Selected(3)), Some(3));
     assert_eq!(
@@ -306,6 +323,37 @@ fn editor_model_reads_missing_nemo_guardrails_component_as_disabled_default() {
         "component disabled, fields none"
     );
     assert!(!guardrails.should_store(nemo_guardrails_configured(&guardrails.config)));
+}
+
+#[test]
+fn editor_save_persists_disabled_nemo_guardrails_policy_only_edits() {
+    let mut config = PluginConfig::default();
+    let mut guardrails = component_nemo_guardrails_state(&config).unwrap();
+    let policy = NeMoGuardrailsConfig::editor_schema()
+        .field("policy")
+        .unwrap();
+
+    set_section_field(
+        &mut guardrails.config,
+        policy,
+        "unknown_field",
+        json!("ignore"),
+    )
+    .unwrap();
+    guardrails.mark_config_touched();
+
+    assert!(!guardrails.enabled);
+    assert!(!nemo_guardrails_configured(&guardrails.config));
+
+    store_nemo_guardrails_state(&mut config, &guardrails).unwrap();
+
+    let component = config
+        .components
+        .iter()
+        .find(|component| component.kind == NEMO_GUARDRAILS_PLUGIN_KIND)
+        .unwrap();
+    assert!(!component.enabled);
+    assert_eq!(component.config["policy"]["unknown_field"], json!("ignore"));
 }
 
 #[test]

--- a/crates/cli/tests/coverage/plugins_tests.rs
+++ b/crates/cli/tests/coverage/plugins_tests.rs
@@ -3,8 +3,12 @@
 
 use super::*;
 use crate::config::{global_plugin_config_path, project_plugin_config_path};
-use nemo_relay::observability::plugin_component::OBSERVABILITY_PLUGIN_KIND;
+use nemo_relay::config_editor::{EditorConfig, EditorSchema};
+use nemo_relay::observability::plugin_component::{OBSERVABILITY_PLUGIN_KIND, ObservabilityConfig};
 use nemo_relay::plugin::{ConfigPolicy, PluginComponentSpec, PluginConfig};
+use nemo_relay::plugins::nemo_guardrails::component::{
+    NEMO_GUARDRAILS_PLUGIN_KIND, NeMoGuardrailsConfig, RemoteBackendConfig,
+};
 use nemo_relay_adaptive::AdaptiveConfig;
 use nemo_relay_adaptive::plugin_component::ADAPTIVE_PLUGIN_KIND;
 
@@ -25,6 +29,20 @@ fn adaptive_component_config(agent_id: &str) -> serde_json::Map<String, Value> {
             "break_chain": false,
             "inject_header": true,
             "inject_body_path": "nvext.agent_hints"
+        }
+    })
+    .as_object()
+    .unwrap()
+    .clone()
+}
+
+fn guardrails_component_config(config_id: &str) -> serde_json::Map<String, Value> {
+    json!({
+        "mode": "remote",
+        "codec": "openai_chat",
+        "remote": {
+            "endpoint": "http://localhost:8000",
+            "config_id": config_id
         }
     })
     .as_object()
@@ -115,6 +133,42 @@ fn typed_editor_model_contains_adaptive_options() {
 }
 
 #[test]
+fn typed_editor_model_contains_nemo_guardrails_options() {
+    let schema = NeMoGuardrailsConfig::editor_schema();
+    assert!(!schema.fields.iter().any(|field| field.name == "version"));
+    assert_eq!(
+        schema.field("mode").unwrap().enum_values,
+        &["remote", "local"]
+    );
+    assert_eq!(schema.field("codec").unwrap().kind, EditorFieldKind::Enum);
+    assert_eq!(
+        schema.field("input").unwrap().kind,
+        EditorFieldKind::Boolean
+    );
+    assert_eq!(
+        schema.field("priority").unwrap().kind,
+        EditorFieldKind::Integer
+    );
+
+    let remote = schema.field("remote").unwrap().schema().unwrap();
+    assert_eq!(
+        remote.field("timeout_millis").unwrap().kind,
+        EditorFieldKind::Integer
+    );
+    assert_eq!(
+        remote.field("headers").unwrap().kind,
+        EditorFieldKind::StringMap
+    );
+
+    let request_defaults = schema.field("request_defaults").unwrap().schema().unwrap();
+    let rails = request_defaults.field("rails").unwrap().schema().unwrap();
+    assert_eq!(
+        rails.field("tool_input").unwrap().kind,
+        EditorFieldKind::Json
+    );
+}
+
+#[test]
 fn plugin_menu_uses_setup_theme_markers() {
     let theme = ColorfulTheme::default();
     let lines = render_menu(
@@ -130,6 +184,34 @@ fn plugin_menu_uses_setup_theme_markers() {
     assert!(rendered.contains('❯'));
     assert!(rendered.contains("↑/↓"));
     assert!(!rendered.contains("> First"));
+}
+
+#[test]
+fn plugin_menu_builds_ordered_component_actions() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = PluginConfig::default();
+    let components = editable_components(&config).unwrap();
+
+    let (items, actions) = plugin_menu_items(&components, &temp.path().join("plugins.toml"));
+
+    assert_eq!(items.len(), actions.len());
+    assert_eq!(items[0].label, "Toggle Observability component [on]");
+    assert_eq!(items[1].label, "  Edit Observability ATOF");
+    assert!(items.iter().any(|item| {
+        item.label
+            .contains("Toggle NeMo Guardrails component [off]")
+    }));
+    assert!(matches!(actions[0], MenuAction::ToggleComponent(0)));
+    assert!(matches!(
+        actions[1],
+        MenuAction::EditField {
+            component_index: 0,
+            field_index: 0
+        }
+    ));
+    assert!(matches!(actions[actions.len() - 3], MenuAction::Preview));
+    assert!(matches!(actions[actions.len() - 2], MenuAction::Save));
+    assert!(matches!(actions[actions.len() - 1], MenuAction::Cancel));
 }
 
 #[test]
@@ -165,12 +247,24 @@ fn plugin_menu_marks_configured_sections_and_fields() {
 fn editor_model_renders_valid_observability_plugin_config() {
     let mut config = PluginConfig::default();
     ensure_observability_component(&mut config).unwrap();
-    let mut observability = component_observability_config(&config).unwrap();
+    let mut observability = component_observability_state(&config).unwrap();
     let atof = ObservabilityConfig::editor_schema().field("atof").unwrap();
-    toggle_section(&mut observability, atof);
-    set_section_field(&mut observability, atof, "output_directory", json!("logs")).unwrap();
-    set_section_field(&mut observability, atof, "filename", json!("events.jsonl")).unwrap();
-    store_observability_config(&mut config, &observability).unwrap();
+    toggle_section(&mut observability.config, atof);
+    set_section_field(
+        &mut observability.config,
+        atof,
+        "output_directory",
+        json!("logs"),
+    )
+    .unwrap();
+    set_section_field(
+        &mut observability.config,
+        atof,
+        "filename",
+        json!("events.jsonl"),
+    )
+    .unwrap();
+    store_observability_state(&mut config, &observability).unwrap();
 
     validate_config(&config).unwrap();
 }
@@ -181,11 +275,37 @@ fn editor_model_adds_disabled_adaptive_component() {
 
     ensure_adaptive_component(&mut config).unwrap();
 
-    let component = adaptive_component(&config).unwrap();
+    let component = config
+        .components
+        .iter()
+        .find(|component| component.kind == ADAPTIVE_PLUGIN_KIND)
+        .unwrap();
     assert_eq!(component.kind, ADAPTIVE_PLUGIN_KIND);
     assert!(!component.enabled);
     assert!(!component.config.contains_key("version"));
     assert!(component.config.contains_key("policy"));
+}
+
+#[test]
+fn editor_model_reads_missing_nemo_guardrails_component_as_disabled_default() {
+    let config = PluginConfig::default();
+
+    let guardrails = component_nemo_guardrails_state(&config).unwrap();
+
+    assert!(!guardrails.enabled);
+    assert!(
+        !config
+            .components
+            .iter()
+            .any(|component| component.kind == NEMO_GUARDRAILS_PLUGIN_KIND)
+    );
+    assert_eq!(guardrails.config.mode, "remote");
+    assert!(!nemo_guardrails_configured(&guardrails.config));
+    assert_eq!(
+        nemo_guardrails_summary(&guardrails),
+        "component disabled, fields none"
+    );
+    assert!(!guardrails.should_store(nemo_guardrails_configured(&guardrails.config)));
 }
 
 #[test]
@@ -246,14 +366,24 @@ fn editor_save_preserves_unknown_observability_fields() {
         }],
         ..PluginConfig::default()
     };
-    let mut observability = component_observability_config(&config).unwrap();
+    let mut observability = component_observability_state(&config).unwrap();
     let atof = ObservabilityConfig::editor_schema().field("atof").unwrap();
-    remove_section_field(&mut observability, atof, "output_directory").unwrap();
-    set_section_field(&mut observability, atof, "filename", json!("events.jsonl")).unwrap();
+    remove_section_field(&mut observability.config, atof, "output_directory").unwrap();
+    set_section_field(
+        &mut observability.config,
+        atof,
+        "filename",
+        json!("events.jsonl"),
+    )
+    .unwrap();
 
-    store_observability_config(&mut config, &observability).unwrap();
+    store_observability_state(&mut config, &observability).unwrap();
 
-    let component = observability_component(&config).unwrap();
+    let component = config
+        .components
+        .iter()
+        .find(|component| component.kind == OBSERVABILITY_PLUGIN_KIND)
+        .unwrap();
     assert_eq!(
         component.config.get("future_top_level"),
         Some(&json!("preserve"))
@@ -295,7 +425,7 @@ fn editor_save_preserves_unknown_adaptive_fields_and_all_sections() {
         }],
         ..PluginConfig::default()
     };
-    let mut adaptive = component_adaptive_config(&config).unwrap();
+    let mut adaptive = component_adaptive_state(&config).unwrap();
     let schema = AdaptiveConfig::editor_schema();
     let state = schema.field("state").unwrap();
     let telemetry = schema.field("telemetry").unwrap();
@@ -303,9 +433,9 @@ fn editor_save_preserves_unknown_adaptive_fields_and_all_sections() {
     let tool_parallelism = schema.field("tool_parallelism").unwrap();
     let acg = schema.field("acg").unwrap();
 
-    set_struct_field(&mut adaptive, "agent_id", json!("planner")).unwrap();
+    set_struct_field(&mut adaptive.config, "agent_id", json!("planner")).unwrap();
     set_section_field(
-        &mut adaptive,
+        &mut adaptive.config,
         state,
         "backend",
         json!({
@@ -318,36 +448,36 @@ fn editor_save_preserves_unknown_adaptive_fields_and_all_sections() {
     )
     .unwrap();
     set_section_field(
-        &mut adaptive,
+        &mut adaptive.config,
         telemetry,
         "learners",
         json!(["tool_parallelism", "acg"]),
     )
     .unwrap();
     set_section_field(
-        &mut adaptive,
+        &mut adaptive.config,
         telemetry,
         "subscriber_name",
         json!("adaptive"),
     )
     .unwrap();
     set_section_field(
-        &mut adaptive,
+        &mut adaptive.config,
         adaptive_hints,
         "inject_body_path",
         json!("nvext.agent_hints"),
     )
     .unwrap();
     set_section_field(
-        &mut adaptive,
+        &mut adaptive.config,
         tool_parallelism,
         "mode",
         json!("inject_hints"),
     )
     .unwrap();
-    set_section_field(&mut adaptive, acg, "provider", json!("anthropic")).unwrap();
+    set_section_field(&mut adaptive.config, acg, "provider", json!("anthropic")).unwrap();
     set_section_field(
-        &mut adaptive,
+        &mut adaptive.config,
         acg,
         "stability_thresholds",
         json!({
@@ -358,9 +488,13 @@ fn editor_save_preserves_unknown_adaptive_fields_and_all_sections() {
     )
     .unwrap();
 
-    store_adaptive_config(&mut config, &adaptive).unwrap();
+    store_adaptive_state(&mut config, &adaptive).unwrap();
 
-    let component = adaptive_component(&config).unwrap();
+    let component = config
+        .components
+        .iter()
+        .find(|component| component.kind == ADAPTIVE_PLUGIN_KIND)
+        .unwrap();
     assert!(!component.config.contains_key("version"));
     assert_eq!(
         component.config.get("future_top_level"),
@@ -388,6 +522,93 @@ fn editor_save_preserves_unknown_adaptive_fields_and_all_sections() {
         component.config["acg"]["stability_thresholds"]["stable_threshold"],
         json!(0.9)
     );
+}
+
+#[test]
+fn editor_save_preserves_unknown_nemo_guardrails_fields_and_sections() {
+    let mut config = PluginConfig {
+        components: vec![PluginComponentSpec {
+            kind: NEMO_GUARDRAILS_PLUGIN_KIND.to_string(),
+            enabled: true,
+            config: json!({
+                "version": 1,
+                "future_top_level": "preserve",
+                "mode": "remote",
+                "codec": "openai_chat",
+                "remote": {
+                    "endpoint": "http://old.example.test",
+                    "config_id": "old",
+                    "future_remote": "preserve"
+                },
+                "request_defaults": {
+                    "future_defaults": "preserve",
+                    "rails": {
+                        "input": true,
+                        "future_rails": "preserve"
+                    }
+                }
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+        }],
+        ..PluginConfig::default()
+    };
+    let mut guardrails = component_nemo_guardrails_state(&config).unwrap();
+    let schema = NeMoGuardrailsConfig::editor_schema();
+    let remote = schema.field("remote").unwrap();
+    let request_defaults = schema.field("request_defaults").unwrap();
+
+    set_struct_field(&mut guardrails.config, "codec", json!("openai_chat")).unwrap();
+    set_section_field(
+        &mut guardrails.config,
+        remote,
+        "endpoint",
+        json!("http://localhost:8000"),
+    )
+    .unwrap();
+    set_section_field(
+        &mut guardrails.config,
+        remote,
+        "config_id",
+        json!("default"),
+    )
+    .unwrap();
+    set_section_field(
+        &mut guardrails.config,
+        request_defaults,
+        "context",
+        json!({"tenant": "docs"}),
+    )
+    .unwrap();
+
+    guardrails.set_enabled(false);
+    store_nemo_guardrails_state(&mut config, &guardrails).unwrap();
+
+    let component = config
+        .components
+        .iter()
+        .find(|component| component.kind == NEMO_GUARDRAILS_PLUGIN_KIND)
+        .unwrap();
+    assert!(!component.enabled);
+    assert!(!component.config.contains_key("version"));
+    assert_eq!(
+        component.config.get("future_top_level"),
+        Some(&json!("preserve"))
+    );
+    let remote = component.config["remote"].as_object().unwrap();
+    assert_eq!(
+        remote.get("endpoint"),
+        Some(&json!("http://localhost:8000"))
+    );
+    assert_eq!(remote.get("future_remote"), Some(&json!("preserve")));
+    let request_defaults = component.config["request_defaults"].as_object().unwrap();
+    assert_eq!(
+        request_defaults.get("future_defaults"),
+        Some(&json!("preserve"))
+    );
+    assert_eq!(request_defaults["context"], json!({"tenant": "docs"}));
+    assert_eq!(request_defaults["rails"]["future_rails"], json!("preserve"));
 }
 
 #[test]
@@ -424,6 +645,48 @@ fn optional_section_without_default(name: &'static str) -> EditorFieldSpec {
         nested_schema: None,
         nested_default: None,
     }
+}
+
+fn depth_root_schema() -> &'static EditorSchema {
+    static FIELDS: [EditorFieldSpec; 1] = [EditorFieldSpec {
+        name: "middle",
+        label: "middle",
+        kind: EditorFieldKind::Section,
+        enum_values: &[],
+        optional: false,
+        nested_schema: Some(depth_middle_schema),
+        nested_default: None,
+    }];
+    static SCHEMA: EditorSchema = EditorSchema { fields: &FIELDS };
+    &SCHEMA
+}
+
+fn depth_middle_schema() -> &'static EditorSchema {
+    static FIELDS: [EditorFieldSpec; 1] = [EditorFieldSpec {
+        name: "leaf",
+        label: "leaf",
+        kind: EditorFieldKind::Section,
+        enum_values: &[],
+        optional: false,
+        nested_schema: Some(depth_leaf_schema),
+        nested_default: None,
+    }];
+    static SCHEMA: EditorSchema = EditorSchema { fields: &FIELDS };
+    &SCHEMA
+}
+
+fn depth_leaf_schema() -> &'static EditorSchema {
+    static FIELDS: [EditorFieldSpec; 1] = [EditorFieldSpec {
+        name: "name",
+        label: "name",
+        kind: EditorFieldKind::String,
+        enum_values: &[],
+        optional: false,
+        nested_schema: None,
+        nested_default: None,
+    }];
+    static SCHEMA: EditorSchema = EditorSchema { fields: &FIELDS };
+    &SCHEMA
 }
 
 #[test]
@@ -468,6 +731,70 @@ fn nested_edit_empty_optional_section_without_default_clears_field() {
 }
 
 #[test]
+fn recursive_value_defaults_flow_from_parent_objects() {
+    let middle = depth_root_schema().field("middle").unwrap();
+    let leaf = depth_middle_schema().field("leaf").unwrap();
+    let default = json!({
+        "middle": {
+            "leaf": {
+                "name": "from-parent"
+            }
+        }
+    });
+
+    let middle_default = value_field_default(Some(&default), middle).unwrap();
+    assert_eq!(
+        value_field_default(Some(&middle_default), leaf),
+        Some(json!({ "name": "from-parent" }))
+    );
+
+    let mut root_value = json!({ "middle": { "leaf": { "name": "custom" } } });
+    reset_value_field(&mut root_value, middle, Some(&default));
+    assert_eq!(root_value["middle"]["leaf"]["name"], json!("from-parent"));
+
+    let mut middle_value = json!({ "leaf": { "name": "custom" } });
+    reset_value_field(&mut middle_value, leaf, Some(&middle_default));
+    assert_eq!(middle_value["leaf"]["name"], json!("from-parent"));
+}
+
+#[test]
+fn merge_known_editor_object_recurses_through_arbitrary_section_depth() {
+    let schema = depth_root_schema();
+    let mut existing = json!({
+        "middle": {
+            "leaf": {
+                "name": "old",
+                "future_leaf": "preserve"
+            },
+            "future_middle": "preserve"
+        },
+        "future_root": "preserve"
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let edited = json!({
+        "middle": {
+            "leaf": {
+                "name": "new"
+            }
+        }
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+
+    merge_known_editor_object(&mut existing, edited, &nested_editor_keys(schema), schema);
+
+    let middle = existing.get("middle").unwrap().as_object().unwrap();
+    let leaf = middle.get("leaf").unwrap().as_object().unwrap();
+    assert_eq!(leaf.get("name"), Some(&json!("new")));
+    assert_eq!(leaf.get("future_leaf"), Some(&json!("preserve")));
+    assert_eq!(middle.get("future_middle"), Some(&json!("preserve")));
+    assert_eq!(existing.get("future_root"), Some(&json!("preserve")));
+}
+
+#[test]
 fn observability_config_field_reset_clears_optional_section() {
     let mut observability = ObservabilityConfig::default();
     let atof = ObservabilityConfig::editor_schema().field("atof").unwrap();
@@ -482,45 +809,100 @@ fn observability_config_field_reset_clears_optional_section() {
 fn adaptive_summary_tracks_component_and_configured_fields() {
     let mut config = PluginConfig::default();
     ensure_adaptive_component(&mut config).unwrap();
-    let mut adaptive = component_adaptive_config(&config).unwrap();
+    let mut adaptive = component_adaptive_state(&config).unwrap();
 
     assert_eq!(
-        adaptive_summary(&config, &adaptive),
+        adaptive_summary(&adaptive),
         "component disabled, fields none"
     );
 
-    set_adaptive_component_enabled(&mut config, true);
-    set_struct_field(&mut adaptive, "agent_id", json!("planner")).unwrap();
+    adaptive.set_enabled(true);
+    set_struct_field(&mut adaptive.config, "agent_id", json!("planner")).unwrap();
     let adaptive_hints = AdaptiveConfig::editor_schema()
         .field("adaptive_hints")
         .unwrap();
-    set_section_field(&mut adaptive, adaptive_hints, "inject_header", json!(true)).unwrap();
+    set_section_field(
+        &mut adaptive.config,
+        adaptive_hints,
+        "inject_header",
+        json!(true),
+    )
+    .unwrap();
 
     assert_eq!(
-        adaptive_summary(&config, &adaptive),
+        adaptive_summary(&adaptive),
         "component enabled, fields fallback_agent_id, adaptive_hints"
     );
+}
+
+#[test]
+fn nemo_guardrails_summary_tracks_component_and_configured_fields() {
+    let config = PluginConfig::default();
+    let mut guardrails = component_nemo_guardrails_state(&config).unwrap();
+
+    assert_eq!(
+        nemo_guardrails_summary(&guardrails),
+        "component disabled, fields none"
+    );
+
+    guardrails.set_enabled(true);
+    set_struct_field(&mut guardrails.config, "codec", json!("openai_chat")).unwrap();
+    let remote = NeMoGuardrailsConfig::editor_schema()
+        .field("remote")
+        .unwrap();
+    set_section_field(
+        &mut guardrails.config,
+        remote,
+        "endpoint",
+        json!("http://localhost:8000"),
+    )
+    .unwrap();
+
+    assert!(nemo_guardrails_configured(&guardrails.config));
+    assert_eq!(
+        nemo_guardrails_summary(&guardrails),
+        "component enabled, fields codec, remote"
+    );
+    assert!(guardrails.should_store(nemo_guardrails_configured(&guardrails.config)));
+
+    let existing = PluginConfig {
+        components: vec![PluginComponentSpec {
+            kind: NEMO_GUARDRAILS_PLUGIN_KIND.to_string(),
+            enabled: false,
+            config: guardrails_component_config("existing"),
+        }],
+        ..PluginConfig::default()
+    };
+    let mut existing = component_nemo_guardrails_state(&existing).unwrap();
+    reset_config_field(
+        &mut existing.config,
+        NeMoGuardrailsConfig::editor_schema()
+            .field("remote")
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(existing.should_store(nemo_guardrails_configured(&existing.config)));
 }
 
 #[test]
 fn component_enablement_and_summary_track_config_state() {
     let mut config = PluginConfig::default();
     ensure_observability_component(&mut config).unwrap();
-    let mut observability = component_observability_config(&config).unwrap();
+    let mut observability = component_observability_state(&config).unwrap();
 
-    assert!(component_enabled(&config));
+    assert!(observability.enabled);
     assert_eq!(
-        observability_summary(&config, &observability),
+        observability_summary(&observability),
         "component enabled, sections none"
     );
 
-    set_component_enabled(&mut config, false);
+    observability.set_enabled(false);
     let atif = ObservabilityConfig::editor_schema().field("atif").unwrap();
-    toggle_section(&mut observability, atif);
+    toggle_section(&mut observability.config, atif);
 
-    assert!(!component_enabled(&config));
+    assert!(!observability.enabled);
     assert_eq!(
-        observability_summary(&config, &observability),
+        observability_summary(&observability),
         "component disabled, sections ATIF"
     );
 }
@@ -576,15 +958,21 @@ fn write_plugin_config_prunes_defaults_and_round_trips() {
         enabled: true,
         config: adaptive_component_config("cli-roundtrip"),
     });
+    config.components.push(PluginComponentSpec {
+        kind: NEMO_GUARDRAILS_PLUGIN_KIND.to_string(),
+        enabled: false,
+        config: guardrails_component_config("cli-roundtrip"),
+    });
 
     write_plugin_config(&path, &config).unwrap();
 
     let rendered = std::fs::read_to_string(&path).unwrap();
     assert!(rendered.contains("kind = \"observability\""));
     assert!(rendered.contains("kind = \"adaptive\""));
+    assert!(rendered.contains("kind = \"nemo_guardrails\""));
     assert!(!rendered.contains("enabled = true"));
     let round_tripped = read_plugin_config(&path).unwrap();
-    assert_eq!(round_tripped.components.len(), 2);
+    assert_eq!(round_tripped.components.len(), 3);
     assert_eq!(round_tripped.components[0].kind, OBSERVABILITY_PLUGIN_KIND);
     let adaptive = round_tripped
         .components
@@ -603,6 +991,16 @@ fn write_plugin_config_prunes_defaults_and_round_trips() {
     assert_eq!(
         adaptive_hints.get("inject_body_path"),
         Some(&json!("nvext.agent_hints"))
+    );
+    let guardrails = round_tripped
+        .components
+        .iter()
+        .find(|component| component.kind == NEMO_GUARDRAILS_PLUGIN_KIND)
+        .unwrap();
+    assert!(!guardrails.enabled);
+    assert_eq!(
+        guardrails.config["remote"]["config_id"],
+        json!("cli-roundtrip")
     );
 }
 
@@ -667,6 +1065,38 @@ fn validate_config_accepts_adaptive_component() {
     };
 
     validate_config(&config).unwrap();
+}
+
+#[test]
+fn validate_config_accepts_nemo_guardrails_component() {
+    let config = PluginConfig {
+        components: vec![PluginComponentSpec {
+            kind: NEMO_GUARDRAILS_PLUGIN_KIND.to_string(),
+            enabled: true,
+            config: guardrails_component_config("cli-validation"),
+        }],
+        ..PluginConfig::default()
+    };
+
+    validate_config(&config).unwrap();
+}
+
+#[test]
+fn nemo_guardrails_config_map_prunes_default_version() {
+    let map = nemo_guardrails_config_map(&NeMoGuardrailsConfig {
+        codec: Some("openai_chat".into()),
+        remote: Some(RemoteBackendConfig {
+            endpoint: Some("http://localhost:8000".into()),
+            config_id: Some("default".into()),
+            ..RemoteBackendConfig::default()
+        }),
+        ..NeMoGuardrailsConfig::default()
+    })
+    .unwrap();
+
+    assert!(!map.contains_key("version"));
+    assert_eq!(map.get("codec"), Some(&json!("openai_chat")));
+    assert_eq!(map["remote"]["config_id"], json!("default"));
 }
 
 #[test]


### PR DESCRIPTION
#### Overview

Adds first-class NeMo Guardrails support to the CLI plugin editor and generalizes the editor state so supported plugin components share one menu/action path.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Enables the CLI `nemo-relay` dependency with the `guardrails-remote` feature so the Guardrails plugin component is available by default.
- Adds NeMo Guardrails to `plugins edit` through shared `ComponentEditorState` and `EditableComponent` handling for Observability, Adaptive, and Guardrails.
- Preserves unknown component fields while editing known schema fields, including nested Guardrails sections.
- Tightens nested section default handling so recursive value editing can carry defaults through arbitrary schema depth.
- Adds focused plugin editor tests for Guardrails schema/menu support, config persistence, validation, and recursive depth behavior.

#### Where should the reviewer start?

Start with `crates/cli/src/plugins/editor_model.rs` for the shared component state model, then `crates/cli/tests/coverage/plugins_tests.rs` for the Guardrails and recursive-depth coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive CLI now supports NeMo Guardrails configuration, including remote-mode settings and persistence.

* **Refactor**
  * Plugin editor unified into a component-driven model for Observability, Adaptive, and Guardrails.
  * Improved default handling, reset/clear behavior, enablement shortcuts, preview and save workflows.

* **Tests**
  * Expanded test coverage for Guardrails, editor merging, enablement summaries, and config round-trips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->