### PR TITLE
refactor: reduce sonar cognitive complexity

### DIFF
--- a/crates/cli/src/plugins.rs
+++ b/crates/cli/src/plugins.rs
@@ -14,6 +14,7 @@ use console::{Key, Term, style};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Input, Select};
 use nemo_relay::config_editor::{EditorFieldKind, EditorFieldSpec};
+use nemo_relay::plugin::PluginConfig;
 use serde_json::{Value, json};
 
 use crate::config::PluginsEditCommand;
@@ -39,6 +40,12 @@ enum MenuResponse {
     Selected(usize),
     Shortcut(MenuShortcut, usize),
     Cancel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EditLoopControl {
+    Continue,
+    Finish,
 }
 
 #[derive(Debug)]
@@ -107,82 +114,152 @@ pub(crate) fn edit(command: PluginsEditCommand) -> Result<(), CliError> {
         if let Some(selected) = menu_response_index(&selection) {
             selected_index = selected;
         }
-        match selection {
-            MenuResponse::Selected(selection) => match actions.get(selection).copied() {
-                Some(MenuAction::ToggleComponent(component_index)) => {
-                    if let Some(component) = components.get_mut(component_index) {
-                        component.toggle_enabled();
-                    }
-                }
-                Some(MenuAction::EditField {
-                    component_index,
-                    field_index,
-                }) => {
-                    if let Some(component) = components.get_mut(component_index)
-                        && let Some(field) = component.fields().get(field_index)
-                    {
-                        edit_component_field(&theme, component, *field)?;
-                    }
-                }
-                Some(MenuAction::Preview) => {
-                    let preview_config = config_with_editable_components(&config, &components)?;
-                    print_preview(&preview_config)?;
-                }
-                Some(MenuAction::Save) => {
-                    store_editable_components(&mut config, &components)?;
-                    validate_config(&config)?;
-                    write_plugin_config(&path, &config)?;
-                    print_save_success(&path);
-                    return Ok(());
-                }
-                Some(MenuAction::Cancel) | None => {
-                    return Err(CliError::Config(
-                        "plugin edit cancelled; no config saved".into(),
-                    ));
-                }
-            },
-            MenuResponse::Shortcut(MenuShortcut::Preview, _) => {
-                let preview_config = config_with_editable_components(&config, &components)?;
-                print_preview(&preview_config)?;
-            }
-            MenuResponse::Shortcut(MenuShortcut::Save, _) => {
-                store_editable_components(&mut config, &components)?;
-                validate_config(&config)?;
-                write_plugin_config(&path, &config)?;
-                print_save_success(&path);
-                return Ok(());
-            }
-            MenuResponse::Shortcut(MenuShortcut::Help, _) => print_editor_help(),
-            MenuResponse::Shortcut(
-                shortcut @ (MenuShortcut::Reset | MenuShortcut::Clear),
-                selected,
-            ) => match actions.get(selected).copied() {
-                Some(MenuAction::ToggleComponent(component_index)) => {
-                    if let Some(component) = components.get_mut(component_index) {
-                        apply_component_enablement_shortcut(component, shortcut);
-                    }
-                }
-                Some(MenuAction::EditField {
-                    component_index,
-                    field_index,
-                }) => {
-                    if let Some(component) = components.get_mut(component_index)
-                        && let Some(field) = component.fields().get(field_index)
-                    {
-                        component.reset_field(*field)?;
-                    }
-                }
-                _ => {
-                    println!("  Select a component or editable field to reset or clear.");
-                }
-            },
-            MenuResponse::Cancel => {
-                return Err(CliError::Config(
-                    "plugin edit cancelled; no config saved".into(),
-                ));
-            }
+        if handle_menu_response(
+            &theme,
+            &path,
+            &mut config,
+            &mut components,
+            &actions,
+            selection,
+        )? == EditLoopControl::Finish
+        {
+            return Ok(());
         }
     }
+}
+
+fn handle_menu_response(
+    theme: &ColorfulTheme,
+    path: &Path,
+    config: &mut PluginConfig,
+    components: &mut [EditableComponent],
+    actions: &[MenuAction],
+    selection: MenuResponse,
+) -> Result<EditLoopControl, CliError> {
+    match selection {
+        MenuResponse::Selected(selection) => handle_menu_action(
+            theme,
+            path,
+            config,
+            components,
+            actions.get(selection).copied(),
+        ),
+        MenuResponse::Shortcut(MenuShortcut::Preview, _) => {
+            preview_components(config, components)?;
+            Ok(EditLoopControl::Continue)
+        }
+        MenuResponse::Shortcut(MenuShortcut::Save, _) => save_components(path, config, components),
+        MenuResponse::Shortcut(MenuShortcut::Help, _) => {
+            print_editor_help();
+            Ok(EditLoopControl::Continue)
+        }
+        MenuResponse::Shortcut(
+            shortcut @ (MenuShortcut::Reset | MenuShortcut::Clear),
+            selected,
+        ) => handle_reset_or_clear_shortcut(components, actions.get(selected).copied(), shortcut),
+        MenuResponse::Cancel => Err(cancelled_error()),
+    }
+}
+
+fn handle_menu_action(
+    theme: &ColorfulTheme,
+    path: &Path,
+    config: &mut PluginConfig,
+    components: &mut [EditableComponent],
+    action: Option<MenuAction>,
+) -> Result<EditLoopControl, CliError> {
+    match action {
+        Some(MenuAction::ToggleComponent(component_index)) => {
+            if let Some(component) = components.get_mut(component_index) {
+                component.toggle_enabled();
+            }
+            Ok(EditLoopControl::Continue)
+        }
+        Some(MenuAction::EditField {
+            component_index,
+            field_index,
+        }) => {
+            edit_selected_component_field(theme, components, component_index, field_index)?;
+            Ok(EditLoopControl::Continue)
+        }
+        Some(MenuAction::Preview) => {
+            preview_components(config, components)?;
+            Ok(EditLoopControl::Continue)
+        }
+        Some(MenuAction::Save) => save_components(path, config, components),
+        Some(MenuAction::Cancel) | None => Err(cancelled_error()),
+    }
+}
+
+fn edit_selected_component_field(
+    theme: &ColorfulTheme,
+    components: &mut [EditableComponent],
+    component_index: usize,
+    field_index: usize,
+) -> Result<(), CliError> {
+    if let Some(component) = components.get_mut(component_index)
+        && let Some(field) = component.fields().get(field_index)
+    {
+        edit_component_field(theme, component, *field)?;
+    }
+    Ok(())
+}
+
+fn preview_components(
+    config: &PluginConfig,
+    components: &[EditableComponent],
+) -> Result<(), CliError> {
+    let preview_config = config_with_editable_components(config, components)?;
+    print_preview(&preview_config)
+}
+
+fn save_components(
+    path: &Path,
+    config: &mut PluginConfig,
+    components: &[EditableComponent],
+) -> Result<EditLoopControl, CliError> {
+    store_editable_components(config, components)?;
+    validate_config(config)?;
+    write_plugin_config(path, config)?;
+    print_save_success(path);
+    Ok(EditLoopControl::Finish)
+}
+
+fn handle_reset_or_clear_shortcut(
+    components: &mut [EditableComponent],
+    action: Option<MenuAction>,
+    shortcut: MenuShortcut,
+) -> Result<EditLoopControl, CliError> {
+    match action {
+        Some(MenuAction::ToggleComponent(component_index)) => {
+            if let Some(component) = components.get_mut(component_index) {
+                apply_component_enablement_shortcut(component, shortcut);
+            }
+        }
+        Some(MenuAction::EditField {
+            component_index,
+            field_index,
+        }) => reset_selected_component_field(components, component_index, field_index)?,
+        _ => println!("  Select a component or editable field to reset or clear."),
+    }
+    Ok(EditLoopControl::Continue)
+}
+
+fn reset_selected_component_field(
+    components: &mut [EditableComponent],
+    component_index: usize,
+    field_index: usize,
+) -> Result<(), CliError> {
+    if let Some(component) = components.get_mut(component_index)
+        && let Some(field) = component.fields().get(field_index)
+    {
+        component.reset_field(*field)?;
+    }
+    Ok(())
+}
+
+fn cancelled_error() -> CliError {
+    CliError::Config("plugin edit cancelled; no config saved".into())
 }
 
 fn edit_component_field(

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -277,27 +277,11 @@ impl SessionManager {
                 continue;
             }
 
-            let mut event = alignment_state.route_event(event);
-            let explicit_subagent_alias = alignment::explicit_subagent_alias(&mut event);
-            let session_id = event.session_id().to_string();
-            let is_agent_started = matches!(&event, NormalizedEvent::AgentStarted(_));
-            if event.is_terminal() && !sessions.contains_key(&session_id) {
+            let Some((event, session_id, is_agent_started)) =
+                route_event_for_session(event, &mut sessions, &mut alignment_state)
+            else {
                 continue;
-            }
-            if let Some((child_session_id, alias)) = explicit_subagent_alias {
-                if sessions
-                    .get(&child_session_id)
-                    .is_none_or(|session| session.can_reparent_as_subagent_alias())
-                {
-                    sessions.remove(&child_session_id);
-                    alignment_state.insert_alias(child_session_id, alias);
-                    alignment_state.align_explicit_subagent_end(&mut event);
-                } else {
-                    continue;
-                }
-            } else {
-                alignment_state.align_explicit_subagent_end(&mut event);
-            }
+            };
             let event_kind = event_agent_kind(&event);
             let should_remove_session = apply_event_to_session(
                 &mut sessions,
@@ -754,6 +738,53 @@ async fn close_idle_sessions_from_parts(
         }
     }
     first_error.map_or(Ok(closed_turns), Err)
+}
+
+fn route_event_for_session(
+    event: NormalizedEvent,
+    sessions: &mut HashMap<String, Session>,
+    alignment_state: &mut SessionAlignmentState,
+) -> Option<(NormalizedEvent, String, bool)> {
+    let mut event = alignment_state.route_event(event);
+    let explicit_subagent_alias = alignment::explicit_subagent_alias(&mut event);
+    let session_id = event.session_id().to_string();
+    let is_agent_started = matches!(&event, NormalizedEvent::AgentStarted(_));
+
+    if event.is_terminal() && !sessions.contains_key(&session_id) {
+        return None;
+    }
+    if !apply_explicit_subagent_alias(
+        &mut event,
+        sessions,
+        alignment_state,
+        explicit_subagent_alias,
+    ) {
+        return None;
+    }
+    Some((event, session_id, is_agent_started))
+}
+
+fn apply_explicit_subagent_alias(
+    event: &mut NormalizedEvent,
+    sessions: &mut HashMap<String, Session>,
+    alignment_state: &mut SessionAlignmentState,
+    explicit_subagent_alias: Option<(String, SessionAlias)>,
+) -> bool {
+    let Some((child_session_id, alias)) = explicit_subagent_alias else {
+        alignment_state.align_explicit_subagent_end(event);
+        return true;
+    };
+
+    if sessions
+        .get(&child_session_id)
+        .is_some_and(|session| !session.can_reparent_as_subagent_alias())
+    {
+        return false;
+    }
+    sessions.remove(&child_session_id);
+    alignment_state.insert_alias(child_session_id, alias);
+    alignment_state.align_explicit_subagent_end(event);
+    true
 }
 
 impl Session {

--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -1753,99 +1753,15 @@ struct AgentScopeTree {
     agent_uuids: HashSet<Uuid>,
 }
 
+type AgentScopeRoles = HashMap<Uuid, Option<String>>;
+
 impl AgentScopeTree {
     fn from_events(events: &[&Event]) -> Self {
-        let mut scope_parent_map = HashMap::new();
-        let mut agent_scope_roles = HashMap::new();
-
-        for event in events {
-            if is_start_event(event) {
-                if let Some(parent_uuid) = event.parent_uuid() {
-                    scope_parent_map.insert(event.uuid(), parent_uuid);
-                }
-                if event.scope_type() == Some(crate::api::scope::ScopeType::Agent) {
-                    agent_scope_roles
-                        .insert(event.uuid(), agent_scope_role(event).map(str::to_string));
-                }
-            }
-        }
-
-        let mut agent_uuids = HashSet::new();
-        for event in events {
-            if !is_start_event(event)
-                || event.scope_type() != Some(crate::api::scope::ScopeType::Agent)
-            {
-                continue;
-            }
-            if agent_scope_role(event) == Some("turn")
-                && nearest_non_turn_agent_parent(
-                    event.parent_uuid(),
-                    &scope_parent_map,
-                    &agent_scope_roles,
-                    Some(event.uuid()),
-                )
-                .is_some()
-            {
-                continue;
-            }
-            agent_uuids.insert(event.uuid());
-        }
-
-        let mut nodes = HashMap::new();
-        for event in events {
-            if !is_start_event(event)
-                || event.scope_type() != Some(crate::api::scope::ScopeType::Agent)
-                || !agent_uuids.contains(&event.uuid())
-            {
-                continue;
-            }
-            let parent_agent = nearest_agent_parent(
-                event.parent_uuid(),
-                &scope_parent_map,
-                &agent_uuids,
-                Some(event.uuid()),
-            );
-            nodes.insert(
-                event.uuid(),
-                AgentScopeNode {
-                    uuid: event.uuid(),
-                    name: event.name().to_string(),
-                    session_id: event
-                        .metadata()
-                        .and_then(|metadata| metadata.get("session_id"))
-                        .and_then(Json::as_str)
-                        .map(ToString::to_string),
-                    referenced_by_parent: is_subagent_reference_event(event),
-                    parent_agent,
-                    children: Vec::new(),
-                    start_timestamp: *event.timestamp(),
-                },
-            );
-        }
-
-        let mut child_links = Vec::new();
-        let mut roots = Vec::new();
-        for node in nodes.values() {
-            if let Some(parent_agent) = node.parent_agent {
-                child_links.push((parent_agent, node.uuid));
-            } else {
-                roots.push(node.uuid);
-            }
-        }
-        for (parent_agent, child) in child_links {
-            if let Some(parent) = nodes.get_mut(&parent_agent) {
-                parent.children.push(child);
-            }
-        }
-        let start_timestamps = nodes
-            .iter()
-            .map(|(uuid, node)| (*uuid, node.start_timestamp))
-            .collect::<HashMap<_, _>>();
-        roots.sort_by_key(|uuid| start_timestamps.get(uuid).copied());
-        for node in nodes.values_mut() {
-            node.children
-                .sort_by_key(|uuid| start_timestamps.get(uuid).copied());
-        }
+        let (scope_parent_map, agent_scope_roles) = agent_scope_maps(events);
+        let agent_uuids = agent_uuids_from_events(events, &scope_parent_map, &agent_scope_roles);
+        let mut nodes = agent_scope_nodes(events, &scope_parent_map, &agent_uuids);
+        let mut roots = link_agent_children(&mut nodes);
+        sort_agent_tree(&mut roots, &mut nodes);
 
         Self {
             nodes,
@@ -1881,6 +1797,128 @@ impl AgentScopeTree {
         }
         let child = self.nodes.get(&event.uuid())?;
         (child.parent_agent == Some(parent)).then_some(child)
+    }
+}
+
+fn agent_scope_maps(events: &[&Event]) -> (HashMap<Uuid, Uuid>, AgentScopeRoles) {
+    let mut scope_parent_map = HashMap::new();
+    let mut agent_scope_roles = HashMap::new();
+
+    for event in events.iter().copied().filter(|event| is_start_event(event)) {
+        if let Some(parent_uuid) = event.parent_uuid() {
+            scope_parent_map.insert(event.uuid(), parent_uuid);
+        }
+        if event.scope_type() == Some(crate::api::scope::ScopeType::Agent) {
+            agent_scope_roles.insert(event.uuid(), agent_scope_role(event).map(str::to_string));
+        }
+    }
+    (scope_parent_map, agent_scope_roles)
+}
+
+fn agent_uuids_from_events(
+    events: &[&Event],
+    scope_parent_map: &HashMap<Uuid, Uuid>,
+    agent_scope_roles: &AgentScopeRoles,
+) -> HashSet<Uuid> {
+    events
+        .iter()
+        .copied()
+        .filter(|event| should_include_agent_scope(event, scope_parent_map, agent_scope_roles))
+        .map(Event::uuid)
+        .collect()
+}
+
+fn should_include_agent_scope(
+    event: &Event,
+    scope_parent_map: &HashMap<Uuid, Uuid>,
+    agent_scope_roles: &AgentScopeRoles,
+) -> bool {
+    if !is_start_event(event) || event.scope_type() != Some(crate::api::scope::ScopeType::Agent) {
+        return false;
+    }
+    agent_scope_role(event) != Some("turn")
+        || nearest_non_turn_agent_parent(
+            event.parent_uuid(),
+            scope_parent_map,
+            agent_scope_roles,
+            Some(event.uuid()),
+        )
+        .is_none()
+}
+
+fn agent_scope_nodes(
+    events: &[&Event],
+    scope_parent_map: &HashMap<Uuid, Uuid>,
+    agent_uuids: &HashSet<Uuid>,
+) -> HashMap<Uuid, AgentScopeNode> {
+    events
+        .iter()
+        .copied()
+        .filter(|event| is_included_agent_scope(event, agent_uuids))
+        .map(|event| {
+            let uuid = event.uuid();
+            (
+                uuid,
+                AgentScopeNode {
+                    uuid,
+                    name: event.name().to_string(),
+                    session_id: agent_session_id(event),
+                    referenced_by_parent: is_subagent_reference_event(event),
+                    parent_agent: nearest_agent_parent(
+                        event.parent_uuid(),
+                        scope_parent_map,
+                        agent_uuids,
+                        Some(uuid),
+                    ),
+                    children: Vec::new(),
+                    start_timestamp: *event.timestamp(),
+                },
+            )
+        })
+        .collect()
+}
+
+fn is_included_agent_scope(event: &Event, agent_uuids: &HashSet<Uuid>) -> bool {
+    is_start_event(event)
+        && event.scope_type() == Some(crate::api::scope::ScopeType::Agent)
+        && agent_uuids.contains(&event.uuid())
+}
+
+fn agent_session_id(event: &Event) -> Option<String> {
+    event
+        .metadata()
+        .and_then(|metadata| metadata.get("session_id"))
+        .and_then(Json::as_str)
+        .map(ToString::to_string)
+}
+
+fn link_agent_children(nodes: &mut HashMap<Uuid, AgentScopeNode>) -> Vec<Uuid> {
+    let mut child_links = Vec::new();
+    let mut roots = Vec::new();
+    for node in nodes.values() {
+        if let Some(parent_agent) = node.parent_agent {
+            child_links.push((parent_agent, node.uuid));
+        } else {
+            roots.push(node.uuid);
+        }
+    }
+    for (parent_agent, child) in child_links {
+        if let Some(parent) = nodes.get_mut(&parent_agent) {
+            parent.children.push(child);
+        }
+    }
+    roots
+}
+
+fn sort_agent_tree(roots: &mut [Uuid], nodes: &mut HashMap<Uuid, AgentScopeNode>) {
+    let start_timestamps = nodes
+        .iter()
+        .map(|(uuid, node)| (*uuid, node.start_timestamp))
+        .collect::<HashMap<_, _>>();
+    roots.sort_by_key(|uuid| start_timestamps.get(uuid).copied());
+    for node in nodes.values_mut() {
+        node.children
+            .sort_by_key(|uuid| start_timestamps.get(uuid).copied());
     }
 }
 

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -264,59 +264,14 @@ fn assert_atif_v17_shape(trajectory: &AtifTrajectory) {
         .collect();
 
     for (index, step) in trajectory.steps.iter().enumerate() {
-        assert_eq!(step.step_id, index + 1);
-        assert!(
-            matches!(step.source.as_str(), "system" | "user" | "agent"),
-            "invalid source {}",
-            step.source
+        assert_atif_step_shape(step, index);
+        let step_tool_call_ids = assert_atif_step_tool_calls(step);
+        assert_atif_step_observation_refs(
+            step,
+            &step_tool_call_ids,
+            &embedded_child_ids,
+            trajectory.subagent_trajectories.is_some(),
         );
-        assert_atif_message_value(&step.message);
-        if let Some(llm_call_count) = step.llm_call_count {
-            assert_eq!(step.source, "agent");
-            if llm_call_count == 0 {
-                assert!(step.metrics.is_none());
-                assert!(step.reasoning_content.is_none());
-            }
-        }
-        let step_tool_call_ids: HashSet<&str> = step
-            .tool_calls
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .map(|tool_call| {
-                assert!(!tool_call.tool_call_id.is_empty());
-                assert!(!tool_call.function_name.is_empty());
-                assert!(tool_call.arguments.is_object());
-                tool_call.tool_call_id.as_str()
-            })
-            .collect();
-        if let Some(observation) = &step.observation {
-            for result in &observation.results {
-                if let Some(content) = &result.content {
-                    assert_atif_message_value(content);
-                }
-                if let Some(source_call_id) = result.source_call_id.as_deref() {
-                    assert!(
-                        step_tool_call_ids.contains(source_call_id),
-                        "unmatched source_call_id {source_call_id}"
-                    );
-                }
-                for reference in result
-                    .subagent_trajectory_ref
-                    .as_deref()
-                    .unwrap_or_default()
-                {
-                    if let Some(trajectory_id) = reference.trajectory_id.as_deref()
-                        && trajectory.subagent_trajectories.is_some()
-                    {
-                        assert!(
-                            embedded_child_ids.contains(trajectory_id),
-                            "unresolved embedded subagent reference {trajectory_id}"
-                        );
-                    }
-                }
-            }
-        }
     }
 
     for child in trajectory
@@ -325,6 +280,95 @@ fn assert_atif_v17_shape(trajectory: &AtifTrajectory) {
         .unwrap_or_default()
     {
         assert_atif_v17_shape(child);
+    }
+}
+
+fn assert_atif_step_shape(step: &AtifStep, index: usize) {
+    assert_eq!(step.step_id, index + 1);
+    assert!(
+        matches!(step.source.as_str(), "system" | "user" | "agent"),
+        "invalid source {}",
+        step.source
+    );
+    assert_atif_message_value(&step.message);
+    if let Some(llm_call_count) = step.llm_call_count {
+        assert_eq!(step.source, "agent");
+        if llm_call_count == 0 {
+            assert!(step.metrics.is_none());
+            assert!(step.reasoning_content.is_none());
+        }
+    }
+}
+
+fn assert_atif_step_tool_calls(step: &AtifStep) -> HashSet<&str> {
+    step.tool_calls
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|tool_call| {
+            assert!(!tool_call.tool_call_id.is_empty());
+            assert!(!tool_call.function_name.is_empty());
+            assert!(tool_call.arguments.is_object());
+            tool_call.tool_call_id.as_str()
+        })
+        .collect()
+}
+
+fn assert_atif_step_observation_refs(
+    step: &AtifStep,
+    step_tool_call_ids: &HashSet<&str>,
+    embedded_child_ids: &HashSet<&str>,
+    has_embedded_children: bool,
+) {
+    let Some(observation) = &step.observation else {
+        return;
+    };
+    for result in &observation.results {
+        assert_atif_observation_result_refs(
+            result,
+            step_tool_call_ids,
+            embedded_child_ids,
+            has_embedded_children,
+        );
+    }
+}
+
+fn assert_atif_observation_result_refs(
+    result: &AtifObservationResult,
+    step_tool_call_ids: &HashSet<&str>,
+    embedded_child_ids: &HashSet<&str>,
+    has_embedded_children: bool,
+) {
+    if let Some(content) = &result.content {
+        assert_atif_message_value(content);
+    }
+    if let Some(source_call_id) = result.source_call_id.as_deref() {
+        assert!(
+            step_tool_call_ids.contains(source_call_id),
+            "unmatched source_call_id {source_call_id}"
+        );
+    }
+    assert_atif_subagent_refs(result, embedded_child_ids, has_embedded_children);
+}
+
+fn assert_atif_subagent_refs(
+    result: &AtifObservationResult,
+    embedded_child_ids: &HashSet<&str>,
+    has_embedded_children: bool,
+) {
+    for reference in result
+        .subagent_trajectory_ref
+        .as_deref()
+        .unwrap_or_default()
+    {
+        if let Some(trajectory_id) = reference.trajectory_id.as_deref()
+            && has_embedded_children
+        {
+            assert!(
+                embedded_child_ids.contains(trajectory_id),
+                "unresolved embedded subagent reference {trajectory_id}"
+            );
+        }
     }
 }
 

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -58,6 +58,28 @@ func TestObservabilityPluginAtofAndAtifFiles(t *testing.T) {
 		requireNoError(t, ClearPluginConfiguration(), ClearPluginConfigurationFailed)
 	})
 	dir := t.TempDir()
+	config := NewAtofAndAtifTestConfig(dir)
+	pluginConfig := PluginConfig{Version: 1, Components: []PluginComponentSpec{ObservabilityComponent(config)}}
+
+	if report, err := ValidatePluginConfig(pluginConfig); err != nil {
+		t.Fatalf("ValidatePluginConfig failed: %v", err)
+	} else if len(report.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", report.Diagnostics)
+	}
+	if _, err := InitializePlugins(pluginConfig); err != nil {
+		t.Fatalf(fatalErrorFormat, InitializePluginsFailed, err)
+	}
+
+	handle := EmitObservabilityTestTrajectory(t)
+	if err := ClearPluginConfiguration(); err != nil {
+		t.Fatalf(fatalErrorFormat, ClearPluginConfigurationFailed, err)
+	}
+
+	AssertAtofRecordCount(t, filepath.Join(dir, eventsJSONLFilename), 3)
+	AssertAtifAgentMetadata(t, TrajectoryFilePath(dir, handle))
+}
+
+func NewAtofAndAtifTestConfig(dir string) ObservabilityConfig {
 	config := NewObservabilityConfig()
 	atof := NewObservabilityAtofConfig()
 	atof.Enabled = true
@@ -65,6 +87,7 @@ func TestObservabilityPluginAtofAndAtifFiles(t *testing.T) {
 	atof.Filename = eventsJSONLFilename
 	atof.Mode = "overwrite"
 	config.Atof = &atof
+
 	atif := NewObservabilityAtifConfig()
 	atif.Enabled = true
 	atif.AgentName = "go-agent"
@@ -75,40 +98,32 @@ func TestObservabilityPluginAtofAndAtifFiles(t *testing.T) {
 	atif.OutputDirectory = dir
 	atif.FilenameTemplate = TrajectoryFilenamePrefix + "{session_id}.json"
 	config.Atif = &atif
+	return config
+}
 
-	if report, err := ValidatePluginConfig(PluginConfig{Version: 1, Components: []PluginComponentSpec{ObservabilityComponent(config)}}); err != nil {
-		t.Fatalf("ValidatePluginConfig failed: %v", err)
-	} else if len(report.Diagnostics) != 0 {
-		t.Fatalf("unexpected diagnostics: %#v", report.Diagnostics)
-	}
-	if _, err := InitializePlugins(PluginConfig{Version: 1, Components: []PluginComponentSpec{ObservabilityComponent(config)}}); err != nil {
-		t.Fatalf(fatalErrorFormat, InitializePluginsFailed, err)
-	}
-
+func EmitObservabilityTestTrajectory(t *testing.T) *ScopeHandle {
+	t.Helper()
 	var handle *ScopeHandle
 	runWithTestScopeStack(t, func() {
 		var err error
 		handle, err = PushScope("go-observability-agent", ScopeTypeAgent, WithInput(json.RawMessage(`{"agent":true}`)))
-		if err != nil {
-			t.Fatalf("PushScope failed: %v", err)
-		}
-		if err := EmitEvent("go-mark", WithEventParent(handle), WithEventData(json.RawMessage(`{"step":1}`))); err != nil {
-			t.Fatalf("EmitEvent failed: %v", err)
-		}
-		if err := PopScope(handle, WithOutput(json.RawMessage(`{"done":true}`))); err != nil {
-			t.Fatalf("PopScope failed: %v", err)
-		}
+		requireNoError(t, err, "PushScope failed")
+		requireNoError(t, EmitEvent("go-mark", WithEventParent(handle), WithEventData(json.RawMessage(`{"step":1}`))), "EmitEvent failed")
+		requireNoError(t, PopScope(handle, WithOutput(json.RawMessage(`{"done":true}`))), "PopScope failed")
 	})
-	if err := ClearPluginConfiguration(); err != nil {
-		t.Fatalf(fatalErrorFormat, ClearPluginConfigurationFailed, err)
-	}
+	return handle
+}
 
-	jsonl := string(mustReadFile(t, filepath.Join(dir, eventsJSONLFilename)))
-	if got := strings.Count(strings.TrimSpace(jsonl), "\n") + 1; got != 3 {
-		t.Fatalf("expected 3 JSONL records, got %d: %s", got, jsonl)
+func AssertAtofRecordCount(t *testing.T, path string, want int) {
+	t.Helper()
+	jsonl := string(mustReadFile(t, path))
+	if got := strings.Count(strings.TrimSpace(jsonl), "\n") + 1; got != want {
+		t.Fatalf("expected %d JSONL records, got %d: %s", want, got, jsonl)
 	}
+}
 
-	trajectoryPath := TrajectoryFilePath(dir, handle)
+func AssertAtifAgentMetadata(t *testing.T, trajectoryPath string) {
+	t.Helper()
 	var trajectory map[string]any
 	if err := json.Unmarshal(mustReadFile(t, trajectoryPath), &trajectory); err != nil {
 		t.Fatalf("failed to read trajectory: %v", err)

--- a/go/nemo_relay/openinference_test.go
+++ b/go/nemo_relay/openinference_test.go
@@ -13,6 +13,12 @@ import (
 	"time"
 )
 
+type otelRequest struct {
+	Path        string
+	ContentType string
+	Body        []byte
+}
+
 func TestNewOpenInferenceConfigDefaults(t *testing.T) {
 	config := NewOpenInferenceConfig()
 
@@ -82,14 +88,28 @@ func TestOpenInferenceSubscriberRejectsInvalidTransport(t *testing.T) {
 }
 
 func TestOpenInferenceSubscriberExportsScopeLifecycleAndMarks(t *testing.T) {
-	type otelRequest struct {
-		Path        string
-		ContentType string
-		Body        []byte
+	requests := make(chan otelRequest, 4)
+	server := NewOtelTestServer(t, requests)
+	defer server.Close()
+
+	subscriber := NewRegisteredOpenInferenceSubscriber(t, server.URL+"/v1/traces")
+	defer subscriber.Close()
+	EmitOpenInferenceScopeLifecycle(t)
+	if err := subscriber.ForceFlush(); err != nil {
+		t.Fatalf("ForceFlush failed: %v", err)
 	}
 
-	requests := make(chan otelRequest, 4)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	select {
+	case request := <-requests:
+		AssertOpenInferenceRequest(t, request)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for OTLP request")
+	}
+}
+
+func NewOtelTestServer(t *testing.T, requests chan<- otelRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("read request body: %v", err)
@@ -101,67 +121,67 @@ func TestOpenInferenceSubscriberExportsScopeLifecycleAndMarks(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer server.Close()
+}
 
+func NewRegisteredOpenInferenceSubscriber(t *testing.T, endpoint string) *OpenInferenceSubscriber {
+	t.Helper()
 	config := NewOpenInferenceConfig()
-	config.Endpoint = server.URL + "/v1/traces"
+	config.Endpoint = endpoint
 	config.ServiceName = "go-agent"
 
 	subscriber, err := NewOpenInferenceSubscriber(config)
 	if err != nil {
 		t.Fatalf("NewOpenInferenceSubscriber failed: %v", err)
 	}
-	defer subscriber.Close()
-
 	name := "go_openinference_e2e_" + time.Now().Format("150405.000000")
 	if err := subscriber.Register(name); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
-	defer func() { _ = subscriber.Deregister(name) }()
+	t.Cleanup(func() { _ = subscriber.Deregister(name) })
+	return subscriber
+}
 
+func EmitOpenInferenceScopeLifecycle(t *testing.T) {
+	t.Helper()
 	runWithTestScopeStack(t, func() {
 		handle, err := PushScope("openinference_scope", ScopeTypeAgent)
 		if err != nil {
 			t.Fatalf("PushScope failed: %v", err)
 		}
-		if err := EmitEvent(
+		requireNoError(t, EmitEvent(
 			"openinference_mark",
 			WithEventParent(handle),
 			WithEventData(json.RawMessage(`{"step":1}`)),
 			WithEventMetadata(json.RawMessage(`{"source":"go"}`)),
-		); err != nil {
-			t.Fatalf("EmitEvent failed: %v", err)
-		}
-		if err := PopScope(handle); err != nil {
-			t.Fatalf("PopScope failed: %v", err)
-		}
+		), "EmitEvent failed")
+		requireNoError(t, PopScope(handle), "PopScope failed")
 	})
-	if err := subscriber.ForceFlush(); err != nil {
-		t.Fatalf("ForceFlush failed: %v", err)
-	}
+}
 
-	select {
-	case request := <-requests:
-		if request.Path != "/v1/traces" {
-			t.Fatalf("expected /v1/traces path, got %q", request.Path)
+func AssertOpenInferenceRequest(t *testing.T, request otelRequest) {
+	t.Helper()
+	if request.Path != "/v1/traces" {
+		t.Fatalf("expected /v1/traces path, got %q", request.Path)
+	}
+	if request.ContentType != "application/x-protobuf" {
+		t.Fatalf("expected protobuf content type, got %q", request.ContentType)
+	}
+	if len(request.Body) == 0 {
+		t.Fatal("expected non-empty OTLP request body")
+	}
+	AssertOpenInferenceBodyContains(t, request.Body)
+}
+
+func AssertOpenInferenceBodyContains(t *testing.T, body []byte) {
+	t.Helper()
+	for _, needle := range [][]byte{
+		[]byte("openinference.span.kind"),
+		[]byte("AGENT"),
+		[]byte("metadata"),
+		[]byte("openinference_mark"),
+	} {
+		if !bytes.Contains(body, needle) {
+			t.Fatalf("expected OTLP request body to contain %q", needle)
 		}
-		if request.ContentType != "application/x-protobuf" {
-			t.Fatalf("expected protobuf content type, got %q", request.ContentType)
-		}
-		if len(request.Body) == 0 {
-			t.Fatal("expected non-empty OTLP request body")
-		}
-		for _, needle := range [][]byte{
-			[]byte("openinference.span.kind"),
-			[]byte("AGENT"),
-			[]byte("metadata"),
-			[]byte("openinference_mark"),
-		} {
-			if !bytes.Contains(request.Body, needle) {
-				t.Fatalf("expected OTLP request body to contain %q", needle)
-			}
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for OTLP request")
 	}
 }


### PR DESCRIPTION
#### Overview

Refactor the functions reported by Sonar for excessive cognitive complexity while preserving runtime behavior. The changes split branch-heavy Rust and Go test logic into focused helpers.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Extracted plugin editor menu action handling into smaller helpers.
- Extracted CLI session event routing and explicit subagent alias handling.
- Split ATIF agent scope tree construction into focused construction, linking, and sorting helpers.
- Split ATIF test shape assertions into targeted helper assertions.
- Split Go observability and OpenInference tests into setup and assertion helpers.

Validation run:

- `cargo fmt --all`
- `gofmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-go`
- `go vet ./...`
- `just test-node`
- `just test-wasm`
- `cargo test -p nemo-relay-cli --bin nemo-relay -- --test-threads=1`

Notes:

- `just test-rust` compiled the affected crates and passed the core/adaptive suites, but hit an existing cwd-sensitive parallel CLI test failure. The failing test passed in isolation and in the serial CLI binary suite listed above.
- `just test-python` is blocked by dependency resolution for `nemo-relay[deepagents]`: the resolver only sees `langchain<=1.3.2` for the Linux split while the existing project requirements ask for `langchain>=1.3.3`.

#### Where should the reviewer start?

Start with `crates/core/src/observability/atif.rs` for the largest decomposition, then `crates/cli/src/session.rs` for the session routing helper extraction.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none