### PR TITLE
test: add NeMo Relay skill eval datasets

### DIFF
--- a/skills/nemo-relay-build-plugin/evals/evals.json
+++ b/skills/nemo-relay-build-plugin/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-build-plugin",
+  "cases": [
+    {
+      "id": "build-subscriber-plugin",
+      "question": "Package my NeMo Relay subscriber setup as a reusable plugin that can be enabled from config and rolled back safely.",
+      "expected_skill": "nemo-relay-build-plugin",
+      "expected_script": null,
+      "ground_truth": "Use the plugin skill to define a stable kind, JSON-compatible config, deterministic validation, PluginContext-based registration, rollback behavior, and tests.",
+      "expected_behavior": [
+        "Decide that reusable config-activated behavior needs a plugin",
+        "Choose a stable plugin kind and JSON-compatible config shape",
+        "Validate config before registering runtime behavior",
+        "Register through PluginContext and cover rollback on activation failure"
+      ]
+    },
+    {
+      "id": "neg-direct-tool-wrapper",
+      "question": "I only need to wrap one existing Python tool call with NeMo Relay events.",
+      "expected_skill": "nemo-relay-instrument-calls",
+      "expected_script": null,
+      "ground_truth": "A one-off direct tool wrapper belongs to nemo-relay-instrument-calls, not plugin packaging.",
+      "expected_behavior": [
+        "nemo-relay-build-plugin stays silent",
+        "nemo-relay-instrument-calls handles the direct wrapping task"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-debug-runtime-integration/evals/evals.json
+++ b/skills/nemo-relay-debug-runtime-integration/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-debug-runtime-integration",
+  "cases": [
+    {
+      "id": "debug-missing-events",
+      "question": "NeMo Relay is installed, but my wrapped tool calls are not emitting events. Help me debug the integration.",
+      "expected_skill": "nemo-relay-debug-runtime-integration",
+      "expected_script": null,
+      "ground_truth": "Use the debug skill to check binding load, active scope, scope stack propagation, subscriber registration, middleware wiring, and event flush behavior.",
+      "expected_behavior": [
+        "Check whether the binding or native artifact loads",
+        "Verify an active scope exists when the tool call runs",
+        "Inspect subscriber and middleware registration",
+        "Recommend a minimal scoped reproduction before broad code changes"
+      ]
+    },
+    {
+      "id": "neg-first-example",
+      "question": "Show me my first NeMo Relay Python example with a scope and one managed tool call.",
+      "expected_skill": "nemo-relay-start",
+      "expected_script": null,
+      "ground_truth": "First examples belong to nemo-relay-start unless the user reports a failure.",
+      "expected_behavior": [
+        "nemo-relay-debug-runtime-integration stays silent",
+        "nemo-relay-start handles first-time setup"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-export-atif-trajectories/evals/evals.json
+++ b/skills/nemo-relay-export-atif-trajectories/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-export-atif-trajectories",
+  "cases": [
+    {
+      "id": "export-atif-for-replay",
+      "question": "Export my NeMo Relay run as ATIF so another tool can replay and analyze the trajectory.",
+      "expected_skill": "nemo-relay-export-atif-trajectories",
+      "expected_script": null,
+      "ground_truth": "Use the ATIF export skill to create an AtifExporter with session and agent metadata, register it before scoped work, run instrumented calls, deregister, flush, and validate the output.",
+      "expected_behavior": [
+        "Choose ATIF rather than live OTLP tracing",
+        "Create and register an AtifExporter before work runs",
+        "Run scoped tool or LLM activity",
+        "Deregister or flush and verify the trajectory output"
+      ]
+    },
+    {
+      "id": "neg-otel-backend",
+      "question": "Send NeMo Relay traces to my OTLP-compatible tracing backend.",
+      "expected_skill": "nemo-relay-export-otel",
+      "expected_script": null,
+      "ground_truth": "OTLP tracing belongs to nemo-relay-export-otel, not ATIF trajectory export.",
+      "expected_behavior": [
+        "nemo-relay-export-atif-trajectories stays silent",
+        "nemo-relay-export-otel handles OTLP setup"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-export-openinference/evals/evals.json
+++ b/skills/nemo-relay-export-openinference/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-export-openinference",
+  "cases": [
+    {
+      "id": "openinference-semantic-export",
+      "question": "Configure NeMo Relay export for a backend that understands OpenInference spans and LLM semantics.",
+      "expected_skill": "nemo-relay-export-openinference",
+      "expected_script": null,
+      "ground_truth": "Use the OpenInference export skill to configure the OpenInference subscriber/export path, preserve model and tool metadata, and validate semantic span fields.",
+      "expected_behavior": [
+        "Choose OpenInference rather than generic OTEL when semantic LLM fields matter",
+        "Configure the OpenInference subscriber or exporter path",
+        "Preserve model, tool, and scope metadata",
+        "Validate emitted semantic fields in the target backend or test output"
+      ]
+    },
+    {
+      "id": "neg-portable-trajectory",
+      "question": "I need a portable ATIF document for offline replay.",
+      "expected_skill": "nemo-relay-export-atif-trajectories",
+      "expected_script": null,
+      "ground_truth": "Portable ATIF documents belong to nemo-relay-export-atif-trajectories.",
+      "expected_behavior": [
+        "nemo-relay-export-openinference stays silent",
+        "nemo-relay-export-atif-trajectories handles the offline trajectory"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-export-otel/evals/evals.json
+++ b/skills/nemo-relay-export-otel/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-export-otel",
+  "cases": [
+    {
+      "id": "configure-otlp-tracing",
+      "question": "Send NeMo Relay runtime traces to an OTLP-compatible collector for production debugging.",
+      "expected_skill": "nemo-relay-export-otel",
+      "expected_script": null,
+      "ground_truth": "Use the OTEL export skill to configure an OpenTelemetry subscriber/exporter, register it before scoped work, attach useful metadata, flush, and verify spans arrive.",
+      "expected_behavior": [
+        "Choose OpenTelemetry for OTLP-compatible tracing",
+        "Configure and register the OTEL subscriber before scoped work",
+        "Attach useful scope, tool, LLM, and model metadata",
+        "Flush or shut down deterministically and verify exported spans"
+      ]
+    },
+    {
+      "id": "neg-openinference-semantics",
+      "question": "My backend expects OpenInference LLM span semantics.",
+      "expected_skill": "nemo-relay-export-openinference",
+      "expected_script": null,
+      "ground_truth": "OpenInference-specific semantics belong to nemo-relay-export-openinference.",
+      "expected_behavior": [
+        "nemo-relay-export-otel stays silent or redirects",
+        "nemo-relay-export-openinference handles semantic LLM export"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-instrument-calls/evals/evals.json
+++ b/skills/nemo-relay-instrument-calls/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-instrument-calls",
+  "cases": [
+    {
+      "id": "wrap-existing-tool-and-llm",
+      "question": "I already have app tool functions and a provider call. Wrap them with NeMo Relay without changing their business logic.",
+      "expected_skill": "nemo-relay-instrument-calls",
+      "expected_script": null,
+      "ground_truth": "Use the instrumentation skill to choose a scope boundary, wrap existing tool and LLM calls with managed execution APIs, preserve caller-visible results, and attach metadata where useful.",
+      "expected_behavior": [
+        "Choose a natural agent, request, workflow, or graph scope boundary",
+        "Use managed execution APIs before manual lifecycle APIs",
+        "Preserve the original callable arguments and results",
+        "Handle metadata and context propagation when needed"
+      ]
+    },
+    {
+      "id": "neg-export-traces",
+      "question": "My calls are already wrapped; now export traces to OpenTelemetry.",
+      "expected_skill": "nemo-relay-export-otel",
+      "expected_script": null,
+      "ground_truth": "Export setup after instrumentation belongs to nemo-relay-export-otel.",
+      "expected_behavior": [
+        "nemo-relay-instrument-calls stays silent or redirects",
+        "nemo-relay-export-otel handles trace export"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-migrate-from-flow/SKILL.md
+++ b/skills/nemo-relay-migrate-from-flow/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nemo-relay-migrate-from-flow
 description: Migrate applications, examples, integrations, documentation, package manifests, and repository code from NeMo Flow naming and packages to NeMo Relay across Python, Rust, Node.js, Go, WebAssembly, C FFI, CLI, config, and observability surfaces; use when a user asks to rename nemo_flow/nemo-flow/NeMo Flow APIs, automate a migration, update imports or dependencies, or validate a Flow-to-Relay conversion
+author: NVIDIA Corporation and Affiliates
 license: Apache-2.0
 ---
 

--- a/skills/nemo-relay-migrate-from-flow/evals/evals.json
+++ b/skills/nemo-relay-migrate-from-flow/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-migrate-from-flow",
+  "cases": [
+    {
+      "id": "migrate-python-flow-imports",
+      "question": "Migrate my Python code and package manifests from NeMo Flow to NeMo Relay naming.",
+      "expected_skill": "nemo-relay-migrate-from-flow",
+      "expected_script": "scripts/migrate_from_nemo_flow.py",
+      "ground_truth": "Use the Flow migration skill to inspect touched surfaces, run the migration helper in dry-run mode, review rename scope, rerun with write only when scoped correctly, and validate remaining Flow names.",
+      "expected_behavior": [
+        "Identify affected language and package surfaces",
+        "Run the bundled migration helper in dry-run mode first",
+        "Review proposed text edits and path renames before writing",
+        "Search for remaining Flow names and validate affected surfaces"
+      ]
+    },
+    {
+      "id": "neg-build-plugin",
+      "question": "Create a new reusable NeMo Relay guardrail plugin from config.",
+      "expected_skill": "nemo-relay-build-plugin",
+      "expected_script": null,
+      "ground_truth": "Plugin authoring belongs to nemo-relay-build-plugin, not Flow-to-Relay migration.",
+      "expected_behavior": [
+        "nemo-relay-migrate-from-flow stays silent",
+        "nemo-relay-build-plugin handles plugin creation"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-setup-observability/evals/evals.json
+++ b/skills/nemo-relay-setup-observability/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-setup-observability",
+  "cases": [
+    {
+      "id": "choose-observability-path",
+      "question": "I want visibility into NeMo Relay activity but I do not know whether I need console events, ATIF, OTEL, or OpenInference.",
+      "expected_skill": "nemo-relay-setup-observability",
+      "expected_script": null,
+      "ground_truth": "Use the observability setup skill to choose between subscribers, ATIF, OpenTelemetry, and OpenInference based on the user's output target and then route to the narrower export skill if needed.",
+      "expected_behavior": [
+        "Ask or infer the desired observability output",
+        "Explain subscriber, ATIF, OTEL, and OpenInference choices",
+        "Register before scoped work and flush when deterministic delivery matters",
+        "Route to a narrower export skill once the target is known"
+      ]
+    },
+    {
+      "id": "neg-known-atif",
+      "question": "I already know I need ATIF trajectories for offline replay.",
+      "expected_skill": "nemo-relay-export-atif-trajectories",
+      "expected_script": null,
+      "ground_truth": "Known ATIF export belongs directly to nemo-relay-export-atif-trajectories.",
+      "expected_behavior": [
+        "nemo-relay-setup-observability stays silent or redirects",
+        "nemo-relay-export-atif-trajectories handles the task"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-start/evals/evals.json
+++ b/skills/nemo-relay-start/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-start",
+  "cases": [
+    {
+      "id": "first-python-scope-tool-llm",
+      "question": "Help me get started with NeMo Relay in Python: one scope, one tool call, and one LLM call.",
+      "expected_skill": "nemo-relay-start",
+      "expected_script": null,
+      "ground_truth": "Use the start skill to choose the Python binding, prefer managed execution APIs, create a minimal scoped example, and defer observability until the basic flow works.",
+      "expected_behavior": [
+        "Pick the Python binding based on the user's language",
+        "Prefer managed execution APIs over manual lifecycle APIs",
+        "Start with one scope, one tool call, and one LLM call",
+        "Mention observability only after the basic flow works"
+      ]
+    },
+    {
+      "id": "neg-existing-code-wrap",
+      "question": "My app already has tool and provider calls; wrap them without changing business logic.",
+      "expected_skill": "nemo-relay-instrument-calls",
+      "expected_script": null,
+      "ground_truth": "Wrapping existing calls belongs to nemo-relay-instrument-calls.",
+      "expected_behavior": [
+        "nemo-relay-start stays silent or redirects",
+        "nemo-relay-instrument-calls handles existing call wrapping"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-tune-adaptive-config/evals/evals.json
+++ b/skills/nemo-relay-tune-adaptive-config/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-tune-adaptive-config",
+  "cases": [
+    {
+      "id": "configure-adaptive-plugin",
+      "question": "Configure the NeMo Relay adaptive plugin with state, telemetry, adaptive hints, and validation before rollout.",
+      "expected_skill": "nemo-relay-tune-adaptive-config",
+      "expected_script": null,
+      "ground_truth": "Use the adaptive config skill to configure the adaptive plugin through the shared plugin system, validate settings, and plan measured rollout.",
+      "expected_behavior": [
+        "Use the shared plugin system for adaptive settings",
+        "Validate state, telemetry, hints, ACG, policy, or parallelism fields",
+        "Avoid unmeasured production rollout",
+        "Connect configuration to later performance tuning"
+      ]
+    },
+    {
+      "id": "neg-consume-hints",
+      "question": "The adaptive plugin is configured; now consume its hints safely in application logic.",
+      "expected_skill": "nemo-relay-tune-adaptive-hints",
+      "expected_script": null,
+      "ground_truth": "Consuming already-configured adaptive hints belongs to nemo-relay-tune-adaptive-hints.",
+      "expected_behavior": [
+        "nemo-relay-tune-adaptive-config stays silent or redirects",
+        "nemo-relay-tune-adaptive-hints handles hint consumption"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-tune-adaptive-hints/evals/evals.json
+++ b/skills/nemo-relay-tune-adaptive-hints/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-tune-adaptive-hints",
+  "cases": [
+    {
+      "id": "consume-adaptive-hints",
+      "question": "The adaptive plugin is already configured. Use its latency sensitivity and tool-parallelism hints safely in my application.",
+      "expected_skill": "nemo-relay-tune-adaptive-hints",
+      "expected_script": null,
+      "ground_truth": "Use the adaptive hints skill to consume predictions and diagnostics safely after the adaptive plugin is configured, with fallbacks and measured behavior.",
+      "expected_behavior": [
+        "Confirm the adaptive plugin is already configured",
+        "Consume latency sensitivity, ACG diagnostics, or tool parallelism guidance safely",
+        "Keep fallback behavior when hints are absent or uncertain",
+        "Recommend measurement before broad rollout"
+      ]
+    },
+    {
+      "id": "neg-configure-plugin",
+      "question": "Set up the adaptive plugin configuration from scratch.",
+      "expected_skill": "nemo-relay-tune-adaptive-config",
+      "expected_script": null,
+      "ground_truth": "Initial adaptive plugin setup belongs to nemo-relay-tune-adaptive-config.",
+      "expected_behavior": [
+        "nemo-relay-tune-adaptive-hints stays silent or redirects",
+        "nemo-relay-tune-adaptive-config handles setup"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-tune-performance/evals/evals.json
+++ b/skills/nemo-relay-tune-performance/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-tune-performance",
+  "cases": [
+    {
+      "id": "measured-performance-rollout",
+      "question": "Plan a measured NeMo Relay adaptive tuning rollout to improve latency and tool parallelism after baseline observability is working.",
+      "expected_skill": "nemo-relay-tune-performance",
+      "expected_script": null,
+      "ground_truth": "Use the performance tuning skill to require a working baseline, choose metrics, tune from runtime signals, and roll out changes with measurement.",
+      "expected_behavior": [
+        "Confirm scopes, tool calls, LLM calls, and observability already work",
+        "Define latency, parallelism, cache, or model-request metrics",
+        "Tune from runtime signals rather than guesses",
+        "Recommend measured rollout and comparison to baseline"
+      ]
+    },
+    {
+      "id": "neg-first-observability",
+      "question": "I do not have NeMo Relay observability working yet; help me choose a trace export path.",
+      "expected_skill": "nemo-relay-setup-observability",
+      "expected_script": null,
+      "ground_truth": "Observability setup comes before performance tuning and belongs to nemo-relay-setup-observability.",
+      "expected_behavior": [
+        "nemo-relay-tune-performance stays silent or redirects",
+        "nemo-relay-setup-observability handles trace setup"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-typed-wrappers-codecs/evals/evals.json
+++ b/skills/nemo-relay-typed-wrappers-codecs/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-typed-wrappers-codecs",
+  "cases": [
+    {
+      "id": "typed-wrapper-preserve-middleware",
+      "question": "Use NeMo Relay typed wrappers and codecs for my LLM request without losing middleware behavior or trace metadata.",
+      "expected_skill": "nemo-relay-typed-wrappers-codecs",
+      "expected_script": null,
+      "ground_truth": "Use the typed wrappers skill to keep typed request/response codecs compatible with managed execution, middleware, and exported semantic metadata.",
+      "expected_behavior": [
+        "Choose typed wrappers/codecs only when typed payloads are needed",
+        "Preserve managed execution and middleware behavior",
+        "Keep semantic metadata available for subscribers and exporters",
+        "Avoid bypassing NeMo Relay with direct provider calls"
+      ]
+    },
+    {
+      "id": "neg-basic-call-wrapping",
+      "question": "Wrap a plain JSON-compatible tool call with NeMo Relay.",
+      "expected_skill": "nemo-relay-instrument-calls",
+      "expected_script": null,
+      "ground_truth": "Basic call wrapping belongs to nemo-relay-instrument-calls.",
+      "expected_behavior": [
+        "nemo-relay-typed-wrappers-codecs stays silent or redirects",
+        "nemo-relay-instrument-calls handles basic wrapping"
+      ]
+    }
+  ]
+}

--- a/skills/nemo-relay-use-context-isolation/evals/evals.json
+++ b/skills/nemo-relay-use-context-isolation/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "nemo-relay-use-context-isolation",
+  "cases": [
+    {
+      "id": "isolate-concurrent-requests",
+      "question": "My service runs concurrent agent requests. Set up NeMo Relay scope-stack isolation so middleware and subscribers do not leak across users.",
+      "expected_skill": "nemo-relay-use-context-isolation",
+      "expected_script": null,
+      "ground_truth": "Use the context isolation skill to create/request scope stacks per concurrent unit, propagate context across async/thread hops, and clean up scope-local registrations.",
+      "expected_behavior": [
+        "Identify the concurrent request or worker boundary",
+        "Use isolated scope stacks for separate units of work",
+        "Handle context propagation across async tasks or threads",
+        "Ensure scope-local middleware and subscribers clean up when work finishes"
+      ]
+    },
+    {
+      "id": "neg-first-scope",
+      "question": "Show me the simplest first NeMo Relay scope example.",
+      "expected_skill": "nemo-relay-start",
+      "expected_script": null,
+      "ground_truth": "A first simple scope example belongs to nemo-relay-start.",
+      "expected_behavior": [
+        "nemo-relay-use-context-isolation stays silent or redirects",
+        "nemo-relay-start handles the first example"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### Overview

This PR adds P0 eval datasets for all public NeMo Relay consumer skills so the skills can move through NVIDIA verified-skills onboarding and become available in the official NVIDIA skills catalog. The datasets give NVSkills/NVCARPS the required `evals/evals.json` inputs before benchmark, skill-card, and signature artifacts are generated.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds NV-BASE-generated `evals/evals.json` for all 14 public `nemo-relay-*` consumer skills.
- Includes 4 cases per skill from `nv-base create-eval-dataset --full`, with positive routing coverage and one negative case per skill.
- Keeps the first-pass datasets scoped to P0 smoke coverage and NVSkills CI onboarding.
- Covers discoverability and routing boundaries across startup, instrumentation, observability, ATIF, OTEL, OpenInference, plugins, adaptive tuning, context isolation, typed wrappers, runtime debugging, and Flow-to-Relay migration.
- Normalizes missing author metadata for `nemo-relay-migrate-from-flow` to match the other public skills.
- Avoids runtime, binding, docs-site, exporter, plugin, or adaptive implementation changes in this PR.

Validated with:
- `nv-base create-eval-dataset skills/<skill> --force --full` for all 14 public NeMo Relay skills
- `jq empty skills/*/evals/evals.json`
- verified all 14 eval files are top-level arrays with 56 total cases
- `nv-base validate skills --external --no-dedup --fail-fast`

#### Where should the reviewer start?

Start with `skills/nemo-relay-start/evals/evals.json` to see the eval shape, then spot-check sibling routing cases in `skills/nemo-relay-instrument-calls/evals/evals.json`, `skills/nemo-relay-setup-observability/evals/evals.json`, and `skills/nemo-relay-migrate-from-flow/evals/evals.json`. The only `SKILL.md` metadata change is in `skills/nemo-relay-migrate-from-flow/SKILL.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to NeMo Relay onboarding for the official NVIDIA skills catalog.

#### Follow-up

After review, a NeMo Relay maintainer/admin should comment `/nvskills-ci` on this PR to generate the benchmark, skill-card, and signature artifacts required for NVIDIA/skills publication.
