### PR TITLE
fix: preserve OpenClaw tool call replay visibility

### DIFF
--- a/integrations/openclaw/src/hook-replay/llm.ts
+++ b/integrations/openclaw/src/hook-replay/llm.ts
@@ -451,12 +451,14 @@ export function buildReplayLlmResponse(
   config: NemoRelayHookBackendConfig,
 ): JsonValue {
   const usage = mapUsage(event.usage);
-  const assistantToolCallNames = toolCallNames(event.assistantToolCalls);
+  const assistantToolCalls = assistantToolCallsForOutput(event, config);
+  const assistantToolCallNames = toolCallNames(assistantToolCalls);
   return toJsonValue({
     role: 'assistant',
     content: config.capture.includeResponses
       ? responseContent(event.assistantTexts, assistantToolCallNames)
       : undefined,
+    tool_calls: assistantToolCalls.length > 0 ? assistantToolCalls : undefined,
     assistant_texts_count: event.assistantTexts.length,
     resolved_ref: event.resolvedRef,
     harness_id: event.harnessId,
@@ -473,6 +475,17 @@ export function buildReplayLlmResponse(
       assistant_tool_call_names: assistantToolCallNames,
     },
   });
+}
+
+/** Return assistant tool calls from the current OpenClaw llm_output contract. */
+function assistantToolCallsForOutput(
+  event: PluginHookLlmOutputEvent,
+  config: NemoRelayHookBackendConfig,
+): unknown[] {
+  const explicit = Array.isArray(event.assistantToolCalls) ? event.assistantToolCalls : [];
+  const inferred = explicit.length > 0 || !isRecord(event.lastAssistant) ? explicit : extractToolCalls(event.lastAssistant);
+  const snapshot = snapshotMessages(inferred);
+  return config.capture.stripToolArgs ? snapshot.map(stripToolCallArgs) : snapshot;
 }
 
 /** Replay an output whose matching input never arrived before the grace timeout. */
@@ -855,6 +868,9 @@ function stripToolCallArgs(value: unknown): unknown {
       stripped[key] = { stripped: true };
     }
   }
+  if (isRecord(stripped.function) && stripped.function.arguments !== undefined) {
+    stripped.function = { ...stripped.function, arguments: { stripped: true } };
+  }
   return stripped;
 }
 
@@ -969,6 +985,8 @@ function isToolCallLike(value: unknown): boolean {
   return (
     isRecord(value) &&
     (value.type === 'toolCall' ||
+      value.type === 'toolcall' ||
+      value.type === 'function_call' ||
       value.type === 'tool_use' ||
       value.type === 'tool-call' ||
       value.toolName !== undefined ||
@@ -987,12 +1005,21 @@ function toolCallNames(toolCalls: unknown[] | undefined): string[] {
       continue;
     }
     const name =
-      stringField(toolCall, 'name') ?? stringField(toolCall, 'toolName') ?? stringField(toolCall, 'functionName');
+      stringField(toolCall, 'name') ??
+      stringField(toolCall, 'toolName') ??
+      stringField(toolCall, 'functionName') ??
+      functionToolCallName(toolCall);
     if (name) {
       names.push(name);
     }
   }
   return names;
+}
+
+/** Read OpenAI-style nested function tool-call names. */
+function functionToolCallName(toolCall: Record<string, unknown>): string | undefined {
+  const fn = toolCall.function;
+  return isRecord(fn) ? stringField(fn, 'name') : undefined;
 }
 
 /** Convert stored message-write usage back into the llm_output usage contract. */

--- a/integrations/openclaw/test/llm-replay.test.ts
+++ b/integrations/openclaw/test/llm-replay.test.ts
@@ -63,6 +63,47 @@ describe('LLM replay', () => {
     assert.equal('token_usage' in response, false);
   });
 
+  it('preserves tool calls from llm output lastAssistant for ATIF and OpenInference', () => {
+    const nf = createNemoRelayRuntime();
+    const backend = createBackend(nf);
+
+    backend.onLlmInput(llmInput(), { runId: 'run-1', sessionId: 'session-1' });
+    backend.onLlmOutput(
+      {
+        ...llmOutput(),
+        assistantTexts: [],
+        lastAssistant: {
+          role: 'assistant',
+          tool_calls: [
+            {
+              id: 'call-search-1',
+              type: 'function',
+              function: {
+                name: 'web_search',
+                arguments: { query: 'private search' },
+              },
+            },
+          ],
+        },
+      },
+      { runId: 'run-1', sessionId: 'session-1' },
+    );
+
+    const response = nf.calls.llmCallEnd[0]?.response as ReplayResponse;
+    assert.equal(response.content, 'tool calls: web_search');
+    assert.deepEqual(response.tool_calls, [
+      {
+        id: 'call-search-1',
+        type: 'function',
+        function: {
+          name: 'web_search',
+          arguments: { stripped: true },
+        },
+      },
+    ]);
+    assert.deepEqual((response.openclaw as ResponseOpenClaw).assistant_tool_call_names, ['web_search']);
+  });
+
   it('uses the observed input time as the fallback llm span start time', () => {
     const now = Date.now;
     const nf = createNemoRelayRuntime();
@@ -781,6 +822,7 @@ type ReplayRequest = {
 
 type ReplayResponse = {
   content?: string;
+  tool_calls?: unknown[];
   assistant_texts_count?: number;
   usage?: Record<string, number>;
   openclaw: Record<string, unknown>;


### PR DESCRIPTION
#### Overview

Preserve OpenClaw assistant tool-call visibility in NeMo Relay replayed LLM responses after the OpenClaw hook payload changed to expose tool calls through `lastAssistant` rather than `assistantToolCalls`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Derive assistant tool calls from `llm_output.lastAssistant` when the legacy `assistantToolCalls` array is absent.
- Include replayed `tool_calls` on LLM responses so ATIF extraction and OpenInference-compatible traces can retain tool-call visibility.
- Preserve the existing capture policy by stripping nested OpenAI-style `function.arguments` when tool argument capture is disabled.
- Add a regression test covering `lastAssistant.tool_calls` replay and stripped arguments.

Supporting evidence for the OpenClaw behavior change:

- The installed OpenClaw `2026.5.26` plugin SDK type for `PluginHookLlmOutputEvent` exposes `lastAssistant?: unknown` and does not expose `assistantToolCalls` (`node_modules/openclaw/dist/plugin-sdk/src/plugins/hook-types.d.ts`).
- The current pinned OpenClaw checkout (`83d7ab0d36`) emits `llm_output` from `third_party/openclaw/src/agents/pi-embedded-runner/run/attempt.ts` with `assistantTexts`, `lastAssistant`, and `usage`; it does not populate `assistantToolCalls`.
- OpenClaw's own wired hook test now exercises `runLlmOutput` with `lastAssistant: { role: "assistant", content: "hi" }` in `third_party/openclaw/src/plugins/wired-hooks-llm.test.ts`.
- Before this PR, NeMo Relay's OpenClaw plugin only looked at `event.assistantToolCalls` when building replayed LLM responses, so direct `llm_output` replay could omit tool-call blocks even when the assistant message still contained them.

Validation:

- `npm test --workspace integrations/openclaw`
- `just test-openclaw`
- `git diff --check`

#### Where should the reviewer start?

Start with `integrations/openclaw/src/hook-replay/llm.ts`, specifically `buildReplayLlmResponse` and the new `assistantToolCallsForOutput` helper.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call processing during LLM replay with enhanced argument sanitization across both top-level and nested structures.
  * Extended tool-call type detection to recognize additional indicators.
  * Refined tool-call inference from assistant message context.

* **Tests**
  * Added tests verifying tool-call preservation and proper sanitization during replay workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
