### PR TITLE
fix: register adaptive plugin in doctor

### DIFF
--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use nemo_relay::observability::plugin_component::OBSERVABILITY_PLUGIN_KIND;
 use nemo_relay::plugin::{DiagnosticLevel, PluginConfig, validate_plugin_config};
+use nemo_relay_adaptive::plugin_component::register_adaptive_component;
 use serde::Serialize;
 use serde_json::Value;
 use tokio::time::timeout;
@@ -592,6 +593,14 @@ async fn collect_observability(gateway: &GatewayConfig) -> Vec<Check> {
             return checks;
         }
     };
+    if let Err(error) = register_adaptive_component() {
+        checks.push(Check {
+            name: "Adaptive plugin",
+            status: Status::Fail,
+            details: format!("registration failed: {error}"),
+        });
+        return checks;
+    }
     let report = validate_plugin_config(&plugin_config);
     if report.diagnostics.is_empty() {
         checks.push(Check {

--- a/crates/cli/tests/coverage/doctor_tests.rs
+++ b/crates/cli/tests/coverage/doctor_tests.rs
@@ -620,6 +620,43 @@ async fn collect_observability_warns_for_missing_atif_dir_without_creating_it() 
     assert!(!missing.exists());
 }
 
+#[tokio::test]
+async fn collect_observability_registers_adaptive_before_validation() {
+    let gateway = GatewayConfig {
+        plugin_config: Some(serde_json::json!({
+            "version": 1,
+            "components": [
+                {
+                    "kind": "observability",
+                    "enabled": true,
+                    "config": { "version": 1 }
+                },
+                {
+                    "kind": "adaptive",
+                    "enabled": false,
+                    "config": {
+                        "policy": {
+                            "unknown_component": "warn",
+                            "unknown_field": "warn",
+                            "unsupported_value": "error"
+                        }
+                    }
+                }
+            ]
+        })),
+        ..GatewayConfig::default()
+    };
+
+    let checks = collect_observability(&gateway).await;
+
+    assert!(
+        !checks.iter().any(|check| check
+            .details
+            .contains("plugin component kind 'adaptive' is unsupported")),
+        "doctor should register adaptive before plugin validation: {checks:?}"
+    );
+}
+
 #[test]
 fn format_agents_human_lists_supported_and_separates_detected() {
     let agents = vec![

--- a/docs/nemo-relay-cli/about.mdx
+++ b/docs/nemo-relay-cli/about.mdx
@@ -42,7 +42,7 @@ NeMo Relay CLI support is experimental and observability-focused.
 | Claude Code | ✅ Yes | ❌ No | ❌ No | Observability only; no known issues. |
 | Codex | ✅ Yes | ❌ No | ❌ No | Observability only; some hooks needed for full feature coverage are missing. |
 | Hermes Agent | ✅ Yes | ❌ No | ❌ No | Observability only; no known issues. |
-| Cursor | ✅ Yes | ❌ No | ❌ No | Observability only; missing hooks under `cursor-agent` limit feature coverage. |
+| Cursor | 🚧 Partial | ❌ No | ❌ No | Observability only; highly experimental |
 
 ## Guides
 

--- a/docs/nemo-relay-cli/cursor.mdx
+++ b/docs/nemo-relay-cli/cursor.mdx
@@ -12,6 +12,20 @@ repository ships a Cursor hook bundle under `integrations/coding-agents/cursor/`
 because this integration does not assume an official Cursor plugin package
 format.
 
+<Error>
+Cursor support is highly experimental and limited. NeMo Relay can install or
+temporarily patch Cursor hooks, but it cannot automatically route Cursor model
+traffic through the gateway. Complete LLM observability requires manual Cursor
+provider/proxy configuration, including any required API keys, and that
+configuration is outside NeMo Relay's control.
+
+Cursor subagents may choose or inherit models independently from the top-level
+session. If those subagent calls bypass the NeMo Relay gateway, their LLM
+requests and responses will not appear in NeMo Relay events even when hook
+events are present.
+
+</Error>
+
 Cursor GUI or IDE sessions can provide agent, subagent, tool, shell, MCP, file,
 and response lifecycle events through `.cursor/hooks.json`. Complete LLM
 lifecycle observability additionally requires Cursor model traffic to route

--- a/integrations/coding-agents/cursor/README.md
+++ b/integrations/coding-agents/cursor/README.md
@@ -9,6 +9,18 @@ This package is a Cursor hook bundle, not an official Cursor plugin package. It
 contains `.cursor/hooks.json` entries that forward canonical Cursor hook JSON to
 `nemo-relay` at `/hooks/cursor`.
 
+> [!CAUTION]
+> Cursor support is highly experimental and limited. NeMo Relay can install or
+> temporarily patch Cursor hooks, but it cannot automatically route Cursor model
+> traffic through the gateway. Complete LLM observability requires manual Cursor
+> provider/proxy configuration, including any required API keys, and that
+> configuration is outside NeMo Relay's control.
+>
+> Cursor subagents may choose or inherit models independently from the top-level
+> session. If those subagent calls bypass the NeMo Relay gateway, their LLM
+> requests and responses will not appear in NeMo Relay events even when hook
+> events are present.
+
 Cursor GUI or IDE sessions can provide agent, subagent, tool, shell, MCP, file,
 and response lifecycle events through `.cursor/hooks.json`. Complete LLM
 lifecycle observability additionally requires Cursor model traffic to route


### PR DESCRIPTION
#### Overview

Register the adaptive plugin component before `nemo-relay doctor` validates plugin configuration, and make Cursor support limitations more explicit in the CLI docs.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Register the built-in adaptive component before doctor plugin validation so adaptive plugin configs no longer report `plugin.unknown_component`.
- Add a focused doctor regression test for adaptive validation.
- Mark Cursor support as partial/highly experimental in the CLI overview.
- Add prominent Cursor cautions for Fern and GitHub docs covering manual proxy/API-key setup, lack of automatic model routing, and subagent model behavior.

Validation:

- `cargo fmt --check`
- `cargo test -p nemo-relay-cli collect_observability_registers_adaptive_before_validation -- --nocapture`
- `just docs`
- Commit pre-checks: docs linkcheck, `cargo fmt`, `cargo clippy`, and `cargo check`

#### Where should the reviewer start?

Start with `crates/cli/src/doctor.rs` for the adaptive registration path, then `docs/nemo-relay-cli/cursor.mdx` for the Cursor support warning.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Cursor integration support as highly experimental with limitations; cannot automatically route model traffic through the gateway
  * Updated observability support matrix for Cursor from fully supported to partial (highly experimental)

* **New Features**
  * Enhanced doctor command to register adaptive components during observability health checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->