### PR TITLE
ci: use current docs helper for release snapshots

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -398,6 +398,13 @@ jobs:
           fi
           printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: workflow-checkout
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Checkout source branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -473,7 +480,7 @@ jobs:
         working-directory: source-checkout
         run: |
           set -euo pipefail
-          uv run --no-sync python scripts/docs/sync_fern_docs_branch.py release-version \
+          uv run --no-sync python "$GITHUB_WORKSPACE/workflow-checkout/scripts/docs/sync_fern_docs_branch.py" release-version \
             --source-root "$GITHUB_WORKSPACE/source-checkout" \
             --target-root "$GITHUB_WORKSPACE/docs-checkout" \
             --tag "${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
#### Overview

Fix manual Fern release snapshot reruns for historical tags. The release job should read documentation from the selected tag, but it must use the current workflow helper script so older tags can be repaired after workflow fixes land.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add a separate `workflow-checkout` in `release-version-docs` for current workflow tooling.
- Keep `source-checkout` pinned to the selected release tag so the docs content remains tag-sourced.
- Invoke `sync_fern_docs_branch.py` from `workflow-checkout`, fixing manual reruns such as `tag=0.3.0` where the tag contains an older helper that does not support `--source-root`.

Validation:

- Reproduced the failing shape from https://github.com/NVIDIA/NeMo-Relay/actions/runs/26668928588/job/78608028705: source checkout from `0.3.0`, helper script from current branch, `release-version --source-root ... --tag 0.3.0`.
- Verified the snapshot writes `fern/pages-v0.3.0` with the detailed release highlights.
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f) }; puts "yaml-ok"'`
- `uv run pre-commit run --files .github/workflows/fern-docs.yml`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start with `.github/workflows/fern-docs.yml` in the `release-version-docs` job. The important detail is that workflow tools and release docs content now come from different checkouts.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: https://github.com/NVIDIA/NeMo-Relay/actions/runs/26668928588/job/78608028705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration for documentation synchronization processes.

**Note:** This release contains no end-user visible changes. Updates are limited to workflow infrastructure improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Relay/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->