### PR TITLE
docs: improve Relay onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,67 +17,201 @@ SPDX-License-Identifier: Apache-2.0
 
 # NVIDIA NeMo Relay
 
-## What Is NeMo Relay?
+NVIDIA NeMo Relay helps you see and control what happens inside agent runs
+without rewriting the agent stack you already have. It gives coding agents,
+applications, framework integrations, middleware, and observability backends a
+shared runtime for scopes, policy, plugins, and lifecycle events.
 
-NVIDIA NeMo Relay is a portable execution runtime for agent systems that already have a
-framework, model provider, policy layer, or observability backend. It gives those
-systems one consistent way to describe, control, and observe what happens when an
-agent crosses a request, tool, or LLM boundary.
+The best first step is to get one real run on disk. Once Relay is writing raw
+events and a trajectory file, you have something concrete to inspect, debug, and
+build from.
 
-Agent applications rarely live inside one clean abstraction. A production stack
-might combine NeMo Agent Toolkit, LangChain, LangGraph, provider SDKs, custom
-harness code, NeMo Guardrails, tracing systems, and evaluation pipelines. NeMo
-Relay sits underneath those choices as the shared runtime contract for scopes,
-middleware, plugins, lifecycle events, adaptive behavior, and observability.
+## Start Here: Capture One Local Agent Run
 
-Built as a Rust core with primary Rust, Python, and Node.js bindings, NeMo Relay
-lets applications keep their orchestration model while runtime behavior stays
-consistent across frameworks and languages.
+This walkthrough gives you an end-to-end success signal. You install the
+`nemo-relay` CLI, turn on local exporters, run either Codex or Claude Code
+through Relay, and check that Relay wrote both raw events and normalized
+trajectories.
 
-## Why Use It?
+> [!TIP]
+> Start by trusting the raw Agent Trajectory Observability Format (ATOF) JSONL.
+> It shows the lifecycle events Relay actually captured before anything is
+> translated into Agent Trajectory Interchange Format (ATIF), OpenTelemetry, or
+> OpenInference output.
 
-- 🧭 **Own execution context across the whole agent run**: Hierarchical scopes
-  attach tools, LLM calls, middleware, subscribers, and events to the same
-  parent-child execution tree.
-- 🛡️ **Package policy once**: Guardrails and intercepts can block work, sanitize
-  observability payloads, transform requests, or wrap execution without
-  rewriting every call site.
-- 📡 **Emit one lifecycle stream**: Subscribers consume canonical runtime events
-  in-process or export them as [ATIF v1.7](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md)
-  trajectories, OpenTelemetry traces, or OpenInference-compatible traces.
-- 🧩 **Integrate without a framework migration**: NeMo Relay can sit below NeMo
-  ecosystem components, third-party agent frameworks, provider adapters, or
-  direct application code.
-- ⚙️ **Install reusable runtime behavior**: Plugins configure middleware,
-  subscribers, adaptive components, observability exporters, and custom runtime
-  behavior from one shared system.
+### 1. Install the CLI
 
-## What You Get
+```bash
+cargo install nemo-relay-cli
+```
 
-- ✅ **Managed tool and LLM execution**: Run call boundaries through consistent
-  lifecycle helpers and middleware ordering.
-- ✅ **Concurrent request isolation**: Keep request-local middleware and
-  subscribers attached to the scope that owns them, then clean them up when that
-  scope closes.
-- ✅ **Multi-language semantics**: Use the same runtime model from Rust, Python,
-  and Node.js.
-- ✅ **Observability-ready events**: Preserve model metadata, tool call IDs,
-  inputs, outputs, scope relationships, and lifecycle timing for downstream
-  analysis.
-- ✅ **Built-in observability plugin**: Configure Agent Trajectory Observability
-  Format (ATOF), ATIF, OpenTelemetry, and OpenInference exporters without
-  registering subscribers by hand.
-- ✅ **Non-blocking subscriber delivery**: Keep managed execution moving while
-  subscriber callbacks and exporters drain in the background. Flush subscribers
-  before relying on callback side effects or exported files in tests and
-  shutdown paths.
-- ✅ **Extension points for framework authors**: Wrap stable tool and provider
-  callbacks while preserving framework-owned scheduling, retries, memory, and
-  result handling.
+If you use `cargo-binstall`, the CLI can also be installed with:
+
+```bash
+cargo binstall nemo-relay-cli
+```
+
+### 2. Enable Local Observability Output
+
+From the project directory you want to observe, open the project-scoped plugin
+editor:
+
+```bash
+nemo-relay plugins edit --project
+```
+
+The editor creates or updates the nearest project plugin file at
+`.nemo-relay/plugins.toml`. In the menu:
+
+1. Enable the `Observability` component.
+2. Open `ATOF`, toggle the section on, and set:
+   - `output_directory` to `.nemo-relay/atof`
+   - `filename` to `events.jsonl`
+   - `mode` to `overwrite`
+3. Open `ATIF`, toggle the section on, and set:
+   - `output_directory` to `.nemo-relay/atif`
+   - `filename_template` to `trajectory-{session_id}.json`
+4. Press `p` to preview the generated TOML.
+5. Press `s` to save.
+
+> [!NOTE]
+> Use `nemo-relay plugins edit` without `--project` only when you want these
+> exporter settings in your user-level Relay config instead of this one project.
+
+### 3. Run Codex or Claude Code Through Relay
+
+Use the host CLI that is installed on your machine.
+
+```bash
+nemo-relay codex -- exec "Summarize this repository."
+```
+
+```bash
+nemo-relay claude -- "Summarize this repository."
+```
+
+The transparent wrapper starts a local Relay gateway, injects host-specific hook
+and provider settings for that launched process, then shuts the gateway down
+when the agent exits.
+
+> [!WARNING]
+> Codex users may need to review and activate generated hooks before events
+> appear. See the [Codex CLI guide](https://docs.nvidia.com/nemo/relay/nemo-relay-cli/codex) for the
+> current hook activation caveat and troubleshooting steps.
+
+### 4. Verify the Run
+
+After the run exits, check that raw events and trajectory files were written:
+
+```bash
+test -s .nemo-relay/atof/events.jsonl
+ls .nemo-relay/atif/*.json
+for file in .nemo-relay/atif/*.json; do
+  python3 -m json.tool "$file" >/dev/null
+done
+```
+
+Then verify that at least one raw ATOF `0.1` event exists:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import json
+
+events_path = Path(".nemo-relay/atof/events.jsonl")
+events = [
+    json.loads(line)
+    for line in events_path.read_text().splitlines()
+    if line.strip()
+]
+
+assert events, "no ATOF events were written"
+assert any(event.get("atof_version") == "0.1" for event in events), "no ATOF 0.1 events found"
+print(f"validated {len(events)} ATOF event(s)")
+PY
+```
+
+A successful run gives you two things to inspect:
+
+- `.nemo-relay/atof/events.jsonl`, the raw canonical event stream.
+- One or more `.nemo-relay/atif/*.json` trajectory files for analysis and
+  evaluation workflows.
+
+> [!TIP]
+> If raw ATOF events exist but LLM spans are missing, provider traffic probably
+> isn't flowing through the Relay gateway. If ATIF is missing, make sure the
+> agent session or turn ended and the output directory is writable. Use
+> [NeMo Relay CLI](https://docs.nvidia.com/nemo/relay/nemo-relay-cli/about) when you are ready for
+> persistent host plugin installation, gateway configuration, exporter options,
+> and agent-specific diagnostics.
+
+## Choose Your Next Path
+
+Pick the row closest to what you are trying to do next.
+
+| Goal | Start With |
+|---|---|
+| Observe Codex, Claude Code, Cursor, or Hermes locally | [NeMo Relay CLI](https://docs.nvidia.com/nemo/relay/nemo-relay-cli/about) |
+| Instrument app-owned LLM or tool calls | [Quick Start](https://docs.nvidia.com/nemo/relay/getting-started/quick-start) |
+| Use LangChain, LangGraph, Deep Agents, or OpenClaw | [Supported Integrations](https://docs.nvidia.com/nemo/relay/supported-integrations/about) |
+| Build a framework or provider integration | [Integrate into Frameworks](https://docs.nvidia.com/nemo/relay/integrate-into-frameworks/about) |
+| Export ATOF, ATIF, OpenTelemetry, or OpenInference | [Observability Plugin](https://docs.nvidia.com/nemo/relay/observability-plugin/about) |
+| Package reusable middleware or exporters | [Build Plugins](https://docs.nvidia.com/nemo/relay/build-plugins/about) |
+| Develop or test this repository from source | [CONTRIBUTING.md](CONTRIBUTING.md) |
+
+## Application Quick Starts
+
+If you own the code that calls the model or tool, install the binding for your
+language and route that boundary through Relay directly.
+
+```bash
+# Python
+uv add nemo-relay
+
+# Node.js
+npm install nemo-relay-node
+
+# Rust
+cargo add nemo-relay
+```
+
+Then run the smallest workflow for that binding:
+
+- [Python Quick Start](https://docs.nvidia.com/nemo/relay/getting-started/quick-start/python)
+- [Node.js Quick Start](https://docs.nvidia.com/nemo/relay/getting-started/quick-start/nodejs)
+- [Rust Quick Start](https://docs.nvidia.com/nemo/relay/getting-started/quick-start/rust)
+
+The Node.js package requires Node.js 24 or newer.
+
+## What Relay Adds
+
+Relay is for the messy middle of agent systems. A production application may
+combine NeMo Agent Toolkit, LangChain, LangGraph, provider SDKs, custom harness
+code, NeMo Guardrails, tracing systems, and evaluation pipelines. Relay gives
+those pieces one runtime contract instead of asking every layer to invent its
+own wrappers and trace vocabulary.
+
+Relay gives those systems:
+
+- 🧭 **Scopes** so runs, turns, tools, LLM calls, and subagents have clear
+  ownership, parent-child lineage, cleanup boundaries, and
+  request isolation.
+- ⚙️ **Managed LLM and tool calls** so the same lifecycle and middleware rules
+  apply around each callback.
+- 🛡️ **Middleware** for the places where Relay must block, sanitize, transform,
+  route, retry, or replace execution.
+- 🧩 **Plugins** so reusable observability, guardrail, adaptive, and exporter
+  behavior can be turned on from configuration.
+- 📡 **Events and subscribers** so raw ATOF, normalized ATIF, OpenTelemetry, and
+  OpenInference output all come from the same runtime stream.
+
+Relay does not replace your framework, model provider, application logic,
+observability backend, or guardrail authoring system. It gives those systems a
+common boundary to meet at.
 
 ```mermaid
 flowchart LR
-    App[Application or Framework]
+    App[Application, Framework, or CLI Harness]
 
     subgraph Runtime[NeMo Relay Runtime]
         direction TB
@@ -97,138 +231,97 @@ flowchart LR
     Events --> Output
 ```
 
-## Installation
+## Support Status
 
-Install the published package for your language:
+> [!NOTE]
+> The main supported paths today are Rust, Python, and Node.js. Go,
+> WebAssembly, and raw C FFI are available for source-first users, but they are
+> still experimental.
 
-```bash
-# Rust
-cargo add nemo-relay
-
-# Python
-uv add nemo-relay
-
-# Node.js
-npm install nemo-relay-node
-```
-
-The Node.js package requires Node.js 24 or newer.
-
-### CLI Installation
-
-The NeMo Relay CLI is offered as a separate crate:
-
-```bash
-cargo install nemo-relay-cli
-```
-
-If `cargo-binstall` is available on your machine:
-
-```bash
-cargo binstall nemo-relay-cli
-```
-
-For source builds, testing, and contribution workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Documentation
-
-End-user documentation lives at [docs.nvidia.com/nemo/relay](https://docs.nvidia.com/nemo/relay).
-
-The primary documentation track covers Rust, Python, and Node.js.
-
-The Go, WebAssembly, and raw FFI surfaces are currently experimental and remain source-first under
-`go/nemo_relay`, `crates/wasm`, and `crates/ffi`.
-
-## Binding Status
-
-The table below summarizes the support level for each binding surface.
+The following table shows which language bindings and CLI features are currently supported:
 
 | Binding | Status | Notes |
 |---|---|---|
-| Python | ✅ Fully Supported | Fully documented with Quick Start and Guides |
-| Node.js | ✅ Fully Supported | Fully documented with Quick Start and Guides  |
-| Rust | ✅ Fully Supported | Fully documented with Quick Start and Guides  |
+| Python | ✅ Fully supported | Documented with Quick Start and Guides. |
+| Node.js | ✅ Fully supported | Documented with Quick Start and Guides. |
+| Rust | ✅ Fully supported | Documented with Quick Start and Guides. |
 | NeMo Relay CLI | 🚧 Experimental | Install with `cargo install nemo-relay-cli`. |
 | Go | 🚧 Experimental | Source-first under `go/nemo_relay`. |
 | WebAssembly | 🚧 Experimental | Source-first under `crates/wasm`. |
 | FFI | 🚧 Experimental | Source-first under `crates/ffi`. |
 
-## Agent Harness Support
+### Agent Harness Support
 
-NeMo Relay CLI offers experimental support for several agent harnesses.
-Refer to the NeMo Relay CLI documentation for additional information.
-
-Below is our support matrix for agent harnesses.
+The CLI support is intentionally conservative. Observability works for the
+listed harnesses; security and optimization depend on the hooks, provider
+routes, and execution controls each harness exposes.
 
 | Agent | Observability | Security | Optimization | Notes |
 |:--|:--:|:--:|:--:|:--|
-| Claude Code | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Tool guardrail support is wired up. LLM optimization is in place. |
-| Codex | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Tool guardrail support is wired up. LLM optimization is in place. Missing some necessary hooks for full feature parity. |
-| Hermes Agent | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Tool guardrail support is wired up. LLM optimization is in place. |
-| Cursor | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Tool guardrail support is wired up. LLM optimization is in place. Not feature-rich, missing hooks under `cursor-agent` |
-
-## Third-Party Integrations
-
-Some framework integrations are maintained as packages in this repository. Other
-sample integrations are maintained as patch sets against upstream projects.
+| Claude Code | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Hook forwarding and gateway-routed LLM observability are supported. |
+| Codex | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Hook activation and missing session-end behavior limit full feature parity. |
+| Hermes Agent | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Hook forwarding and gateway-routed LLM observability are supported. |
+| Cursor | 🚧 Partial | ⚠️ Partial | ❌ No | Missing hooks under `cursor-agent` limit full feature coverage. |
 
 ### Public API Integrations
 
-Some integrations can be implemented using public APIs without patching. Public
-API-based integrations live under language-specific integration packages such as
-`python/nemo_relay/integrations/` and `integrations/`.
-
-Below is the support matrix for our public API integrations.
+Use these integrations when the framework exposes stable callbacks, middleware,
+or plugin hooks that preserve enough lifecycle fidelity.
 
 | Agent / Library | Observability | Security | Optimization | Notes |
 |:--|:--:|:--:|:--:|:--|
-| LangChain | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped Tool and LLM calling |
-| LangGraph | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped Tool and LLM calling |
-| Deep Agents | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped Tool and LLM calling |
+| LangChain | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
+| LangGraph | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
+| Deep Agents | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
 | OpenClaw | ✅ Yes | ⚠️ Partial | ❌ No | Hook-backed telemetry with pre-tool guardrails. Managed execution rewrites require the patch-based integration. |
 
-#### LangChain
+The Python `nemo-relay` package ships extras for LangChain, LangGraph, and Deep
+Agents:
 
-The Python `nemo-relay` package ships several extras that offer comprehensive
-middleware support for the following packages:
+```bash
+uv add "nemo-relay[langchain,langgraph,deepagents]"
+```
 
-- LangChain
-- LangGraph
-- Deep Agents
-
-See the [Python package README](python/nemo_relay/README.md) for more information.
-
-#### OpenClaw
-
-An OpenClaw plugin is available as a Node package `nemo-relay-openclaw`.
-It relies on OpenClaw public plugin hooks plus the generic NeMo Relay plugin
-configuration shape to export telemetry. See the
-[OpenClaw package README](integrations/openclaw/README.md) for more information.
+See [Supported Integrations](https://docs.nvidia.com/nemo/relay/supported-integrations/about) for setup
+guides and current caveats.
 
 ### Patch-based Integrations
 
-Patch-based integrations offer experimental support. Our roadmap includes switching over to first-party plugins and packages where upstream extension points allow it.
-
-Use [third_party/README.md](third_party/README.md) for the clone, checkout, and
-patch-application workflow for those integrations.
-
-The following table summarizes maintained third-party integrations and whether each provides observability, security, and optimization support.
+Patch-based integrations are experimental samples maintained against pinned
+upstream checkouts. Use [third_party/README.md](third_party/README.md) for the
+clone, checkout, and patch-application workflow.
 
 | Integration | Observability | Security | Optimization | Notes |
 |:---|:---:|:---:|:---:|:---|
-| [LangChain](third_party/README-langchain.md), [LangGraph](third_party/README-langgraph.md), [LangChain NVIDIA](third_party/README-langchain-nvidia.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code requiring no middleware |
-| [opencode](third_party/README-opencode.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code |
-| [OpenClaw](third_party/README-openclaw.md) | ✅ Yes | ✅ Yes | ✅ Yes | Adds new middleware support to OpenClaw and a built-in plugin |
-| [Hermes Agent](third_party/README-hermes-agent.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code |
+| [LangChain](third_party/README-langchain.md), [LangGraph](third_party/README-langgraph.md), [LangChain NVIDIA](third_party/README-langchain-nvidia.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
+| [opencode](third_party/README-opencode.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
+| [OpenClaw](third_party/README-openclaw.md) | ✅ Yes | ✅ Yes | ✅ Yes | Adds middleware support to OpenClaw and a built-in plugin. |
+| [Hermes Agent](third_party/README-hermes-agent.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
+
+## Documentation
+
+End-user documentation lives at
+[docs.nvidia.com/nemo/relay](https://docs.nvidia.com/nemo/relay).
+
+Important local entry points:
+
+- [Overview](https://docs.nvidia.com/nemo/relay/about-nemo-relay/overview)
+- [Installation](https://docs.nvidia.com/nemo/relay/getting-started/installation)
+- [Agent Runtime Primer](https://docs.nvidia.com/nemo/relay/getting-started/agent-runtime-primer)
+- [Testing and Docs](https://docs.nvidia.com/nemo/relay/contribute/testing-and-docs)
+
+For source builds, tests, and contribution workflow, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Roadmap
 
-The following roadmap outlines planned features and integrations for upcoming releases.
-
 - [ ] NemoClaw support and integration for managed tool and LLM execution flows.
-- [ ] Deeper NVIDIA NeMo ecosystem integration across agent, guardrail, evaluation, and observability workflows.
-- [ ] Expanded adaptive optimization capabilities for performance-aware scheduling, hints, and cache behavior.
-- [ ] First-party plugins and/or packages for common agent runtimes and frameworks.
+- [ ] Deeper NVIDIA NeMo ecosystem integration across agent, guardrail,
+      evaluation, and observability workflows.
+- [ ] Expanded adaptive optimization capabilities for performance-aware
+      scheduling, hints, and cache behavior.
+- [ ] First-party plugins and packages for common agent runtimes and frameworks
+      where upstream extension points allow it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ when the agent exits.
 
 > [!WARNING]
 > Codex users may need to review and activate generated hooks before events
-> appear. See the [Codex CLI guide](https://docs.nvidia.com/nemo/relay/nemo-relay-cli/codex) for the
+> appear. Refer to the [Codex CLI guide](https://docs.nvidia.com/nemo/relay/nemo-relay-cli/codex) for the
 > current hook activation caveat and troubleshooting steps.
 
 ### 4. Verify the Run
@@ -147,7 +147,7 @@ A successful run gives you two things to inspect:
 
 ## Choose Your Next Path
 
-Pick the row closest to what you are trying to do next.
+Pick the row closest to what you are trying to do next. Refer to the corresponding documentation for more information.
 
 | Goal | Start With |
 |---|---|
@@ -185,7 +185,7 @@ The Node.js package requires Node.js 24 or newer.
 
 ## What Relay Adds
 
-Relay is for the messy middle of agent systems. A production application may
+Relay is the liaison between agent systems. A production application may
 combine NeMo Agent Toolkit, LangChain, LangGraph, provider SDKs, custom harness
 code, NeMo Guardrails, tracing systems, and evaluation pipelines. Relay gives
 those pieces one runtime contract instead of asking every layer to invent its
@@ -193,16 +193,16 @@ own wrappers and trace vocabulary.
 
 Relay gives those systems:
 
-- 🧭 **Scopes** so runs, turns, tools, LLM calls, and subagents have clear
+- **Scopes** so runs, turns, tools, LLM calls, and subagents have clear
   ownership, parent-child lineage, cleanup boundaries, and
   request isolation.
-- ⚙️ **Managed LLM and tool calls** so the same lifecycle and middleware rules
+- **Managed LLM and tool calls** so the same lifecycle and middleware rules
   apply around each callback.
-- 🛡️ **Middleware** for the places where Relay must block, sanitize, transform,
+- **Middleware** for the places where Relay must block, sanitize, transform,
   route, retry, or replace execution.
-- 🧩 **Plugins** so reusable observability, guardrail, adaptive, and exporter
+- **Plugins** so reusable observability, guardrail, adaptive, and exporter
   behavior can be turned on from configuration.
-- 📡 **Events and subscribers** so raw ATOF, normalized ATIF, OpenTelemetry, and
+- **Events and subscribers** so raw ATOF, normalized ATIF, OpenTelemetry, and
   OpenInference output all come from the same runtime stream.
 
 Relay does not replace your framework, model provider, application logic,
@@ -242,27 +242,29 @@ The following table shows which language bindings and CLI features are currently
 
 | Binding | Status | Notes |
 |---|---|---|
-| Python | ✅ Fully supported | Documented with Quick Start and Guides. |
-| Node.js | ✅ Fully supported | Documented with Quick Start and Guides. |
-| Rust | ✅ Fully supported | Documented with Quick Start and Guides. |
-| NeMo Relay CLI | ✅ Supported | Local observability and hook-backed security are supported; optimization is partial and host-dependent. |
-| Go | 🚧 Experimental | Source-first under `go/nemo_relay`. |
-| WebAssembly | 🚧 Experimental | Source-first under `crates/wasm`. |
-| FFI | 🚧 Experimental | Source-first under `crates/ffi`. |
+| Python | Fully supported | Documented with Quick Start and Guides. |
+| Node.js | Fully supported | Documented with Quick Start and Guides. |
+| Rust | Fully supported | Documented with Quick Start and Guides. |
+| NeMo Relay CLI | Supported | Local observability and hook-backed security are supported; optimization is partial and host-dependent. |
+| Go | Experimental | Source-first under `go/nemo_relay`. |
+| WebAssembly | Experimental | Source-first under `crates/wasm`. |
+| FFI | Experimental | Source-first under `crates/ffi`. |
 
 ### Agent Harness Support
 
 The CLI support matrix separates the supported CLI surface from host-specific
-coverage. Observability works for the listed harnesses; security is supported
-when the host exposes blocking hooks; optimization remains partial and
-host-dependent.
+coverage.
+
+- Observability works for the listed harnesses.
+- Security is supported when the host exposes blocking hooks.
+- Optimization remains partial and host-dependent.
 
 | Agent | Observability | Security | Optimization | Notes |
 |:--|:--:|:--:|:--:|:--|
-| Claude Code | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook forwarding, pre-tool blocking, and gateway-routed LLM observability are supported. |
-| Codex | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook activation is required; missing session-end behavior limits trajectory finalization and full optimization coverage. |
-| Hermes Agent | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook forwarding, pre-tool blocking, and gateway-routed or hook-backed LLM observability are supported. |
-| Cursor | 🚧 Partial | ⚠️ Limited | ❌ No | Missing hooks under `cursor-agent` and manual gateway routing limit full feature coverage. |
+| Claude Code | Yes | Yes | Partial | Hook forwarding, pre-tool blocking, and gateway-routed LLM observability are supported. |
+| Codex | Yes | Yes | Partial | Hook activation is required; missing session-end behavior limits trajectory finalization and full optimization coverage. |
+| Hermes Agent | Yes | Yes | Partial | Hook forwarding, pre-tool blocking, and gateway-routed or hook-backed LLM observability are supported. |
+| Cursor | Partial | Limited | No | Missing hooks under `cursor-agent` and manual gateway routing limit full feature coverage. |
 
 ### Public API Integrations
 
@@ -271,10 +273,10 @@ or plugin hooks that preserve enough lifecycle fidelity.
 
 | Agent / Library | Observability | Security | Optimization | Notes |
 |:--|:--:|:--:|:--:|:--|
-| LangChain | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
-| LangGraph | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
-| Deep Agents | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
-| OpenClaw | ✅ Yes | ⚠️ Partial | ❌ No | Hook-backed telemetry with pre-tool guardrails. Managed execution rewrites require the patch-based integration. |
+| LangChain | Yes | Yes | Yes | Wrapped tool and LLM calling. |
+| LangGraph | Yes | Yes | Yes | Wrapped tool and LLM calling. |
+| Deep Agents | Yes | Yes | Yes | Wrapped tool and LLM calling. |
+| OpenClaw | Yes | Partial | No | Hook-backed telemetry with pre-tool guardrails. Managed execution rewrites require the patch-based integration. |
 
 The Python `nemo-relay` package ships extras for LangChain, LangGraph, and Deep
 Agents:
@@ -283,10 +285,10 @@ Agents:
 uv add "nemo-relay[langchain,langgraph,deepagents]"
 ```
 
-See [Supported Integrations](https://docs.nvidia.com/nemo/relay/supported-integrations/about) for setup
+Refer to [Supported Integrations](https://docs.nvidia.com/nemo/relay/supported-integrations/about) for setup
 guides and current caveats.
 
-### Patch-based Integrations
+### Patch-Based Integrations
 
 Patch-based integrations are experimental samples maintained against pinned
 upstream checkouts. Use [third_party/README.md](third_party/README.md) for the
@@ -294,15 +296,15 @@ clone, checkout, and patch-application workflow.
 
 | Integration | Observability | Security | Optimization | Notes |
 |:---|:---:|:---:|:---:|:---|
-| [LangChain](third_party/README-langchain.md), [LangGraph](third_party/README-langgraph.md), [LangChain NVIDIA](third_party/README-langchain-nvidia.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
-| [opencode](third_party/README-opencode.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
-| [OpenClaw](third_party/README-openclaw.md) | ✅ Yes | ✅ Yes | ✅ Yes | Adds middleware support to OpenClaw and a built-in plugin. |
-| [Hermes Agent](third_party/README-hermes-agent.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
+| [LangChain](third_party/README-langchain.md), [LangGraph](third_party/README-langgraph.md), [LangChain NVIDIA](third_party/README-langchain-nvidia.md) | Yes | Yes | Yes | Directly patches behavior into code. |
+| [opencode](third_party/README-opencode.md) | Yes | Yes | Yes | Directly patches behavior into code. |
+| [OpenClaw](third_party/README-openclaw.md) | Yes | Yes | Yes | Adds middleware support to OpenClaw and a built-in plugin. |
+| [Hermes Agent](third_party/README-hermes-agent.md) | Yes | Yes | Yes | Directly patches behavior into code. |
 
 ## Documentation
 
 End-user documentation lives at
-[docs.nvidia.com/nemo/relay](https://docs.nvidia.com/nemo/relay).
+[NVIDIA NeMo Relay documentation](https://docs.nvidia.com/nemo/relay).
 
 Important local entry points:
 
@@ -311,7 +313,7 @@ Important local entry points:
 - [Agent Runtime Primer](https://docs.nvidia.com/nemo/relay/getting-started/agent-runtime-primer)
 - [Testing and Docs](https://docs.nvidia.com/nemo/relay/contribute/testing-and-docs)
 
-For source builds, tests, and contribution workflow, see
+For source builds, tests, and contribution workflow, refer to
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -17,67 +17,201 @@ SPDX-License-Identifier: Apache-2.0
 
 # NVIDIA NeMo Relay
 
-## What Is NeMo Relay?
+NVIDIA NeMo Relay helps you see and control what happens inside agent runs
+without rewriting the agent stack you already have. It gives coding agents,
+applications, framework integrations, middleware, and observability backends a
+shared runtime for scopes, policy, plugins, and lifecycle events.
 
-NVIDIA NeMo Relay is a portable execution runtime for agent systems that already have a
-framework, model provider, policy layer, or observability backend. It gives those
-systems one consistent way to describe, control, and observe what happens when an
-agent crosses a request, tool, or LLM boundary.
+The best first step is to get one real run on disk. Once Relay is writing raw
+events and a trajectory file, you have something concrete to inspect, debug, and
+build from.
 
-Agent applications rarely live inside one clean abstraction. A production stack
-might combine NeMo Agent Toolkit, LangChain, LangGraph, provider SDKs, custom
-harness code, NeMo Guardrails, tracing systems, and evaluation pipelines. NeMo
-Relay sits underneath those choices as the shared runtime contract for scopes,
-middleware, plugins, lifecycle events, adaptive behavior, and observability.
+## Start Here: Capture One Local Agent Run
 
-Built as a Rust core with primary Rust, Python, and Node.js bindings, NeMo Relay
-lets applications keep their orchestration model while runtime behavior stays
-consistent across frameworks and languages.
+This walkthrough gives you an end-to-end success signal. You install the
+`nemo-relay` CLI, turn on local exporters, run either Codex or Claude Code
+through Relay, and check that Relay wrote both raw events and normalized
+trajectories.
 
-## Why Use It?
+> [!TIP]
+> Start by trusting the raw Agent Trajectory Observability Format (ATOF) JSONL.
+> It shows the lifecycle events Relay actually captured before anything is
+> translated into Agent Trajectory Interchange Format (ATIF), OpenTelemetry, or
+> OpenInference output.
 
-- 🧭 **Own execution context across the whole agent run**: Hierarchical scopes
-  attach tools, LLM calls, middleware, subscribers, and events to the same
-  parent-child execution tree.
-- 🛡️ **Package policy once**: Guardrails and intercepts can block work, sanitize
-  observability payloads, transform requests, or wrap execution without
-  rewriting every call site.
-- 📡 **Emit one lifecycle stream**: Subscribers consume canonical runtime events
-  in-process or export them as [ATIF v1.7](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md)
-  trajectories, OpenTelemetry traces, or OpenInference-compatible traces.
-- 🧩 **Integrate without a framework migration**: NeMo Relay can sit below NeMo
-  ecosystem components, third-party agent frameworks, provider adapters, or
-  direct application code.
-- ⚙️ **Install reusable runtime behavior**: Plugins configure middleware,
-  subscribers, adaptive components, observability exporters, and custom runtime
-  behavior from one shared system.
+### 1. Install the CLI
 
-## What You Get
+```bash
+cargo install nemo-relay-cli
+```
 
-- ✅ **Managed tool and LLM execution**: Run call boundaries through consistent
-  lifecycle helpers and middleware ordering.
-- ✅ **Concurrent request isolation**: Keep request-local middleware and
-  subscribers attached to the scope that owns them, then clean them up when that
-  scope closes.
-- ✅ **Multi-language semantics**: Use the same runtime model from Rust, Python,
-  and Node.js.
-- ✅ **Observability-ready events**: Preserve model metadata, tool call IDs,
-  inputs, outputs, scope relationships, and lifecycle timing for downstream
-  analysis.
-- ✅ **Built-in observability plugin**: Configure Agent Trajectory Observability
-  Format (ATOF), ATIF, OpenTelemetry, and OpenInference exporters without
-  registering subscribers by hand.
-- ✅ **Non-blocking subscriber delivery**: Keep managed execution moving while
-  subscriber callbacks and exporters drain in the background. Flush subscribers
-  before relying on callback side effects or exported files in tests and
-  shutdown paths.
-- ✅ **Extension points for framework authors**: Wrap stable tool and provider
-  callbacks while preserving framework-owned scheduling, retries, memory, and
-  result handling.
+If you use `cargo-binstall`, the CLI can also be installed with:
+
+```bash
+cargo binstall nemo-relay-cli
+```
+
+### 2. Enable Local Observability Output
+
+From the project directory you want to observe, open the project-scoped plugin
+editor:
+
+```bash
+nemo-relay plugins edit --project
+```
+
+The editor creates or updates the nearest project plugin file at
+`.nemo-relay/plugins.toml`. In the menu:
+
+1. Enable the `Observability` component.
+2. Open `ATOF`, toggle the section on, and set:
+   - `output_directory` to `.nemo-relay/atof`
+   - `filename` to `events.jsonl`
+   - `mode` to `overwrite`
+3. Open `ATIF`, toggle the section on, and set:
+   - `output_directory` to `.nemo-relay/atif`
+   - `filename_template` to `trajectory-{session_id}.json`
+4. Press `p` to preview the generated TOML.
+5. Press `s` to save.
+
+> [!NOTE]
+> Use `nemo-relay plugins edit` without `--project` only when you want these
+> exporter settings in your user-level Relay config instead of this one project.
+
+### 3. Run Codex or Claude Code Through Relay
+
+Use the host CLI that is installed on your machine.
+
+```bash
+nemo-relay codex -- exec "Summarize this repository."
+```
+
+```bash
+nemo-relay claude -- "Summarize this repository."
+```
+
+The transparent wrapper starts a local Relay gateway, injects host-specific hook
+and provider settings for that launched process, then shuts the gateway down
+when the agent exits.
+
+> [!WARNING]
+> Codex users may need to review and activate generated hooks before events
+> appear. See the [Codex CLI guide](https://docs.nvidia.com/nemo/relay/nemo-relay-cli/codex) for the
+> current hook activation caveat and troubleshooting steps.
+
+### 4. Verify the Run
+
+After the run exits, check that raw events and trajectory files were written:
+
+```bash
+test -s .nemo-relay/atof/events.jsonl
+ls .nemo-relay/atif/*.json
+for file in .nemo-relay/atif/*.json; do
+  python3 -m json.tool "$file" >/dev/null
+done
+```
+
+Then verify that at least one raw ATOF `0.1` event exists:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import json
+
+events_path = Path(".nemo-relay/atof/events.jsonl")
+events = [
+    json.loads(line)
+    for line in events_path.read_text().splitlines()
+    if line.strip()
+]
+
+assert events, "no ATOF events were written"
+assert any(event.get("atof_version") == "0.1" for event in events), "no ATOF 0.1 events found"
+print(f"validated {len(events)} ATOF event(s)")
+PY
+```
+
+A successful run gives you two things to inspect:
+
+- `.nemo-relay/atof/events.jsonl`, the raw canonical event stream.
+- One or more `.nemo-relay/atif/*.json` trajectory files for analysis and
+  evaluation workflows.
+
+> [!TIP]
+> If raw ATOF events exist but LLM spans are missing, provider traffic probably
+> isn't flowing through the Relay gateway. If ATIF is missing, make sure the
+> agent session or turn ended and the output directory is writable. Use
+> [NeMo Relay CLI](https://docs.nvidia.com/nemo/relay/nemo-relay-cli/about) when you are ready for
+> persistent host plugin installation, gateway configuration, exporter options,
+> and agent-specific diagnostics.
+
+## Choose Your Next Path
+
+Pick the row closest to what you are trying to do next.
+
+| Goal | Start With |
+|---|---|
+| Observe Codex, Claude Code, Cursor, or Hermes locally | [NeMo Relay CLI](https://docs.nvidia.com/nemo/relay/nemo-relay-cli/about) |
+| Instrument app-owned LLM or tool calls | [Quick Start](https://docs.nvidia.com/nemo/relay/getting-started/quick-start) |
+| Use LangChain, LangGraph, Deep Agents, or OpenClaw | [Supported Integrations](https://docs.nvidia.com/nemo/relay/supported-integrations/about) |
+| Build a framework or provider integration | [Integrate into Frameworks](https://docs.nvidia.com/nemo/relay/integrate-into-frameworks/about) |
+| Export ATOF, ATIF, OpenTelemetry, or OpenInference | [Observability Plugin](https://docs.nvidia.com/nemo/relay/observability-plugin/about) |
+| Package reusable middleware or exporters | [Build Plugins](https://docs.nvidia.com/nemo/relay/build-plugins/about) |
+| Develop or test this repository from source | [CONTRIBUTING.md](CONTRIBUTING.md) |
+
+## Application Quick Starts
+
+If you own the code that calls the model or tool, install the binding for your
+language and route that boundary through Relay directly.
+
+```bash
+# Python
+uv add nemo-relay
+
+# Node.js
+npm install nemo-relay-node
+
+# Rust
+cargo add nemo-relay
+```
+
+Then run the smallest workflow for that binding:
+
+- [Python Quick Start](https://docs.nvidia.com/nemo/relay/getting-started/quick-start/python)
+- [Node.js Quick Start](https://docs.nvidia.com/nemo/relay/getting-started/quick-start/nodejs)
+- [Rust Quick Start](https://docs.nvidia.com/nemo/relay/getting-started/quick-start/rust)
+
+The Node.js package requires Node.js 24 or newer.
+
+## What Relay Adds
+
+Relay is for the messy middle of agent systems. A production application may
+combine NeMo Agent Toolkit, LangChain, LangGraph, provider SDKs, custom harness
+code, NeMo Guardrails, tracing systems, and evaluation pipelines. Relay gives
+those pieces one runtime contract instead of asking every layer to invent its
+own wrappers and trace vocabulary.
+
+Relay gives those systems:
+
+- 🧭 **Scopes** so runs, turns, tools, LLM calls, and subagents have clear
+  ownership, parent-child lineage, cleanup boundaries, and
+  request isolation.
+- ⚙️ **Managed LLM and tool calls** so the same lifecycle and middleware rules
+  apply around each callback.
+- 🛡️ **Middleware** for the places where Relay must block, sanitize, transform,
+  route, retry, or replace execution.
+- 🧩 **Plugins** so reusable observability, guardrail, adaptive, and exporter
+  behavior can be turned on from configuration.
+- 📡 **Events and subscribers** so raw ATOF, normalized ATIF, OpenTelemetry, and
+  OpenInference output all come from the same runtime stream.
+
+Relay does not replace your framework, model provider, application logic,
+observability backend, or guardrail authoring system. It gives those systems a
+common boundary to meet at.
 
 ```mermaid
 flowchart LR
-    App[Application or Framework]
+    App[Application, Framework, or CLI Harness]
 
     subgraph Runtime[NeMo Relay Runtime]
         direction TB
@@ -97,138 +231,98 @@ flowchart LR
     Events --> Output
 ```
 
-## Installation
+## Support Status
 
-Install the published package for your language:
+> [!NOTE]
+> The main supported paths today are Rust, Python, and Node.js. Go,
+> WebAssembly, and raw C FFI are available for source-first users, but they are
+> still experimental.
 
-```bash
-# Rust
-cargo add nemo-relay
-
-# Python
-uv add nemo-relay
-
-# Node.js
-npm install nemo-relay-node
-```
-
-The Node.js package requires Node.js 24 or newer.
-
-### CLI Installation
-
-The NeMo Relay CLI is offered as a separate crate:
-
-```bash
-cargo install nemo-relay-cli
-```
-
-If `cargo-binstall` is available on your machine:
-
-```bash
-cargo binstall nemo-relay-cli
-```
-
-For source builds, testing, and contribution workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Documentation
-
-End-user documentation lives at [docs.nvidia.com/nemo/relay](https://docs.nvidia.com/nemo/relay).
-
-The primary documentation track covers Rust, Python, and Node.js.
-
-The Go, WebAssembly, and raw FFI surfaces are currently experimental and remain source-first under
-`go/nemo_relay`, `crates/wasm`, and `crates/ffi`.
-
-## Binding Status
-
-The table below summarizes the support level for each binding surface.
+The following table shows which language bindings and CLI features are currently supported:
 
 | Binding | Status | Notes |
 |---|---|---|
-| Python | ✅ Fully Supported | Fully documented with Quick Start and Guides |
-| Node.js | ✅ Fully Supported | Fully documented with Quick Start and Guides  |
-| Rust | ✅ Fully Supported | Fully documented with Quick Start and Guides  |
-| NeMo Relay CLI | 🚧 Experimental | Install with `cargo install nemo-relay-cli`. |
+| Python | ✅ Fully supported | Documented with Quick Start and Guides. |
+| Node.js | ✅ Fully supported | Documented with Quick Start and Guides. |
+| Rust | ✅ Fully supported | Documented with Quick Start and Guides. |
+| NeMo Relay CLI | ✅ Supported | Local observability and hook-backed security are supported; optimization is partial and host-dependent. |
 | Go | 🚧 Experimental | Source-first under `go/nemo_relay`. |
 | WebAssembly | 🚧 Experimental | Source-first under `crates/wasm`. |
 | FFI | 🚧 Experimental | Source-first under `crates/ffi`. |
 
-## Agent Harness Support
+### Agent Harness Support
 
-NeMo Relay CLI offers experimental support for several agent harnesses.
-Refer to the NeMo Relay CLI documentation for additional information.
-
-Below is our support matrix for agent harnesses.
+The CLI support matrix separates the supported CLI surface from host-specific
+coverage. Observability works for the listed harnesses; security is supported
+when the host exposes blocking hooks; optimization remains partial and
+host-dependent.
 
 | Agent | Observability | Security | Optimization | Notes |
 |:--|:--:|:--:|:--:|:--|
-| Claude Code | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Tool guardrail support is wired up. LLM optimization is in place. |
-| Codex | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Tool guardrail support is wired up. LLM optimization is in place. Missing some necessary hooks for full feature parity. |
-| Hermes Agent | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Tool guardrail support is wired up. LLM optimization is in place. |
-| Cursor | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Tool guardrail support is wired up. LLM optimization is in place. Not feature-rich, missing hooks under `cursor-agent` |
-
-## Third-Party Integrations
-
-Some framework integrations are maintained as packages in this repository. Other
-sample integrations are maintained as patch sets against upstream projects.
+| Claude Code | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook forwarding, pre-tool blocking, and gateway-routed LLM observability are supported. |
+| Codex | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook activation is required; missing session-end behavior limits trajectory finalization and full optimization coverage. |
+| Hermes Agent | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook forwarding, pre-tool blocking, and gateway-routed or hook-backed LLM observability are supported. |
+| Cursor | 🚧 Partial | ⚠️ Limited | ❌ No | Missing hooks under `cursor-agent` and manual gateway routing limit full feature coverage. |
 
 ### Public API Integrations
 
-Some integrations can be implemented using public APIs without patching. Public
-API-based integrations live under language-specific integration packages such as
-`python/nemo_relay/integrations/` and `integrations/`.
-
-Below is the support matrix for our public API integrations.
+Use these integrations when the framework exposes stable callbacks, middleware,
+or plugin hooks that preserve enough lifecycle fidelity.
 
 | Agent / Library | Observability | Security | Optimization | Notes |
 |:--|:--:|:--:|:--:|:--|
-| LangChain | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped Tool and LLM calling |
-| LangGraph | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped Tool and LLM calling |
-| Deep Agents | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped Tool and LLM calling |
+| LangChain | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
+| LangGraph | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
+| Deep Agents | ✅ Yes | ✅ Yes | ✅ Yes | Wrapped tool and LLM calling. |
 | OpenClaw | ✅ Yes | ⚠️ Partial | ❌ No | Hook-backed telemetry with pre-tool guardrails. Managed execution rewrites require the patch-based integration. |
 
-#### LangChain
+The Python `nemo-relay` package ships extras for LangChain, LangGraph, and Deep
+Agents:
 
-The Python `nemo-relay` package ships several extras that offer comprehensive
-middleware support for the following packages:
+```bash
+uv add "nemo-relay[langchain,langgraph,deepagents]"
+```
 
-- LangChain
-- LangGraph
-- Deep Agents
-
-See the [Python package README](python/nemo_relay/README.md) for more information.
-
-#### OpenClaw
-
-An OpenClaw plugin is available as a Node package `nemo-relay-openclaw`.
-It relies on OpenClaw public plugin hooks plus the generic NeMo Relay plugin
-configuration shape to export telemetry. See the
-[OpenClaw package README](integrations/openclaw/README.md) for more information.
+See [Supported Integrations](https://docs.nvidia.com/nemo/relay/supported-integrations/about) for setup
+guides and current caveats.
 
 ### Patch-based Integrations
 
-Patch-based integrations offer experimental support. Our roadmap includes switching over to first-party plugins and packages where upstream extension points allow it.
-
-Use [third_party/README.md](third_party/README.md) for the clone, checkout, and
-patch-application workflow for those integrations.
-
-The following table summarizes maintained third-party integrations and whether each provides observability, security, and optimization support.
+Patch-based integrations are experimental samples maintained against pinned
+upstream checkouts. Use [third_party/README.md](third_party/README.md) for the
+clone, checkout, and patch-application workflow.
 
 | Integration | Observability | Security | Optimization | Notes |
 |:---|:---:|:---:|:---:|:---|
-| [LangChain](third_party/README-langchain.md), [LangGraph](third_party/README-langgraph.md), [LangChain NVIDIA](third_party/README-langchain-nvidia.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code requiring no middleware |
-| [opencode](third_party/README-opencode.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code |
-| [OpenClaw](third_party/README-openclaw.md) | ✅ Yes | ✅ Yes | ✅ Yes | Adds new middleware support to OpenClaw and a built-in plugin |
-| [Hermes Agent](third_party/README-hermes-agent.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code |
+| [LangChain](third_party/README-langchain.md), [LangGraph](third_party/README-langgraph.md), [LangChain NVIDIA](third_party/README-langchain-nvidia.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
+| [opencode](third_party/README-opencode.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
+| [OpenClaw](third_party/README-openclaw.md) | ✅ Yes | ✅ Yes | ✅ Yes | Adds middleware support to OpenClaw and a built-in plugin. |
+| [Hermes Agent](third_party/README-hermes-agent.md) | ✅ Yes | ✅ Yes | ✅ Yes | Directly patches behavior into code. |
+
+## Documentation
+
+End-user documentation lives at
+[docs.nvidia.com/nemo/relay](https://docs.nvidia.com/nemo/relay).
+
+Important local entry points:
+
+- [Overview](https://docs.nvidia.com/nemo/relay/about-nemo-relay/overview)
+- [Installation](https://docs.nvidia.com/nemo/relay/getting-started/installation)
+- [Agent Runtime Primer](https://docs.nvidia.com/nemo/relay/getting-started/agent-runtime-primer)
+- [Testing and Docs](https://docs.nvidia.com/nemo/relay/contribute/testing-and-docs)
+
+For source builds, tests, and contribution workflow, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Roadmap
 
-The following roadmap outlines planned features and integrations for upcoming releases.
-
 - [ ] NemoClaw support and integration for managed tool and LLM execution flows.
-- [ ] Deeper NVIDIA NeMo ecosystem integration across agent, guardrail, evaluation, and observability workflows.
-- [ ] Expanded adaptive optimization capabilities for performance-aware scheduling, hints, and cache behavior.
-- [ ] First-party plugins and/or packages for common agent runtimes and frameworks.
+- [ ] Deeper NVIDIA NeMo ecosystem integration across agent, guardrail,
+      evaluation, and observability workflows.
+- [ ] Expanded adaptive optimization capabilities for performance-aware
+      scheduling, hints, and cache behavior.
+- [ ] First-party plugins and packages for common agent runtimes and frameworks
+      where upstream extension points allow it.
 
 ## License
 

--- a/docs/about-nemo-relay/overview.mdx
+++ b/docs/about-nemo-relay/overview.mdx
@@ -8,72 +8,116 @@ import { MermaidStyles } from "@/components/MermaidStyles";
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
+NVIDIA NeMo Relay helps you see and control what happens inside agent runs
+without rewriting the agent stack you already have. It gives coding agents,
+applications, framework integrations, middleware, and observability backends a
+shared runtime for scopes, policy, plugins, and lifecycle events.
 
-NVIDIA NeMo Relay is a portable execution runtime for agent systems that already have a
-framework, model provider, policy layer, or observability backend. It gives those
-systems one consistent way to describe what is happening when an agent crosses a
-request, tool, or LLM boundary.
+Agent systems usually cross several boundaries in one request: an entrypoint
+starts work, a model is called, tools run, subagents may branch off, and
+observability or policy systems need to understand what happened. Relay gives
+those boundaries one runtime contract instead of asking each layer to invent its
+own wrappers, trace vocabulary, and cleanup rules.
 
-That layer is useful because agent applications rarely live inside one clean
-abstraction. A production stack might combine NeMo Agent Toolkit, LangChain,
-LangGraph, provider SDKs, custom harness code, NeMo Guardrails, tracing systems,
-and evaluation pipelines. NeMo Relay sits underneath those choices as the shared
-runtime contract for scopes, middleware, plugins, lifecycle events, adaptive
-behavior, and observability. Under the NeMo Relay scope stack and middleware, the scoped execution path is referred to as work.
+## Where Relay Fits
 
-The result is a framework-neutral substrate for agent execution. Applications
-keep their orchestration model, providers keep their native clients, and
-middleware authors get one place to package policy, interception, telemetry, and
-adaptive behavior across Rust, Python, and Node.js.
+Relay sits around the work you want to observe or control. Work can be a local
+coding-agent session, a request, a turn, an LLM call, a tool call, a subagent
+run, or a framework-specific lifecycle unit.
 
-## Benefits
+<Note>
+Relay does not replace your agent framework, model provider, application logic,
+observability backend, or guardrail authoring system. It gives those systems a
+common runtime boundary to meet at.
+</Note>
 
-NeMo Relay is designed for teams that need agent runtime behavior to stay
-consistent as applications grow across frameworks, languages, and deployment
-targets.
+The first design question is simple: where can Relay see or control the real
+work? The answer determines whether you should use a CLI sidecar, direct SDK
+instrumentation, a maintained integration, a framework wrapper, or a plugin.
 
-- **Instrument once at the execution boundary**: Managed tool and LLM helpers
-  attach work to the active scope, emit lifecycle events, and run the same
-  middleware pipeline without scattering custom wrappers through every call site.
-- **Keep concurrent agents isolated**: Hierarchical scopes preserve parent-child
-  event relationships, expose request-local middleware and subscribers, and
-  clean up scope-owned registrations when work finishes.
-- **Turn policy into reusable runtime components**: Guardrails and intercepts can
-  block work, sanitize observability payloads, transform requests, or wrap
-  execution. Plugins package that behavior so applications and framework
-  integrations can install it from configuration.
-- **Export one event stream to many backends**: Subscribers consume the canonical
-  lifecycle stream in-process or translate it to Agent Trajectory Interchange
-  Format (ATIF) trajectories, OpenTelemetry traces, and OpenInference-compatible
-  traces for debugging, evaluation, and production observability.
-- **Adopt without replacing the stack**: NeMo Relay can sit below NeMo ecosystem
-  components, third-party agent frameworks, provider adapters, or direct
-  application code, so teams can add shared runtime semantics without a
-  framework migration.
-- **Share semantics across primary bindings**: The Rust core, Python wrapper,
-  and Node.js binding expose the same execution model, which helps framework
-  authors, plugin authors, and application teams reason about behavior
-  consistently.
+## Choose Your First Path
 
-## What Should I Read First?
+Pick the row closest to what you are trying to do.
 
-Use the reading path that matches your task:
+| Goal | Start With | Why |
+|---|---|---|
+| Observe Codex, Claude Code, Cursor, or Hermes locally | [NeMo Relay CLI](/nemo-relay-cli/about) and [Basic Usage](/nemo-relay-cli/basic-usage) | Relay runs as a local sidecar, forwards hooks, routes provider traffic when configured, and writes observability artifacts without changing application code. |
+| Run the smallest binding-specific example | [Quick Start](/getting-started/quick-start) | Use this when you want a minimal Rust, Python, or Node.js workflow before adding Relay to real application code. |
+| Instrument application-owned LLM or tool calls | [Instrument Applications](/instrument-applications/about) | Direct SDK instrumentation gives Relay full managed-call semantics around callbacks your code owns. |
+| Use LangChain, LangGraph, Deep Agents, or OpenClaw | [Supported Integrations](/supported-integrations/about) | Maintained integrations use public framework or plugin APIs where they preserve enough lifecycle fidelity. |
+| Build a framework, host, or provider integration | [Integrate into Frameworks](/integrate-into-frameworks/about) | Integration guidance helps you choose managed wrappers, explicit lifecycle APIs, hook replay, provider codecs, or upstream support. |
+| Package reusable exporters, middleware, or policy | [Build Plugins](/build-plugins/about), [Observability](/observability-plugin/about), and [NeMo Guardrails Plugin](/nemo-guardrails-plugin/about) | Plugins are the configuration-driven path for behavior that should be shared across applications or teams. |
+| Develop or validate the repository itself | [Development Setup](/contribute/development-setup) and [Testing and Docs](/contribute/testing-and-docs) | Use the contributor workflow when you are changing Relay source, docs, examples, bindings, or integration patches. |
+
+<Note>
+If you are unsure how much Relay you need, capture one boundary first. Confirm
+that Relay emits raw lifecycle events, then add normalized exports, middleware,
+guardrails, or adaptive behavior.
+</Note>
+
+## Validate Raw Capture First
+
+Start with [Agent Trajectory Observability Format (ATOF) JSONL](/observability-plugin/atof),
+the raw canonical event stream. It shows the lifecycle events Relay actually
+captured before anything is translated into
+[Agent Trajectory Interchange Format (ATIF)](/observability-plugin/atif),
+OpenTelemetry, or OpenInference output.
+
+A good first integration usually looks like this:
+
+1. Create or identify one scope boundary.
+2. Capture one LLM, tool, session, or turn boundary.
+3. Export ATOF JSONL and inspect the raw event stream.
+4. Add ATIF, OpenTelemetry, or OpenInference when the raw events are trustworthy.
+5. Add middleware only when Relay must block, sanitize, rewrite, route, or
+   replace real execution.
+
+## What Relay Adds
+
+- 🧭 **Scopes** so runs, turns, tools, LLM calls, and subagents have clear
+  ownership, parent-child lineage, cleanup boundaries, and request isolation.
+- ⚙️ **Managed LLM and tool calls** so the same lifecycle and middleware rules
+  apply around each callback.
+- 🛡️ **Middleware** for the places where Relay must block, sanitize, transform,
+  route, retry, or replace execution.
+- 🧩 **Plugins** so reusable observability, guardrail, adaptive, and exporter
+  behavior can be turned on from configuration.
+- 📡 **Events and subscribers** so raw ATOF, normalized ATIF, OpenTelemetry, and
+  OpenInference output all come from the same runtime stream.
+
+Use [Concepts](/about-nemo-relay/concepts) when you want the deeper model for
+scopes, events, middleware, subscribers, and plugins.
+
+## Developer Background
+
+Rust is the source of truth for runtime behavior. The Python and Node.js
+bindings expose the same core model for primary application use. Go,
+WebAssembly, and raw C FFI are experimental and source-first surfaces.
+
+Developers building integrations should start by identifying who owns the real
+LLM or tool call. If Relay can wrap the real callback, use managed execution. If
+the framework exposes lifecycle hooks but not execution control, use explicit
+lifecycle APIs or hook replay. If provider-shaped payload capture matters,
+consider the gateway/provider path and treat it as production traffic.
+
+<Warning>
+Do not add behavior to one primary binding without checking Rust, Python, and
+Node.js parity. Public behavior should stay consistent across the supported
+runtime surfaces.
+</Warning>
+
+## Read Next
+
+Use the tasks below to build your understanding and set up Relay:
 
 | Task | Start With |
 |---|---|
-| Understand what NeMo Relay adds | [Agent Runtime Primer](/getting-started/agent-runtime-primer) |
-| Run a minimal example | [Quick Start](/getting-started/quick-start) |
 | Install packages | [Installation](/getting-started/installation) |
-| Develop from source | [Development Setup](/contribute/development-setup) |
-| Understand the runtime model | [Concepts](/about-nemo-relay/concepts) |
-| Instrument an application | [Instrument Applications](/instrument-applications/about) |
-| Use a maintained integration | [Supported Integrations](/supported-integrations/about) |
-| Integrate a framework | [Integrate into Frameworks](/integrate-into-frameworks/about) |
-| Observe a local coding-agent CLI | [NeMo Relay CLI](/nemo-relay-cli/about) |
-| Package reusable behavior | [Build Plugins](/build-plugins/about) |
+| Understand the mental model | [Agent Runtime Primer](/getting-started/agent-runtime-primer) |
+| Configure plugin files | [Plugin Configuration Files](/build-plugins/plugin-configuration-files) |
 | Export traces or trajectories | [Observability](/observability-plugin/about) |
-| Debug trace incidents | [Trace Incident Runbook](/resources/troubleshooting/trace-incident-runbook) |
 | Tune performance with adaptive behavior | [Adaptive](/adaptive-plugin/about) |
+| Debug trace incidents | [Trace Incident Runbook](/resources/troubleshooting/trace-incident-runbook) |
 | Look up symbols | [APIs](/reference/api) |
 
 ## Conceptual Diagram

--- a/docs/about-nemo-relay/overview.mdx
+++ b/docs/about-nemo-relay/overview.mdx
@@ -8,7 +8,7 @@ import { MermaidStyles } from "@/components/MermaidStyles";
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-NVIDIA NeMo Relay helps you see and control what happens inside agent runs
+NVIDIA NeMo Relay helps you observe and control what happens inside agent runs
 without rewriting the agent stack you already have. It gives coding agents,
 applications, framework integrations, middleware, and observability backends a
 shared runtime for scopes, policy, plugins, and lifecycle events.
@@ -19,7 +19,7 @@ observability or policy systems need to understand what happened. Relay gives
 those boundaries one runtime contract instead of asking each layer to invent its
 own wrappers, trace vocabulary, and cleanup rules.
 
-## Where Relay Fits
+## Integrating With Relay
 
 Relay sits around the work you want to observe or control. Work can be a local
 coding-agent session, a request, a turn, an LLM call, a tool call, a subagent
@@ -31,7 +31,7 @@ observability backend, or guardrail authoring system. It gives those systems a
 common runtime boundary to meet at.
 </Note>
 
-The first design question is simple: where can Relay see or control the real
+The first design question is simple: where can Relay observe or control the real
 work? The answer determines whether you should use a CLI sidecar, direct SDK
 instrumentation, a maintained integration, a framework wrapper, or a plugin.
 
@@ -63,7 +63,7 @@ captured before anything is translated into
 [Agent Trajectory Interchange Format (ATIF)](/observability-plugin/atif),
 OpenTelemetry, or OpenInference output.
 
-A good first integration usually looks like this:
+A good first integration process workflow is as follows:
 
 1. Create or identify one scope boundary.
 2. Capture one LLM, tool, session, or turn boundary.
@@ -72,17 +72,19 @@ A good first integration usually looks like this:
 5. Add middleware only when Relay must block, sanitize, rewrite, route, or
    replace real execution.
 
-## What Relay Adds
+## Key Features
 
-- 🧭 **Scopes** so runs, turns, tools, LLM calls, and subagents have clear
+NeMo Relay offers the following features when you use it with your agent stacks:
+
+- **Scopes** so runs, turns, tools, LLM calls, and subagents have clear
   ownership, parent-child lineage, cleanup boundaries, and request isolation.
-- ⚙️ **Managed LLM and tool calls** so the same lifecycle and middleware rules
+- **Managed LLM and tool calls** so the same lifecycle and middleware rules
   apply around each callback.
-- 🛡️ **Middleware** for the places where Relay must block, sanitize, transform,
+- **Middleware** for the places where Relay must block, sanitize, transform,
   route, retry, or replace execution.
-- 🧩 **Plugins** so reusable observability, guardrail, adaptive, and exporter
+- **Plugins** so reusable observability, guardrail, adaptive, and exporter
   behavior can be turned on from configuration.
-- 📡 **Events and subscribers** so raw ATOF, normalized ATIF, OpenTelemetry, and
+- **Events and subscribers** so raw ATOF, normalized ATIF, OpenTelemetry, and
   OpenInference output all come from the same runtime stream.
 
 Use [Concepts](/about-nemo-relay/concepts) when you want the deeper model for
@@ -106,7 +108,7 @@ Node.js parity. Public behavior should stay consistent across the supported
 runtime surfaces.
 </Warning>
 
-## Read Next
+## Documentation
 
 Use the tasks below to build your understanding and set up Relay:
 

--- a/docs/about-nemo-relay/release-notes/known-issues.mdx
+++ b/docs/about-nemo-relay/release-notes/known-issues.mdx
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 This page lists current limitations and support notes for the release
 documentation set.
 
-## NVIDIA NeMo Relay 0.3
+## NeMo Relay 0.3
 
 These notes apply to the NeMo Relay 0.3 release. The following known issues
 and limitations apply to NeMo Relay 0.3:
@@ -17,9 +17,9 @@ and limitations apply to NeMo Relay 0.3:
 - Go, WebAssembly, and the raw C FFI surface are experimental and source-first.
 - Generated API pages cover Rust, Python, and Node.js. Experimental bindings do
   not yet have the same generated documentation depth.
-- NeMo Relay CLI host coverage varies by agent. Cursor remains limited by
-  incomplete hook and gateway-routing coverage, Codex requires manual hook
-  activation, and optimization depends on the host and provider route.
+- The NeMo Relay CLI is experimental. Coding agent observability support varies
+  due to capabilities of hooks. Any encountered problems should be filed as
+  bugs.
 - Node.js 24 or newer is required for Node.js binding and package workflows.
 - OpenClaw support uses public hook-backed telemetry with partial security and
   optimization support. Security is limited to pre-tool conditional guardrails,

--- a/docs/about-nemo-relay/release-notes/known-issues.mdx
+++ b/docs/about-nemo-relay/release-notes/known-issues.mdx
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 This page lists current limitations and support notes for the release
 documentation set.
 
-## NeMo Relay 0.3
+## NVIDIA NeMo Relay 0.3
 
 These notes apply to the NeMo Relay 0.3 release. The following known issues
 and limitations apply to NeMo Relay 0.3:
@@ -17,9 +17,9 @@ and limitations apply to NeMo Relay 0.3:
 - Go, WebAssembly, and the raw C FFI surface are experimental and source-first.
 - Generated API pages cover Rust, Python, and Node.js. Experimental bindings do
   not yet have the same generated documentation depth.
-- The NeMo Relay CLI is experimental. Coding agent observability support varies
-  due to capabilities of hooks. Any encountered problems should be filed as
-  bugs.
+- NeMo Relay CLI host coverage varies by agent. Cursor remains limited by
+  incomplete hook and gateway-routing coverage, Codex requires manual hook
+  activation, and optimization depends on the host and provider route.
 - Node.js 24 or newer is required for Node.js binding and package workflows.
 - OpenClaw support uses public hook-backed telemetry with partial security and
   optimization support. Security is limited to pre-tool conditional guardrails,

--- a/docs/getting-started/quick-start/index.mdx
+++ b/docs/getting-started/quick-start/index.mdx
@@ -6,7 +6,32 @@ position: 5
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-Choose the Quick Start guide for the primary binding that you plan to use.
+Choose the Quick Start path for the boundary you want Relay to observe or
+control.
+
+## Local Coding-Agent Runs
+
+Use the NVIDIA NeMo Relay CLI when you want to observe a local Codex, Claude
+Code, Cursor, or Hermes Agent session without changing application code.
+
+<CardGroup cols={1}>
+<Card
+  title="CLI Basic Usage"
+  icon="terminal"
+  iconPosition="left"
+  href="/nemo-relay-cli/basic-usage"
+>
+
+Run a coding-agent CLI through Relay, forward hooks, route model traffic through
+the local gateway, and export traces or trajectories.
+</Card>
+
+</CardGroup>
+
+## Application-Owned Code
+
+Use a binding Quick Start when your application owns the LLM or tool call and
+you want to instrument that boundary directly.
 
 <CardGroup cols={3}>
 <Card

--- a/docs/nemo-relay-cli/about.mdx
+++ b/docs/nemo-relay-cli/about.mdx
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 
 Use this section when you want the `nemo-relay` binary to observe local coding
-agent sessions through hooks, a passthrough LLM gateway, and NeMo Relay
+agent sessions through hooks, a passthrough LLM gateway, and NVIDIA NeMo Relay
 observability exporters.
 
 The NeMo Relay CLI is installed by the `nemo-relay-cli` Cargo package. It can run
@@ -38,16 +38,17 @@ If you are instrumenting an application or framework directly, use
 
 ## Agent Harness Support
 
-NeMo Relay CLI support is experimental. Observability is supported, while
-security and optimization support are partial and depend on the hooks each
-agent exposes.
+The NeMo Relay CLI is a supported surface for local coding-agent observability
+and hook-backed security. Optimization remains partial and host-dependent
+because each agent exposes different hooks, provider routes, and execution
+controls.
 
 | Agent | Observability | Security | Optimization | Notes |
 | --- | --- | --- | --- | --- |
-| Claude Code | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Pre-tool hook responses are supported. LLM optimization uses gateway-routed traffic; full coverage depends on loaded Claude Code hooks. |
-| Codex | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Hook forwarding and gateway-routed LLM optimization are supported. Codex hook activation and the missing session-end hook limit full coverage. |
-| Hermes Agent | ✅ Yes | ⚠️ Partial | ⚠️ Partial | Hook forwarding and Hermes API-request telemetry are supported. Guardrail and optimization support depend on Hermes shell and API-request hook coverage. |
-| Cursor | 🚧 Partial | ⚠️ Partial | ❌ No | Hook forwarding is supported. Gateway observability is limited. Missing hooks under `cursor-agent` limit full feature coverage. |
+| Claude Code | ✅ Yes | ✅ Yes | ⚠️ Partial | Pre-tool hook responses are supported. LLM optimization uses gateway-routed traffic; full coverage depends on loaded Claude Code hooks. |
+| Codex | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook forwarding and gateway-routed LLM optimization are supported after hooks are reviewed and activated. The missing session-end hook limits full coverage. |
+| Hermes Agent | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook forwarding, pre-tool guardrails, and Hermes API-request telemetry are supported. Optimization depends on Hermes shell and API-request hook coverage. |
+| Cursor | 🚧 Partial | ⚠️ Limited | ❌ No | Hook forwarding is supported. Gateway observability is limited. Missing hooks under `cursor-agent` limit full feature coverage. |
 
 ## Guides
 

--- a/docs/nemo-relay-cli/about.mdx
+++ b/docs/nemo-relay-cli/about.mdx
@@ -45,10 +45,10 @@ controls.
 
 | Agent | Observability | Security | Optimization | Notes |
 | --- | --- | --- | --- | --- |
-| Claude Code | ✅ Yes | ✅ Yes | ⚠️ Partial | Pre-tool hook responses are supported. LLM optimization uses gateway-routed traffic; full coverage depends on loaded Claude Code hooks. |
-| Codex | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook forwarding and gateway-routed LLM optimization are supported after hooks are reviewed and activated. The missing session-end hook limits full coverage. |
-| Hermes Agent | ✅ Yes | ✅ Yes | ⚠️ Partial | Hook forwarding, pre-tool guardrails, and Hermes API-request telemetry are supported. Optimization depends on Hermes shell and API-request hook coverage. |
-| Cursor | 🚧 Partial | ⚠️ Limited | ❌ No | Hook forwarding is supported. Gateway observability is limited. Missing hooks under `cursor-agent` limit full feature coverage. |
+| Claude Code | Yes | Yes | Partial | Pre-tool hook responses are supported. LLM optimization uses gateway-routed traffic; full coverage depends on loaded Claude Code hooks. |
+| Codex | Yes | Yes | Partial | Hook forwarding and gateway-routed LLM optimization are supported after hooks are reviewed and activated. The missing session-end hook limits full coverage. |
+| Hermes Agent | Yes | Yes | Partial | Hook forwarding, pre-tool guardrails, and Hermes API-request telemetry are supported. Optimization depends on Hermes shell and API-request hook coverage. |
+| Cursor | Partial | Limited | No | Hook forwarding is supported. Gateway observability is limited. Missing hooks under `cursor-agent` limit full feature coverage. |
 
 ## Guides
 


### PR DESCRIPTION
#### Overview

Refresh the NVIDIA NeMo Relay README and documentation overview so new users and developers get a clearer onboarding path before diving into API details.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Rewrites the top-level README around an end-to-end CLI success path for capturing one local agent run.
- Adds project-scoped `nemo-relay plugins edit --project` guidance for enabling ATOF and ATIF exporters.
- Uses GitHub-flavored admonitions for ATOF-first validation, project vs user config, Codex hook activation, support status, and troubleshooting.
- Updates the documentation overview to establish background for users and developers, route readers to the right docs path, and explain ATOF-first validation without duplicating the full README example.
- Keeps the first prose reference as `NVIDIA NeMo Relay` in both entrypoints.

#### Where should the reviewer start?

Start with `README.md`, then compare `docs/about-nemo-relay/overview.mdx` to confirm the docs entrypoint matches the same onboarding model without duplicating the full example.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes: RELAY-256


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote README into a “Start Here” onboarding with capture-first CLI walkthrough and end-to-end artifact validation (ATOF JSONL + ATIF JSON); Node.js 24+ note
  * Added “Choose Your Next/First Path” navigation tables and rephrased Roadmap
  * Substantially updated overview page and Quick Start paths
  * Revised support status and agent-harness matrix
  * Updated integrations, extras install guidance, and known-issues wording about CLI host coverage variability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->