### PR TITLE
fix: preserve Hermes tool-result ATIF observations

### DIFF
--- a/crates/cli/tests/coverage/server_tests.rs
+++ b/crates/cli/tests/coverage/server_tests.rs
@@ -668,6 +668,122 @@ async fn serve_listener_hermes_api_request_error_writes_lossy_atof_error_event()
 }
 
 #[tokio::test]
+async fn serve_listener_hermes_post_tool_call_writes_atof_tool_events() {
+    let _guard = PLUGIN_TEST_LOCK.lock().await;
+    let _ = nemo_relay::plugin::clear_plugin_configuration();
+
+    let temp = tempfile::tempdir().unwrap();
+    let atof_dir = temp.path().join("atof");
+    std::fs::create_dir_all(&atof_dir).unwrap();
+    let mut config = test_config();
+    config.plugin_config = Some(json!({
+        "version": 1,
+        "components": [
+            {
+                "kind": "observability",
+                "enabled": true,
+                "config": {
+                    "version": 1,
+                    "atof": {
+                        "enabled": true,
+                        "output_directory": atof_dir,
+                        "filename": "events.jsonl",
+                        "mode": "overwrite"
+                    }
+                }
+            }
+        ]
+    }));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let url = format!("http://{address}");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let handle =
+        tokio::spawn(async move { serve_listener(listener, config, Some(shutdown_rx)).await });
+
+    wait_for_gateway(&url).await;
+    let client = test_http_client();
+
+    for payload in [
+        json!({
+            "hook_event_name": "on_session_start",
+            "session_id": "hermes-tool-atof"
+        }),
+        json!({
+            "hook_event_name": "pre_tool_call",
+            "session_id": "hermes-tool-atof",
+            "tool_name": "search_files",
+            "tool_input": { "query": "needle" },
+            "extra": {
+                "task_id": "task-1",
+                "tool_call_id": "call-search-1"
+            }
+        }),
+        json!({
+            "hook_event_name": "post_tool_call",
+            "session_id": "hermes-tool-atof",
+            "tool_name": "search_files",
+            "tool_input": { "query": "needle" },
+            "tool_response": { "total_count": 6 },
+            "extra": {
+                "task_id": "task-1",
+                "tool_call_id": "call-search-1"
+            }
+        }),
+        json!({
+            "hook_event_name": "on_session_finalize",
+            "session_id": "hermes-tool-atof"
+        }),
+    ] {
+        let response = client
+            .post(format!("{url}/hooks/hermes"))
+            .json(&payload)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    shutdown_tx.send(()).unwrap();
+    handle.await.unwrap().unwrap();
+
+    let events = std::fs::read_to_string(temp.path().join("atof/events.jsonl")).unwrap();
+    let tool_events = events
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .filter(|event| event["category"] == "tool")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        tool_events.len(),
+        2,
+        "expected Hermes tool start/end exports, got {tool_events:?}"
+    );
+
+    let start = tool_events
+        .iter()
+        .find(|event| event["scope_category"] == "start")
+        .unwrap();
+    assert_eq!(start["name"], json!("search_files"));
+    assert_eq!(
+        start["category_profile"]["tool_call_id"],
+        json!("call-search-1")
+    );
+    assert_eq!(start["data"]["query"], json!("needle"));
+
+    let end = tool_events
+        .iter()
+        .find(|event| event["scope_category"] == "end")
+        .unwrap();
+    assert_eq!(end["name"], json!("search_files"));
+    assert_eq!(
+        end["category_profile"]["tool_call_id"],
+        json!("call-search-1")
+    );
+    assert_eq!(end["data"]["total_count"], json!(6));
+}
+
+#[tokio::test]
 async fn serve_listener_routed_gateway_wire_formats_write_atof_category_profile_and_usage() {
     let _guard = PLUGIN_TEST_LOCK.lock().await;
     let _ = nemo_relay::plugin::clear_plugin_configuration();

--- a/crates/cli/tests/coverage/session_tests.rs
+++ b/crates/cli/tests/coverage/session_tests.rs
@@ -2002,6 +2002,134 @@ async fn hermes_task_id_tool_hooks_reuse_api_session() {
 }
 
 #[tokio::test]
+async fn hermes_post_tool_call_writes_atif_observation_with_source_call_id() {
+    let _guard = OBSERVABILITY_PLUGIN_TEST_LOCK.lock().await;
+    let temp = tempfile::tempdir().unwrap();
+    let atif_dir = temp.path().join("atif");
+    install_test_atif_plugin(&atif_dir).await;
+    let config = session_test_config();
+    let manager = SessionManager::new(config);
+    let headers = HeaderMap::new();
+
+    for payload in [
+        json!({
+            "hook_event_name": "on_session_start",
+            "session_id": "hermes-tool-result"
+        }),
+        json!({
+            "hook_event_name": "pre_api_request",
+            "session_id": "hermes-tool-result",
+            "extra": {
+                "task_id": "task-1",
+                "api_request_id": "turn-1:api:1",
+                "api_call_count": 1,
+                "provider": "custom",
+                "model": "qwen",
+                "request": {
+                    "body": {
+                        "model": "qwen",
+                        "messages": [
+                            { "role": "user", "content": "search for needle" }
+                        ],
+                        "tools": [
+                            {
+                                "type": "function",
+                                "function": { "name": "search_files" }
+                            }
+                        ]
+                    }
+                }
+            }
+        }),
+        json!({
+            "hook_event_name": "post_api_request",
+            "session_id": "hermes-tool-result",
+            "extra": {
+                "task_id": "task-1",
+                "api_request_id": "turn-1:api:1",
+                "api_call_count": 1,
+                "provider": "custom",
+                "model": "qwen",
+                "response": {
+                    "assistant_message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call-search-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "search_files",
+                                    "arguments": "{\"query\":\"needle\"}"
+                                }
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls"
+                }
+            }
+        }),
+        json!({
+            "hook_event_name": "pre_tool_call",
+            "session_id": "hermes-tool-result",
+            "tool_name": "search_files",
+            "tool_input": { "query": "needle" },
+            "extra": {
+                "task_id": "task-1",
+                "tool_call_id": "call-search-1"
+            }
+        }),
+        json!({
+            "hook_event_name": "post_tool_call",
+            "session_id": "hermes-tool-result",
+            "tool_name": "search_files",
+            "tool_input": { "query": "needle" },
+            "tool_response": { "total_count": 6 },
+            "extra": {
+                "task_id": "task-1",
+                "tool_call_id": "call-search-1"
+            }
+        }),
+        json!({
+            "hook_event_name": "on_session_finalize",
+            "session_id": "hermes-tool-result"
+        }),
+    ] {
+        let outcome = crate::adapters::hermes::adapt(payload, &headers);
+        manager
+            .apply_events(&headers, outcome.events)
+            .await
+            .unwrap();
+    }
+
+    clear_plugin_configuration().unwrap();
+    let atif = read_atif_for_session(&atif_dir, "hermes-tool-result");
+    let steps = atif["steps"].as_array().unwrap();
+    assert_eq!(steps.len(), 2);
+    assert_eq!(steps[0]["message"], json!("search for needle"));
+
+    let agent = &steps[1];
+    assert_eq!(agent["source"], json!("agent"));
+    assert_eq!(
+        agent["tool_calls"][0]["tool_call_id"],
+        json!("call-search-1")
+    );
+    assert_eq!(
+        agent["tool_calls"][0]["function_name"],
+        json!("search_files")
+    );
+    assert_eq!(
+        agent["observation"]["results"][0]["source_call_id"],
+        json!("call-search-1")
+    );
+    assert!(agent["observation"]["results"][0].get("content").is_none());
+    assert_eq!(
+        agent["observation"]["results"][0]["extra"]["tool_result"]["total_count"],
+        json!(6)
+    );
+}
+
+#[tokio::test]
 async fn hermes_orphan_subagent_stop_exports_readable_mark_with_lineage() {
     let _guard = OBSERVABILITY_PLUGIN_TEST_LOCK.lock().await;
     let temp = tempfile::tempdir().unwrap();

--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -2737,7 +2737,9 @@ fn prune_subagent_refs(steps: &mut Vec<AtifStep>, child_trajectory_ids: &HashSet
                     result.subagent_trajectory_ref = None;
                 }
             }
-            result.content.is_some() || result.subagent_trajectory_ref.is_some()
+            result.content.is_some()
+                || result.subagent_trajectory_ref.is_some()
+                || observation_result_has_tool_result_extra(result)
         });
         if observation.results.is_empty() {
             step.observation = None;
@@ -2761,6 +2763,14 @@ fn renumber_steps(steps: &mut [AtifStep]) {
     for (index, step) in steps.iter_mut().enumerate() {
         step.step_id = index + 1;
     }
+}
+
+fn observation_result_has_tool_result_extra(result: &AtifObservationResult) -> bool {
+    result
+        .extra
+        .as_ref()
+        .and_then(|extra| extra.as_object())
+        .is_some_and(|extra| extra.contains_key("tool_result"))
 }
 
 fn refresh_tool_call_lookup(

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -2057,6 +2057,122 @@ fn test_exporter_synthesizes_tool_call_for_active_subagent_dispatch() {
 }
 
 #[test]
+fn test_exporter_keeps_structured_tool_observation_on_agent_scope_tree() {
+    let root_uuid = Uuid::now_v7();
+    let turn_uuid = Uuid::now_v7();
+    let llm_uuid = Uuid::now_v7();
+    let tool_uuid = Uuid::now_v7();
+    let exporter = AtifExporter::new(root_uuid.to_string(), make_agent_info());
+    let base = base_timestamp();
+
+    let mut root_start = event_builder(root_uuid, EventType::Start)
+        .name("hermes")
+        .scope_type(ScopeType::Agent)
+        .metadata(json!({
+            "nemo_relay_scope_role": "session",
+            "session_id": "session-1",
+        }))
+        .build();
+    let mut turn_start = event_builder(turn_uuid, EventType::Start)
+        .name("hermes-turn")
+        .parent_uuid(root_uuid)
+        .scope_type(ScopeType::Agent)
+        .metadata(json!({
+            "nemo_relay_scope_role": "turn",
+            "turn_index": 1,
+            "turn_source": "implicit",
+        }))
+        .build();
+    let mut llm_start = event_builder(llm_uuid, EventType::Start)
+        .name("custom")
+        .parent_uuid(turn_uuid)
+        .scope_type(ScopeType::Llm)
+        .input(json!({
+            "messages": [{"role": "user", "content": "search for needle"}],
+            "model": "qwen",
+        }))
+        .model_name("qwen")
+        .build();
+    let mut llm_end = event_builder(llm_uuid, EventType::End)
+        .name("custom")
+        .parent_uuid(turn_uuid)
+        .scope_type(ScopeType::Llm)
+        .output(json!({
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call-search-1",
+                "type": "function",
+                "function": {
+                    "name": "search_files",
+                    "arguments": "{\"query\":\"needle\"}",
+                }
+            }]
+        }))
+        .model_name("qwen")
+        .build();
+    let mut tool_start = event_builder(tool_uuid, EventType::Start)
+        .name("search_files")
+        .parent_uuid(turn_uuid)
+        .scope_type(ScopeType::Tool)
+        .input(json!({"query": "needle"}))
+        .tool_call_id("call-search-1")
+        .build();
+    let mut tool_end = event_builder(tool_uuid, EventType::End)
+        .name("search_files")
+        .parent_uuid(turn_uuid)
+        .scope_type(ScopeType::Tool)
+        .output(json!({"total_count": 6}))
+        .tool_call_id("call-search-1")
+        .build();
+    let mut turn_end = event_builder(turn_uuid, EventType::End)
+        .name("hermes-turn")
+        .parent_uuid(root_uuid)
+        .scope_type(ScopeType::Agent)
+        .build();
+    let mut root_end = event_builder(root_uuid, EventType::End)
+        .name("hermes")
+        .scope_type(ScopeType::Agent)
+        .build();
+
+    for (offset, event) in [
+        &mut root_start,
+        &mut turn_start,
+        &mut llm_start,
+        &mut llm_end,
+        &mut tool_start,
+        &mut tool_end,
+        &mut turn_end,
+        &mut root_end,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        set_event_timestamp(event, base + chrono::Duration::milliseconds(offset as i64));
+    }
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state.events.extend([
+            root_start, turn_start, llm_start, llm_end, tool_start, tool_end, turn_end, root_end,
+        ]);
+    }
+
+    let trajectory = exporter.export().unwrap();
+    assert_atif_v17_shape(&trajectory);
+    assert_eq!(trajectory.steps.len(), 2);
+
+    let agent_step = &trajectory.steps[1];
+    let observation = agent_step.observation.as_ref().unwrap();
+    assert_eq!(observation.results.len(), 1);
+    assert_eq!(
+        observation.results[0].source_call_id.as_deref(),
+        Some("call-search-1")
+    );
+    assert_structured_observation_result_extra(&observation.results[0], json!({"total_count": 6}));
+}
+
+#[test]
 fn test_exporter_drops_empty_subagent_trajectory_and_parent_ref() {
     let root_uuid = Uuid::now_v7();
     let child_uuid = Uuid::now_v7();


### PR DESCRIPTION
#### Overview

This PR preserves Hermes tool-result observations in ATIF by fixing a shared pruning bug that dropped structured tool results when the observation had no text content, and adds exporter-visible Hermes coverage for the affected tool-result path.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Fixes shared ATIF observation pruning so structured tool results are not dropped just because the observation has no textual `content`.
- Adds a focused core ATIF regression for the agent-scope-tree export path that exposed this bug.
- Adds Hermes ATIF validation that `post_tool_call` preserves `source_call_id` and structured `tool_result` data on the agent-step observation.
- Adds Hermes ATOF validation that `post_tool_call` exports the expected tool start/end events with stable `tool_call_id` and structured tool-result payloads.
- Keeps the scope intentionally narrow to Hermes tool-result observation preservation.
- Leaves Hermes-specific OpenInference follow-up out of scope because the audit found the real gap in shared ATIF pruning, while existing shared OpenInference tool-result coverage was already sufficient.

Validated with:
- `cargo test -p nemo-relay-cli serve_listener_hermes_post_tool_call_writes_atof_tool_events -- --nocapture`
- `cargo test -p nemo-relay-cli hermes_post_tool_call_writes_atif_observation_with_source_call_id -- --nocapture`
- `cargo test -p nemo-relay atif -- --nocapture`
- `cargo fmt --all`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start in `crates/core/src/observability/atif.rs` for the pruning fix, then `crates/core/tests/unit/atif_tests.rs` for the focused shared regression, followed by `crates/cli/tests/coverage/session_tests.rs` for the Hermes ATIF regression and `crates/cli/tests/coverage/server_tests.rs` for the Hermes ATOF regression.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to Hermes observability consistency work.