### PR TITLE
fix: remove race condition in LC integration tests

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -137,7 +137,7 @@ jobs:
         run: just --set ci true --set output_dir "${{ github.workspace }}" test-python
 
       - name: Run Python LangChain integration tests
-        if: ${{ inputs.run_integration_langchain == 'true' }}
+        if: ${{ inputs.run_integration_langchain }}
         working-directory: ${{ env.NEMO_RELAY_CI_WORKSPACE }}
         run: just --set ci true --set output_dir "${{ github.workspace }}" test-python-langchain
 

--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -3123,8 +3123,9 @@ limitations under the License.
 
 ## block-buffer - 0.10.4
 **Repository URL**: https://github.com/RustCrypto/utils
-**License Type(s)**: Apache-2.0
-### License: https://spdx.org/licenses/Apache-2.0.html
+**License Type(s)**: MIT OR Apache-2.0
+### License: https://spdx.org/licenses/
+### License File: LICENSE-APACHE
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -3327,7 +3328,35 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
 
+### License File: LICENSE-MIT
+```
+Copyright (c) 2018-2019 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ## block-buffer - 0.12.0
@@ -7898,8 +7927,9 @@ limitations under the License.
 
 ## crypto-common - 0.1.7
 **Repository URL**: https://github.com/RustCrypto/traits
-**License Type(s)**: Apache-2.0
-### License: https://spdx.org/licenses/Apache-2.0.html
+**License Type(s)**: MIT OR Apache-2.0
+### License: https://spdx.org/licenses/
+### License File: LICENSE-APACHE
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -8102,7 +8132,35 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
 
+### License File: LICENSE-MIT
+```
+Copyright (c) 2021 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ## crypto-common - 0.2.1
@@ -8555,8 +8613,9 @@ SOFTWARE.
 
 ## digest - 0.10.7
 **Repository URL**: https://github.com/RustCrypto/traits
-**License Type(s)**: Apache-2.0
-### License: https://spdx.org/licenses/Apache-2.0.html
+**License Type(s)**: MIT OR Apache-2.0
+### License: https://spdx.org/licenses/
+### License File: LICENSE-APACHE
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -8759,7 +8818,35 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
 
+### License File: LICENSE-MIT
+```
+Copyright (c) 2017 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ## digest - 0.11.2
@@ -13273,6 +13360,7 @@ limitations under the License.
 **Repository URL**: https://github.com/fizyk20/generic-array.git
 **License Type(s)**: MIT
 ### License: https://spdx.org/licenses/MIT.html
+### License File: LICENSE
 ```
 The MIT License (MIT)
 
@@ -20342,8 +20430,9 @@ SOFTWARE.
 
 ## md-5 - 0.10.6
 **Repository URL**: https://github.com/RustCrypto/hashes
-**License Type(s)**: Apache-2.0
-### License: https://spdx.org/licenses/Apache-2.0.html
+**License Type(s)**: MIT OR Apache-2.0
+### License: https://spdx.org/licenses/
+### License File: LICENSE-APACHE
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -20546,7 +20635,37 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
 
+### License File: LICENSE-MIT
+```
+Copyright (c) 2006-2009 Graydon Hoare
+Copyright (c) 2009-2013 Mozilla Foundation
+Copyright (c) 2016 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ## memchr - 2.8.0
@@ -38798,8 +38917,9 @@ limitations under the License.
 
 ## version_check - 0.9.5
 **Repository URL**: https://github.com/SergioBenitez/version_check
-**License Type(s)**: Apache-2.0
-### License: https://spdx.org/licenses/Apache-2.0.html
+**License Type(s)**: MIT/Apache-2.0
+### License: https://spdx.org/licenses/
+### License File: LICENSE-APACHE
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -39002,7 +39122,29 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
 
+### License File: LICENSE-MIT
+```
+The MIT License (MIT)
+Copyright (c) 2017-2018 Sergio Benitez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ## walkdir - 2.5.0

--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -3123,9 +3123,8 @@ limitations under the License.
 
 ## block-buffer - 0.10.4
 **Repository URL**: https://github.com/RustCrypto/utils
-**License Type(s)**: MIT OR Apache-2.0
-### License: https://spdx.org/licenses/
-### License File: LICENSE-APACHE
+**License Type(s)**: Apache-2.0
+### License: https://spdx.org/licenses/Apache-2.0.html
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -3328,35 +3327,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-```
 
-### License File: LICENSE-MIT
-```
-Copyright (c) 2018-2019 The RustCrypto Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 ```
 
 ## block-buffer - 0.12.0
@@ -7927,9 +7898,8 @@ limitations under the License.
 
 ## crypto-common - 0.1.7
 **Repository URL**: https://github.com/RustCrypto/traits
-**License Type(s)**: MIT OR Apache-2.0
-### License: https://spdx.org/licenses/
-### License File: LICENSE-APACHE
+**License Type(s)**: Apache-2.0
+### License: https://spdx.org/licenses/Apache-2.0.html
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -8132,35 +8102,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-```
 
-### License File: LICENSE-MIT
-```
-Copyright (c) 2021 RustCrypto Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 ```
 
 ## crypto-common - 0.2.1
@@ -8613,9 +8555,8 @@ SOFTWARE.
 
 ## digest - 0.10.7
 **Repository URL**: https://github.com/RustCrypto/traits
-**License Type(s)**: MIT OR Apache-2.0
-### License: https://spdx.org/licenses/
-### License File: LICENSE-APACHE
+**License Type(s)**: Apache-2.0
+### License: https://spdx.org/licenses/Apache-2.0.html
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -8818,35 +8759,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-```
 
-### License File: LICENSE-MIT
-```
-Copyright (c) 2017 Artyom Pavlov
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 ```
 
 ## digest - 0.11.2
@@ -13360,7 +13273,6 @@ limitations under the License.
 **Repository URL**: https://github.com/fizyk20/generic-array.git
 **License Type(s)**: MIT
 ### License: https://spdx.org/licenses/MIT.html
-### License File: LICENSE
 ```
 The MIT License (MIT)
 
@@ -20430,9 +20342,8 @@ SOFTWARE.
 
 ## md-5 - 0.10.6
 **Repository URL**: https://github.com/RustCrypto/hashes
-**License Type(s)**: MIT OR Apache-2.0
-### License: https://spdx.org/licenses/
-### License File: LICENSE-APACHE
+**License Type(s)**: Apache-2.0
+### License: https://spdx.org/licenses/Apache-2.0.html
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -20635,37 +20546,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-```
 
-### License File: LICENSE-MIT
-```
-Copyright (c) 2006-2009 Graydon Hoare
-Copyright (c) 2009-2013 Mozilla Foundation
-Copyright (c) 2016 Artyom Pavlov
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 ```
 
 ## memchr - 2.8.0
@@ -38917,9 +38798,8 @@ limitations under the License.
 
 ## version_check - 0.9.5
 **Repository URL**: https://github.com/SergioBenitez/version_check
-**License Type(s)**: MIT/Apache-2.0
-### License: https://spdx.org/licenses/
-### License File: LICENSE-APACHE
+**License Type(s)**: Apache-2.0
+### License: https://spdx.org/licenses/Apache-2.0.html
 ```
                               Apache License
                         Version 2.0, January 2004
@@ -39122,29 +39002,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-```
 
-### License File: LICENSE-MIT
-```
-The MIT License (MIT)
-Copyright (c) 2017-2018 Sergio Benitez
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ## walkdir - 2.5.0

--- a/python/tests/integrations/deepagents_tests/test_deepagents_integration.py
+++ b/python/tests/integrations/deepagents_tests/test_deepagents_integration.py
@@ -258,6 +258,7 @@ def test_e2e_agent(
     with nemo_relay.scope.scope("deepagents-request", nemo_relay.ScopeType.Agent):
         result = agent.invoke({"messages": [{"role": "user", "content": "Create a file named turtle."}]})
 
+    nemo_relay.subscribers.flush()
     assert (tmp_path / "turtle").read_text() == "shell"
     assert result["messages"][-1].content == "created turtle after reviewer verified turtle"
     found_write_file_message = False

--- a/python/tests/integrations/deepagents_tests/test_deepagents_integration.py
+++ b/python/tests/integrations/deepagents_tests/test_deepagents_integration.py
@@ -75,6 +75,7 @@ def test_before_agent_emits_configuration_mark(
     with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
         middleware.before_agent(MagicMock(name="mock_state"), MagicMock(name="mock_runtime"))
 
+    nemo_relay.subscribers.flush()
     marks = _filter_mark_events(subscribed_events)
     assert [mark.name for mark in marks] == ["DeepAgents Skills Configured"]
     assert _mark_metadata(marks[0])["deepagents_kind"] == "skill"
@@ -121,6 +122,7 @@ def test_callback_handler_emits_human_in_the_loop_marks(
             )
         )
 
+    nemo_relay.subscribers.flush()
     marks = _filter_mark_events(subscribed_events)
     assert [mark.name for mark in marks] == [
         "DeepAgents Human In The Loop Interrupt",
@@ -159,6 +161,7 @@ def test_callback_handler_falls_back_for_non_hitl_interrupt(
             )
         )
 
+    nemo_relay.subscribers.flush()
     marks = _filter_mark_events(subscribed_events)
     assert [mark.name for mark in marks] == ["Graph Interrupt", "Graph Resume"]
     assert _mark_metadata(marks[0])["integration"] == "langgraph"

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
@@ -342,7 +343,8 @@ def test_awrap_tool_call_routes_through_tool_execute(
 
 
 @pytest.mark.parametrize("use_async", [False, True])
-def test_agent_integration(use_async: bool, nemo_relay_middleware: NemoRelayMiddleware):
+def test_agent_integration(use_async: bool,
+                           nemo_relay_middleware: NemoRelayMiddleware):
     """An integration test to verify that the middleware correctly wraps a model call end-to-end."""
     from langchain.agents import create_agent
     from langchain_core.messages import AIMessage
@@ -351,13 +353,13 @@ def test_agent_integration(use_async: bool, nemo_relay_middleware: NemoRelayMidd
     model_responses = [
         AIMessage(
             content="",
-            tool_calls=[
-                {
-                    "name": "get_weather",
-                    "args": {"location": "San Francisco"},
-                    "id": "call-1",
-                }
-            ],
+            tool_calls=[{
+                "name": "get_weather",
+                "args": {
+                    "location": "San Francisco"
+                },
+                "id": "call-1",
+            }],
         ),
         AIMessage(content=_DEFAULT_MOCK_RESPONSE_MSG),
     ]
@@ -369,15 +371,15 @@ def test_agent_integration(use_async: bool, nemo_relay_middleware: NemoRelayMidd
         """Get the current weather for a location."""
         return f"The weather in {location} is sunny and 72 degrees."
 
-    agent = create_agent(model=mock_model, tools=[get_weather], middleware=[nemo_relay_middleware])
+    agent = create_agent(model=mock_model,
+                         tools=[get_weather],
+                         middleware=[nemo_relay_middleware])
 
     input_payload = {
-        "messages": [
-            {
-                "role": "user",
-                "content": "What is the weather in San Francisco?",
-            }
-        ]
+        "messages": [{
+            "role": "user",
+            "content": "What is the weather in San Francisco?",
+        }]
     }
 
     events = []
@@ -398,16 +400,19 @@ def test_agent_integration(use_async: bool, nemo_relay_middleware: NemoRelayMidd
     nemo_relay.subscribers.register("event_recorder", event_recorder)
 
     try:
-        with nemo_relay.scope.scope("langchain-request", nemo_relay.ScopeType.Agent):
+        with nemo_relay.scope.scope("langchain-request",
+                                    nemo_relay.ScopeType.Agent):
             if use_async:
                 result = asyncio.run(agent.ainvoke(input_payload))
             else:
                 result = agent.invoke(input_payload)
     finally:
+        nemo_relay.subscribers.flush()
         nemo_relay.subscribers.deregister("event_recorder")
 
-    assert any(
-        message.content == "The weather in San Francisco is sunny and 72 degrees." for message in result["messages"]
-    )
+    assert any(message.content ==
+               "The weather in San Francisco is sunny and 72 degrees."
+               for message in result["messages"])
     assert result["messages"][-1].content == _DEFAULT_MOCK_RESPONSE_MSG
+
     assert events == expected_events

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
@@ -343,8 +342,7 @@ def test_awrap_tool_call_routes_through_tool_execute(
 
 
 @pytest.mark.parametrize("use_async", [False, True])
-def test_agent_integration(use_async: bool,
-                           nemo_relay_middleware: NemoRelayMiddleware):
+def test_agent_integration(use_async: bool, nemo_relay_middleware: NemoRelayMiddleware):
     """An integration test to verify that the middleware correctly wraps a model call end-to-end."""
     from langchain.agents import create_agent
     from langchain_core.messages import AIMessage
@@ -353,13 +351,13 @@ def test_agent_integration(use_async: bool,
     model_responses = [
         AIMessage(
             content="",
-            tool_calls=[{
-                "name": "get_weather",
-                "args": {
-                    "location": "San Francisco"
-                },
-                "id": "call-1",
-            }],
+            tool_calls=[
+                {
+                    "name": "get_weather",
+                    "args": {"location": "San Francisco"},
+                    "id": "call-1",
+                }
+            ],
         ),
         AIMessage(content=_DEFAULT_MOCK_RESPONSE_MSG),
     ]
@@ -371,15 +369,15 @@ def test_agent_integration(use_async: bool,
         """Get the current weather for a location."""
         return f"The weather in {location} is sunny and 72 degrees."
 
-    agent = create_agent(model=mock_model,
-                         tools=[get_weather],
-                         middleware=[nemo_relay_middleware])
+    agent = create_agent(model=mock_model, tools=[get_weather], middleware=[nemo_relay_middleware])
 
     input_payload = {
-        "messages": [{
-            "role": "user",
-            "content": "What is the weather in San Francisco?",
-        }]
+        "messages": [
+            {
+                "role": "user",
+                "content": "What is the weather in San Francisco?",
+            }
+        ]
     }
 
     events = []
@@ -400,8 +398,7 @@ def test_agent_integration(use_async: bool,
     nemo_relay.subscribers.register("event_recorder", event_recorder)
 
     try:
-        with nemo_relay.scope.scope("langchain-request",
-                                    nemo_relay.ScopeType.Agent):
+        with nemo_relay.scope.scope("langchain-request", nemo_relay.ScopeType.Agent):
             if use_async:
                 result = asyncio.run(agent.ainvoke(input_payload))
             else:
@@ -410,9 +407,9 @@ def test_agent_integration(use_async: bool,
         nemo_relay.subscribers.flush()
         nemo_relay.subscribers.deregister("event_recorder")
 
-    assert any(message.content ==
-               "The weather in San Francisco is sunny and 72 degrees."
-               for message in result["messages"])
+    assert any(
+        message.content == "The weather in San Francisco is sunny and 72 degrees." for message in result["messages"]
+    )
     assert result["messages"][-1].content == _DEFAULT_MOCK_RESPONSE_MSG
 
     assert events == expected_events

--- a/python/tests/integrations/langgraph_tests/test_langgraph_integration.py
+++ b/python/tests/integrations/langgraph_tests/test_langgraph_integration.py
@@ -102,8 +102,7 @@ class TestGraphCallbacks:
         callback_handler: NemoRelayCallbackHandler,
     ):
         with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
-            result = sync_graph.invoke(
-                {"value": 1}, config={"callbacks": [callback_handler]})
+            result = sync_graph.invoke({"value": 1}, config={"callbacks": [callback_handler]})
 
         nemo_relay.subscribers.flush()
 
@@ -117,8 +116,7 @@ class TestGraphCallbacks:
         callback_handler: NemoRelayCallbackHandler,
     ):
         with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
-            result = await async_graph.ainvoke(
-                {"value": 1}, config={"callbacks": [callback_handler]})
+            result = await async_graph.ainvoke({"value": 1}, config={"callbacks": [callback_handler]})
 
         nemo_relay.subscribers.flush()
 

--- a/python/tests/integrations/langgraph_tests/test_langgraph_integration.py
+++ b/python/tests/integrations/langgraph_tests/test_langgraph_integration.py
@@ -102,7 +102,10 @@ class TestGraphCallbacks:
         callback_handler: NemoRelayCallbackHandler,
     ):
         with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
-            result = sync_graph.invoke({"value": 1}, config={"callbacks": [callback_handler]})
+            result = sync_graph.invoke(
+                {"value": 1}, config={"callbacks": [callback_handler]})
+
+        nemo_relay.subscribers.flush()
 
         assert result == {"value": 2}
         assert _events_to_strings(subscribed_events) == self._expected_events
@@ -114,7 +117,10 @@ class TestGraphCallbacks:
         callback_handler: NemoRelayCallbackHandler,
     ):
         with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
-            result = await async_graph.ainvoke({"value": 1}, config={"callbacks": [callback_handler]})
+            result = await async_graph.ainvoke(
+                {"value": 1}, config={"callbacks": [callback_handler]})
+
+        nemo_relay.subscribers.flush()
 
         assert result == {"value": 2}
         assert _events_to_strings(subscribed_events) == self._expected_events
@@ -156,6 +162,7 @@ def test_graph_lifecycle_callbacks_emit_marks(
             )
         )
 
+    nemo_relay.subscribers.flush()
     assert _events_to_strings(subscribed_events) == expected_event_strings
 
     interrupt_event = subscribed_events[1]


### PR DESCRIPTION
#### Overview

Ensure `nemo_relay.subscribers.flush()` prior to testing based on subscribed events/marks, and ensure integration tests are run in CI

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced integration tests with improved event flushing to ensure reliable assertion verification.

* **Chores**
  * Updated CI workflow conditional logic for more accurate test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->