### PR TITLE
docs: update documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For source builds, testing, and contribution workflow, see [CONTRIBUTING.md](CON
 
 ## Documentation
 
-End-user documentation lives at [nvidia.github.io/NeMo-Relay](https://nvidia.github.io/NeMo-Relay/).
+End-user documentation lives at [docs.nvidia.com/nemo/relay](https://docs.nvidia.com/nemo/relay).
 
 The primary documentation track covers Rust, Python, and Node.js.
 

--- a/crates/adaptive/README.md
+++ b/crates/adaptive/README.md
@@ -103,4 +103,4 @@ of the adaptive pipeline.
 
 ## Documentation
 
-NeMo Relay Documentation: https://nvidia.github.io/NeMo-Relay
+NeMo Relay Documentation: https://docs.nvidia.com/nemo/relay

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -132,4 +132,4 @@ output_directory = "./atif"
 
 ## Documentation
 
-NeMo Relay Documentation: https://nvidia.github.io/NeMo-Relay/
+NeMo Relay Documentation: https://docs.nvidia.com/nemo/relay

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -113,4 +113,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Documentation
 
-NeMo Relay Documentation: https://nvidia.github.io/NeMo-Relay
+NeMo Relay Documentation: https://docs.nvidia.com/nemo/relay

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -79,4 +79,4 @@ applications should prefer the supported packages for those languages.
 
 ## Documentation
 
-NeMo Relay Documentation: https://nvidia.github.io/NeMo-Relay
+NeMo Relay Documentation: https://docs.nvidia.com/nemo/relay

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -95,4 +95,4 @@ are available at `nemo-relay-node/typed`, `nemo-relay-node/plugin`,
 
 ## Documentation
 
-NeMo Relay Documentation: https://nvidia.github.io/NeMo-Relay
+NeMo Relay Documentation: https://docs.nvidia.com/nemo/relay

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -78,4 +78,4 @@ with nemo_relay.scope.scope("demo-agent", nemo_relay.ScopeType.Agent) as handle:
 
 ## Documentation
 
-NeMo Relay Documentation: https://nvidia.github.io/NeMo-Relay
+NeMo Relay Documentation: https://docs.nvidia.com/nemo/relay

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -112,4 +112,4 @@ are available at `nemo-relay-wasm/typed`, `nemo-relay-wasm/plugin`,
 
 ## Documentation
 
-NeMo Relay Documentation: https://nvidia.github.io/NeMo-Relay
+NeMo Relay Documentation: https://docs.nvidia.com/nemo/relay

--- a/docs/about-nemo-relay/overview.mdx
+++ b/docs/about-nemo-relay/overview.mdx
@@ -9,7 +9,7 @@ import { MermaidStyles } from "@/components/MermaidStyles";
 SPDX-License-Identifier: Apache-2.0 */}
 
 
-NeMo Relay is a portable execution runtime for agent systems that already have a
+NVIDIA NeMo Relay is a portable execution runtime for agent systems that already have a
 framework, model provider, policy layer, or observability backend. It gives those
 systems one consistent way to describe what is happening when an agent crosses a
 request, tool, or LLM boundary.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -3,7 +3,7 @@
 
 navigation:
   - folder: ./about-nemo-relay
-    title: "About NeMo Relay"
+    title: "About NVIDIA NeMo Relay"
     slug: about-nemo-relay
     title-source: frontmatter
   - folder: ./getting-started
@@ -11,7 +11,7 @@ navigation:
     slug: getting-started
     title-source: frontmatter
   - folder: ./nemo-relay-cli
-    title: "NeMo Relay CLI"
+    title: "NVIDIA NeMo Relay CLI"
     slug: nemo-relay-cli
     title-source: frontmatter
   - folder: ./supported-integrations

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,9 +14,13 @@ navbar-links:
 
 global-theme: nvidia
 
+announcement:
+  message: "🔔 NVIDIA NeMo Relay is <strong>beta software</strong>. APIs and behavior may change with each release."
+
 experimental:
   mdx-components:
   - ./components
+
 products:
 - display-name: "NeMo Relay"
   slug: /

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -175,7 +175,7 @@ do not use, or set their `enabled` fields to `false`.
 Fields inside `config.plugins` are NeMo Relay generic plugin configuration, so
 they use `snake_case` regardless of language. For the full exporter field list,
 see the NeMo Relay Observability Plugin schema in the top-level NeMo Relay
-documentation at [nvidia.github.io/NeMo-Relay](https://nvidia.github.io/NeMo-Relay/).
+documentation at [docs.nvidia.com/nemo/relay](https://docs.nvidia.com/nemo/relay).
 
 ## Verify the Integration
 

--- a/python/nemo_relay/README.md
+++ b/python/nemo_relay/README.md
@@ -193,4 +193,4 @@ The compiled extension is exposed as `nemo_relay._native`.
 
 ## Documentation
 
-NeMo Relay Documentation: https://nvidia.github.io/NeMo-Relay
+NeMo Relay Documentation: https://docs.nvidia.com/nemo/relay


### PR DESCRIPTION
#### Overview

Update NeMo Relay documentation links and docs metadata to point to the NVIDIA-hosted documentation site.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replaced GitHub Pages documentation references with `https://docs.nvidia.com/nemo/relay` in the top-level README, package READMEs, and OpenClaw integration README.
- Updated docs navigation text to use the NVIDIA NeMo Relay product name.
- Added the Fern docs beta announcement metadata.

Validation: not run; docs-only URL, navigation, and metadata updates.

#### Where should the reviewer start?

Start with `README.md` for the canonical documentation URL change, then `fern/docs.yml` for the docs-site metadata update.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Migrated all documentation references to the official NVIDIA documentation site for improved accessibility and centralized maintenance.
  * Enhanced documentation navigation structure and section titles for better organization.
  * Added beta software status announcement to the documentation portal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->