### PR TITLE
test: validate OpenClaw nested subagent exports

### DIFF
--- a/crates/core/tests/unit/observability/atof_tests.rs
+++ b/crates/core/tests/unit/observability/atof_tests.rs
@@ -138,6 +138,37 @@ fn wire_format_llm_event(
     ))
 }
 
+fn openclaw_agent_scope_event(
+    uuid: Uuid,
+    parent_uuid: Option<Uuid>,
+    scope_category: ScopeCategory,
+    name: &str,
+    session_id: &str,
+    scope_role: Option<&str>,
+) -> Event {
+    let mut metadata = Map::new();
+    metadata.insert("source".to_string(), json!("openclaw.session_start"));
+    metadata.insert("hook_event_name".to_string(), json!("session_start"));
+    metadata.insert("session_id".to_string(), json!(session_id));
+    if let Some(scope_role) = scope_role {
+        metadata.insert("nemo_relay_scope_role".to_string(), json!(scope_role));
+    }
+
+    Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(uuid)
+            .parent_uuid_opt(parent_uuid)
+            .name(name)
+            .data(json!({"session_id": session_id}))
+            .metadata(serde_json::Value::Object(metadata))
+            .build(),
+        scope_category,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ))
+}
+
 fn read_jsonl(path: &Path) -> Vec<serde_json::Value> {
     fs::read_to_string(path)
         .unwrap()
@@ -435,6 +466,108 @@ fn subscriber_preserves_wire_format_llm_lifecycle_payloads_as_raw_jsonl() {
         2
     );
     assert_eq!(lines[5]["data"]["usage"]["cost_usd"], 0.001);
+}
+
+#[test]
+fn openclaw_subagent_events_preserve_nested_and_fallback_parent_uuid() {
+    let dir = temp_dir("atof-openclaw-subagent-parentage");
+    let exporter = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&dir)
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+    let subscriber = exporter.subscriber();
+    let parent_uuid = Uuid::now_v7();
+    let nested_child_uuid = Uuid::now_v7();
+    let fallback_child_uuid = Uuid::now_v7();
+
+    let events = [
+        openclaw_agent_scope_event(
+            parent_uuid,
+            None,
+            ScopeCategory::Start,
+            "requester-agent",
+            "parent-session",
+            None,
+        ),
+        openclaw_agent_scope_event(
+            nested_child_uuid,
+            Some(parent_uuid),
+            ScopeCategory::Start,
+            "nested-worker",
+            "nested-child-session",
+            Some("subagent"),
+        ),
+        openclaw_agent_scope_event(
+            nested_child_uuid,
+            Some(parent_uuid),
+            ScopeCategory::End,
+            "nested-worker",
+            "nested-child-session",
+            Some("subagent"),
+        ),
+        openclaw_agent_scope_event(
+            parent_uuid,
+            None,
+            ScopeCategory::End,
+            "requester-agent",
+            "parent-session",
+            None,
+        ),
+        openclaw_agent_scope_event(
+            fallback_child_uuid,
+            None,
+            ScopeCategory::Start,
+            "fallback-worker",
+            "fallback-child-session",
+            Some("subagent"),
+        ),
+        openclaw_agent_scope_event(
+            fallback_child_uuid,
+            None,
+            ScopeCategory::End,
+            "fallback-worker",
+            "fallback-child-session",
+            Some("subagent"),
+        ),
+    ];
+
+    for event in &events {
+        subscriber(event);
+    }
+    exporter.force_flush().unwrap();
+
+    let lines = read_jsonl(exporter.path());
+    let nested_start = lines
+        .iter()
+        .find(|line| {
+            line["uuid"] == nested_child_uuid.to_string() && line["scope_category"] == "start"
+        })
+        .unwrap();
+    assert_eq!(nested_start["parent_uuid"], parent_uuid.to_string());
+    assert_eq!(
+        nested_start["metadata"]["nemo_relay_scope_role"],
+        json!("subagent")
+    );
+
+    let fallback_start = lines
+        .iter()
+        .find(|line| {
+            line["uuid"] == fallback_child_uuid.to_string() && line["scope_category"] == "start"
+        })
+        .unwrap();
+    assert!(
+        !fallback_start
+            .as_object()
+            .unwrap()
+            .contains_key("parent_uuid")
+            || fallback_start["parent_uuid"].is_null()
+    );
+    assert_eq!(
+        fallback_start["metadata"]["nemo_relay_scope_role"],
+        json!("subagent")
+    );
 }
 
 #[test]

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -760,6 +760,129 @@ fn openclaw_replay_payloads_emit_flattened_openinference_llm_attributes() {
 }
 
 #[test]
+fn openclaw_subagent_scopes_preserve_nested_and_fallback_parent_linkage() {
+    let (provider, exporter) = make_provider();
+    let mut processor =
+        OpenInferenceEventProcessor::new(provider.clone(), "test-scope".to_string());
+    let parent_uuid = Uuid::now_v7();
+    let nested_child_uuid = Uuid::now_v7();
+    let fallback_child_uuid = Uuid::now_v7();
+
+    let nested_parent_start = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(parent_uuid)
+            .name("requester-agent")
+            .metadata(json!({
+                "source": "openclaw.session_start",
+                "hook_event_name": "session_start",
+                "session_id": "parent-session"
+            }))
+            .build(),
+        ScopeCategory::Start,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ));
+    let nested_child_start = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(nested_child_uuid)
+            .parent_uuid(parent_uuid)
+            .name("nested-worker")
+            .metadata(json!({
+                "source": "openclaw.session_start",
+                "hook_event_name": "session_start",
+                "session_id": "nested-child-session",
+                "nemo_relay_scope_role": "subagent"
+            }))
+            .build(),
+        ScopeCategory::Start,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ));
+    let nested_child_end = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(nested_child_uuid)
+            .parent_uuid(parent_uuid)
+            .name("nested-worker")
+            .build(),
+        ScopeCategory::End,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ));
+    let nested_parent_end = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(parent_uuid)
+            .name("requester-agent")
+            .build(),
+        ScopeCategory::End,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ));
+    let fallback_child_start = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(fallback_child_uuid)
+            .name("fallback-worker")
+            .metadata(json!({
+                "source": "openclaw.session_start",
+                "hook_event_name": "session_start",
+                "session_id": "fallback-child-session",
+                "nemo_relay_scope_role": "subagent"
+            }))
+            .build(),
+        ScopeCategory::Start,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ));
+    let fallback_child_end = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(fallback_child_uuid)
+            .name("fallback-worker")
+            .build(),
+        ScopeCategory::End,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ));
+
+    for event in [
+        nested_parent_start,
+        nested_child_start,
+        nested_child_end,
+        nested_parent_end,
+        fallback_child_start,
+        fallback_child_end,
+    ] {
+        processor.process(&event);
+    }
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    let nested_child_span = spans
+        .iter()
+        .find(|span| span.name.as_ref() == "nested-worker")
+        .unwrap();
+    let fallback_child_span = spans
+        .iter()
+        .find(|span| span.name.as_ref() == "fallback-worker")
+        .unwrap();
+    let nested_child_attributes = attr_map(&nested_child_span.attributes);
+    let fallback_child_attributes = attr_map(&fallback_child_span.attributes);
+
+    assert_eq!(
+        nested_child_attributes.get("nemo_relay.parent_uuid"),
+        Some(&parent_uuid.to_string())
+    );
+    assert_eq!(
+        fallback_child_attributes.get("nemo_relay.parent_uuid"),
+        Some(&String::new())
+    );
+}
+
+#[test]
 fn generic_unannotated_llm_output_does_not_emit_flattened_output_message_attrs() {
     let (provider, exporter) = make_provider();
     let mut processor =

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -4,7 +4,7 @@
 //! Unit tests for the built-in observability plugin component.
 
 use super::*;
-use crate::api::event::{BaseEvent, EventCategory, ScopeEvent};
+use crate::api::event::{BaseEvent, EventCategory, MarkEvent, ScopeEvent};
 use crate::api::runtime::NemoRelayContextState;
 use crate::api::runtime::global_context;
 use crate::api::scope::{PopScopeParams, PushScopeParams};
@@ -768,6 +768,119 @@ fn atif_routes_global_descendant_events_by_parent_uuid() {
         child_uuid.to_string()
     );
     pop(&agent);
+}
+
+#[test]
+fn atif_keeps_openclaw_child_only_fallback_as_a_top_level_trajectory() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+    reset_runtime();
+    let dir = temp_dir("observability-atif-openclaw-child-fallback");
+    let root_uuid = crate::api::runtime::current_scope_stack()
+        .read()
+        .unwrap()
+        .root_uuid();
+    let child_uuid = Uuid::now_v7();
+    let child_mark_uuid = Uuid::now_v7();
+    let manager = Arc::new(Mutex::new(AtifDispatcher::new(AtifSectionConfig {
+        enabled: true,
+        output_directory: Some(dir.clone()),
+        ..AtifSectionConfig::default()
+    })));
+    let empty_storage: Arc<Vec<Arc<AtifRemoteStorage>>> = Arc::new(Vec::new());
+
+    let child_start_event = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(child_uuid)
+            .parent_uuid(root_uuid)
+            .name("worker-agent")
+            .metadata(json!({
+                "session_id": "child-session",
+                "nemo_relay_scope_role": "subagent"
+            }))
+            .build(),
+        ScopeCategory::Start,
+        vec![],
+        EventCategory::agent(),
+        None,
+    ));
+    assert!(
+        manager
+            .lock()
+            .unwrap()
+            .observe_global(
+                &child_start_event,
+                "__test__",
+                Arc::clone(&manager),
+                Arc::clone(&empty_storage),
+            )
+            .is_none()
+    );
+
+    let child_mark_event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .uuid(child_mark_uuid)
+            .parent_uuid(child_uuid)
+            .name("worker-started")
+            .data(json!({"status": "started"}))
+            .build(),
+        None,
+        None,
+    ));
+    assert!(
+        manager
+            .lock()
+            .unwrap()
+            .observe_global(
+                &child_mark_event,
+                "__test__",
+                Arc::clone(&manager),
+                Arc::clone(&empty_storage),
+            )
+            .is_none()
+    );
+
+    let child_end_event = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(child_uuid)
+            .parent_uuid(root_uuid)
+            .name("worker-agent")
+            .build(),
+        ScopeCategory::End,
+        vec![],
+        EventCategory::agent(),
+        None,
+    ));
+    let (pending_write, targets) = manager
+        .lock()
+        .unwrap()
+        .observe_global(
+            &child_end_event,
+            "__test__",
+            Arc::clone(&manager),
+            Arc::clone(&empty_storage),
+        )
+        .unwrap();
+    let path = dir.join(format!("nemo-relay-atif-{child_uuid}.json"));
+    let results = write_atif(&pending_write, empty_storage.as_slice(), &targets);
+    for (label, result) in &results {
+        assert!(result.is_ok(), "{label:?}: {result:?}");
+    }
+    let scope_subscriber = manager
+        .lock()
+        .unwrap()
+        .complete_scope_write(child_uuid, results);
+    if let Some((scope_uuid, name)) = scope_subscriber {
+        let _ = scope_deregister_subscriber(&scope_uuid, &name);
+    }
+
+    let value: Json = serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+    assert_eq!(value["trajectory_id"], child_uuid.to_string());
+    assert_eq!(value["steps"].as_array().unwrap().len(), 1);
+    assert_eq!(value["steps"][0]["message"], "worker-started");
+    assert!(
+        value.get("subagent_trajectories").is_none() || value["subagent_trajectories"].is_null()
+    );
+    assert!(!value.to_string().contains("subagent_trajectory_ref"));
 }
 
 #[test]


### PR DESCRIPTION
#### Overview

This PR is the test-only follow-up to #210 and adds exporter-visible validation for OpenClaw nested subagent lineage across ATIF, ATOF, and OpenInference.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds ATIF validation that OpenClaw child-only fallback remains a top-level trajectory instead of inventing nested `subagent_trajectory_ref` output.
- Adds ATOF validation that nested OpenClaw child scopes preserve `parent_uuid`, while child-only fallback scopes remain unnested.
- Adds OpenInference validation that nested OpenClaw child scopes preserve `nemo_relay.parent_uuid`, while child-only fallback scopes remain unlinked.
- Keeps the change test-only and focused on exporter-visible proof of the runtime lineage behavior added in #210.
- Avoids runtime, adapter, provider-event, or exporter implementation changes in this PR.

Validated with:
- `cargo test -p nemo-relay atif`
- `cargo test -p nemo-relay atof`
- `cargo test -p nemo-relay openinference`
- `cargo fmt --all --check`
- `uv run pre-commit run --files crates/core/tests/unit/observability/atof_tests.rs crates/core/tests/unit/observability/openinference_tests.rs crates/core/tests/unit/observability/plugin_component_tests.rs`

#### Where should the reviewer start?

Start in `crates/core/tests/unit/observability/plugin_component_tests.rs` for the ATIF fallback trajectory proof, then review `crates/core/tests/unit/observability/atof_tests.rs` and `crates/core/tests/unit/observability/openinference_tests.rs` for the nested-versus-fallback parent-linkage assertions.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #210
- Relates to OpenClaw observability consistency work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests for subagent event handling to verify parent UUID preservation in nested and fallback worker scenarios.
  * Added tests validating OpenInference scope linkage for subagent scopes.
  * Added tests ensuring proper trajectory generation for child-only fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->