### PR TITLE
fix: correlate ATIF tool observations

### DIFF
--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -464,8 +464,8 @@ fn atif_content_value(value: &Json) -> Json {
     }
 }
 
-fn observation_content_value(value: &Json) -> Json {
-    value.clone()
+fn observation_content_value(value: &Json) -> Option<Json> {
+    (!value.is_null()).then(|| value.clone())
 }
 
 fn is_atif_content_parts(value: &Json) -> bool {
@@ -1109,10 +1109,15 @@ struct LlmToolCallRecord {
 
 fn build_tool_call_correlations(events: &[&Event]) -> HashMap<Uuid, String> {
     let (mut correlations, executions, tool_calls) = collect_tool_correlation_inputs(events);
+    let consumed_tool_call_ids = consumed_tool_call_ids(&correlations);
     let executions_by_key = group_unmatched_executions_by_key(executions, &correlations);
-    let tool_calls_by_key = group_tool_calls_by_key(tool_calls);
+    let tool_calls_by_key = group_tool_calls_by_key(tool_calls, &consumed_tool_call_ids);
     apply_keyed_tool_correlations(&mut correlations, executions_by_key, &tool_calls_by_key);
     correlations
+}
+
+fn consumed_tool_call_ids(correlations: &HashMap<Uuid, String>) -> HashSet<String> {
+    correlations.values().cloned().collect()
 }
 
 fn collect_tool_correlation_inputs(
@@ -1213,9 +1218,13 @@ fn group_unmatched_executions_by_key(
 
 fn group_tool_calls_by_key(
     tool_calls: Vec<LlmToolCallRecord>,
+    consumed_tool_call_ids: &HashSet<String>,
 ) -> HashMap<ToolCallMatchKey, Vec<String>> {
     let mut grouped: HashMap<ToolCallMatchKey, Vec<String>> = HashMap::new();
     for tool_call in tool_calls {
+        if consumed_tool_call_ids.contains(&tool_call.tool_call_id) {
+            continue;
+        }
         if let Some(key) = tool_call.key {
             grouped.entry(key).or_default().push(tool_call.tool_call_id);
         }
@@ -1734,12 +1743,46 @@ impl StepConversionState {
             .map(ToOwned::to_owned)
             .or_else(|| self.tool_scope_call_ids.get(&event.uuid()).cloned())
             .or_else(|| lookups.tool_call_ids.get(&event.uuid()).cloned())
-            .or_else(|| self.last_tool_call_map.get(event.name()).cloned())
-            .or_else(|| {
-                self.current_agent
-                    .has_active_step()
-                    .then(|| event.uuid().to_string())
-            })
+            .or_else(|| self.current_step_tool_call_id_by_name(event.name()))
+            .or_else(|| self.synthetic_tool_call_id_for_start(event))
+    }
+
+    fn current_step_tool_call_id_by_name(&self, name: &str) -> Option<String> {
+        let step_idx = self.current_agent.step_idx?;
+        let matches = self.current_step_tool_call_ids_by_name(step_idx, name);
+        match matches.as_slice() {
+            [tool_call_id] => Some(tool_call_id.clone()),
+            _ => None,
+        }
+    }
+
+    fn current_step_tool_call_ids_by_name(&self, step_idx: usize, name: &str) -> Vec<String> {
+        self.steps
+            .get(step_idx)
+            .and_then(|step| step.tool_calls.as_deref())
+            .unwrap_or_default()
+            .iter()
+            .filter(|tool_call| tool_call.function_name == name)
+            .map(|tool_call| tool_call.tool_call_id.clone())
+            .collect()
+    }
+
+    fn synthetic_tool_call_id_for_start(&self, event: &Event) -> Option<String> {
+        if self.current_step_has_duplicate_tool_name(event.name()) {
+            return None;
+        }
+        self.current_agent
+            .has_active_step()
+            .then(|| event.uuid().to_string())
+    }
+
+    fn current_step_has_duplicate_tool_name(&self, name: &str) -> bool {
+        let Some(step_idx) = self.current_agent.step_idx else {
+            return false;
+        };
+        self.current_step_tool_call_ids_by_name(step_idx, name)
+            .len()
+            > 1
     }
 
     fn ensure_tool_call_on_current_agent(&mut self, event: &Event, source_call_id: &str) -> bool {
@@ -1792,7 +1835,7 @@ impl StepConversionState {
             return Some(tool_call_id.clone());
         }
 
-        let candidate = self.last_tool_call_map.get(event.name()).cloned()?;
+        let candidate = self.current_step_tool_call_id_by_name(event.name())?;
 
         if self.current_agent.has_tool_call_id(&candidate)
             || self
@@ -1816,7 +1859,7 @@ impl StepConversionState {
             }
             self.pending_observations.push(AtifObservationResult {
                 source_call_id: source_call_id.clone(),
-                content: Some(observation_content_value(output)),
+                content: observation_content_value(output),
                 subagent_trajectory_ref: None,
                 extra: Some(event_extra(event)),
             });
@@ -2028,10 +2071,14 @@ fn remove_projected_tool_call_duplicates(steps: &mut Vec<AtifStep>) {
     let mut keep = vec![true; steps.len()];
 
     for (idx, step) in steps.iter().enumerate().rev() {
+        if step.source != "agent" {
+            observed_later.clear();
+            continue;
+        }
         if projected_tool_call_duplicate(step, &observed_later) {
             keep[idx] = false;
         }
-        extend_observed_tool_call_ids(&mut observed_later, step);
+        extend_observed_tool_call_keys(&mut observed_later, step);
     }
 
     let mut idx = 0;
@@ -2042,15 +2089,25 @@ fn remove_projected_tool_call_duplicates(steps: &mut Vec<AtifStep>) {
     });
 }
 
-fn projected_tool_call_duplicate(step: &AtifStep, observed_later: &HashSet<String>) -> bool {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ToolCallDedupeKey {
+    tool_call_id: String,
+    function_name: String,
+    arguments: String,
+}
+
+fn projected_tool_call_duplicate(
+    step: &AtifStep,
+    observed_later: &HashSet<ToolCallDedupeKey>,
+) -> bool {
     if !projected_tool_call_candidate(step) {
         return false;
     }
-    let tool_call_ids = step_tool_call_ids(step);
-    !tool_call_ids.is_empty()
-        && tool_call_ids
+    let tool_call_keys = step_tool_call_dedupe_keys(step);
+    !tool_call_keys.is_empty()
+        && tool_call_keys
             .iter()
-            .all(|tool_call_id| observed_later.contains(tool_call_id))
+            .all(|tool_call_key| observed_later.contains(tool_call_key))
 }
 
 fn projected_tool_call_candidate(step: &AtifStep) -> bool {
@@ -2066,33 +2123,61 @@ fn projected_tool_call_candidate(step: &AtifStep) -> bool {
             .is_some_and(|tool_calls| !tool_calls.is_empty())
 }
 
-fn extend_observed_tool_call_ids(observed_later: &mut HashSet<String>, step: &AtifStep) {
-    for tool_call_id in observed_tool_call_ids(step) {
-        observed_later.insert(tool_call_id);
+fn extend_observed_tool_call_keys(
+    observed_later: &mut HashSet<ToolCallDedupeKey>,
+    step: &AtifStep,
+) {
+    for tool_call_key in observed_tool_call_keys(step) {
+        observed_later.insert(tool_call_key);
     }
 }
 
-fn observed_tool_call_ids(step: &AtifStep) -> Vec<String> {
-    let step_tool_call_ids = step_tool_call_ids(step);
+fn observed_tool_call_keys(step: &AtifStep) -> Vec<ToolCallDedupeKey> {
+    let step_tool_call_keys = step_tool_call_dedupe_keys(step);
     step.observation
         .as_ref()
-        .map(|observation| matching_observation_source_ids(observation, &step_tool_call_ids))
+        .map(|observation| matching_observation_tool_call_keys(observation, &step_tool_call_keys))
         .unwrap_or_default()
 }
 
-fn matching_observation_source_ids(
+fn matching_observation_tool_call_keys(
     observation: &AtifObservation,
-    step_tool_call_ids: &[String],
-) -> Vec<String> {
+    step_tool_call_keys: &[ToolCallDedupeKey],
+) -> Vec<ToolCallDedupeKey> {
     observation
         .results
         .iter()
         .filter_map(|result| result.source_call_id.as_ref())
-        .filter(|source_call_id| step_tool_call_ids.contains(source_call_id))
+        .flat_map(|source_call_id| matching_tool_call_keys(source_call_id, step_tool_call_keys))
+        .collect()
+}
+
+fn matching_tool_call_keys(
+    source_call_id: &str,
+    step_tool_call_keys: &[ToolCallDedupeKey],
+) -> Vec<ToolCallDedupeKey> {
+    step_tool_call_keys
+        .iter()
+        .filter(|tool_call_key| tool_call_key.tool_call_id == source_call_id)
         .cloned()
         .collect()
 }
 
+fn step_tool_call_dedupe_keys(step: &AtifStep) -> Vec<ToolCallDedupeKey> {
+    step.tool_calls
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter(|tool_call| !tool_call.tool_call_id.is_empty())
+        .map(|tool_call| ToolCallDedupeKey {
+            tool_call_id: tool_call.tool_call_id.clone(),
+            function_name: tool_call.function_name.clone(),
+            arguments: json_to_string(&tool_call.arguments),
+        })
+        .collect()
+}
+
+#[cfg(test)]
 fn step_tool_call_ids(step: &AtifStep) -> Vec<String> {
     step.tool_calls
         .as_deref()

--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -464,6 +464,10 @@ fn atif_content_value(value: &Json) -> Json {
     }
 }
 
+fn observation_content_value(value: &Json) -> Json {
+    value.clone()
+}
+
 fn is_atif_content_parts(value: &Json) -> bool {
     let Some(parts) = value.as_array() else {
         return false;
@@ -1047,10 +1051,27 @@ fn json_string_at(value: &Json, path: &[&str]) -> Option<String> {
 struct EventLookupMaps {
     name_map: std::collections::HashMap<Uuid, String>,
     start_ts_map: std::collections::HashMap<Uuid, DateTime<Utc>>,
+    tool_call_ids: std::collections::HashMap<Uuid, String>,
 }
 
 impl EventLookupMaps {
     fn from_events(events: &[&Event]) -> Self {
+        Self::from_events_with_correlation_events(events, events)
+    }
+
+    fn from_events_for_agent(events: &[&Event], tree: &AgentScopeTree, agent_uuid: Uuid) -> Self {
+        let correlation_events = events
+            .iter()
+            .copied()
+            .filter(|event| tree.owner_agent(event) == Some(agent_uuid))
+            .collect::<Vec<_>>();
+        Self::from_events_with_correlation_events(events, &correlation_events)
+    }
+
+    fn from_events_with_correlation_events(
+        events: &[&Event],
+        correlation_events: &[&Event],
+    ) -> Self {
         let mut name_map = std::collections::HashMap::new();
         let mut start_ts_map = std::collections::HashMap::new();
         for event in events {
@@ -1062,8 +1083,186 @@ impl EventLookupMaps {
         Self {
             name_map,
             start_ts_map,
+            tool_call_ids: build_tool_call_correlations(correlation_events),
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ToolCallMatchKey {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Debug, Clone)]
+struct ToolExecutionRecord {
+    uuid: Uuid,
+    explicit_call_id: Option<String>,
+    key: Option<ToolCallMatchKey>,
+}
+
+#[derive(Debug, Clone)]
+struct LlmToolCallRecord {
+    tool_call_id: String,
+    key: Option<ToolCallMatchKey>,
+}
+
+fn build_tool_call_correlations(events: &[&Event]) -> HashMap<Uuid, String> {
+    let (mut correlations, executions, tool_calls) = collect_tool_correlation_inputs(events);
+    let executions_by_key = group_unmatched_executions_by_key(executions, &correlations);
+    let tool_calls_by_key = group_tool_calls_by_key(tool_calls);
+    apply_keyed_tool_correlations(&mut correlations, executions_by_key, &tool_calls_by_key);
+    correlations
+}
+
+fn collect_tool_correlation_inputs(
+    events: &[&Event],
+) -> (
+    HashMap<Uuid, String>,
+    Vec<ToolExecutionRecord>,
+    Vec<LlmToolCallRecord>,
+) {
+    let mut explicit = HashMap::new();
+    let mut executions = Vec::new();
+    let mut tool_calls = Vec::new();
+
+    for event in events {
+        collect_tool_correlation_event(event, &mut explicit, &mut executions, &mut tool_calls);
+    }
+
+    (explicit, executions, tool_calls)
+}
+
+fn collect_tool_correlation_event(
+    event: &Event,
+    explicit: &mut HashMap<Uuid, String>,
+    executions: &mut Vec<ToolExecutionRecord>,
+    tool_calls: &mut Vec<LlmToolCallRecord>,
+) {
+    match event_signature(event) {
+        ("scope", Some(crate::api::event::ScopeCategory::Start), Some("tool")) => {
+            collect_tool_execution_start(event, explicit, executions)
+        }
+        ("scope", Some(crate::api::event::ScopeCategory::End), Some("tool")) => {
+            collect_explicit_tool_call_id(event, explicit)
+        }
+        ("scope", Some(crate::api::event::ScopeCategory::End), Some("llm")) => {
+            collect_llm_tool_calls(event, tool_calls)
+        }
+        _ => {}
+    }
+}
+
+fn event_signature(
+    event: &Event,
+) -> (&str, Option<crate::api::event::ScopeCategory>, Option<&str>) {
+    (
+        event.kind(),
+        event.scope_category(),
+        event.category().map(|category| category.as_str()),
+    )
+}
+
+fn collect_tool_execution_start(
+    event: &Event,
+    explicit: &mut HashMap<Uuid, String>,
+    executions: &mut Vec<ToolExecutionRecord>,
+) {
+    let record = ToolExecutionRecord {
+        uuid: event.uuid(),
+        explicit_call_id: event.tool_call_id().map(ToOwned::to_owned),
+        key: tool_execution_match_key(event),
+    };
+    if let Some(tool_call_id) = &record.explicit_call_id {
+        explicit.insert(record.uuid, tool_call_id.clone());
+    }
+    executions.push(record);
+}
+
+fn collect_explicit_tool_call_id(event: &Event, explicit: &mut HashMap<Uuid, String>) {
+    if let Some(tool_call_id) = event.tool_call_id() {
+        explicit.insert(event.uuid(), tool_call_id.to_string());
+    }
+}
+
+fn collect_llm_tool_calls(event: &Event, tool_calls: &mut Vec<LlmToolCallRecord>) {
+    let Some(calls) = event.data().and_then(extract_tool_calls) else {
+        return;
+    };
+    tool_calls.extend(calls.into_iter().map(|tool_call| LlmToolCallRecord {
+        key: tool_call_match_key(&tool_call.function_name, &tool_call.arguments),
+        tool_call_id: tool_call.tool_call_id,
+    }));
+}
+
+fn group_unmatched_executions_by_key(
+    executions: Vec<ToolExecutionRecord>,
+    correlations: &HashMap<Uuid, String>,
+) -> HashMap<ToolCallMatchKey, Vec<Uuid>> {
+    let mut grouped: HashMap<ToolCallMatchKey, Vec<Uuid>> = HashMap::new();
+    for execution in executions {
+        if correlations.contains_key(&execution.uuid) {
+            continue;
+        }
+        if let Some(key) = execution.key {
+            grouped.entry(key).or_default().push(execution.uuid);
+        }
+    }
+    grouped
+}
+
+fn group_tool_calls_by_key(
+    tool_calls: Vec<LlmToolCallRecord>,
+) -> HashMap<ToolCallMatchKey, Vec<String>> {
+    let mut grouped: HashMap<ToolCallMatchKey, Vec<String>> = HashMap::new();
+    for tool_call in tool_calls {
+        if let Some(key) = tool_call.key {
+            grouped.entry(key).or_default().push(tool_call.tool_call_id);
+        }
+    }
+    grouped
+}
+
+fn apply_keyed_tool_correlations(
+    correlations: &mut HashMap<Uuid, String>,
+    executions_by_key: HashMap<ToolCallMatchKey, Vec<Uuid>>,
+    tool_calls_by_key: &HashMap<ToolCallMatchKey, Vec<String>>,
+) {
+    for (key, execution_uuids) in executions_by_key {
+        let Some(tool_call_ids) = tool_calls_by_key.get(&key) else {
+            continue;
+        };
+        if execution_uuids.len() == tool_call_ids.len() {
+            insert_keyed_tool_correlations(correlations, execution_uuids, tool_call_ids);
+        }
+    }
+}
+
+fn insert_keyed_tool_correlations(
+    correlations: &mut HashMap<Uuid, String>,
+    execution_uuids: Vec<Uuid>,
+    tool_call_ids: &[String],
+) {
+    for (uuid, tool_call_id) in execution_uuids.into_iter().zip(tool_call_ids) {
+        correlations.insert(uuid, tool_call_id.clone());
+    }
+}
+
+fn tool_execution_match_key(event: &Event) -> Option<ToolCallMatchKey> {
+    let arguments = event
+        .data()
+        .map(|data| normalize_tool_arguments(Some(data)))?;
+    tool_call_match_key(event.name(), &arguments)
+}
+
+fn tool_call_match_key(name: &str, arguments: &Json) -> Option<ToolCallMatchKey> {
+    if name.is_empty() {
+        return None;
+    }
+    Some(ToolCallMatchKey {
+        name: name.to_string(),
+        arguments: json_to_string(arguments),
+    })
 }
 
 #[derive(Default)]
@@ -1176,8 +1375,15 @@ struct StepConversionState {
     active_tool_call_id: Option<String>,
     pending_observations: Vec<AtifObservationResult>,
     pending_obs_timestamp: Option<String>,
+    deferred_observations: HashMap<String, Vec<DeferredToolObservation>>,
+    deferred_tool_metadata: HashMap<String, Vec<(AtifAncestry, AtifInvocationInfo)>>,
     current_reasoning_effort: Option<Json>,
     current_agent: PendingAgentStep,
+}
+
+struct DeferredToolObservation {
+    result: AtifObservationResult,
+    timestamp: Option<String>,
 }
 
 impl StepConversionState {
@@ -1194,7 +1400,7 @@ impl StepConversionState {
                 self.handle_llm_end(event, lookups)
             }
             ("scope", Some(crate::api::event::ScopeCategory::Start), Some("tool")) => {
-                self.handle_tool_start(event)
+                self.handle_tool_start(event, lookups)
             }
             ("scope", Some(crate::api::event::ScopeCategory::End), Some("tool")) => {
                 self.handle_tool_end(event, lookups)
@@ -1210,46 +1416,83 @@ impl StepConversionState {
         }
 
         let timestamp = self.pending_obs_timestamp.take();
-        let mut observations = std::mem::take(&mut self.pending_observations);
+        let observations = std::mem::take(&mut self.pending_observations);
+        let (attached, standalone) = self.route_observations(observations, timestamp.clone());
+        self.attach_observations_to_current_step(attached);
+        self.push_standalone_observation_step(standalone, timestamp);
+    }
 
-        if let Some(step_idx) = self.current_agent.step_idx
-            && let Some(step) = self.steps.get_mut(step_idx)
-        {
-            let mut attached = Vec::new();
-            let mut standalone = Vec::new();
-            for mut result in observations {
-                let matches_current_tool_call =
-                    result.source_call_id.as_deref().is_some_and(|id| {
-                        step.tool_calls
-                            .as_deref()
-                            .unwrap_or_default()
-                            .iter()
-                            .any(|tool_call| tool_call.tool_call_id == id)
-                    });
-                if matches_current_tool_call {
-                    attached.push(result);
-                } else {
+    fn route_observations(
+        &mut self,
+        observations: Vec<AtifObservationResult>,
+        timestamp: Option<String>,
+    ) -> (Vec<AtifObservationResult>, Vec<AtifObservationResult>) {
+        let mut attached = Vec::new();
+        let mut standalone = Vec::new();
+        for mut result in observations {
+            match result.source_call_id.clone() {
+                Some(source_call_id) => {
+                    self.route_correlated_observation(
+                        source_call_id,
+                        result,
+                        timestamp.clone(),
+                        &mut attached,
+                    );
+                }
+                None => {
                     result.source_call_id = None;
                     standalone.push(result);
                 }
             }
-            if !attached.is_empty() {
-                let observation = step.observation.get_or_insert_with(|| AtifObservation {
-                    results: Vec::new(),
-                });
-                for result in attached {
-                    merge_observation_result(observation, result);
-                }
-            }
-            observations = standalone;
         }
+        (attached, standalone)
+    }
 
+    fn route_correlated_observation(
+        &mut self,
+        source_call_id: String,
+        result: AtifObservationResult,
+        timestamp: Option<String>,
+        attached: &mut Vec<AtifObservationResult>,
+    ) {
+        if self.current_step_has_tool_call(&source_call_id) {
+            attached.push(result);
+        } else {
+            self.defer_observation(source_call_id, result, timestamp);
+        }
+    }
+
+    fn attach_observations_to_current_step(&mut self, attached: Vec<AtifObservationResult>) {
+        if attached.is_empty() {
+            return;
+        }
+        let Some(step_idx) = self.current_agent.step_idx else {
+            return;
+        };
+        let Some(step) = self.steps.get_mut(step_idx) else {
+            return;
+        };
+        let observation = step.observation.get_or_insert_with(|| AtifObservation {
+            results: Vec::new(),
+        });
+        for result in attached {
+            merge_observation_result(observation, result);
+        }
+    }
+
+    fn push_standalone_observation_step(
+        &mut self,
+        mut observations: Vec<AtifObservationResult>,
+        timestamp: Option<String>,
+    ) {
         if observations.is_empty() {
             return;
         }
 
         for result in &mut observations {
-            result.source_call_id = None;
+            if result.source_call_id.is_some() {
+                result.source_call_id = None;
+            }
         }
 
         self.steps.push(AtifStep {
@@ -1273,6 +1516,116 @@ impl StepConversionState {
 
     fn finalize_agent_extra(&mut self) {
         self.current_agent.finalize_into(&mut self.steps);
+    }
+
+    fn current_step_has_tool_call(&self, source_call_id: &str) -> bool {
+        let Some(step_idx) = self.current_agent.step_idx else {
+            return false;
+        };
+        self.steps
+            .get(step_idx)
+            .and_then(|step| step.tool_calls.as_deref())
+            .unwrap_or_default()
+            .iter()
+            .any(|tool_call| tool_call.tool_call_id == source_call_id)
+    }
+
+    fn defer_observation(
+        &mut self,
+        source_call_id: String,
+        result: AtifObservationResult,
+        timestamp: Option<String>,
+    ) {
+        self.deferred_observations
+            .entry(source_call_id)
+            .or_default()
+            .push(DeferredToolObservation { result, timestamp });
+    }
+
+    fn attach_deferred_to_current_agent(&mut self) {
+        let Some(step_idx) = self.current_agent.step_idx else {
+            return;
+        };
+        let tool_call_ids = self.tool_call_ids_for_step(step_idx);
+
+        for source_call_id in tool_call_ids {
+            self.attach_deferred_observations(step_idx, &source_call_id);
+            self.attach_deferred_tool_metadata(&source_call_id);
+        }
+    }
+
+    fn tool_call_ids_for_step(&self, step_idx: usize) -> Vec<String> {
+        self.steps
+            .get(step_idx)
+            .and_then(|step| step.tool_calls.as_deref())
+            .unwrap_or_default()
+            .iter()
+            .map(|tool_call| tool_call.tool_call_id.clone())
+            .collect()
+    }
+
+    fn attach_deferred_observations(&mut self, step_idx: usize, source_call_id: &str) {
+        let Some(observations) = self.deferred_observations.remove(source_call_id) else {
+            return;
+        };
+        let Some(step) = self.steps.get_mut(step_idx) else {
+            return;
+        };
+        let observation = step.observation.get_or_insert_with(|| AtifObservation {
+            results: Vec::new(),
+        });
+        for deferred in observations {
+            merge_observation_result(observation, deferred.result);
+        }
+    }
+
+    fn attach_deferred_tool_metadata(&mut self, source_call_id: &str) {
+        let Some(metadata) = self.deferred_tool_metadata.remove(source_call_id) else {
+            return;
+        };
+        for (ancestry, invocation) in metadata {
+            self.current_agent.push_tool_metadata(ancestry, invocation);
+        }
+    }
+
+    fn flush_deferred_observations_as_standalone(&mut self) {
+        if self.deferred_observations.is_empty() {
+            return;
+        }
+        let mut deferred = std::mem::take(&mut self.deferred_observations)
+            .into_values()
+            .flatten()
+            .collect::<Vec<_>>();
+        deferred.sort_by_key(|entry| entry.timestamp.clone());
+        let timestamp = deferred.iter().find_map(|entry| entry.timestamp.clone());
+        let mut observations = deferred
+            .into_iter()
+            .map(|mut entry| {
+                entry.result.source_call_id = None;
+                entry.result
+            })
+            .collect::<Vec<_>>();
+        if observations.is_empty() {
+            return;
+        }
+        self.deferred_tool_metadata.clear();
+        self.steps.push(AtifStep {
+            step_id: 0,
+            source: "system".to_string(),
+            message: empty_message(),
+            timestamp,
+            model_name: None,
+            reasoning_effort: None,
+            reasoning_content: None,
+            tool_calls: None,
+            observation: Some(AtifObservation {
+                results: std::mem::take(&mut observations),
+            }),
+            metrics: None,
+            llm_call_count: None,
+            is_copied_context: None,
+            extra: None,
+        });
     }
 
     fn handle_llm_start(&mut self, event: &Event, lookups: &EventLookupMaps) {
@@ -1353,29 +1706,40 @@ impl StepConversionState {
             tool_call_order,
             output.clone(),
         );
+        self.attach_deferred_to_current_agent();
     }
 
-    fn handle_tool_start(&mut self, event: &Event) {
-        let Some(source_call_id) = self.source_call_id_for_tool_start(event) else {
+    fn handle_tool_start(&mut self, event: &Event, lookups: &EventLookupMaps) {
+        let Some(source_call_id) = self.source_call_id_for_tool_start(event, lookups) else {
             return;
         };
+        self.tool_scope_call_ids
+            .insert(event.uuid(), source_call_id.clone());
+        if !self.current_agent.has_active_step() {
+            return;
+        }
         if !self.ensure_tool_call_on_current_agent(event, &source_call_id) {
             return;
         }
-        self.tool_scope_call_ids
-            .insert(event.uuid(), source_call_id.clone());
         self.active_tool_call_id = Some(source_call_id);
     }
 
-    fn source_call_id_for_tool_start(&self, event: &Event) -> Option<String> {
-        if !self.current_agent.has_active_step() {
-            return None;
-        }
+    fn source_call_id_for_tool_start(
+        &self,
+        event: &Event,
+        lookups: &EventLookupMaps,
+    ) -> Option<String> {
         event
             .tool_call_id()
             .map(ToOwned::to_owned)
+            .or_else(|| self.tool_scope_call_ids.get(&event.uuid()).cloned())
+            .or_else(|| lookups.tool_call_ids.get(&event.uuid()).cloned())
             .or_else(|| self.last_tool_call_map.get(event.name()).cloned())
-            .or_else(|| Some(event.uuid().to_string()))
+            .or_else(|| {
+                self.current_agent
+                    .has_active_step()
+                    .then(|| event.uuid().to_string())
+            })
     }
 
     fn ensure_tool_call_on_current_agent(&mut self, event: &Event, source_call_id: &str) -> bool {
@@ -1417,18 +1781,26 @@ impl StepConversionState {
         true
     }
 
-    fn resolve_source_call_id(&self, event: &Event) -> Option<String> {
-        let candidate = event
-            .tool_call_id()
-            .map(ToOwned::to_owned)
-            .or_else(|| self.tool_scope_call_ids.get(&event.uuid()).cloned())
-            .or_else(|| self.last_tool_call_map.get(event.name()).cloned())?;
+    fn resolve_source_call_id(&self, event: &Event, lookups: &EventLookupMaps) -> Option<String> {
+        if let Some(tool_call_id) = event.tool_call_id() {
+            return Some(tool_call_id.to_string());
+        }
+        if let Some(tool_call_id) = self.tool_scope_call_ids.get(&event.uuid()) {
+            return Some(tool_call_id.clone());
+        }
+        if let Some(tool_call_id) = lookups.tool_call_ids.get(&event.uuid()) {
+            return Some(tool_call_id.clone());
+        }
+
+        let candidate = self.last_tool_call_map.get(event.name()).cloned()?;
 
         if self.current_agent.has_tool_call_id(&candidate)
             || self
                 .last_tool_call_map
                 .values()
                 .any(|known_id| known_id == &candidate)
+            || self.deferred_observations.contains_key(&candidate)
+            || self.deferred_tool_metadata.contains_key(&candidate)
         {
             Some(candidate)
         } else {
@@ -1437,14 +1809,14 @@ impl StepConversionState {
     }
 
     fn handle_tool_end(&mut self, event: &Event, lookups: &EventLookupMaps) {
-        let source_call_id = self.resolve_source_call_id(event);
+        let source_call_id = self.resolve_source_call_id(event, lookups);
         if let Some(output) = event.data() {
             if self.pending_obs_timestamp.is_none() {
                 self.pending_obs_timestamp = Some(event.timestamp().to_rfc3339());
             }
             self.pending_observations.push(AtifObservationResult {
                 source_call_id: source_call_id.clone(),
-                content: Some(atif_content_value(output)),
+                content: Some(observation_content_value(output)),
                 subagent_trajectory_ref: None,
                 extra: Some(event_extra(event)),
             });
@@ -1454,14 +1826,27 @@ impl StepConversionState {
             self.active_tool_call_id = None;
         }
 
-        if !self.current_agent.has_active_step() || source_call_id.is_none() {
+        let Some(source_call_id) = source_call_id else {
             return;
-        }
+        };
         let start_ts = lookups.start_ts_map.get(&event.uuid()).cloned();
-        let invocation =
-            build_invocation_info(start_ts, *event.timestamp(), source_call_id, "nemo_relay");
-        self.current_agent
-            .push_tool_metadata(build_ancestry(event, &lookups.name_map), invocation);
+        let invocation = build_invocation_info(
+            start_ts,
+            *event.timestamp(),
+            Some(source_call_id.clone()),
+            "nemo_relay",
+        );
+        let ancestry = build_ancestry(event, &lookups.name_map);
+        if self.current_agent.has_active_step()
+            && self.current_agent.has_tool_call_id(&source_call_id)
+        {
+            self.current_agent.push_tool_metadata(ancestry, invocation);
+        } else {
+            self.deferred_tool_metadata
+                .entry(source_call_id)
+                .or_default()
+                .push((ancestry, invocation));
+        }
     }
 
     fn resolve_subagent_source_call_id(&self, event: &Event) -> Option<String> {
@@ -1547,6 +1932,9 @@ impl StepConversionState {
     }
 
     fn handle_mark(&mut self, mark: &Event, lookups: &EventLookupMaps) {
+        if is_llm_chunk_mark(mark) {
+            return;
+        }
         self.flush_observations();
         let Some(data) = mark.data() else {
             return;
@@ -1627,10 +2015,92 @@ impl StepConversionState {
 
     fn finish(mut self) -> Vec<AtifStep> {
         self.flush_observations();
+        self.flush_deferred_observations_as_standalone();
         self.finalize_agent_extra();
+        remove_projected_tool_call_duplicates(&mut self.steps);
         renumber_steps(&mut self.steps);
         self.steps
     }
+}
+
+fn remove_projected_tool_call_duplicates(steps: &mut Vec<AtifStep>) {
+    let mut observed_later = HashSet::new();
+    let mut keep = vec![true; steps.len()];
+
+    for (idx, step) in steps.iter().enumerate().rev() {
+        if projected_tool_call_duplicate(step, &observed_later) {
+            keep[idx] = false;
+        }
+        extend_observed_tool_call_ids(&mut observed_later, step);
+    }
+
+    let mut idx = 0;
+    steps.retain(|_| {
+        let retain_step = keep[idx];
+        idx += 1;
+        retain_step
+    });
+}
+
+fn projected_tool_call_duplicate(step: &AtifStep, observed_later: &HashSet<String>) -> bool {
+    if !projected_tool_call_candidate(step) {
+        return false;
+    }
+    let tool_call_ids = step_tool_call_ids(step);
+    !tool_call_ids.is_empty()
+        && tool_call_ids
+            .iter()
+            .all(|tool_call_id| observed_later.contains(tool_call_id))
+}
+
+fn projected_tool_call_candidate(step: &AtifStep) -> bool {
+    step.source == "agent"
+        && step.message == empty_message()
+        && step.observation.is_none()
+        && step.reasoning_content.is_none()
+        && step.reasoning_effort.is_none()
+        && step.llm_call_count == Some(1)
+        && step
+            .tool_calls
+            .as_ref()
+            .is_some_and(|tool_calls| !tool_calls.is_empty())
+}
+
+fn extend_observed_tool_call_ids(observed_later: &mut HashSet<String>, step: &AtifStep) {
+    for tool_call_id in observed_tool_call_ids(step) {
+        observed_later.insert(tool_call_id);
+    }
+}
+
+fn observed_tool_call_ids(step: &AtifStep) -> Vec<String> {
+    let step_tool_call_ids = step_tool_call_ids(step);
+    step.observation
+        .as_ref()
+        .map(|observation| matching_observation_source_ids(observation, &step_tool_call_ids))
+        .unwrap_or_default()
+}
+
+fn matching_observation_source_ids(
+    observation: &AtifObservation,
+    step_tool_call_ids: &[String],
+) -> Vec<String> {
+    observation
+        .results
+        .iter()
+        .filter_map(|result| result.source_call_id.as_ref())
+        .filter(|source_call_id| step_tool_call_ids.contains(source_call_id))
+        .cloned()
+        .collect()
+}
+
+fn step_tool_call_ids(step: &AtifStep) -> Vec<String> {
+    step.tool_calls
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|tool_call| tool_call.tool_call_id.clone())
+        .filter(|tool_call_id| !tool_call_id.is_empty())
+        .collect()
 }
 
 fn merge_observation_result(observation: &mut AtifObservation, mut result: AtifObservationResult) {
@@ -2123,7 +2593,7 @@ fn events_to_steps_for_agent(
     tree: &AgentScopeTree,
     agent_uuid: Uuid,
 ) -> Vec<AtifStep> {
-    let lookups = EventLookupMaps::from_events(events);
+    let lookups = EventLookupMaps::from_events_for_agent(events, tree, agent_uuid);
     let mut state = StepConversionState::default();
 
     for event in events {
@@ -2175,6 +2645,16 @@ fn events_to_steps(events: &[&Event]) -> Vec<AtifStep> {
 
 fn is_empty_mark_payload(data: &Json) -> bool {
     data.is_null() || data.as_object().is_some_and(|object| object.is_empty())
+}
+
+fn is_llm_chunk_mark(mark: &Event) -> bool {
+    mark.name() == "llm.chunk"
+        || mark
+            .metadata()
+            .and_then(Json::as_object)
+            .and_then(|metadata| metadata.get("hook_event_name"))
+            .and_then(Json::as_str)
+            == Some("llm.chunk")
 }
 
 // A runtime mark is point-in-time telemetry rather than a scoped call with start/end events. Agent

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -486,6 +486,36 @@ fn test_exporter_tool_lifecycle() {
 }
 
 #[test]
+fn test_exporter_omits_null_tool_observation_content() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+    let tool_uuid = Uuid::now_v7();
+
+    let end = event_builder(tool_uuid, EventType::End)
+        .name("noop")
+        .scope_type(ScopeType::Tool)
+        .output(json!(null))
+        .tool_call_id("call_123")
+        .build();
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state.events.push(end);
+    }
+
+    let trajectory = exporter.export();
+    let result = &trajectory.steps[0].observation.as_ref().unwrap().results[0];
+
+    assert_eq!(result.content, None);
+    assert!(
+        !serde_json::to_value(result)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .contains_key("content")
+    );
+}
+
+#[test]
 fn test_exporter_llm_lifecycle() {
     let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
     let llm_uuid = Uuid::now_v7();
@@ -2291,6 +2321,82 @@ fn test_exporter_correlates_repeated_identical_tool_calls_by_ordinal() {
 }
 
 #[test]
+fn test_exporter_correlates_mixed_explicit_implicit_duplicate_tool_calls() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+    let base = base_timestamp();
+    let tool1_uuid = Uuid::now_v7();
+    let tool2_uuid = Uuid::now_v7();
+    let llm_uuid = Uuid::now_v7();
+    let args = json!({"path": "./same.py", "offset": 0, "limit": 10});
+
+    let mut tool1_start = event_builder(tool1_uuid, EventType::Start)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .input(args.clone())
+        .tool_call_id("c1")
+        .build();
+    let mut tool1_end = event_builder(tool1_uuid, EventType::End)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .output(json!("first"))
+        .build();
+    let mut tool2_start = event_builder(tool2_uuid, EventType::Start)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .input(args)
+        .build();
+    let mut tool2_end = event_builder(tool2_uuid, EventType::End)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .output(json!("second"))
+        .build();
+    let mut llm_end = event_builder(llm_uuid, EventType::End)
+        .scope_type(ScopeType::Llm)
+        .output(json!({
+            "content": null,
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"./same.py\",\"offset\":0,\"limit\":10}"}},
+                {"id": "c2", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"./same.py\",\"offset\":0,\"limit\":10}"}}
+            ]
+        }))
+        .build();
+
+    for (idx, event) in [
+        &mut tool1_start,
+        &mut tool1_end,
+        &mut tool2_start,
+        &mut tool2_end,
+        &mut llm_end,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        set_event_timestamp(event, base + chrono::Duration::milliseconds(idx as i64));
+    }
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state
+            .events
+            .extend([tool1_start, tool1_end, tool2_start, tool2_end, llm_end]);
+    }
+
+    let trajectory = exporter.export();
+    let observation = trajectory.steps[0].observation.as_ref().unwrap();
+
+    assert_eq!(observation.results.len(), 2);
+    assert_eq!(
+        observation.results[0].source_call_id,
+        Some("c1".to_string())
+    );
+    assert_eq!(
+        observation.results[1].source_call_id,
+        Some("c2".to_string())
+    );
+}
+
+#[test]
 fn test_exporter_does_not_guess_ambiguous_tool_calls_without_arguments() {
     let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
     let base = base_timestamp();
@@ -2346,6 +2452,73 @@ fn test_exporter_does_not_guess_ambiguous_tool_calls_without_arguments() {
         state
             .events
             .extend([tool1_start, tool1_end, tool2_start, tool2_end, llm_end]);
+    }
+
+    let trajectory = exporter.export();
+    let agent_step = trajectory
+        .steps
+        .iter()
+        .find(|step| step.source == "agent")
+        .unwrap();
+    assert!(agent_step.observation.is_none());
+
+    let standalone = trajectory
+        .steps
+        .iter()
+        .find(|step| step.source == "system" && step.observation.is_some())
+        .unwrap();
+    let observation = standalone.observation.as_ref().unwrap();
+    assert_eq!(observation.results.len(), 2);
+    assert!(
+        observation
+            .results
+            .iter()
+            .all(|result| result.source_call_id.is_none())
+    );
+}
+
+#[test]
+fn test_exporter_does_not_guess_by_name_for_active_duplicate_tool_names() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+    let llm_uuid = Uuid::now_v7();
+    let tool1_uuid = Uuid::now_v7();
+    let tool2_uuid = Uuid::now_v7();
+
+    let llm_end = event_builder(llm_uuid, EventType::End)
+        .scope_type(ScopeType::Llm)
+        .output(json!({
+            "content": null,
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}},
+                {"id": "c2", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+            ]
+        }))
+        .build();
+    let tool1_start = event_builder(tool1_uuid, EventType::Start)
+        .name("lookup")
+        .scope_type(ScopeType::Tool)
+        .build();
+    let tool1_end = event_builder(tool1_uuid, EventType::End)
+        .name("lookup")
+        .scope_type(ScopeType::Tool)
+        .output(json!("first"))
+        .build();
+    let tool2_start = event_builder(tool2_uuid, EventType::Start)
+        .name("lookup")
+        .scope_type(ScopeType::Tool)
+        .build();
+    let tool2_end = event_builder(tool2_uuid, EventType::End)
+        .name("lookup")
+        .scope_type(ScopeType::Tool)
+        .output(json!("second"))
+        .build();
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state
+            .events
+            .extend([llm_end, tool1_start, tool1_end, tool2_start, tool2_end]);
     }
 
     let trajectory = exporter.export();
@@ -3001,6 +3174,24 @@ fn cleanup_test_agent_step(
     }
 }
 
+fn cleanup_test_user_step() -> AtifStep {
+    AtifStep {
+        step_id: 0,
+        source: "user".to_string(),
+        message: json!("next turn"),
+        timestamp: None,
+        model_name: None,
+        reasoning_effort: None,
+        reasoning_content: None,
+        tool_calls: None,
+        observation: None,
+        metrics: None,
+        llm_call_count: None,
+        is_copied_context: None,
+        extra: None,
+    }
+}
+
 #[test]
 fn test_projected_duplicate_tool_call_step_is_removed() {
     let mut steps = vec![
@@ -3043,6 +3234,20 @@ fn test_projected_duplicate_tool_call_step_with_metrics_is_removed() {
     assert_eq!(steps.len(), 1);
     assert_eq!(step_tool_call_ids(&steps[0]), vec!["call_dup"]);
     assert!(steps[0].observation.is_some());
+}
+
+#[test]
+fn test_projected_duplicate_cleanup_keeps_same_id_across_turn_boundary() {
+    let mut steps = vec![
+        cleanup_test_agent_step(empty_message(), &["terminal:1"], &[]),
+        cleanup_test_user_step(),
+        cleanup_test_agent_step(empty_message(), &["terminal:1"], &["terminal:1"]),
+    ];
+
+    remove_projected_tool_call_duplicates(&mut steps);
+
+    assert_eq!(steps.len(), 3);
+    assert_eq!(step_tool_call_ids(&steps[0]), vec!["terminal:1"]);
 }
 
 #[test]

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -340,7 +340,7 @@ fn assert_atif_observation_result_refs(
     has_embedded_children: bool,
 ) {
     if let Some(content) = &result.content {
-        assert_atif_message_value(content);
+        assert_atif_observation_content_value(content);
     }
     if let Some(source_call_id) = result.source_call_id.as_deref() {
         assert!(
@@ -382,6 +382,13 @@ fn assert_atif_message_value(value: &serde_json::Value) {
         return;
     }
     panic!("ATIF message/content must be a string or content-part array: {value}");
+}
+
+fn assert_atif_observation_content_value(value: &serde_json::Value) {
+    assert!(
+        !value.is_null(),
+        "ATIF observation content must not be null"
+    );
 }
 
 fn is_atif_content_part(part: &serde_json::Value) -> bool {
@@ -468,10 +475,9 @@ fn test_exporter_tool_lifecycle() {
     let obs = step1.observation.as_ref().unwrap();
     assert_eq!(obs.results.len(), 1);
     assert_eq!(obs.results[0].source_call_id, None);
-    let content = obs.results[0].content.as_ref().unwrap().as_str().unwrap();
     assert_eq!(
-        serde_json::from_str::<serde_json::Value>(content).unwrap(),
-        json!({"results": ["result1"]})
+        obs.results[0].content,
+        Some(json!({"results": ["result1"]}))
     );
     assert_eq!(
         obs.results[0].extra.as_ref().unwrap()["event_name"],
@@ -817,13 +823,7 @@ fn test_exporter_openai_responses_function_calls_promoted_and_correlated() {
 
     let result = &agent_step.observation.as_ref().unwrap().results[0];
     assert_eq!(result.source_call_id.as_deref(), Some("call_terminal_1"));
-    assert_eq!(
-        serde_json::from_str::<serde_json::Value>(
-            result.content.as_ref().unwrap().as_str().unwrap()
-        )
-        .unwrap(),
-        json!({"stdout": "/workspace"})
-    );
+    assert_eq!(result.content, Some(json!({"stdout": "/workspace"})));
 }
 
 #[test]
@@ -984,15 +984,9 @@ fn test_exporter_hermes_wrapper_payload_is_atif_v17_compatible() {
         observation.results[0].source_call_id,
         Some("call_terminal_1".to_string())
     );
-    let content = observation.results[0]
-        .content
-        .as_ref()
-        .unwrap()
-        .as_str()
-        .unwrap();
     assert_eq!(
-        serde_json::from_str::<serde_json::Value>(content).unwrap(),
-        json!({"stdout": "hi", "exit_code": 0})
+        observation.results[0].content,
+        Some(json!({"stdout": "hi", "exit_code": 0}))
     );
 }
 
@@ -1368,13 +1362,7 @@ fn test_exporter_attaches_subagent_ref_to_delegating_tool_observation() {
 
     let result = &agent_step.observation.as_ref().unwrap().results[0];
     assert_eq!(result.source_call_id.as_deref(), Some("call_delegate"));
-    assert_eq!(
-        serde_json::from_str::<serde_json::Value>(
-            result.content.as_ref().unwrap().as_str().unwrap()
-        )
-        .unwrap(),
-        json!({"status": "launched"})
-    );
+    assert_eq!(result.content, Some(json!({"status": "launched"})));
     let refs = result.subagent_trajectory_ref.as_ref().unwrap();
     assert_eq!(refs[0].trajectory_id, Some(child_uuid.to_string()));
     assert_eq!(refs[0].session_id, Some("child-session".to_string()));
@@ -1487,13 +1475,7 @@ fn test_exporter_synthesizes_tool_call_for_active_subagent_dispatch() {
         result.source_call_id.as_deref(),
         Some(tool_call_id.as_str())
     );
-    assert_eq!(
-        serde_json::from_str::<serde_json::Value>(
-            result.content.as_ref().unwrap().as_str().unwrap()
-        )
-        .unwrap(),
-        json!({"status": "completed"})
-    );
+    assert_eq!(result.content, Some(json!({"status": "completed"})));
     let refs = result.subagent_trajectory_ref.as_ref().unwrap();
     assert_eq!(refs[0].trajectory_id, Some(child_uuid.to_string()));
     assert_eq!(refs[0].session_id, Some("child-session".to_string()));
@@ -1765,6 +1747,39 @@ fn test_exporter_skips_empty_mark_payloads() {
 }
 
 #[test]
+fn test_exporter_skips_llm_chunk_marks() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state.events.push(
+            event_builder(Uuid::now_v7(), EventType::Mark)
+                .name("llm.chunk")
+                .data(json!({"delta": "partial"}))
+                .build(),
+        );
+        state.events.push(
+            event_builder(Uuid::now_v7(), EventType::Mark)
+                .name("hook_mark")
+                .metadata(json!({"hook_event_name": "llm.chunk"}))
+                .data(json!({"delta": "partial"}))
+                .build(),
+        );
+        state.events.push(
+            event_builder(Uuid::now_v7(), EventType::Mark)
+                .name("agent.status")
+                .data(json!({"status": "ok"}))
+                .build(),
+        );
+    }
+
+    let trajectory = exporter.export();
+
+    assert_eq!(trajectory.steps.len(), 1);
+    assert_eq!(trajectory.steps[0].message, json!("agent.status"));
+}
+
+#[test]
 fn test_trajectory_serde_roundtrip() {
     let trajectory = AtifTrajectory {
         schema_version: ATIF_SCHEMA_VERSION.to_string(),
@@ -2006,6 +2021,354 @@ fn test_exporter_source_call_id_correlation_by_name() {
     let obs = trajectory.steps[0].observation.as_ref().unwrap();
     // Correlated by function name "search" → "call_xyz"
     assert_eq!(obs.results[0].source_call_id, Some("call_xyz".to_string()));
+}
+
+#[test]
+fn test_exporter_correlates_hermes_style_tool_outputs_before_llm_calls() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+    let base = base_timestamp();
+    let search_uuid = Uuid::now_v7();
+    let read_uuid = Uuid::now_v7();
+    let patch_uuid = Uuid::now_v7();
+    let llm1_uuid = Uuid::now_v7();
+    let llm2_uuid = Uuid::now_v7();
+    let llm3_uuid = Uuid::now_v7();
+
+    let mut search_start = event_builder(search_uuid, EventType::Start)
+        .name("search_files")
+        .scope_type(ScopeType::Tool)
+        .input(json!({"path": ".", "pattern": "ReadOnlyPasswordHashField", "target": "content"}))
+        .build();
+    let mut search_end = event_builder(search_uuid, EventType::End)
+        .name("search_files")
+        .scope_type(ScopeType::Tool)
+        .output(json!({"total_count": 6}))
+        .build();
+    let mut mark1 = event_builder(Uuid::now_v7(), EventType::Mark)
+        .name("hermes_step")
+        .data(json!({"iteration": 2, "previous_tools": ["search_files"]}))
+        .build();
+    let mut read_start = event_builder(read_uuid, EventType::Start)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .input(json!({"path": "./django/contrib/auth/forms.py", "offset": 50, "limit": 20}))
+        .build();
+    let mut read_end = event_builder(read_uuid, EventType::End)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .output(json!({"content": "class ReadOnlyPasswordHashField", "total_lines": 453}))
+        .build();
+    let mut patch_start = event_builder(patch_uuid, EventType::Start)
+        .name("patch")
+        .scope_type(ScopeType::Tool)
+        .input(json!({
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "kwargs.setdefault(\"required\", False)",
+            "new_string": "kwargs.setdefault(\"disabled\", True)"
+        }))
+        .build();
+    let mut patch_end = event_builder(patch_uuid, EventType::End)
+        .name("patch")
+        .scope_type(ScopeType::Tool)
+        .output(json!({"success": true, "files_modified": ["./django/contrib/auth/forms.py"]}))
+        .build();
+
+    let mut llm1_start = event_builder(llm1_uuid, EventType::Start)
+        .name("hermes_assistant_message")
+        .scope_type(ScopeType::Llm)
+        .input(json!({"messages": [], "model": "policy_model", "projection_index": 0}))
+        .build();
+    let mut llm1_end = event_builder(llm1_uuid, EventType::End)
+        .name("hermes_assistant_message")
+        .scope_type(ScopeType::Llm)
+        .output(json!({
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call-search",
+                "type": "function",
+                "function": {
+                    "name": "search_files",
+                    "arguments": "{\"path\":\".\",\"pattern\":\"ReadOnlyPasswordHashField\",\"target\":\"content\"}"
+                }
+            }]
+        }))
+        .build();
+    let mut llm2_start = event_builder(llm2_uuid, EventType::Start)
+        .name("hermes_assistant_message")
+        .scope_type(ScopeType::Llm)
+        .input(json!({"messages": [], "model": "policy_model", "projection_index": 2}))
+        .build();
+    let mut llm2_end = event_builder(llm2_uuid, EventType::End)
+        .name("hermes_assistant_message")
+        .scope_type(ScopeType::Llm)
+        .output(json!({
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call-read",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": "{\"path\":\"./django/contrib/auth/forms.py\",\"offset\":50,\"limit\":20}"
+                }
+            }]
+        }))
+        .build();
+    let mut llm3_start = event_builder(llm3_uuid, EventType::Start)
+        .name("hermes_assistant_message")
+        .scope_type(ScopeType::Llm)
+        .input(json!({"messages": [], "model": "policy_model", "projection_index": 4}))
+        .build();
+    let mut llm3_end = event_builder(llm3_uuid, EventType::End)
+        .name("hermes_assistant_message")
+        .scope_type(ScopeType::Llm)
+        .output(json!({
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call-patch",
+                "type": "function",
+                "function": {
+                    "name": "patch",
+                    "arguments": "{\"path\":\"./django/contrib/auth/forms.py\",\"old_string\":\"kwargs.setdefault(\\\"required\\\", False)\",\"new_string\":\"kwargs.setdefault(\\\"disabled\\\", True)\"}"
+                }
+            }]
+        }))
+        .build();
+
+    for (idx, event) in [
+        &mut search_start,
+        &mut search_end,
+        &mut mark1,
+        &mut read_start,
+        &mut read_end,
+        &mut patch_start,
+        &mut patch_end,
+        &mut llm1_start,
+        &mut llm1_end,
+        &mut llm2_start,
+        &mut llm2_end,
+        &mut llm3_start,
+        &mut llm3_end,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        set_event_timestamp(event, base + chrono::Duration::milliseconds(idx as i64));
+    }
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state.events.extend([
+            search_start,
+            search_end,
+            mark1,
+            read_start,
+            read_end,
+            patch_start,
+            patch_end,
+            llm1_start,
+            llm1_end,
+            llm2_start,
+            llm2_end,
+            llm3_start,
+            llm3_end,
+        ]);
+    }
+
+    let trajectory = exporter.export();
+    let agent_steps = trajectory
+        .steps
+        .iter()
+        .filter(|step| step.source == "agent" && step.tool_calls.is_some())
+        .collect::<Vec<_>>();
+    assert_eq!(agent_steps.len(), 3);
+
+    let expected = [
+        ("call-search", json!({"total_count": 6})),
+        (
+            "call-read",
+            json!({"content": "class ReadOnlyPasswordHashField", "total_lines": 453}),
+        ),
+        (
+            "call-patch",
+            json!({"success": true, "files_modified": ["./django/contrib/auth/forms.py"]}),
+        ),
+    ];
+    for (step, (source_call_id, content)) in agent_steps.into_iter().zip(expected) {
+        let observation = step.observation.as_ref().unwrap();
+        assert_eq!(observation.results.len(), 1);
+        assert_eq!(
+            observation.results[0].source_call_id,
+            Some(source_call_id.to_string())
+        );
+        assert_eq!(observation.results[0].content, Some(content));
+    }
+
+    assert!(!trajectory.steps.iter().any(|step| {
+        step.source == "system"
+            && step
+                .observation
+                .as_ref()
+                .is_some_and(|observation| !observation.results.is_empty())
+    }));
+}
+
+#[test]
+fn test_exporter_correlates_repeated_identical_tool_calls_by_ordinal() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+    let base = base_timestamp();
+    let tool1_uuid = Uuid::now_v7();
+    let tool2_uuid = Uuid::now_v7();
+    let llm_uuid = Uuid::now_v7();
+
+    let mut tool1_start = event_builder(tool1_uuid, EventType::Start)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .input(json!({"path": "./same.py", "offset": 0, "limit": 10}))
+        .build();
+    let mut tool1_end = event_builder(tool1_uuid, EventType::End)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .output(json!("first"))
+        .build();
+    let mut tool2_start = event_builder(tool2_uuid, EventType::Start)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .input(json!({"path": "./same.py", "offset": 0, "limit": 10}))
+        .build();
+    let mut tool2_end = event_builder(tool2_uuid, EventType::End)
+        .name("read_file")
+        .scope_type(ScopeType::Tool)
+        .output(json!("second"))
+        .build();
+    let mut llm_end = event_builder(llm_uuid, EventType::End)
+        .scope_type(ScopeType::Llm)
+        .output(json!({
+            "content": null,
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"./same.py\",\"offset\":0,\"limit\":10}"}},
+                {"id": "c2", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"./same.py\",\"offset\":0,\"limit\":10}"}}
+            ]
+        }))
+        .build();
+
+    for (idx, event) in [
+        &mut tool1_start,
+        &mut tool1_end,
+        &mut tool2_start,
+        &mut tool2_end,
+        &mut llm_end,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        set_event_timestamp(event, base + chrono::Duration::milliseconds(idx as i64));
+    }
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state
+            .events
+            .extend([tool1_start, tool1_end, tool2_start, tool2_end, llm_end]);
+    }
+
+    let trajectory = exporter.export();
+    let observation = trajectory.steps[0].observation.as_ref().unwrap();
+    assert_eq!(observation.results.len(), 2);
+    assert_eq!(
+        observation.results[0].source_call_id,
+        Some("c1".to_string())
+    );
+    assert_eq!(observation.results[0].content, Some(json!("first")));
+    assert_eq!(
+        observation.results[1].source_call_id,
+        Some("c2".to_string())
+    );
+    assert_eq!(observation.results[1].content, Some(json!("second")));
+}
+
+#[test]
+fn test_exporter_does_not_guess_ambiguous_tool_calls_without_arguments() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+    let base = base_timestamp();
+    let tool1_uuid = Uuid::now_v7();
+    let tool2_uuid = Uuid::now_v7();
+    let llm_uuid = Uuid::now_v7();
+
+    let mut tool1_start = event_builder(tool1_uuid, EventType::Start)
+        .name("lookup")
+        .scope_type(ScopeType::Tool)
+        .build();
+    let mut tool1_end = event_builder(tool1_uuid, EventType::End)
+        .name("lookup")
+        .scope_type(ScopeType::Tool)
+        .output(json!("first"))
+        .build();
+    let mut tool2_start = event_builder(tool2_uuid, EventType::Start)
+        .name("lookup")
+        .scope_type(ScopeType::Tool)
+        .build();
+    let mut tool2_end = event_builder(tool2_uuid, EventType::End)
+        .name("lookup")
+        .scope_type(ScopeType::Tool)
+        .output(json!("second"))
+        .build();
+    let mut llm_end = event_builder(llm_uuid, EventType::End)
+        .scope_type(ScopeType::Llm)
+        .output(json!({
+            "content": null,
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}},
+                {"id": "c2", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+            ]
+        }))
+        .build();
+
+    for (idx, event) in [
+        &mut tool1_start,
+        &mut tool1_end,
+        &mut tool2_start,
+        &mut tool2_end,
+        &mut llm_end,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        set_event_timestamp(event, base + chrono::Duration::milliseconds(idx as i64));
+    }
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state
+            .events
+            .extend([tool1_start, tool1_end, tool2_start, tool2_end, llm_end]);
+    }
+
+    let trajectory = exporter.export();
+    let agent_step = trajectory
+        .steps
+        .iter()
+        .find(|step| step.source == "agent")
+        .unwrap();
+    assert!(agent_step.observation.is_none());
+
+    let standalone = trajectory
+        .steps
+        .iter()
+        .find(|step| step.source == "system" && step.observation.is_some())
+        .unwrap();
+    let observation = standalone.observation.as_ref().unwrap();
+    assert_eq!(observation.results.len(), 2);
+    assert!(
+        observation
+            .results
+            .iter()
+            .all(|result| result.source_call_id.is_none())
+    );
 }
 
 #[test]
@@ -2592,4 +2955,118 @@ fn test_step_extra_tool_ancestry_does_not_bleed_across_turns() {
     // Turn 2 agent step has only lookup — no bleed from turn 1
     assert_eq!(extra2.tool_ancestry.len(), 1);
     assert_eq!(extra2.tool_ancestry[0].function_name, "lookup");
+}
+
+fn cleanup_test_agent_step(
+    message: serde_json::Value,
+    tool_call_ids: &[&str],
+    observation_source_ids: &[&str],
+) -> AtifStep {
+    let observation = (!observation_source_ids.is_empty()).then(|| AtifObservation {
+        results: observation_source_ids
+            .iter()
+            .map(|source_call_id| AtifObservationResult {
+                source_call_id: Some((*source_call_id).to_string()),
+                content: Some(json!("done")),
+                subagent_trajectory_ref: None,
+                extra: None,
+            })
+            .collect(),
+    });
+
+    AtifStep {
+        step_id: 0,
+        source: "agent".to_string(),
+        message,
+        timestamp: None,
+        model_name: None,
+        reasoning_effort: None,
+        reasoning_content: None,
+        tool_calls: Some(
+            tool_call_ids
+                .iter()
+                .map(|tool_call_id| AtifToolCall {
+                    tool_call_id: (*tool_call_id).to_string(),
+                    function_name: "terminal".to_string(),
+                    arguments: json!({"command": "pwd"}),
+                    extra: None,
+                })
+                .collect(),
+        ),
+        observation,
+        metrics: None,
+        llm_call_count: Some(1),
+        is_copied_context: None,
+        extra: None,
+    }
+}
+
+#[test]
+fn test_projected_duplicate_tool_call_step_is_removed() {
+    let mut steps = vec![
+        cleanup_test_agent_step(empty_message(), &["call_dup"], &[]),
+        cleanup_test_agent_step(empty_message(), &["call_dup"], &["call_dup"]),
+    ];
+
+    remove_projected_tool_call_duplicates(&mut steps);
+
+    assert_eq!(steps.len(), 1);
+    assert_eq!(step_tool_call_ids(&steps[0]), vec!["call_dup"]);
+    assert_eq!(
+        steps[0]
+            .observation
+            .as_ref()
+            .unwrap()
+            .results
+            .first()
+            .unwrap()
+            .source_call_id
+            .as_deref(),
+        Some("call_dup")
+    );
+}
+
+#[test]
+fn test_projected_duplicate_tool_call_step_with_metrics_is_removed() {
+    let mut steps = vec![
+        cleanup_test_agent_step(empty_message(), &["call_dup"], &[]),
+        cleanup_test_agent_step(empty_message(), &["call_dup"], &["call_dup"]),
+    ];
+    steps[0].metrics = Some(AtifMetrics {
+        prompt_tokens: Some(10),
+        completion_tokens: Some(5),
+        ..Default::default()
+    });
+
+    remove_projected_tool_call_duplicates(&mut steps);
+
+    assert_eq!(steps.len(), 1);
+    assert_eq!(step_tool_call_ids(&steps[0]), vec!["call_dup"]);
+    assert!(steps[0].observation.is_some());
+}
+
+#[test]
+fn test_projected_duplicate_cleanup_preserves_meaningful_agent_content() {
+    let mut steps = vec![
+        cleanup_test_agent_step(json!("I will run terminal."), &["call_dup"], &[]),
+        cleanup_test_agent_step(empty_message(), &["call_dup"], &["call_dup"]),
+    ];
+
+    remove_projected_tool_call_duplicates(&mut steps);
+
+    assert_eq!(steps.len(), 2);
+    assert_eq!(steps[0].message, json!("I will run terminal."));
+}
+
+#[test]
+fn test_projected_duplicate_cleanup_preserves_partial_multi_call_step() {
+    let mut steps = vec![
+        cleanup_test_agent_step(empty_message(), &["call_a", "call_b"], &[]),
+        cleanup_test_agent_step(empty_message(), &["call_a"], &["call_a"]),
+    ];
+
+    remove_projected_tool_call_duplicates(&mut steps);
+
+    assert_eq!(steps.len(), 2);
+    assert_eq!(step_tool_call_ids(&steps[0]), vec!["call_a", "call_b"]);
 }

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -2356,8 +2356,7 @@ fn test_exporter_correlates_mixed_explicit_implicit_duplicate_tool_calls() {
             "content": null,
             "role": "assistant",
             "tool_calls": [
-                {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"./same.py\",\"offset\":0,\"limit\":10}"}},
-                {"id": "c2", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"./same.py\",\"offset\":0,\"limit\":10}"}}
+                {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"./same.py\",\"offset\":0,\"limit\":10}"}}
             ]
         }))
         .build();
@@ -2383,16 +2382,29 @@ fn test_exporter_correlates_mixed_explicit_implicit_duplicate_tool_calls() {
     }
 
     let trajectory = exporter.export();
-    let observation = trajectory.steps[0].observation.as_ref().unwrap();
+    let results = trajectory
+        .steps
+        .iter()
+        .filter_map(|step| step.observation.as_ref())
+        .flat_map(|observation| observation.results.iter())
+        .collect::<Vec<_>>();
 
-    assert_eq!(observation.results.len(), 2);
+    assert_eq!(results.len(), 2);
     assert_eq!(
-        observation.results[0].source_call_id,
+        results
+            .iter()
+            .find(|result| result.content == Some(json!("first")))
+            .unwrap()
+            .source_call_id,
         Some("c1".to_string())
     );
     assert_eq!(
-        observation.results[1].source_call_id,
-        Some("c2".to_string())
+        results
+            .iter()
+            .find(|result| result.content == Some(json!("second")))
+            .unwrap()
+            .source_call_id,
+        None
     );
 }
 


### PR DESCRIPTION
#### Overview

Fix ATIF export so tool outputs can be correlated to LLM tool calls even when the tool execution events are emitted before the LLM events that declare `tool_calls`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds an internal ATIF correlation pre-pass that maps tool scope UUIDs to LLM tool call IDs using explicit IDs first, then exact tool name plus normalized arguments.
- Defers correlated tool observations until the matching agent step exists, so Hermes-style traces attach observations to the correct `tool_calls` instead of emitting standalone system observations.
- Keeps ambiguous unmatched tool results standalone rather than guessing, and preserves structured JSON observation content for object/array tool outputs.
- Adds unit coverage for Hermes-style ordering, repeated identical calls, ambiguous no-argument calls, and structured observation content.

#### Where should the reviewer start?

Start with `crates/core/src/observability/atif.rs`, especially the correlation lookup and deferred observation handling. The regression coverage is in `crates/core/tests/unit/atif_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-169

Validation:

- `cargo test -p nemo-relay atif`
- commit hooks: `cargo fmt`, `cargo clippy`, `cargo check`, docs linkcheck, and file hygiene hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-agent correlation of tool lifecycle events to LLM tool calls, reducing misattributed observations and ensuring tool metadata/lineage attach correctly or are deferred and flushed as standalone observations.
  * Removed duplicate projected tool-call steps and ignored runtime “llm.chunk” marks; observation content is now enforced non-null in exports.

* **Tests**
  * Added tests covering out-of-order and repeated tool-call correlation, duplicate removal, chunk-mark skipping, and observation content validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->