### PR TITLE
ci: make release publishing resumable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -371,7 +371,19 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
         run: |
           set -euo pipefail
-          for package in nemo-relay nemo-relay-adaptive nemo-relay-ffi nemo-relay-cli; do
+          version="${{ github.ref_name }}"
+          packages=(
+            nemo-relay
+            nemo-relay-adaptive
+            nemo-relay-pii-redaction
+            nemo-relay-ffi
+            nemo-relay-cli
+          )
+          for package in "${packages[@]}"; do
+            if cargo info "${package}@${version}" --registry crates-io >/dev/null 2>&1; then
+              echo "${package} ${version} already exists on crates.io; skipping"
+              continue
+            fi
             cargo publish --package "$package" --no-verify --allow-dirty
           done
 
@@ -395,6 +407,8 @@ jobs:
 
       - name: Publish to PyPI with trusted publishing
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
 
   publish-npm:
     name: Publish (npm)
@@ -449,6 +463,11 @@ jobs:
       - name: Publish Node.js package to npm
         run: |
           set -euo pipefail
+          version="${{ github.ref_name }}"
+          if npm view "nemo-relay-node@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "nemo-relay-node ${version} already exists on npm; skipping"
+            exit 0
+          fi
           unzip -q ./consolidated.zip -d combined
           echo "Platform binaries included:"
           ls -la combined/package/*.node
@@ -457,6 +476,11 @@ jobs:
       - name: Publish OpenClaw plugin package to npm
         run: |
           set -euo pipefail
+          version="${{ github.ref_name }}"
+          if npm view "nemo-relay-openclaw@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "nemo-relay-openclaw ${version} already exists on npm; skipping"
+            exit 0
+          fi
           for pkg in ./openclaw-package/*.tgz; do
             echo "Publishing ${pkg}..."
             npm publish "${pkg}" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
@@ -464,7 +488,12 @@ jobs:
 
       - name: Publish WebAssembly package to npm
         run: |
-          set -e
+          set -euo pipefail
+          version="${{ github.ref_name }}"
+          if npm view "nemo-relay-wasm@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "nemo-relay-wasm ${version} already exists on npm; skipping"
+            exit 0
+          fi
           for pkg in ./wasm-package/*.tgz; do
             echo "Publishing ${pkg}..."
             npm publish "${pkg}" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,7 +30,7 @@ The release pipeline publishes these package surfaces from a tag push:
 
 | Ecosystem | Published Surface |
 |---|---|
-| crates.io | `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-ffi`, `nemo-relay-cli` |
+| crates.io | `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-pii-redaction`, `nemo-relay-ffi`, `nemo-relay-cli` |
 | PyPI | `nemo-relay` |
 | npm | `nemo-relay-node`, `nemo-relay-openclaw`, `nemo-relay-wasm` |
 | GitHub Releases | CLI binaries and `SHA256SUMS` |
@@ -50,9 +50,9 @@ NeMo Relay versions are anchored on the workspace SemVer in the repository root
 
 - The root `Cargo.toml` `workspace.package.version` is the canonical release
   version for the Rust workspace.
-- The root `Cargo.toml` `workspace.dependencies` entries for
-  `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-ffi`, and `nemo-relay-cli` must
-  stay aligned with that same version.
+- The root `Cargo.toml` `workspace.dependencies` entries for `nemo-relay`,
+  `nemo-relay-adaptive`, `nemo-relay-pii-redaction`, `nemo-relay-ffi`, and
+  `nemo-relay-cli` must stay aligned with that same version.
 - `crates/node/package.json` carries the base npm version for the Node.js
   package. The repository-root `package-lock.json` carries the npm workspace
   lock entries and must be updated with it.
@@ -133,7 +133,8 @@ Before you create a release tag, confirm the following:
 4. Registry credentials and repository settings are in place:
    - GitHub Actions `id-token: write` access for the top-level crates.io publish job
    - crates.io trusted publishers for `nemo-relay`, `nemo-relay-adaptive`,
-     `nemo-relay-ffi`, and `nemo-relay-cli` are configured for the top-level
+     `nemo-relay-pii-redaction`, `nemo-relay-ffi`, and `nemo-relay-cli` are
+     configured for the top-level
      [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) workflow
    - GitHub Actions `id-token: write` access is available for the top-level npm publish job
    - GitHub Actions `id-token: write` access for the top-level PyPI publish job
@@ -153,7 +154,8 @@ The helper updates:
 
 1. The root [`Cargo.toml`](Cargo.toml) workspace version.
 2. The root [`Cargo.toml`](Cargo.toml) `workspace.dependencies` versions for
-   `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-ffi`, and `nemo-relay-cli`.
+   `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-pii-redaction`,
+   `nemo-relay-ffi`, and `nemo-relay-cli`.
 3. [`crates/node/package.json`](crates/node/package.json) and the `crates/node`
    entry in the root [`package-lock.json`](package-lock.json) to the same
    release version.
@@ -242,8 +244,8 @@ The release pipeline then:
    jobs complete:
    - `publish-rust` stamps Cargo workspace versions from the release tag, then
      runs `cargo publish --package` for `nemo-relay`, `nemo-relay-adaptive`,
-     `nemo-relay-ffi`, and `nemo-relay-cli` through trusted publishing from
-     the top-level workflow
+     `nemo-relay-pii-redaction`, `nemo-relay-ffi`, and `nemo-relay-cli`
+     through trusted publishing from the top-level workflow
    - `publish-python` uploads the wheel artifacts to PyPI with trusted
      publishing from the top-level workflow
    - `publish-npm` publishes the Node.js, OpenClaw plugin, and WebAssembly npm
@@ -308,7 +310,8 @@ for that tag.
 
 After the release is live, verify:
 
-1. The expected crates are visible on crates.io.
+1. The `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-pii-redaction`,
+   `nemo-relay-ffi`, and `nemo-relay-cli` crates are visible on crates.io.
 2. The `nemo-relay` wheel is visible on PyPI.
 3. The `nemo-relay-node`, `nemo-relay-openclaw`, and `nemo-relay-wasm` packages
    are visible on npm.


### PR DESCRIPTION
#### Overview

Make the release publish jobs safe to rerun after a registry publish partially succeeds.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `nemo-relay-pii-redaction` to the crates.io publish order before packages that depend on it.
- Skips crates.io package versions that already exist so a partial Rust publish can resume.
- Enables PyPI `skip-existing` for trusted publishing.
- Skips npm package versions that already exist for `nemo-relay-node`, `nemo-relay-openclaw`, and `nemo-relay-wasm`.

#### Where should the reviewer start?

Start with `.github/workflows/ci.yaml`, especially the `publish-rust`, `publish-python`, and `publish-npm` jobs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD now skips publishing package versions that already exist on target registries, reducing redundant publishes for Rust, Python, and Node packages.
* **Documentation**
  * Release playbook updated to include the new crate in version-alignment, publishing checks, and post-release verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->