### PR TITLE
test: validate OpenClaw model timing diagnostic exports

### DIFF
--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -974,6 +974,75 @@ fn test_exporter_openclaw_placeholder_replay_preserves_empty_user_step_and_raw_r
 }
 
 #[test]
+fn test_exporter_openclaw_timing_marks_become_system_steps_with_payloads() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+    let base = base_timestamp();
+
+    let ambiguous_payload = json!({
+        "runId": "run-1",
+        "sessionId": "session-1",
+        "provider": "openai",
+        "model": "gpt-4",
+        "candidateCount": 2
+    });
+    let unpaired_payload = json!({
+        "runId": "run-1",
+        "callId": "call-1",
+        "provider": "openai",
+        "model": "gpt-4",
+        "durationMs": 42,
+        "outcome": "completed"
+    });
+
+    let mut ambiguous = event_builder(Uuid::now_v7(), EventType::Mark)
+        .name("openclaw.model_call_timing_ambiguous")
+        .data(ambiguous_payload.clone())
+        .build();
+    let mut unpaired = event_builder(Uuid::now_v7(), EventType::Mark)
+        .name("openclaw.model_call_timing_unpaired")
+        .data(unpaired_payload.clone())
+        .build();
+
+    set_event_timestamp(&mut ambiguous, base);
+    set_event_timestamp(&mut unpaired, base + chrono::Duration::milliseconds(1));
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state.events.extend([ambiguous, unpaired]);
+    }
+
+    let trajectory = exporter.export().unwrap();
+    assert_atif_v17_shape(&trajectory);
+    assert_eq!(trajectory.steps.len(), 2);
+
+    let ambiguous_step = &trajectory.steps[0];
+    assert_eq!(ambiguous_step.source, "system");
+    assert_eq!(
+        ambiguous_step.message,
+        json!("openclaw.model_call_timing_ambiguous")
+    );
+    let ambiguous_extra: AtifStepExtra =
+        serde_json::from_value(ambiguous_step.extra.clone().unwrap()).unwrap();
+    assert_eq!(
+        ambiguous_extra.event_payload.as_ref(),
+        Some(&ambiguous_payload)
+    );
+
+    let unpaired_step = &trajectory.steps[1];
+    assert_eq!(unpaired_step.source, "system");
+    assert_eq!(
+        unpaired_step.message,
+        json!("openclaw.model_call_timing_unpaired")
+    );
+    let unpaired_extra: AtifStepExtra =
+        serde_json::from_value(unpaired_step.extra.clone().unwrap()).unwrap();
+    assert_eq!(
+        unpaired_extra.event_payload.as_ref(),
+        Some(&unpaired_payload)
+    );
+}
+
+#[test]
 fn test_openai_responses_input_extracts_latest_user_content_block() {
     let message = extract_user_messages(&json!({
         "input": [

--- a/crates/core/tests/unit/observability/atof_tests.rs
+++ b/crates/core/tests/unit/observability/atof_tests.rs
@@ -197,6 +197,24 @@ fn openclaw_replay_llm_event(
     ))
 }
 
+fn openclaw_timing_mark_event(
+    uuid: Uuid,
+    parent_uuid: Option<Uuid>,
+    name: &str,
+    data: serde_json::Value,
+) -> Event {
+    Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .uuid(uuid)
+            .parent_uuid_opt(parent_uuid)
+            .name(name)
+            .data(data)
+            .build(),
+        None,
+        None,
+    ))
+}
+
 fn read_jsonl(path: &Path) -> Vec<serde_json::Value> {
     fs::read_to_string(path)
         .unwrap()
@@ -666,6 +684,65 @@ fn subscriber_preserves_openclaw_placeholder_replay_payloads_as_raw_jsonl() {
     assert_eq!(lines[0]["data"]["content"]["messages"], json!([]));
     assert_eq!(lines[1]["scope_category"], "end");
     assert_eq!(lines[1]["data"]["content"], "I will search.");
+}
+
+#[test]
+fn subscriber_preserves_openclaw_model_timing_marks_as_raw_jsonl() {
+    let dir = temp_dir("atof-openclaw-model-timing");
+    let exporter = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&dir)
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+    let subscriber = exporter.subscriber();
+
+    let parent_uuid = Uuid::now_v7();
+    let events = [
+        openclaw_timing_mark_event(
+            Uuid::now_v7(),
+            Some(parent_uuid),
+            "openclaw.model_call_timing_ambiguous",
+            json!({
+                "runId": "run-1",
+                "sessionId": "session-1",
+                "provider": "openai",
+                "model": "gpt-4",
+                "candidateCount": 2
+            }),
+        ),
+        openclaw_timing_mark_event(
+            Uuid::now_v7(),
+            Some(parent_uuid),
+            "openclaw.model_call_timing_unpaired",
+            json!({
+                "runId": "run-1",
+                "callId": "call-1",
+                "provider": "openai",
+                "model": "gpt-4",
+                "durationMs": 42,
+                "outcome": "completed"
+            }),
+        ),
+    ];
+
+    for event in &events {
+        subscriber(event);
+    }
+    exporter.force_flush().unwrap();
+
+    let lines = read_jsonl(exporter.path());
+    assert_eq!(lines.len(), events.len());
+    for (line, event) in lines.iter().zip(events.iter()) {
+        assert_eq!(line, &event.try_to_json_value().unwrap());
+        assert_eq!(line["kind"], "mark");
+        assert_eq!(line["parent_uuid"], parent_uuid.to_string());
+    }
+
+    assert_eq!(lines[0]["name"], "openclaw.model_call_timing_ambiguous");
+    assert_eq!(lines[0]["data"]["candidateCount"], 2);
+    assert_eq!(lines[1]["name"], "openclaw.model_call_timing_unpaired");
+    assert_eq!(lines[1]["data"]["durationMs"], 42);
 }
 
 #[test]

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -629,6 +629,115 @@ fn records_span_start_mark_and_end() {
 }
 
 #[test]
+fn openclaw_model_timing_marks_attach_to_parent_spans() {
+    let (provider, exporter) = make_provider();
+    let mut processor =
+        OpenInferenceEventProcessor::new(provider.clone(), "test-scope".to_string());
+    let root_uuid = Uuid::now_v7();
+
+    processor.process(&make_start_event(
+        root_uuid,
+        None,
+        "openclaw.session",
+        ScopeType::Agent,
+        Some(json!({"sessionId": "session-1"})),
+    ));
+    processor.process(&make_mark_event(
+        Some(root_uuid),
+        "openclaw.model_call_timing_ambiguous",
+        Some(json!({
+            "runId": "run-1",
+            "sessionId": "session-1",
+            "provider": "openai",
+            "model": "gpt-4",
+            "candidateCount": 2
+        })),
+    ));
+    processor.process(&make_mark_event(
+        Some(root_uuid),
+        "openclaw.model_call_timing_unpaired",
+        Some(json!({
+            "runId": "run-1",
+            "callId": "call-1",
+            "provider": "openai",
+            "model": "gpt-4",
+            "durationMs": 42,
+            "outcome": "completed"
+        })),
+    ));
+    processor.process(&make_end_event(
+        root_uuid,
+        None,
+        "openclaw.session",
+        ScopeType::Agent,
+        Some(json!({"status": "closed"})),
+    ));
+
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name.as_ref(), "openclaw.session");
+    assert_eq!(span.events.events.len(), 2);
+    assert_eq!(
+        span.events.events[0].name.as_ref(),
+        "openclaw.model_call_timing_ambiguous"
+    );
+    assert_eq!(
+        span.events.events[1].name.as_ref(),
+        "openclaw.model_call_timing_unpaired"
+    );
+
+    let ambiguous_attributes = attr_map(&span.events.events[0].attributes);
+    assert_eq!(
+        ambiguous_attributes.get("nemo_relay.mark.parent_uuid"),
+        Some(&root_uuid.to_string())
+    );
+    let ambiguous_data: serde_json::Value = serde_json::from_str(
+        ambiguous_attributes
+            .get("nemo_relay.mark.data_json")
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        ambiguous_data,
+        json!({
+            "runId": "run-1",
+            "sessionId": "session-1",
+            "provider": "openai",
+            "model": "gpt-4",
+            "candidateCount": 2
+        })
+    );
+    assert!(!ambiguous_attributes.contains_key("nemo_relay.mark.metadata_json"));
+
+    let unpaired_attributes = attr_map(&span.events.events[1].attributes);
+    assert_eq!(
+        unpaired_attributes.get("nemo_relay.mark.parent_uuid"),
+        Some(&root_uuid.to_string())
+    );
+    let unpaired_data: serde_json::Value = serde_json::from_str(
+        unpaired_attributes
+            .get("nemo_relay.mark.data_json")
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        unpaired_data,
+        json!({
+            "runId": "run-1",
+            "callId": "call-1",
+            "provider": "openai",
+            "model": "gpt-4",
+            "durationMs": 42,
+            "outcome": "completed"
+        })
+    );
+    assert!(!unpaired_attributes.contains_key("nemo_relay.mark.metadata_json"));
+}
+
+#[test]
 fn llm_input_value_omits_request_headers() {
     let (provider, exporter) = make_provider();
     let mut processor =


### PR DESCRIPTION
#### Overview

This PR adds exporter-visible validation for OpenClaw model timing diagnostics across ATIF, ATOF, and OpenInference so the hook-backed timing fallback behavior stays explicit and honest in exported observability outputs.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds ATIF validation that `openclaw.model_call_timing_ambiguous` and `openclaw.model_call_timing_unpaired` export as `system` steps with preserved event payloads.
- Adds ATOF validation that OpenClaw timing diagnostic marks are preserved as raw JSONL, including parent linkage and payload contents.
- Adds OpenInference validation that OpenClaw timing diagnostic marks attach to the parent session span as mark events with preserved payloads.
- Keeps the change test-only and focused on exporter-visible proof of existing OpenClaw timing diagnostic behavior.
- Avoids runtime, adapter, provider-event, or exporter implementation changes in this PR.

Validated with:
- `cargo test -p nemo-relay atif`
- `cargo test -p nemo-relay atof`
- `cargo test -p nemo-relay openinference`
- `cargo fmt --all --check`
- `uv run pre-commit run --files crates/core/tests/unit/atif_tests.rs crates/core/tests/unit/observability/atof_tests.rs crates/core/tests/unit/observability/openinference_tests.rs`

#### Where should the reviewer start?

Start in `crates/core/tests/unit/observability/openinference_tests.rs` for the parent-span mark assertion, then review `crates/core/tests/unit/atif_tests.rs` for the ATIF `system` step export proof and `crates/core/tests/unit/observability/atof_tests.rs` for the raw JSONL preservation check.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to OpenClaw observability consistency work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for OpenClaw timing mark handling across ATIF v1.7, JSONL, and OpenInference export formats, validating proper payload preservation, system-level event classification, and span attachment functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->