### PR TITLE
fix: include pii redaction in version updates

### DIFF
--- a/.agents/skills/update-project-version/SKILL.md
+++ b/.agents/skills/update-project-version/SKILL.md
@@ -45,14 +45,30 @@ pre-release or build-metadata variants used during packaging.
    - `[workspace.package].version`
    - `workspace.dependencies.nemo-relay.version`
    - `workspace.dependencies.nemo-relay-adaptive.version`
+   - `workspace.dependencies.nemo-relay-pii-redaction.version`
    - `workspace.dependencies.nemo-relay-ffi.version`
+   - `workspace.dependencies.nemo-relay-cli.version`
    - `crates/node/package.json` `version`
    - `integrations/openclaw/package.json` `version`
    - `package-lock.json` `packages["crates/node"].version`
    - `package-lock.json` `packages["integrations/openclaw"].version`
-3. If editing helper code, keep `set_project_version`,
-   `set_cargo_workspace_version`, and `set_node_package_versions` aligned with
-   those same fields. `set_node_package_version` remains a compatibility alias.
+   - `integrations/openclaw/package.json` `dependencies["nemo-relay-node"]`
+   - `package-lock.json`
+     `packages["integrations/openclaw"].dependencies["nemo-relay-node"]`
+3. If editing helper code, keep helper inputs aligned with those same fields:
+   - `set_project_version` should call the Cargo, Node, and coding-agent plugin
+     version helpers for the same target version.
+   - `set_cargo_workspace_version` should update `[workspace.package].version`
+     plus `workspace.dependencies.nemo-relay.version`,
+     `workspace.dependencies.nemo-relay-adaptive.version`,
+     `workspace.dependencies.nemo-relay-pii-redaction.version`,
+     `workspace.dependencies.nemo-relay-ffi.version`, and
+     `workspace.dependencies.nemo-relay-cli.version`.
+   - `set_node_package_versions` should update `crates/node/package.json`,
+     `integrations/openclaw/package.json`, the corresponding `package-lock.json`
+     package entries, and the OpenClaw `nemo-relay-node` dependency entries in
+     both files.
+   `set_node_package_version` remains a compatibility alias.
    `set_npm_package_version` remains the reusable npm JSON helper for Node and
    WebAssembly packaging recipes.
 4. Refresh generated surfaces:
@@ -74,7 +90,7 @@ pre-release or build-metadata variants used during packaging.
 
 ## Validation
 
-- `rg -n '^version =|nemo-relay = \\{ version =|nemo-relay-adaptive = \\{ version =' Cargo.toml`
+- `rg -n '^version =|nemo-relay = \\{ version =|nemo-relay-adaptive = \\{ version =|nemo-relay-pii-redaction = \\{ version =|nemo-relay-ffi = \\{ version =|nemo-relay-cli = \\{ version =' Cargo.toml`
 - `rg -n '\"version\"' crates/node/package.json integrations/openclaw/package.json package-lock.json`
 - `cargo check --workspace`
 - If Rust attribution files are expected to stay current:

--- a/justfile
+++ b/justfile
@@ -452,7 +452,13 @@ section = ""
 output = []
 changed = []
 found_workspace_version = False
-local_dependencies = ("nemo-relay", "nemo-relay-adaptive", "nemo-relay-ffi", "nemo-relay-cli")
+local_dependencies = (
+    "nemo-relay",
+    "nemo-relay-adaptive",
+    "nemo-relay-pii-redaction",
+    "nemo-relay-ffi",
+    "nemo-relay-cli",
+)
 found_dependencies = set()
 
 for line in text.splitlines(keepends=True):


### PR DESCRIPTION
#### Overview

Fix `just set-version` so it updates the first-party PII redaction crate workspace dependency alongside the other NeMo Relay workspace crates.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `nemo-relay-pii-redaction` to the `set_cargo_workspace_version` local dependency list in `justfile`.
- Keeps the change scoped to the version update helper so release and code-freeze bumps do not leave the workspace dependency entry stale.
- Updates skills to reference the pii-redaction crate where appropriate.

#### Where should the reviewer start?

Start with `justfile`, in the `set_cargo_workspace_version` helper dependency list.

Validation:

- `just set-version 0.4.0`
- `git diff --check`
- signed-off commit pre-commit hooks for the changed file

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved version-setting tooling to recognize and update a broader set of local workspace dependencies.
  * Enhanced validation and workflow instructions to ensure package/version fields (including dependency entries) are aligned when running the workspace version update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->