### PR TITLE
ci: add NVSkills CI request workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
#### Overview

Add the NVSkills CI request wrapper so maintainers can trigger central validation with `/nvskills-ci` comments after the repository secret is configured.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `.github/workflows/request-nvskills-ci.yml` using the central NVSkills CI request pattern
- Preserves the repository SPDX header convention for workflow files
- Dispatches through `NVIDIA/skills/.github/workflows/team-request.yml@main` with `NVSKILLS_CI_DISPATCH_TOKEN`

Follow-up: set the `NVSKILLS_CI_DISPATCH_TOKEN` repository secret before testing `/nvskills-ci`. Central allowlist PR: https://github.com/NVIDIA/nvskills-ci/pull/38

#### Where should the reviewer start?

`.github/workflows/request-nvskills-ci.yml`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to NVSkills CI onboarding for NeMo-Relay


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow enabling NVSkills CI validation requests via pull request comments with `/nvskills-ci` command or automated bot triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->