### PR TITLE
ci: stop nightly alpha tags for release 0.3

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,4 +3,3 @@
 
 branches:
   - main
-  - release/0.3


### PR DESCRIPTION
#### Overview

Remove `release/0.3` from the nightly alpha tag branch list now that the release line no longer needs nightly tags.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Removed `release/0.3` from `.github/nightly-alpha-branches.yaml`.
- Left `main` as the only branch configured for nightly alpha tags.

#### Where should the reviewer start?

`.github/nightly-alpha-branches.yaml`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly build configuration to consolidate releases and focus on the main development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->