### PR TITLE
docs: flush subscribers before deregister in package README examples

### DIFF
--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -66,6 +66,7 @@ const {
   ScopeType,
   deregisterSubscriber,
   event,
+  flushSubscribers,
   registerSubscriber,
   withScope,
 } = require("nemo-relay-node");
@@ -80,6 +81,7 @@ async function main() {
     event("initialized", handle, { binding: "node" }, null);
   });
 
+  flushSubscribers();
   deregisterSubscriber("printer");
 }
 

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -83,6 +83,7 @@ const {
   ScopeType,
   deregisterSubscriber,
   event,
+  flushSubscribers,
   registerSubscriber,
   withScope,
 } = require("nemo-relay-wasm");
@@ -97,6 +98,7 @@ async function main() {
     event("initialized", handle, { binding: "wasm" }, null);
   });
 
+  flushSubscribers();
   deregisterSubscriber("printer");
 }
 

--- a/go/nemo_relay/README.md
+++ b/go/nemo_relay/README.md
@@ -100,6 +100,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer nemo.DeregisterSubscriber("printer")
+	defer nemo.FlushSubscribers()
 
 	handle, err := scope.Push("demo-agent", nemo.ScopeTypeAgent)
 	if err != nil {

--- a/python/nemo_relay/README.md
+++ b/python/nemo_relay/README.md
@@ -142,8 +142,12 @@ nemo_relay.subscribers.register("printer", on_event)
 with nemo_relay.scope.scope("demo-agent", nemo_relay.ScopeType.Agent) as handle:
     nemo_relay.scope.event("initialized", handle=handle, data={"binding": "python"})
 
+nemo_relay.subscribers.flush()
 nemo_relay.subscribers.deregister("printer")
 ```
+
+Native subscriber delivery is asynchronous, so call
+`nemo_relay.subscribers.flush()` before you read subscriber output or exit.
 
 For host integrations that need a serialized event shape, consume the
 canonical JSON payload from the subscriber event object:
@@ -164,6 +168,7 @@ try:
     with nemo_relay.scope.scope("demo-agent", nemo_relay.ScopeType.Agent):
         nemo_relay.scope.event("initialized", data={"binding": "python"})
 finally:
+    nemo_relay.subscribers.flush()
     nemo_relay.subscribers.deregister("host-exporter")
 ```
 


### PR DESCRIPTION
#### Overview

The package READMEs' "Getting Started" examples register a subscriber, emit events, then deregister without calling flush. Native subscriber delivery is non-blocking, so an example that exits right after deregistering can lose queued events. This updates all four package READMEs to flush before deregister, matching the quickstarts (which already flush).

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

**Functional fixes** (verified by running — the example dropped events without flush):
- `python/nemo_relay/README.md`: printed nothing, or intermittently a single partial line; the `to_dict()` / `to_json()` callback never ran. Adds `nemo_relay.subscribers.flush()` before each `deregister(...)`.
- `go/nemo_relay/README.md`: flaky — dropped the trailing tool-end and scope-end events on exit (2 of 3 runs partial). Adds `defer nemo.FlushSubscribers()`, ordered to run after the deferred `scope.Pop` emits the scope-end event and before the deferred deregister.

**Parity** (not currently broken; updated so every README models the same pattern):
- `crates/node/README.md`: Node keeps the event loop alive via the ref'd ThreadsafeFunction, so it already delivers; adds `flushSubscribers()` for consistency.
- `crates/wasm/README.md`: WASM's `flushSubscribers()` is a single-threaded no-op (tested as such); adds it for consistency.

#### Where should the reviewer start?

The four README diffs — each adds a flush before `deregister(...)` (Node/WASM also import `flushSubscribers`). Verified by running each example with the flush added: events deliver deterministically (Go 5/5, Python and Node 3/3 across repeated runs). WASM's `flushSubscribers` is an exported no-op (`crates/wasm/src/api/mod.rs`; covered by `crates/wasm/tests-js/scope_tests.mjs`).

Note: the `crates/node/README.md` example also depends on the Node binding change in #196 (pass a real `ScopeHandle` to `withScope` callbacks). That is orthogonal to this flush change — #196 is code-only and does not touch the README.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #196 (Node `withScope` ScopeHandle; orthogonal, touches the same Node README example)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started examples across Python, Node.js, WebAssembly, and Go language bindings to reflect the proper sequence for flushing subscribers before deregistration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->