### PR TITLE
chore: prepare 0.4 code freeze

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,3 +3,4 @@
 
 branches:
   - main
+  - release/0.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-adaptive"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-node"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "napi",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-pii-redaction"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures",
  "nemo-relay",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-python"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ exclude = [".tmp", ".uv-cache"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/NeMo-Relay"
 
 [workspace.dependencies]
-nemo-relay = { version = "0.4.0", path = "crates/core", default-features = false }
-nemo-relay-adaptive = { version = "0.4.0", path = "crates/adaptive" }
-nemo-relay-pii-redaction = { version = "0.4.0", path = "crates/pii-redaction" }
-nemo-relay-ffi = { version = "0.4.0", path = "crates/ffi" }
-nemo-relay-cli = { version = "0.4.0", path = "crates/cli" }
+nemo-relay = { version = "0.5.0", path = "crates/core", default-features = false }
+nemo-relay-adaptive = { version = "0.5.0", path = "crates/adaptive" }
+nemo-relay-pii-redaction = { version = "0.5.0", path = "crates/pii-redaction" }
+nemo-relay-ffi = { version = "0.5.0", path = "crates/ffi" }
+nemo-relay-cli = { version = "0.5.0", path = "crates/cli" }
 opentelemetry = { version = "0.31", default-features = false }
 opentelemetry_sdk = { version = "0.31", default-features = false }
 uuid = "=1.18.1"

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-node",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Node.js bindings for the NeMo Relay agent runtime.",
   "keywords": [
     "agents",

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -20,7 +20,7 @@ Install the NeMo Relay CLI when you want the `nemo-relay` executable for
 coding-agent hook and LLM gateway observability.
 
 ```bash
-cargo install nemo-relay-cli@0.4.0
+cargo install nemo-relay-cli@0.5.0
 ```
 
 After installation, `nemo-relay` can also install persistent Claude Code and
@@ -40,7 +40,7 @@ Install the Python package when your application uses NeMo Relay through the
 Python wrapper.
 
 ```bash
-uv add nemo-relay@0.4.0
+uv add nemo-relay@0.5.0
 ```
 
 Use `uv add` from an application project that has a `pyproject.toml`; it records
@@ -63,8 +63,8 @@ npm install nemo-relay-node
 Add the Rust crates when your application uses NeMo Relay directly from Rust.
 
 ```bash
-cargo add nemo-relay@0.4.0
-cargo add nemo-relay-adaptive@0.4.0
+cargo add nemo-relay@0.5.0
+cargo add nemo-relay-adaptive@0.5.0
 ```
 
 - `nemo-relay` provides the core runtime APIs for scopes, middleware, subscribers, plugins, tool calls, and LLM calls.
@@ -81,7 +81,7 @@ Install the OpenClaw plugin through OpenClaw so OpenClaw can register and manage
 the package:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.4.0
+openclaw plugins install npm:nemo-relay-openclaw@0.5.0
 openclaw gateway restart
 ```
 
@@ -96,7 +96,7 @@ Install the Python package with the supported framework extras when your
 application uses LangChain, LangGraph, or Deep Agents.
 
 ```bash
-uv add "nemo-relay[langchain,langgraph,deepagents]@0.4.0"
+uv add "nemo-relay[langchain,langgraph,deepagents]@0.5.0"
 ```
 
 The extras install the NeMo Relay Python package plus the dependencies needed by

--- a/docs/getting-started/quick-start/python.mdx
+++ b/docs/getting-started/quick-start/python.mdx
@@ -20,7 +20,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-uv add nemo-relay@0.4.0
+uv add nemo-relay@0.5.0
 ```
 
 Run `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/quick-start/rust.mdx
+++ b/docs/getting-started/quick-start/rust.mdx
@@ -18,8 +18,8 @@ local checkout.
 Use the published crates when you are consuming a release:
 
 ```bash
-cargo add nemo-relay@0.4.0
-cargo add nemo-relay-adaptive@0.4.0
+cargo add nemo-relay@0.5.0
+cargo add nemo-relay-adaptive@0.5.0
 cargo add serde_json
 ```
 
@@ -27,7 +27,7 @@ Install the published NeMo Relay CLI separately when you need coding-agent hook
 and LLM gateway observability:
 
 ```bash
-cargo install nemo-relay-cli@0.4.0
+cargo install nemo-relay-cli@0.5.0
 ```
 
 ### Install from the Repository
@@ -43,7 +43,7 @@ serde_json = "1"
 
 - `nemo-relay` is the core Rust runtime surface.
 - `nemo-relay-adaptive` is the companion crate for adaptive runtime primitives and Redis-backed learning components.
-- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.4.0` when
+- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.5.0` when
   you need the NeMo Relay CLI.
 
 ## Push a Scope and Emit a Mark

--- a/docs/observability-plugin/configuration.mdx
+++ b/docs/observability-plugin/configuration.mdx
@@ -87,7 +87,7 @@ transport = "http_binary"
 endpoint = "http://localhost:4318/v1/traces"
 service_name = "nemo-relay"
 service_namespace = "agent"
-service_version = "0.4.0"
+service_version = "0.5.0"
 instrumentation_scope = "nemo-relay-observability"
 timeout_millis = 3000
 
@@ -104,7 +104,7 @@ transport = "http_binary"
 endpoint = "http://localhost:6006/v1/traces"
 service_name = "nemo-relay"
 service_namespace = "agent"
-service_version = "0.4.0"
+service_version = "0.5.0"
 instrumentation_scope = "nemo-relay-openinference"
 timeout_millis = 3000
 
@@ -161,7 +161,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:4318/v1/traces",
                     service_name="nemo-relay",
                     service_namespace="agent",
-                    service_version="0.4.0",
+                    service_version="0.5.0",
                     instrumentation_scope="nemo-relay-observability",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -170,7 +170,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:6006/v1/traces",
                     service_name="nemo-relay",
                     service_namespace="agent",
-                    service_version="0.4.0",
+                    service_version="0.5.0",
                     instrumentation_scope="nemo-relay-openinference",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -219,7 +219,7 @@ await plugin.initialize({
         endpoint: "http://localhost:4318/v1/traces",
         service_name: "nemo-relay",
         service_namespace: "agent",
-        service_version: "0.4.0",
+        service_version: "0.5.0",
         instrumentation_scope: "nemo-relay-observability",
         resource_attributes: {
           "deployment.environment": "dev",
@@ -230,7 +230,7 @@ await plugin.initialize({
         endpoint: "http://localhost:6006/v1/traces",
         service_name: "nemo-relay",
         service_namespace: "agent",
-        service_version: "0.4.0",
+        service_version: "0.5.0",
         instrumentation_scope: "nemo-relay-openinference",
         resource_attributes: {
           "deployment.environment": "dev",
@@ -281,7 +281,7 @@ let component = ComponentSpec::new(ObservabilityConfig {
         endpoint: Some("http://localhost:4318/v1/traces".into()),
         service_name: "nemo-relay".into(),
         service_namespace: Some("agent".into()),
-        service_version: Some("0.4.0".into()),
+        service_version: Some("0.5.0".into()),
         instrumentation_scope: Some("nemo-relay-observability".into()),
         resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
         ..OtlpSectionConfig::default()
@@ -291,7 +291,7 @@ let component = ComponentSpec::new(ObservabilityConfig {
         endpoint: Some("http://localhost:6006/v1/traces".into()),
         service_name: "nemo-relay".into(),
         service_namespace: Some("agent".into()),
-        service_version: Some("0.4.0".into()),
+        service_version: Some("0.5.0".into()),
         instrumentation_scope: Some("nemo-relay-openinference".into()),
         resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
         ..OtlpSectionConfig::default()

--- a/docs/supported-integrations/openclaw-plugin.mdx
+++ b/docs/supported-integrations/openclaw-plugin.mdx
@@ -41,7 +41,7 @@ Optional:
 Install the plugin with OpenClaw so OpenClaw can register and manage it:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.4.0
+openclaw plugins install npm:nemo-relay-openclaw@0.5.0
 openclaw gateway restart
 ```
 
@@ -54,7 +54,7 @@ If you manage OpenClaw plugin dependencies directly in a Node.js project,
 install the package with npm:
 
 ```bash
-npm install nemo-relay-openclaw@0.4.0
+npm install nemo-relay-openclaw@0.5.0
 ```
 
 Installing with npm makes the package available to that project. Use

--- a/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
+++ b/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Claude Code hooks that forward canonical lifecycle payloads to nemo-relay.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/coding-agents/codex/.codex-plugin/plugin.json
+++ b/integrations/coding-agents/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Codex hooks that forward canonical lifecycle payloads to nemo-relay.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-openclaw",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "NeMo Relay-authored observability plugin for OpenClaw.",
   "type": "module",
   "repository": {
@@ -63,7 +63,7 @@
     "openclaw": "^2026.5.26"
   },
   "dependencies": {
-    "nemo-relay-node": "0.4.0"
+    "nemo-relay-node": "0.5.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/justfile
+++ b/justfile
@@ -452,7 +452,13 @@ section = ""
 output = []
 changed = []
 found_workspace_version = False
-local_dependencies = ("nemo-relay", "nemo-relay-adaptive", "nemo-relay-ffi", "nemo-relay-cli")
+local_dependencies = (
+    "nemo-relay",
+    "nemo-relay-adaptive",
+    "nemo-relay-pii-redaction",
+    "nemo-relay-ffi",
+    "nemo-relay-cli",
+)
 found_dependencies = set()
 
 for line in text.splitlines(keepends=True):

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
     },
     "crates/node": {
       "name": "nemo-relay-node",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -836,10 +836,10 @@
     },
     "integrations/openclaw": {
       "name": "nemo-relay-openclaw",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nemo-relay-node": "0.4.0"
+        "nemo-relay-node": "0.5.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",


### PR DESCRIPTION
#### Overview

Prepare the 0.4 code freeze follow-up on `main` after creating `release/0.4` from `upstream/main`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Created `release/0.4` from latest `upstream/main` for release-bound PRs.
- Added `release/0.4` to `.github/nightly-alpha-branches.yaml` so nightly alpha tags continue for the frozen release line.
- Ran `just set-version 0.5.0` to bump `main` to the next release line across Cargo, npm, OpenClaw, and coding-agent plugin package surfaces.
- Updated current docs install/configuration examples from `0.4.0` to `0.5.0`; no intentional `0.4.0` leftovers remain in `README.md`, `docs`, or `fern`.
- Added `nemo-relay-pii-redaction` to the `just set-version` local dependency list so the workspace dependency stays aligned in future bumps.

#### Where should the reviewer start?

Start with `.github/nightly-alpha-branches.yaml` for the freeze-line nightly config, then `Cargo.toml` and `justfile` for version alignment.

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/nightly-alpha-branches.yaml"); YAML.load_file(".github/workflows/nightly-alpha-tag.yaml")'
- `just set-version 0.5.0`
- `rg -n '0\\.4\\.0' Cargo.toml package.json package-lock.json crates integrations README.md docs fern --glob '!docs/_build/**' || true`
- `git diff --check`
- signed-off commit pre-commit hooks, including package lock and attribution checks

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.5.0 across all packages and integrations.
  * Updated plugin metadata versions to 0.5.0.

* **Documentation**
  * Installation and quick-start guides updated to reference version 0.5.0 for all supported package managers.
  * Plugin configuration documentation updated with new version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->