### PR TITLE
docs: register plugin kind before activating it in the plugin guide

### DIFF
--- a/docs/build-plugins/register-behavior.mdx
+++ b/docs/build-plugins/register-behavior.mdx
@@ -25,82 +25,6 @@ That gives the plugin system three important guarantees:
 
 Use the context only after validation succeeds. Validation should inspect config and return diagnostics; registration should create runtime objects and attach them to the context.
 
-## Activation APIs
-
-Use the plugin APIs in this order:
-
-1. Register the plugin kind.
-2. Build a `PluginConfig`.
-3. Validate the config.
-4. Initialize the config.
-5. Inspect the activation report.
-6. Clear active config during teardown when needed.
-
-<Tabs>
-<Tab title="Python" language="python">
-```python
-import nemo_relay
-
-config = nemo_relay.plugin.PluginConfig()
-config.components = [
-    nemo_relay.plugin.ComponentSpec(
-        kind="header-plugin",
-        config={"header_name": "x-tenant", "value": "tenant-a"},
-    )
-]
-
-report = nemo_relay.plugin.validate(config)
-active_report = await nemo_relay.plugin.initialize(config)
-kinds = nemo_relay.plugin.list_kinds()
-nemo_relay.plugin.clear()
-```
-
-</Tab>
-
-<Tab title="Node.js" language="node">
-```ts
-import * as plugin from 'nemo-relay-node/plugin';
-
-const config = plugin.defaultConfig();
-config.components = [
-  plugin.ComponentSpec(
-    'header-plugin',
-    { header_name: 'x-tenant', value: 'tenant-a' },
-    { enabled: true },
-  ),
-];
-
-const report = plugin.validate(config);
-const activeReport = await plugin.initialize(config);
-const kinds = plugin.listKinds();
-plugin.clear();
-```
-
-</Tab>
-
-<Tab title="Rust" language="rust">
-```rust
-use nemo_relay::plugin::{
-    clear_plugin_configuration, initialize_plugins, list_plugin_kinds, validate_plugin_config,
-    PluginComponentSpec, PluginConfig,
-};
-
-let mut config = PluginConfig::default();
-let mut component = PluginComponentSpec::new("header-plugin");
-component.config.insert("header_name".into(), "x-tenant".into());
-component.config.insert("value".into(), "tenant-a".into());
-config.components.push(component);
-
-let report = validate_plugin_config(&config);
-let active_report = initialize_plugins(config).await?;
-let kinds = list_plugin_kinds();
-clear_plugin_configuration()?;
-```
-
-</Tab>
-
-</Tabs>
-
 ## Header Plugin Example
 
 The same model applies in every binding: validate component-local config, then install middleware through the component-scoped registration context.
@@ -251,6 +175,83 @@ impl Plugin for HeaderPlugin {
 }
 
 register_plugin(Arc::new(HeaderPlugin))?;
+```
+
+</Tab>
+
+</Tabs>
+
+## Activation APIs
+
+With the plugin kind registered (see the Header Plugin Example above), use the plugin APIs in this order:
+
+1. Build a `PluginConfig`.
+2. Validate the config.
+3. Initialize the config.
+4. Inspect the activation report.
+5. Clear active config during teardown when needed.
+
+Register the plugin kind before you initialize. An unregistered kind is reported by `validate()` only as a warning under the default `unknown_component="warn"` policy, so an error-only check still passes, but `initialize()` raises for a kind that was never registered.
+
+<Tabs>
+<Tab title="Python" language="python">
+```python
+import nemo_relay
+
+config = nemo_relay.plugin.PluginConfig()
+config.components = [
+    nemo_relay.plugin.ComponentSpec(
+        kind="header-plugin",
+        config={"header_name": "x-tenant", "value": "tenant-a"},
+    )
+]
+
+report = nemo_relay.plugin.validate(config)
+active_report = await nemo_relay.plugin.initialize(config)
+kinds = nemo_relay.plugin.list_kinds()
+nemo_relay.plugin.clear()
+```
+
+</Tab>
+
+<Tab title="Node.js" language="node">
+```ts
+import * as plugin from 'nemo-relay-node/plugin';
+
+const config = plugin.defaultConfig();
+config.components = [
+  plugin.ComponentSpec(
+    'header-plugin',
+    { header_name: 'x-tenant', value: 'tenant-a' },
+    { enabled: true },
+  ),
+];
+
+const report = plugin.validate(config);
+const activeReport = await plugin.initialize(config);
+const kinds = plugin.listKinds();
+plugin.clear();
+```
+
+</Tab>
+
+<Tab title="Rust" language="rust">
+```rust
+use nemo_relay::plugin::{
+    clear_plugin_configuration, initialize_plugins, list_plugin_kinds, validate_plugin_config,
+    PluginComponentSpec, PluginConfig,
+};
+
+let mut config = PluginConfig::default();
+let mut component = PluginComponentSpec::new("header-plugin");
+component.config.insert("header_name".into(), "x-tenant".into());
+component.config.insert("value".into(), "tenant-a".into());
+config.components.push(component);
+
+let report = validate_plugin_config(&config);
+let active_report = initialize_plugins(config).await?;
+let kinds = list_plugin_kinds();
+clear_plugin_configuration()?;
 ```
 
 </Tab>

--- a/docs/build-plugins/validate-configuration.mdx
+++ b/docs/build-plugins/validate-configuration.mdx
@@ -126,6 +126,14 @@ Prefer stable diagnostic codes over prose-only messages. The message can improve
 
 Use the validation API before initialization and fail deployment if the report contains errors.
 
+<Warning>
+This error check does not catch an unknown or unregistered component kind. Under
+the default `unknown_component="warn"` policy that case is reported as a warning,
+not an error, so the check below passes while `initialize()` still raises for a
+kind that is not registered. Register every kind before initialization, or set
+`unknown_component="error"` to make validation fail on unknown kinds.
+</Warning>
+
 <Tabs>
 <Tab title="Python" language="python">
 ```python


### PR DESCRIPTION
#### Overview

Reorder the "Register Plugin Behavior" guide so a plugin kind is registered before it is activated, and document the `validate()`-warns / `initialize()`-raises behavior. Run on its own, the **Activation APIs** example previously failed with `RuntimeError: ... 'header-plugin' is not registered`, because the kind it activates is only registered later on the page in the **Header Plugin Example**.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- `docs/build-plugins/register-behavior.mdx`: move the **Header Plugin Example** (which calls `plugin.register("header-plugin", ...)`) above the **Activation APIs** lifecycle so the page reads and runs top to bottom. Drop the now-redundant "Register the plugin kind" item from the activation list, and note that an unregistered kind is reported by `validate()` only as a warning under the default `unknown_component="warn"` policy, while `initialize()` raises. The reorder moves whole sections only; no code-block content changed (verified by an order-independent line diff).
- `docs/build-plugins/validate-configuration.mdx`: add the same clarification to **Validate Before Initialization** — the error-only `has_errors` check does not catch an unknown/unregistered kind; register kinds first, or set `unknown_component="error"`.

Heads-up: this edits the same `register-behavior.mdx` **Activation APIs** section as #199 (which adds `plugin.layer(...)` to that example but does not change the registration ordering). The two overlap, so whichever lands second will need a small conflict resolution.

#### Where should the reviewer start?

`docs/build-plugins/register-behavior.mdx` — confirm the section reorder preserved every code block (an order-independent line diff shows only the numbered list and intro changed) and that the Activation APIs example now follows the Header Plugin Example that registers the kind.

Verified locally: running the Header Plugin Example block and then the Activation APIs block in one process registers `header-plugin`, after which `validate()` / `initialize()` / `clear()` succeed with empty diagnostics and no `RuntimeError`. Targeted `pre-commit` (trailing whitespace, end-of-files, docs markdown linkcheck) passes on both files.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #199 (edits the same `register-behavior.mdx` section)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that plugin kinds must be registered before calling initialize()
  * Explained that unknown/unregistered component kinds are reported as warnings by default during validation and may still cause errors at initialization unless policy is changed
  * Reorganized and updated the activation guide and language across Python/Node/Rust examples for clearer ordering and guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->