### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,5 @@
 ATTRIBUTIONS-*.md @nvidia/nat-dep-approvers
 
 # Documentation changes must go to technical writers
-docs/*.mdx @lvojtku
-fern/* @lvojtku
+docs/ @lvojtku
+fern/ @lvojtku

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,9 @@
 # Default ownership for repository files.
 * @nvidia/nat-developers
 
-# Lockfiles and attribution files require dependency approver review.
-Cargo.lock @nvidia/nat-dep-approvers
-uv.lock @nvidia/nat-dep-approvers
-package-lock.json @nvidia/nat-dep-approvers
-
+# Attribution files require dependency approver review due to change in version(s)
 ATTRIBUTIONS-*.md @nvidia/nat-dep-approvers
+
+# Documentation changes must go to technical writers
+docs/*.mdx @lvojtku
+fern/* @lvojtku


### PR DESCRIPTION
#### Overview

Update CODEOWNERS review routing for dependency attribution files and documentation ownership.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Keep dependency approver review ownership for `ATTRIBUTIONS-*.md` files.
- Remove dependency approver ownership for lockfiles.
- Add technical writer review ownership for Fern documentation paths.

Validation: not run; CODEOWNERS-only change.

#### Where should the reviewer start?

Start with `.github/CODEOWNERS` to review the ownership routing changes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership rules: limited dependency-approver review to attribution files, removed automatic ownership for lockfiles, and assigned documentation paths to a documentation owner to streamline review responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->