### PR TITLE
ci: stop release 0.4 nightly tags

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,4 +3,3 @@
 
 branches:
   - main
-  - release/0.4


### PR DESCRIPTION
#### Overview

Stop nightly alpha tag creation for the `release/0.4` branch by removing it from the scheduled nightly branch list.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Removed `release/0.4` from `.github/nightly-alpha-branches.yaml`.
- Left `main` as the only branch receiving scheduled nightly alpha tags.

#### Where should the reviewer start?

`.github/nightly-alpha-branches.yaml` contains the full change.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly-alpha build configuration to include the `main` branch and removed `release/0.4` from the configured branches for nightly-alpha releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->