### PR TITLE
docs: clarify Codex gateway config

### DIFF
--- a/docs/nemo-relay-cli/codex.mdx
+++ b/docs/nemo-relay-cli/codex.mdx
@@ -97,8 +97,8 @@ wrapper:
 nemo-relay --bind 127.0.0.1:4040
 ```
 
-Then configure local Codex to use a gateway provider alias instead of
-overriding the reserved built-in `openai` provider:
+Then edit `~/.codex/config.toml` and configure local Codex to use a gateway
+provider alias instead of overriding the reserved built-in `openai` provider:
 
 ```toml
 model_provider = "nemo-relay-openai"
@@ -110,6 +110,20 @@ wire_api = "responses"
 requires_openai_auth = true
 supports_websockets = false
 ```
+
+After saving the file, restart the Codex GUI or app so it reloads the provider
+configuration. For CLI usage, start a new `codex` process.
+
+<Warning>
+Some Codex GUI or app versions appear to scope visible conversation history by
+the active provider configuration. If existing conversations disappear after
+switching `model_provider` to `nemo-relay-openai`, the history has not been
+removed if it returns after restoring the previous provider configuration. Use
+this standalone provider alias only while capturing gateway telemetry, or prefer
+the transparent wrapper for CLI sessions. See the upstream Codex
+[history visibility discussion](https://github.com/openai/codex/issues/15494#issuecomment-4164170537)
+for context.
+</Warning>
 
 Local Codex GUI or app sessions have the same support level only when they read
 the same local hook/plugin config and provider routing. Cloud tasks may still

--- a/integrations/coding-agents/codex/README.md
+++ b/integrations/coding-agents/codex/README.md
@@ -99,8 +99,8 @@ the wrapper. Start the gateway manually:
 nemo-relay --bind 127.0.0.1:4040
 ```
 
-Then configure local Codex to use a gateway provider alias instead of
-overriding the reserved built-in `openai` provider:
+Then edit `~/.codex/config.toml` and configure local Codex to use a gateway
+provider alias instead of overriding the reserved built-in `openai` provider:
 
 ```toml
 model_provider = "nemo-relay-openai"
@@ -112,6 +112,18 @@ wire_api = "responses"
 requires_openai_auth = true
 supports_websockets = false
 ```
+
+After saving the file, restart the Codex GUI or app so it reloads the provider
+configuration. For CLI usage, start a new `codex` process.
+
+Some Codex GUI or app versions appear to scope visible conversation history by
+the active provider configuration. If existing conversations disappear after
+switching `model_provider` to `nemo-relay-openai`, the history has not been
+removed if it returns after restoring the previous provider configuration. Use
+this standalone provider alias only while capturing gateway telemetry, or prefer
+the transparent wrapper for CLI sessions. See the upstream Codex
+[history visibility discussion](https://github.com/openai/codex/issues/15494#issuecomment-4164170537)
+for context.
 
 ## Verify
 


### PR DESCRIPTION
#### Overview

Clarifies the standalone Codex gateway setup so users know where to add the
provider alias, when to restart Codex, and why existing local history may appear
hidden after switching providers.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Identifies `~/.codex/config.toml` as the file that should contain the
  `nemo-relay-openai` provider alias.
- Adds a restart note for Codex GUI/app users and a new-process note for CLI
  users.
- Documents that some Codex GUI/app versions scope visible history by active
  provider configuration, with an upstream Codex issue link for context.
- Mirrors the guidance in both the Fern Codex CLI page and the coding-agent
  integration README.

Validation:

- `just docs`
- commit-time pre-commit hooks, including docs markdown linkcheck

#### Where should the reviewer start?

Start with `docs/nemo-relay-cli/codex.mdx`, then compare the mirrored wording in
`integrations/coding-agents/codex/README.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Standalone Gateway setup instructions with improved clarity on local provider configuration.
  * Added restart guidance for the application after saving provider configuration changes.
  * Clarified conversation history behavior with different provider configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->