### PR TITLE
docs: fix stale naming and add Quick Start binding cards

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# NVIDIA NeMo Agent Toolkit Code of Conduct
+# NVIDIA NeMo Flow Code of Conduct
 This project has adopted the [Contributor Covenant Code of Conduct](https://docs.rapids.ai/resources/conduct/).

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -3,5 +3,5 @@ SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# NVIDIA NeMo Flow Code of Conduct
+# NVIDIA NeMo Relay Code of Conduct
 This project has adopted the [Contributor Covenant Code of Conduct](https://docs.rapids.ai/resources/conduct/).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,10 +227,12 @@ Use the stable root-level wrappers:
 `apply-patches.sh` expects clean third-party checkouts. After editing an integration checkout, run `./scripts/generate-patches.sh` to regenerate patch files and verify they apply to a clean detached checkout.
 
 ### Public API-based Integrations
-Some integrations can be implemented using public APIs without patching. Currently the Python based integrations are located under `python/nemo_relay/integrations/` with their own README files and test suites.
+Some integrations can be implemented using public APIs without patching. The Python integrations live under `python/nemo_relay/integrations/`, are documented in `docs/supported-integrations/`, and have test suites under `python/tests/integrations/`.
 
 Current public API-based integrations include:
 - LangChain: `python/nemo_relay/integrations/langchain`
+- LangGraph: `python/nemo_relay/integrations/langgraph`
+- Deep Agents: `python/nemo_relay/integrations/deepagents`
 
 ## Documentation And Contribution Workflow
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ agent crosses a request, tool, or LLM boundary.
 Agent applications rarely live inside one clean abstraction. A production stack
 might combine NeMo Agent Toolkit, LangChain, LangGraph, provider SDKs, custom
 harness code, NeMo Guardrails, tracing systems, and evaluation pipelines. NeMo
-Flow sits underneath those choices as the shared runtime contract for scopes,
+Relay sits underneath those choices as the shared runtime contract for scopes,
 middleware, plugins, lifecycle events, adaptive behavior, and observability.
 
 Built as a Rust core with primary Rust, Python, and Node.js bindings, NeMo Relay

--- a/docs/about-nemo-relay/ecosystem.mdx
+++ b/docs/about-nemo-relay/ecosystem.mdx
@@ -49,22 +49,22 @@ flowchart TB
     User[User / Application]
     Framework[Agent Framework or Harness]
     Toolkit[NeMo Agent Toolkit / Framework Integrations]
-    Flow[NeMo Relay Runtime]
+    Relay[NeMo Relay Runtime]
     Provider[Model, Tool, or Provider SDK]
     Obs[Subscribers and Observability Backends]
     Policy[Guardrails, Intercepts, and Plugins]
 
     User --> Framework
     Framework --> Toolkit
-    Toolkit --> Flow
-    Framework -. direct instrumentation .-> Flow
-    Flow --> Provider
-    Policy --> Flow
-    Flow --> Obs
+    Toolkit --> Relay
+    Framework -. direct instrumentation .-> Relay
+    Relay --> Provider
+    Policy --> Relay
+    Relay --> Obs
 
     class Framework yellow-lightest;
     class Toolkit blue-lightest;
-    class Flow green-light;
+    class Relay green-light;
     class Provider purple-lightest;
     class Obs grey-light;
     class Policy green-lightest;

--- a/docs/getting-started/quick-start/index.mdx
+++ b/docs/getting-started/quick-start/index.mdx
@@ -7,3 +7,36 @@ position: 5
 SPDX-License-Identifier: Apache-2.0 */}
 
 Choose the Quick Start guide for the primary binding that you plan to use.
+
+<CardGroup cols={3}>
+<Card
+  title="Python Quick Start"
+  icon="brands python"
+  iconPosition="left"
+  href="/getting-started/quick-start/python"
+>
+
+Smallest Python workflow that emits scope, tool, and LLM events.
+</Card>
+
+<Card
+  title="Node.js Quick Start"
+  icon="brands node-js"
+  iconPosition="left"
+  href="/getting-started/quick-start/nodejs"
+>
+
+Smallest Node.js workflow that emits scope, tool, and LLM events.
+</Card>
+
+<Card
+  title="Rust Quick Start"
+  icon="brands rust"
+  iconPosition="left"
+  href="/getting-started/quick-start/rust"
+>
+
+Smallest Rust workflow that emits scope, tool, and LLM events.
+</Card>
+
+</CardGroup>

--- a/docs/integrate-into-frameworks/about.mdx
+++ b/docs/integrate-into-frameworks/about.mdx
@@ -54,7 +54,7 @@ Codex, Cursor, and Hermes Agent support.
 
 Start by identifying the framework's stable tool and LLM boundaries. Prefer
 managed execution wrappers wherever the framework exposes a callback that NeMo
-Flow can own. Use explicit API calls only when the framework owns invocation
+Relay can own. Use explicit API calls only when the framework owns invocation
 internally but exposes reliable start and finish hooks.
 
 Validate that application-visible framework behavior does not change. Then

--- a/docs/integrate-into-frameworks/non-serializable-data.mdx
+++ b/docs/integrate-into-frameworks/non-serializable-data.mdx
@@ -28,7 +28,7 @@ NeMo Relay middleware surfaces operate on JSON-compatible data. Frameworks do no
 ## Recommended Strategies
 
 These strategies keep provider and framework data JSON-compatible before it reaches NeMo
-Flow.
+Relay.
 
 - Convert provider payloads into a stable request shape before NeMo Relay sees them.
 - Preserve opaque framework objects outside the middleware path and pass only the serializable projection into the runtime.

--- a/docs/nemo-relay-cli/hermes.mdx
+++ b/docs/nemo-relay-cli/hermes.mdx
@@ -132,7 +132,7 @@ ls .nemo-relay/atif
 The gateway writes or updates an ATIF snapshot when it receives
 `on_session_end`, `on_session_finalize`, or `on_session_reset`.
 `on_session_end` is a per-turn snapshot boundary: it does not close the NeMo
-Flow session and does not emit a visible trajectory mark. `on_session_finalize`
+Relay session and does not emit a visible trajectory mark. `on_session_finalize`
 and `on_session_reset` close the session.
 
 ## Troubleshoot LLM Lifecycle

--- a/docs/resources/support-and-faqs.mdx
+++ b/docs/resources/support-and-faqs.mdx
@@ -82,7 +82,7 @@ plugins.
 
 ### Why The Name "NeMo Relay"?
 
-"NeMo" places the project in the NVIDIA NeMo ecosystem. "Flow" refers to the
+"NeMo" places the project in the NVIDIA NeMo ecosystem. "Relay" refers to the
 runtime flow of agent work through scopes, middleware, events, subscribers,
 plugins, and exporters.
 

--- a/integrations/coding-agents/README.md
+++ b/integrations/coding-agents/README.md
@@ -32,8 +32,6 @@ environment variables, or shared TOML config.
 - Hermes does not require a static bundle in this directory. The setup wizard
   (`nemo-relay config`) merges hook commands into `.hermes/config.yaml` when
   hermes is selected.
-- `hermes/` contains a native Hermes Python plugin prototype that writes ATIF
-  from Hermes plugin middleware without running the gateway HTTP process.
 
 ## Transparent Setup
 


### PR DESCRIPTION
#### Overview

Documentation cleanup that removes stale "NeMo Flow" / "NAT" / "NeMo Agent
Toolkit" naming in favor of the current project name (NeMo Relay), refreshes the
Quick Start landing page with per-binding navigation, and corrects a few stale
integration notes. Docs-only; no runtime or public API behavior changes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Quick Start (`docs/getting-started/quick-start/index.mdx`): add a 3-column
  `CardGroup` linking to the Python, Node.js, and Rust Quick Start guides.
- Correct stale naming to "NeMo Relay":
  - `.github/CODE_OF_CONDUCT.md`: title is now "NVIDIA NeMo Relay Code of Conduct".
  - `README.md`, `docs/integrate-into-frameworks/about.mdx`,
    `docs/integrate-into-frameworks/non-serializable-data.mdx`,
    `docs/nemo-relay-cli/hermes.mdx`, `docs/resources/support-and-faqs.mdx`:
    replace leftover "NeMo Flow" references with "NeMo Relay".
  - `docs/about-nemo-relay/ecosystem.mdx`: rename the `Flow` node to `Relay` in
    the architecture mermaid diagram.
- `AGENTS.md`: refresh the public-API integration notes to list LangGraph and
  Deep Agents alongside LangChain, and point to `docs/supported-integrations/`
  and `python/tests/integrations/`.
- `integrations/coding-agents/README.md`: remove the stale `hermes/` native
  plugin bundle bullet.

#### Where should the reviewer start?

Start with the naming corrections, especially `.github/CODE_OF_CONDUCT.md` (it
was mistakenly set to "NeMo Flow") and the mermaid node rename in
`docs/about-nemo-relay/ecosystem.mdx`. Then review the new `CardGroup` in
`docs/getting-started/quick-start/index.mdx`. Validated with `just docs-linkcheck`
(0 errors; the only warning is the auth-gated redirects check being skipped).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive quick-start cards for Python, Node.js, and Rust linking to language guides.

* **Documentation**
  * Broadened public integrations list to include LangGraph and Deep Agents.
  * Standardized product name/terminology from “Flow” to “Relay” across docs and diagrams.
  * Clarified framework boundary guidance and non-serializable data wording.
  * Updated Hermes agent guidance and support/FAQ wording.
  * Adjusted Hermes packaging guidance in integrations docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->