### PR TITLE
chore: prepare 0.3 code freeze

### DIFF
--- a/.agents/skills/prepare-code-freeze/SKILL.md
+++ b/.agents/skills/prepare-code-freeze/SKILL.md
@@ -40,19 +40,34 @@ This workflow assumes `upstream` is the NVIDIA repository remote
    branch.
 6. Run `just set-version <next-version>` to bump all release-versioned package
    surfaces on `main`.
-7. Validate with targeted checks:
+7. Search documentation source for references to the old version and update
+   current-version install commands, package examples, and configuration
+   examples to `<next-version>` where appropriate:
+
+   ```bash
+   rg -n '<old-version>' README.md docs fern --glob '!docs/_build/**' || true
+   ```
+
+   Review matches before changing them. Leave intentional historical references
+   alone, such as release notes, changelogs, generated build output, and
+   third-party dependency attribution entries.
+8. Validate with targeted checks:
 
    ```bash
    ruby -e 'require "yaml"; YAML.load_file(".github/nightly-alpha-branches.yaml"); YAML.load_file(".github/workflows/nightly-alpha-tag.yaml")'
    just set-version <next-version>
+   rg -n '<old-version>' README.md docs fern --glob '!docs/_build/**' || true
    git diff --check
    ```
 
-8. Open a PR targeting `main` using `.github/pull_request_template.md`. The PR
+   Any remaining documentation matches for `<old-version>` should be intentional
+   and called out in the PR description.
+9. Open a PR targeting `main` using `.github/pull_request_template.md`. The PR
    must mention:
    - the new release branch
    - the nightly alpha branch config update
    - the `just set-version <next-version>` bump
+   - documentation old-version reference updates or intentional leftovers
    - that release-bound PRs now target the new `release/*` branch
 
 ## Guardrails

--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,3 +3,4 @@
 
 branches:
   - main
+  - release/0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-adaptive"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-ffi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "napi",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-python"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ exclude = [".tmp", ".uv-cache"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/NeMo-Relay"
 
 [workspace.dependencies]
-nemo-relay = { version = "0.3.0", path = "crates/core", default-features = false }
-nemo-relay-adaptive = { version = "0.3.0", path = "crates/adaptive" }
-nemo-relay-ffi = { version = "0.3.0", path = "crates/ffi" }
-nemo-relay-cli = { version = "0.3.0", path = "crates/cli" }
+nemo-relay = { version = "0.4.0", path = "crates/core", default-features = false }
+nemo-relay-adaptive = { version = "0.4.0", path = "crates/adaptive" }
+nemo-relay-ffi = { version = "0.4.0", path = "crates/ffi" }
+nemo-relay-cli = { version = "0.4.0", path = "crates/cli" }
 uuid = "=1.18.1"
 
 [workspace.lints.rust]

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Node.js bindings for the NeMo Relay agent runtime.",
   "keywords": [
     "agents",

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -20,7 +20,7 @@ Install the NeMo Relay CLI when you want the `nemo-relay` executable for
 coding-agent hook and LLM gateway observability.
 
 ```bash
-cargo install nemo-relay-cli@0.3.0
+cargo install nemo-relay-cli@0.4.0
 ```
 
 ## Python
@@ -29,7 +29,7 @@ Install the Python package when your application uses NeMo Relay through the
 Python wrapper.
 
 ```bash
-uv add nemo-relay@0.3.0
+uv add nemo-relay@0.4.0
 ```
 
 Use `uv add` from an application project that has a `pyproject.toml`; it records
@@ -52,8 +52,8 @@ npm install nemo-relay-node
 Add the Rust crates when your application uses NeMo Relay directly from Rust.
 
 ```bash
-cargo add nemo-relay@0.3.0
-cargo add nemo-relay-adaptive@0.3.0
+cargo add nemo-relay@0.4.0
+cargo add nemo-relay-adaptive@0.4.0
 ```
 
 - `nemo-relay` provides the core runtime APIs for scopes, middleware, subscribers, plugins, tool calls, and LLM calls.
@@ -70,7 +70,7 @@ Install the OpenClaw plugin through OpenClaw so OpenClaw can register and manage
 the package:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.3.0
+openclaw plugins install npm:nemo-relay-openclaw@0.4.0
 openclaw gateway restart
 ```
 
@@ -85,7 +85,7 @@ Install the Python package with the supported framework extras when your
 application uses LangChain, LangGraph, or Deep Agents.
 
 ```bash
-uv add "nemo-relay[langchain,langgraph,deepagents]@0.3.0"
+uv add "nemo-relay[langchain,langgraph,deepagents]@0.4.0"
 ```
 
 The extras install the NeMo Relay Python package plus the dependencies needed by

--- a/docs/getting-started/quick-start/python.mdx
+++ b/docs/getting-started/quick-start/python.mdx
@@ -20,7 +20,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-uv add nemo-relay@0.3.0
+uv add nemo-relay@0.4.0
 ```
 
 Run `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/quick-start/rust.mdx
+++ b/docs/getting-started/quick-start/rust.mdx
@@ -18,8 +18,8 @@ local checkout.
 Use the published crates when you are consuming a release:
 
 ```bash
-cargo add nemo-relay@0.3.0
-cargo add nemo-relay-adaptive@0.3.0
+cargo add nemo-relay@0.4.0
+cargo add nemo-relay-adaptive@0.4.0
 cargo add serde_json
 ```
 
@@ -27,7 +27,7 @@ Install the published NeMo Relay CLI separately when you need coding-agent hook
 and LLM gateway observability:
 
 ```bash
-cargo install nemo-relay-cli@0.3.0
+cargo install nemo-relay-cli@0.4.0
 ```
 
 ### Install from the Repository
@@ -43,7 +43,7 @@ serde_json = "1"
 
 - `nemo-relay` is the core Rust runtime surface.
 - `nemo-relay-adaptive` is the companion crate for adaptive runtime primitives and Redis-backed learning components.
-- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.3.0` when
+- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.4.0` when
   you need the NeMo Relay CLI.
 
 ## Push a Scope and Emit a Mark

--- a/docs/observability-plugin/configuration.mdx
+++ b/docs/observability-plugin/configuration.mdx
@@ -79,7 +79,7 @@ transport = "http_binary"
 endpoint = "http://localhost:4318/v1/traces"
 service_name = "nemo-relay"
 service_namespace = "agent"
-service_version = "0.3.0"
+service_version = "0.4.0"
 instrumentation_scope = "nemo-relay-observability"
 timeout_millis = 3000
 
@@ -96,7 +96,7 @@ transport = "http_binary"
 endpoint = "http://localhost:6006/v1/traces"
 service_name = "nemo-relay"
 service_namespace = "agent"
-service_version = "0.3.0"
+service_version = "0.4.0"
 instrumentation_scope = "nemo-relay-openinference"
 timeout_millis = 3000
 
@@ -153,7 +153,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:4318/v1/traces",
                     service_name="nemo-relay",
                     service_namespace="agent",
-                    service_version="0.3.0",
+                    service_version="0.4.0",
                     instrumentation_scope="nemo-relay-observability",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -162,7 +162,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:6006/v1/traces",
                     service_name="nemo-relay",
                     service_namespace="agent",
-                    service_version="0.3.0",
+                    service_version="0.4.0",
                     instrumentation_scope="nemo-relay-openinference",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -211,7 +211,7 @@ await plugin.initialize({
         endpoint: "http://localhost:4318/v1/traces",
         service_name: "nemo-relay",
         service_namespace: "agent",
-        service_version: "0.3.0",
+        service_version: "0.4.0",
         instrumentation_scope: "nemo-relay-observability",
         resource_attributes: {
           "deployment.environment": "dev",
@@ -222,7 +222,7 @@ await plugin.initialize({
         endpoint: "http://localhost:6006/v1/traces",
         service_name: "nemo-relay",
         service_namespace: "agent",
-        service_version: "0.3.0",
+        service_version: "0.4.0",
         instrumentation_scope: "nemo-relay-openinference",
         resource_attributes: {
           "deployment.environment": "dev",
@@ -267,7 +267,7 @@ let component = ComponentSpec::new(ObservabilityConfig {
         endpoint: Some("http://localhost:4318/v1/traces".into()),
         service_name: "nemo-relay".into(),
         service_namespace: Some("agent".into()),
-        service_version: Some("0.3.0".into()),
+        service_version: Some("0.4.0".into()),
         instrumentation_scope: Some("nemo-relay-observability".into()),
         resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
         ..OtlpSectionConfig::default()
@@ -277,7 +277,7 @@ let component = ComponentSpec::new(ObservabilityConfig {
         endpoint: Some("http://localhost:6006/v1/traces".into()),
         service_name: "nemo-relay".into(),
         service_namespace: Some("agent".into()),
-        service_version: Some("0.3.0".into()),
+        service_version: Some("0.4.0".into()),
         instrumentation_scope: Some("nemo-relay-openinference".into()),
         resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
         ..OtlpSectionConfig::default()

--- a/docs/supported-integrations/openclaw-plugin.mdx
+++ b/docs/supported-integrations/openclaw-plugin.mdx
@@ -40,7 +40,7 @@ Optional:
 Install the plugin with OpenClaw so OpenClaw can register and manage it:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.3.0
+openclaw plugins install npm:nemo-relay-openclaw@0.4.0
 openclaw gateway restart
 ```
 
@@ -53,7 +53,7 @@ If you manage OpenClaw plugin dependencies directly in a Node.js project,
 install the package with npm:
 
 ```bash
-npm install nemo-relay-openclaw@0.3.0
+npm install nemo-relay-openclaw@0.4.0
 ```
 
 Installing with npm makes the package available to that project. Use

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-openclaw",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "NeMo Relay-authored observability plugin for OpenClaw.",
   "type": "module",
   "repository": {
@@ -63,7 +63,7 @@
     "openclaw": "^2026.5.26"
   },
   "dependencies": {
-    "nemo-relay-node": "0.3.0"
+    "nemo-relay-node": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
     },
     "crates/node": {
       "name": "nemo-relay-node",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -836,10 +836,10 @@
     },
     "integrations/openclaw": {
       "name": "nemo-relay-openclaw",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nemo-relay-node": "0.3.0"
+        "nemo-relay-node": "0.4.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",


### PR DESCRIPTION
#### Overview

Prepare the repository for the 0.3 code freeze by cutting the release branch, moving main to the next development version, and cleaning up current-version documentation references.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Created and pushed `release/0.3` from `upstream/main` commit `932248c37e92d2918cde1c545c19662bc8b786bd`.
- Added `release/0.3` to `.github/nightly-alpha-branches.yaml` so nightly alpha tagging covers the frozen branch.
- Ran `just set-version 0.4.0` to bump main release-versioned package surfaces after the branch cut.
- Updated current-version docs examples from `0.3.0` to `0.4.0` for install commands, OpenClaw package examples, and observability service-version examples.
- Updated the code-freeze skill to search documentation source for old release-version references during future freezes.
- Release-bound PRs for 0.3 should now target `release/0.3`; main continues toward `0.4.0`.

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/nightly-alpha-branches.yaml"); YAML.load_file(".github/workflows/nightly-alpha-tag.yaml")'`
- `just set-version 0.4.0`
- `rg -n '0\.3\.0' README.md docs fern --glob '!docs/_build/**' || true` returned no source-doc matches
- `git diff --check`
- `cargo check --workspace`
- `just docs`
- Commit hook changed-file checks

#### Where should the reviewer start?

Start with `.github/nightly-alpha-branches.yaml`, then verify the `0.4.0` version bump in `Cargo.toml`, the package lockfiles, and the docs version-reference updates.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.4.0 across packages, integrations, and workspace artifacts.
  * Updated nightly build configuration to include additional branch patterns.

* **Documentation**
  * Updated installation and quick-start docs, observability examples, and integration guides to reference v0.4.0.
  * Added guidance to the release/prepare checklist to require targeted doc-version updates and verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->