### PR TITLE
docs: mention immutability of `LLMRequest` in Python bindings

### DIFF
--- a/docs/build-plugins/code-examples.mdx
+++ b/docs/build-plugins/code-examples.mdx
@@ -18,10 +18,12 @@ LLM request intercepts receive three arguments: `name`, `request`, and `annotate
 <Tabs>
 <Tab title="Python" language="python">
 ```python
+from typing import Any
+
 import nemo_relay
 
 class HeaderPlugin:
-    def validate(self, plugin_config):
+    def validate(self, plugin_config: dict[str, Any]) -> list[dict[str, str]]:
         if "header_name" not in plugin_config or "value" not in plugin_config:
             return [{
                 "level": "error",
@@ -30,8 +32,13 @@ class HeaderPlugin:
             }]
         return []
 
-    def register(self, plugin_config, context):
-        def add_header(name, request, annotated):
+    def register(self, plugin_config: dict[str, Any], context: nemo_relay.plugin.PluginContext):
+        def add_header(
+            name: str,
+            request: nemo_relay.LLMRequest,
+            annotated: nemo_relay.AnnotatedLLMRequest | None
+        ) -> tuple[nemo_relay.LLMRequest, nemo_relay.AnnotatedLLMRequest | None]:
+            # The request object is immutable, however we can return a new instance with updated headers.
             headers = request.headers.copy()
             headers[plugin_config["header_name"]] = plugin_config["value"]
             return nemo_relay.LLMRequest(headers=headers, content=request.content), annotated

--- a/docs/build-plugins/register-behavior.mdx
+++ b/docs/build-plugins/register-behavior.mdx
@@ -108,10 +108,12 @@ The same model applies in every binding: validate component-local config, then i
 <Tabs>
 <Tab title="Python" language="python">
 ```python
+from typing import Any
+
 import nemo_relay
 
 class HeaderPlugin:
-    def validate(self, plugin_config):
+    def validate(self, plugin_config: dict[str, Any]) -> list[dict[str, str]]:
         if "header_name" not in plugin_config or "value" not in plugin_config:
             return [{
                 "level": "error",
@@ -120,8 +122,12 @@ class HeaderPlugin:
             }]
         return []
 
-    def register(self, plugin_config, context):
-        def add_header(name, request, annotated):
+    def register(self, plugin_config: dict[str, Any], context: nemo_relay.plugin.PluginContext):
+        def add_header(
+            name: str,
+            request: nemo_relay.LLMRequest,
+            annotated: nemo_relay.AnnotatedLLMRequest | None
+        ) -> tuple[nemo_relay.LLMRequest, nemo_relay.AnnotatedLLMRequest | None]:
             headers = request.headers.copy()
             headers[plugin_config["header_name"]] = plugin_config["value"]
             return nemo_relay.LLMRequest(headers=headers, content=request.content), annotated

--- a/python/nemo_relay/__init__.py
+++ b/python/nemo_relay/__init__.py
@@ -37,7 +37,12 @@ Example::
     def redact_args(tool_name, args):
         return {**args, "api_key": "***"}
 
-    def add_header(name, request, annotated):
+    def add_header(
+        name: str,
+        request: nemo_relay.LLMRequest,
+        annotated: nemo_relay.AnnotatedLLMRequest | None
+    ) -> tuple[nemo_relay.LLMRequest, nemo_relay.AnnotatedLLMRequest | None]:
+        # The request object is immutable, however we can return a new instance with updated headers.
         headers = request.headers.copy()
         headers["Authorization"] = "Bearer test-token"
         return nemo_relay.LLMRequest(headers=headers, content=request.content), annotated

--- a/python/nemo_relay/intercepts.py
+++ b/python/nemo_relay/intercepts.py
@@ -10,7 +10,12 @@ Example::
 
     import nemo_relay
 
-    def add_header(name, request, annotated):
+    def add_header(
+        name: str,
+        request: nemo_relay.LLMRequest,
+        annotated: nemo_relay.AnnotatedLLMRequest | None
+    ) -> tuple[nemo_relay.LLMRequest, nemo_relay.AnnotatedLLMRequest | None]:
+        # The request object is immutable, however we can return a new instance with updated headers.
         headers = request.headers.copy()
         headers["X-Trace"] = "demo"
         return nemo_relay.LLMRequest(headers=headers, content=request.content), annotated
@@ -178,7 +183,10 @@ def register_llm_request(name: str, priority: int, break_chain: bool, fn: LlmReq
 
         import nemo_relay
 
-        def add_header(name, request, annotated):
+        def add_header(
+            name: str, request: nemo_relay.LLMRequest,
+            annotated: nemo_relay.AnnotatedLLMRequest | None
+        ) -> tuple[nemo_relay.LLMRequest, nemo_relay.AnnotatedLLMRequest | None]:
             headers = request.headers.copy()
             headers["X-Trace"] = "req-123"
             return nemo_relay.LLMRequest(headers=headers, content=request.content), annotated


### PR DESCRIPTION
#### Overview

The `nemo_relay.LLMRequest` object is immutable in the Python bindings, however authors of LLM intercepts can return a new instance of an `nemo_relay.LLMRequest`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

* Ensure that existing code examples of LLM intercepts include a comment explaiining that the object is immutable.
* Add type hints to existing examples.

I looked into the Node.js examples, and noticed two things:
1. They were already returning copies of the request object
2. The request object is mutable

I re-worked the `inject-header` example to modify the request headers in-place rather than return a new instance:
```js
  register(pluginConfig, context) {
    context.registerLlmRequestIntercept('inject-header', 100, false, ({ request, annotated }) => {
      request.headers[pluginConfig.header_name] = pluginConfig.value;
      return {
        request: request,
        annotated,
      };
    });
  },
```
It worked as expected.

#### Where should the reviewer start?

`docs/build-plugins/code-examples.mdx`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced plugin development documentation with refreshed code examples throughout. Updated Python code samples in plugin registration, request interception, and implementation guides to improve consistency and clarity. The examples now include more comprehensive parameter specifications and demonstrate modern Python best practices, providing developers with clearer guidance for building custom plugins.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->