### PR TITLE
test(wasm): drop --test-force-exit to avoid Windows libuv abort

### DIFF
--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "build:pkg": "node scripts/build_pkg.mjs",
     "pretest:pkg": "npm run build:pkg",
-    "test:pkg": "node --test --test-force-exit tests-js/*.mjs",
+    "test:pkg": "node --test tests-js/*.mjs",
     "precoverage:pkg": "npm run build:pkg",
-    "coverage:pkg": "c8 --include=\"pkg/**/*.js\" --exclude=\"tests-js/**\" --reporter=text --reporter=json-summary --reporter=cobertura --reports-dir coverage node --test --test-force-exit --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=junit.xml tests-js/*.mjs && node scripts/normalize_coverage.mjs coverage/cobertura-coverage.xml"
+    "coverage:pkg": "c8 --include=\"pkg/**/*.js\" --exclude=\"tests-js/**\" --reporter=text --reporter=json-summary --reporter=cobertura --reports-dir coverage node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=junit.xml tests-js/*.mjs && node scripts/normalize_coverage.mjs coverage/cobertura-coverage.xml"
   },
   "devDependencies": {
     "c8": "^11.0.0"


### PR DESCRIPTION
#### Overview

The `WebAssembly / Test (windows-arm64)` CI job intermittently aborts during test **teardown** with:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
✖ tests-js\llm_tests.mjs
```

This is the known Node ≥ 23 / Windows libuv bug ([nodejs/node#56645](https://github.com/nodejs/node/issues/56645), [#58091](https://github.com/nodejs/node/issues/58091)): `--test-force-exit` calls `process.exit()` once the test files finish, and on Windows that races libuv's async-handle teardown and aborts. It is **not** a defect in the WASM runtime or the tests — the WASM module is single-threaded (wasm-bindgen) and creates no `uv_async_t` of its own; the heaviest per-file subprocess (`tests-js/llm_tests.mjs`) simply loses the race most often. It is non-deterministic and **non-blocking** (the Windows legs are `continue-on-error`), which is why it usually goes unnoticed — the same flake hit a different contributor's PR (#245, commit `11502554`) with the identical assertion.

This PR removes `--test-force-exit` from the WASM JS test scripts so each subprocess exits via a natural, ordered event-loop drain instead of a forced `process.exit()`, removing the trigger for the abort.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

`crates/wasm/package.json` — drop `--test-force-exit` from the `test:pkg` and `coverage:pkg` scripts. That is the entire change (+2 / −2).

Why this is the right and minimal fix:

- `--test-force-exit` exists to force the process to exit even if the loop is kept alive. The WASM JS suite doesn't need it — it is microtask-driven and awaits its async work, so each per-file subprocess drains and exits on its own. Letting libuv shut down in order is exactly what avoids the Windows assertion; the forced `process.exit()` is the only thing that triggers it.
- Scoped to `crates/wasm` only. The Node binding uses the same flag and the same `continue-on-error` Windows posture, but it did not fail here, so parity is left as a separate follow-up rather than widening this change.

Optional follow-up (intentionally **not** included to keep this minimal): with the flag gone, the shared OTLP collector test helper (`scripts/test-support/otel_test_utils.mjs`) has two backstop `setTimeout(…, 5000)` timers that aren't `unref()`'d, so the `otel`/`openinference` subprocesses now wait up to ~5 s for those timers before exiting. It is a delay, not a hang, and does not affect pass/fail; `.unref()`-ing them would make exit prompt.

#### Where should the reviewer start?

`crates/wasm/package.json` — the two one-line script edits. The design decision to weigh is that a natural event-loop drain (rather than a forced `process.exit()`) is what sidesteps the Windows libuv teardown race ([nodejs/node#56645](https://github.com/nodejs/node/issues/56645) / [#58091](https://github.com/nodejs/node/issues/58091)).

Validation (macOS / Node 24, fresh `wasm-pack` build): the full WASM JS suite passes **with and without** the flag (71/71), and the `coverage:pkg` path (c8 + spec/junit reporters + `normalize_coverage`) exits on its own and regenerates every report. The abort only reproduces on Windows CI and is non-blocking, so the Windows `WebAssembly / Test` job is the real confirmation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none — no tracking issue. Prior occurrence of the same flake: PR #245 (commit `11502554`, identical `UV_HANDLE_CLOSING` assertion on `windows-arm64`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test runner configuration to improve test execution consistency and process handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->