### PR TITLE
feat: add adaptive runtime binding parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,7 @@ dependencies = [
  "nemo-relay",
  "nemo-relay-adaptive",
  "nemo-relay-pii-redaction",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-stream",

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -22,6 +22,7 @@ nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }
 nemo-relay-pii-redaction.workspace = true
 chrono = "0.4"
 libc = "0.2"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { workspace = true, features = ["v7"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -110,6 +110,11 @@ enum NemoRelayScopeType {
 typedef int32_t NemoRelayScopeType;
 
 /**
+ * Opaque owned adaptive runtime handle.
+ */
+typedef struct FfiAdaptiveRuntime FfiAdaptiveRuntime;
+
+/**
  * Opaque ATIF exporter handle.
  */
 typedef struct FfiAtifExporter FfiAtifExporter;
@@ -412,6 +417,97 @@ NemoRelayStatus nemo_relay_llm_request_intercepts(const char *name,
  * All pointers must be valid.
  */
 NemoRelayStatus nemo_relay_llm_conditional_execution(const char *native_json);
+
+/**
+ * Validate an adaptive config document and return the diagnostics report as JSON.
+ *
+ * # Safety
+ * `config_json` must be a valid C string and `out_json` must be a valid, non-null pointer.
+ */
+NemoRelayStatus nemo_relay_adaptive_validate_config(const char *config_json, char **out_json);
+
+/**
+ * Create an owned adaptive runtime handle from config JSON.
+ *
+ * # Safety
+ * `config_json` must be a valid C string and `out` must be a valid, non-null pointer.
+ */
+NemoRelayStatus nemo_relay_adaptive_runtime_create(const char *config_json,
+                                                   struct FfiAdaptiveRuntime **out);
+
+/**
+ * Register configured adaptive runtime features.
+ *
+ * # Safety
+ * `runtime` must be a valid adaptive runtime pointer.
+ */
+NemoRelayStatus nemo_relay_adaptive_runtime_register(struct FfiAdaptiveRuntime *runtime);
+
+/**
+ * Deregister configured adaptive runtime features.
+ *
+ * # Safety
+ * `runtime` must be a valid adaptive runtime pointer.
+ */
+NemoRelayStatus nemo_relay_adaptive_runtime_deregister(struct FfiAdaptiveRuntime *runtime);
+
+/**
+ * Shut down the adaptive runtime and consume its Rust runtime state.
+ *
+ * # Safety
+ * `runtime` must be a valid adaptive runtime pointer.
+ */
+NemoRelayStatus nemo_relay_adaptive_runtime_shutdown(struct FfiAdaptiveRuntime *runtime);
+
+/**
+ * Wait until the adaptive telemetry drain has processed pending events.
+ *
+ * # Safety
+ * `runtime` must be a valid adaptive runtime pointer.
+ */
+NemoRelayStatus nemo_relay_adaptive_runtime_wait_for_idle(struct FfiAdaptiveRuntime *runtime);
+
+/**
+ * Return the runtime construction report as JSON.
+ *
+ * # Safety
+ * `runtime` and `out_json` must be valid pointers.
+ */
+NemoRelayStatus nemo_relay_adaptive_runtime_report_json(struct FfiAdaptiveRuntime *runtime,
+                                                        char **out_json);
+
+/**
+ * Bind ACG request rewrites to a scope.
+ *
+ * # Safety
+ * `runtime` and `scope` must be valid pointers.
+ */
+NemoRelayStatus nemo_relay_adaptive_runtime_bind_scope(struct FfiAdaptiveRuntime *runtime,
+                                                       const struct FfiScopeHandle *scope);
+
+/**
+ * Build cache request facts as JSON.
+ *
+ * # Safety
+ * `runtime`, `options_json`, and `out_json` must be valid pointers.
+ */
+NemoRelayStatus nemo_relay_adaptive_runtime_build_cache_request_facts(struct FfiAdaptiveRuntime *runtime,
+                                                                      const char *options_json,
+                                                                      char **out_json);
+
+/**
+ * Build one cache telemetry event as JSON.
+ *
+ * # Safety
+ * `options_json` and `out_json` must be valid pointers.
+ */
+NemoRelayStatus nemo_relay_adaptive_build_cache_telemetry_event(const char *options_json,
+                                                                char **out_json);
+
+/**
+ * Set manual latency sensitivity on the current scope.
+ */
+NemoRelayStatus nemo_relay_adaptive_set_latency_sensitivity(uint32_t value);
 
 /**
  * Begin a manual LLM call lifecycle span.
@@ -2123,6 +2219,15 @@ void nemo_relay_otel_subscriber_free(struct FfiOpenTelemetrySubscriber *ptr);
  * `nemo_relay_openinference_subscriber_create`, or null.
  */
 void nemo_relay_openinference_subscriber_free(struct FfiOpenInferenceSubscriber *ptr);
+
+/**
+ * Free an adaptive runtime handle previously returned by
+ * `nemo_relay_adaptive_runtime_create`.
+ *
+ * # Safety
+ * `ptr` must be a valid pointer returned by `nemo_relay_adaptive_runtime_create`, or null.
+ */
+void nemo_relay_adaptive_runtime_free(struct FfiAdaptiveRuntime *ptr);
 
 /**
  * Free a codec handle previously returned by one of the codec constructor

--- a/crates/ffi/src/api/adaptive.rs
+++ b/crates/ffi/src/api/adaptive.rs
@@ -1,0 +1,487 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use chrono::{DateTime, Utc};
+use libc::c_char;
+use nemo_relay::codec::request::AnnotatedLlmRequest;
+use nemo_relay::codec::response::Usage;
+use nemo_relay_adaptive::acg::{
+    AgentIdentity, CacheRequestFacts, CacheTelemetryEvent, CacheTelemetryProvider,
+};
+use nemo_relay_adaptive::context_helpers::set_latency_sensitivity;
+use nemo_relay_adaptive::{AdaptiveConfig, AdaptiveRuntime};
+use serde::Deserialize;
+use serde_json::Value as Json;
+use uuid::Uuid;
+
+use crate::convert::{c_str_to_json, json_to_c_string};
+use crate::error::{NemoRelayStatus, clear_last_error, set_last_error};
+use crate::types::{FfiAdaptiveRuntime, FfiScopeHandle};
+
+use super::tokio_runtime;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheTelemetryOptions {
+    provider: String,
+    #[serde(alias = "request_id")]
+    request_id: String,
+    usage: Option<Json>,
+    #[serde(default, alias = "request_facts")]
+    request_facts: Option<Json>,
+    #[serde(alias = "agent_id")]
+    agent_id: String,
+    #[serde(alias = "template_version")]
+    template_version: String,
+    #[serde(alias = "toolset_hash")]
+    toolset_hash: String,
+    #[serde(alias = "model_family")]
+    model_family: String,
+    #[serde(alias = "tenant_scope")]
+    tenant_scope: String,
+    timestamp: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheRequestFactsOptions {
+    provider: String,
+    #[serde(alias = "request_id")]
+    request_id: String,
+    #[serde(alias = "annotated_request")]
+    annotated_request: Json,
+    #[serde(alias = "agent_id")]
+    agent_id: String,
+    timestamp: Option<String>,
+}
+
+fn parse_adaptive_config(config_json: *const c_char) -> Result<AdaptiveConfig, NemoRelayStatus> {
+    let config_json = c_str_to_json(config_json).ok_or(NemoRelayStatus::InvalidJson)?;
+    serde_json::from_value(config_json).map_err(|error| {
+        set_last_error(&format!("invalid adaptive config: {error}"));
+        NemoRelayStatus::InvalidJson
+    })
+}
+
+fn parse_provider(provider: &str) -> Result<CacheTelemetryProvider, NemoRelayStatus> {
+    match provider {
+        "anthropic" => Ok(CacheTelemetryProvider::Anthropic),
+        "openai" => Ok(CacheTelemetryProvider::OpenAI),
+        other => {
+            set_last_error(&format!("unsupported provider: {other}"));
+            Err(NemoRelayStatus::InvalidArg)
+        }
+    }
+}
+
+fn parse_request_id(request_id: &str) -> Result<Uuid, NemoRelayStatus> {
+    Uuid::parse_str(request_id).map_err(|error| {
+        set_last_error(&format!("invalid request_id UUID: {error}"));
+        NemoRelayStatus::InvalidArg
+    })
+}
+
+fn parse_timestamp(timestamp: Option<&str>) -> Result<DateTime<Utc>, NemoRelayStatus> {
+    match timestamp {
+        Some(value) => DateTime::parse_from_rfc3339(value)
+            .map(|value| value.with_timezone(&Utc))
+            .map_err(|error| {
+                set_last_error(&format!("invalid timestamp: {error}"));
+                NemoRelayStatus::InvalidArg
+            }),
+        None => Ok(Utc::now()),
+    }
+}
+
+fn lock_runtime(
+    runtime: *mut FfiAdaptiveRuntime,
+) -> Result<std::sync::MutexGuard<'static, Option<AdaptiveRuntime>>, NemoRelayStatus> {
+    if runtime.is_null() {
+        set_last_error("adaptive runtime pointer is null");
+        return Err(NemoRelayStatus::NullPointer);
+    }
+    unsafe { &*runtime }.0.lock().map_err(|error| {
+        set_last_error(&format!("adaptive runtime lock poisoned: {error}"));
+        NemoRelayStatus::Internal
+    })
+}
+
+fn with_runtime_mut<R>(
+    runtime: *mut FfiAdaptiveRuntime,
+    f: impl FnOnce(&mut AdaptiveRuntime) -> Result<R, NemoRelayStatus>,
+) -> Result<R, NemoRelayStatus> {
+    let mut guard = lock_runtime(runtime)?;
+    let Some(runtime) = guard.as_mut() else {
+        set_last_error("adaptive runtime already shut down");
+        return Err(NemoRelayStatus::InvalidArg);
+    };
+    f(runtime)
+}
+
+/// Validate an adaptive config document and return the diagnostics report as JSON.
+///
+/// # Safety
+/// `config_json` must be a valid C string and `out_json` must be a valid, non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_validate_config(
+    config_json: *const c_char,
+    out_json: *mut *mut c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if out_json.is_null() {
+        set_last_error("out_json pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    let config = match parse_adaptive_config(config_json) {
+        Ok(config) => config,
+        Err(status) => return status,
+    };
+    let report = AdaptiveRuntime::validate_config(&config);
+    match serde_json::to_value(&report) {
+        Ok(value) => {
+            unsafe { *out_json = json_to_c_string(&value) };
+            NemoRelayStatus::Ok
+        }
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Create an owned adaptive runtime handle from config JSON.
+///
+/// # Safety
+/// `config_json` must be a valid C string and `out` must be a valid, non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_create(
+    config_json: *const c_char,
+    out: *mut *mut FfiAdaptiveRuntime,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if out.is_null() {
+        set_last_error("out pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    let config = match parse_adaptive_config(config_json) {
+        Ok(config) => config,
+        Err(status) => return status,
+    };
+    match tokio_runtime().block_on(AdaptiveRuntime::new(config)) {
+        Ok(runtime) => {
+            unsafe {
+                *out = Box::into_raw(Box::new(FfiAdaptiveRuntime(std::sync::Mutex::new(Some(
+                    runtime,
+                )))))
+            };
+            NemoRelayStatus::Ok
+        }
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::InvalidArg
+        }
+    }
+}
+
+/// Register configured adaptive runtime features.
+///
+/// # Safety
+/// `runtime` must be a valid adaptive runtime pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_register(
+    runtime: *mut FfiAdaptiveRuntime,
+) -> NemoRelayStatus {
+    clear_last_error();
+    match with_runtime_mut(runtime, |runtime| {
+        tokio_runtime()
+            .block_on(runtime.register())
+            .map_err(|error| {
+                set_last_error(&error.to_string());
+                NemoRelayStatus::Internal
+            })
+    }) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+/// Deregister configured adaptive runtime features.
+///
+/// # Safety
+/// `runtime` must be a valid adaptive runtime pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_deregister(
+    runtime: *mut FfiAdaptiveRuntime,
+) -> NemoRelayStatus {
+    clear_last_error();
+    match with_runtime_mut(runtime, |runtime| {
+        runtime.deregister().map_err(|error| {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        })
+    }) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+/// Shut down the adaptive runtime and consume its Rust runtime state.
+///
+/// # Safety
+/// `runtime` must be a valid adaptive runtime pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_shutdown(
+    runtime: *mut FfiAdaptiveRuntime,
+) -> NemoRelayStatus {
+    clear_last_error();
+    let mut guard = match lock_runtime(runtime) {
+        Ok(guard) => guard,
+        Err(status) => return status,
+    };
+    let Some(runtime) = guard.take() else {
+        set_last_error("adaptive runtime already shut down");
+        return NemoRelayStatus::InvalidArg;
+    };
+    match tokio_runtime().block_on(runtime.shutdown()) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Wait until the adaptive telemetry drain has processed pending events.
+///
+/// # Safety
+/// `runtime` must be a valid adaptive runtime pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_wait_for_idle(
+    runtime: *mut FfiAdaptiveRuntime,
+) -> NemoRelayStatus {
+    clear_last_error();
+    match with_runtime_mut(runtime, |runtime| {
+        runtime.wait_for_idle();
+        Ok(())
+    }) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+/// Return the runtime construction report as JSON.
+///
+/// # Safety
+/// `runtime` and `out_json` must be valid pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_report_json(
+    runtime: *mut FfiAdaptiveRuntime,
+    out_json: *mut *mut c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if out_json.is_null() {
+        set_last_error("out_json pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    match with_runtime_mut(runtime, |runtime| {
+        serde_json::to_value(runtime.report()).map_err(|error| {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        })
+    }) {
+        Ok(value) => {
+            unsafe { *out_json = json_to_c_string(&value) };
+            NemoRelayStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// Bind ACG request rewrites to a scope.
+///
+/// # Safety
+/// `runtime` and `scope` must be valid pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_bind_scope(
+    runtime: *mut FfiAdaptiveRuntime,
+    scope: *const FfiScopeHandle,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if scope.is_null() {
+        set_last_error("scope handle pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    let scope_uuid = unsafe { (*scope).0.uuid };
+    match with_runtime_mut(runtime, |runtime| {
+        runtime.bind_scope(scope_uuid).map_err(|error| {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        })
+    }) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+/// Build cache request facts as JSON.
+///
+/// # Safety
+/// `runtime`, `options_json`, and `out_json` must be valid pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_build_cache_request_facts(
+    runtime: *mut FfiAdaptiveRuntime,
+    options_json: *const c_char,
+    out_json: *mut *mut c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if out_json.is_null() {
+        set_last_error("out_json pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    let options_json = match c_str_to_json(options_json) {
+        Some(value) => value,
+        None => return NemoRelayStatus::InvalidJson,
+    };
+    let options: CacheRequestFactsOptions = match serde_json::from_value(options_json) {
+        Ok(options) => options,
+        Err(error) => {
+            set_last_error(&format!("invalid cache request facts options: {error}"));
+            return NemoRelayStatus::InvalidJson;
+        }
+    };
+    if let Err(status) = parse_request_id(&options.request_id) {
+        return status;
+    }
+    if let Err(status) = parse_timestamp(options.timestamp.as_deref()) {
+        return status;
+    }
+    let annotated_request: AnnotatedLlmRequest =
+        match serde_json::from_value(options.annotated_request) {
+            Ok(request) => request,
+            Err(error) => {
+                set_last_error(&format!("invalid annotated_request: {error}"));
+                return NemoRelayStatus::InvalidJson;
+            }
+        };
+    match with_runtime_mut(runtime, |runtime| {
+        Ok(runtime.build_cache_request_facts(
+            &options.agent_id,
+            &options.provider,
+            &annotated_request,
+        ))
+    }) {
+        Ok(facts) => match serde_json::to_value(facts) {
+            Ok(value) => {
+                unsafe { *out_json = json_to_c_string(&value) };
+                NemoRelayStatus::Ok
+            }
+            Err(error) => {
+                set_last_error(&error.to_string());
+                NemoRelayStatus::Internal
+            }
+        },
+        Err(status) => status,
+    }
+}
+
+/// Build one cache telemetry event as JSON.
+///
+/// # Safety
+/// `options_json` and `out_json` must be valid pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_build_cache_telemetry_event(
+    options_json: *const c_char,
+    out_json: *mut *mut c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if out_json.is_null() {
+        set_last_error("out_json pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    let options_json = match c_str_to_json(options_json) {
+        Some(value) => value,
+        None => return NemoRelayStatus::InvalidJson,
+    };
+    let options: CacheTelemetryOptions = match serde_json::from_value(options_json) {
+        Ok(options) => options,
+        Err(error) => {
+            set_last_error(&format!("invalid cache telemetry options: {error}"));
+            return NemoRelayStatus::InvalidJson;
+        }
+    };
+    let provider = match parse_provider(&options.provider) {
+        Ok(provider) => provider,
+        Err(status) => return status,
+    };
+    let request_id = match parse_request_id(&options.request_id) {
+        Ok(request_id) => request_id,
+        Err(status) => return status,
+    };
+    let timestamp = match parse_timestamp(options.timestamp.as_deref()) {
+        Ok(timestamp) => timestamp,
+        Err(status) => return status,
+    };
+    let Some(usage_json) = options.usage else {
+        unsafe { *out_json = json_to_c_string(&Json::Null) };
+        return NemoRelayStatus::Ok;
+    };
+    let usage: Usage = match serde_json::from_value(usage_json) {
+        Ok(usage) => usage,
+        Err(error) => {
+            set_last_error(&format!("invalid usage: {error}"));
+            return NemoRelayStatus::InvalidJson;
+        }
+    };
+    let request_facts: Option<CacheRequestFacts> = match options.request_facts {
+        Some(value) => match serde_json::from_value(value) {
+            Ok(facts) => Some(facts),
+            Err(error) => {
+                set_last_error(&format!("invalid request_facts: {error}"));
+                return NemoRelayStatus::InvalidJson;
+            }
+        },
+        None => None,
+    };
+    let agent_identity = AgentIdentity {
+        agent_id: options.agent_id,
+        template_version: options.template_version,
+        toolset_hash: options.toolset_hash,
+        model_family: options.model_family,
+        tenant_scope: options.tenant_scope,
+    };
+    let event = CacheTelemetryEvent::from_usage(
+        request_id,
+        agent_identity,
+        provider,
+        &usage,
+        timestamp,
+        request_facts.as_ref(),
+    );
+    match serde_json::to_value(event) {
+        Ok(value) => {
+            unsafe { *out_json = json_to_c_string(&value) };
+            NemoRelayStatus::Ok
+        }
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Set manual latency sensitivity on the current scope.
+#[unsafe(no_mangle)]
+pub extern "C" fn nemo_relay_adaptive_set_latency_sensitivity(value: u32) -> NemoRelayStatus {
+    clear_last_error();
+    if value == 0 {
+        set_last_error("sensitivity must be positive (> 0)");
+        return NemoRelayStatus::InvalidArg;
+    }
+    match set_latency_sensitivity(value) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => {
+            set_last_error(&error);
+            NemoRelayStatus::Internal
+        }
+    }
+}

--- a/crates/ffi/src/api/mod.rs
+++ b/crates/ffi/src/api/mod.rs
@@ -63,6 +63,7 @@ use nemo_relay::plugin::{
 use nemo_relay_adaptive::plugin_component::register_adaptive_component;
 use tokio::runtime::Runtime;
 
+mod adaptive;
 mod llm;
 mod llm_registry;
 mod observability;
@@ -73,6 +74,7 @@ mod scope_stack;
 mod tool_lifecycle;
 mod tool_registry;
 
+pub use adaptive::*;
 pub use llm::*;
 pub use llm_registry::*;
 pub use observability::*;

--- a/crates/ffi/src/types/mod.rs
+++ b/crates/ffi/src/types/mod.rs
@@ -26,6 +26,7 @@ use nemo_relay::api::scope::{ScopeHandle, ScopeType};
 use nemo_relay::api::tool::ToolAttributes;
 use nemo_relay::api::tool::ToolHandle;
 use nemo_relay::codec::traits::{LlmCodec, LlmResponseCodec};
+use nemo_relay_adaptive::AdaptiveRuntime;
 
 use crate::convert::{json_to_c_string, str_to_c_string};
 use crate::error::set_last_error;
@@ -61,6 +62,8 @@ pub struct FfiOpenTelemetrySubscriber(pub nemo_relay::observability::otel::OpenT
 pub struct FfiOpenInferenceSubscriber(
     pub nemo_relay::observability::openinference::OpenInferenceSubscriber,
 );
+/// Opaque owned adaptive runtime handle.
+pub struct FfiAdaptiveRuntime(pub std::sync::Mutex<Option<AdaptiveRuntime>>);
 /// Opaque plugin registration context.
 ///
 /// This wrapper contains a borrowed raw pointer to an
@@ -267,6 +270,18 @@ pub unsafe extern "C" fn nemo_relay_otel_subscriber_free(ptr: *mut FfiOpenTeleme
 pub unsafe extern "C" fn nemo_relay_openinference_subscriber_free(
     ptr: *mut FfiOpenInferenceSubscriber,
 ) {
+    if !ptr.is_null() {
+        drop(unsafe { Box::from_raw(ptr) });
+    }
+}
+
+/// Free an adaptive runtime handle previously returned by
+/// `nemo_relay_adaptive_runtime_create`.
+///
+/// # Safety
+/// `ptr` must be a valid pointer returned by `nemo_relay_adaptive_runtime_create`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_adaptive_runtime_free(ptr: *mut FfiAdaptiveRuntime) {
     if !ptr.is_null() {
         drop(unsafe { Box::from_raw(ptr) });
     }

--- a/crates/node/adaptive.d.ts
+++ b/crates/node/adaptive.d.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Json } from './index';
+import type { Json, ScopeHandle } from './index';
 import type { ConfigPolicy, ConfigDiagnostic, ConfigReport } from './plugin';
 
 export { ConfigPolicy, ConfigDiagnostic, ConfigReport };
@@ -69,6 +69,96 @@ export interface ComponentSpec {
   kind: 'adaptive';
   enabled?: boolean;
   config: Config;
+}
+
+/** Normalized LLM token usage for cache telemetry. */
+export interface CacheUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  cost?: Json;
+}
+
+/** Identity of the agent associated with cache telemetry. */
+export interface AgentIdentity {
+  agent_id: string;
+  template_version: string;
+  toolset_hash: string;
+  model_family: string;
+  tenant_scope: string;
+}
+
+/** Input for building cache request facts. */
+export interface CacheRequestFactsOptions {
+  provider: string;
+  requestId: string;
+  annotatedRequest: Json;
+  agentId: string;
+  timestamp?: string;
+}
+
+/** Request-time facts used to classify cache misses. */
+export interface CacheRequestFacts {
+  provider: string;
+  stable_prefix_length: number;
+  stable_prefix_tokens?: number;
+  required_min_tokens?: number;
+  first_mismatch_span_id?: string;
+  first_mismatch_sequence_index?: number;
+  expected_hash_prefix?: string;
+  actual_hash_prefix?: string;
+  retention_window_secs?: number;
+  observed_gap_secs?: number;
+  missing_facts?: string[];
+}
+
+/** Input for building cache telemetry events. */
+export interface CacheTelemetryEventOptions {
+  provider: 'anthropic' | 'openai' | string;
+  requestId: string;
+  usage?: CacheUsage | null;
+  requestFacts?: CacheRequestFacts | null;
+  agentId: string;
+  templateVersion: string;
+  toolsetHash: string;
+  modelFamily: string;
+  tenantScope: string;
+  timestamp?: string;
+}
+
+/** Normalized adaptive cache telemetry event. */
+export interface CacheTelemetryEvent {
+  request_id: string;
+  agent_identity: AgentIdentity;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_prompt_tokens: number;
+  hit_rate: number;
+  miss_reason?: Record<string, Json>;
+  miss_diagnosis?: Record<string, Json>;
+  provider: string;
+  timestamp: string;
+}
+
+/** Owned adaptive runtime outside the generic plugin system. */
+export declare class AdaptiveRuntime {
+  constructor(config: Config);
+  /** Register all configured adaptive runtime features. */
+  register(): Promise<void>;
+  /** Deregister all previously registered adaptive runtime features. */
+  deregister(): void;
+  /** Shut down the adaptive runtime and consume its Rust runtime state. */
+  shutdown(): Promise<void>;
+  /** Block until adaptive telemetry has processed pending events. */
+  waitForIdle(): void;
+  /** Return the validation report captured during construction. */
+  report(): ConfigReport;
+  /** Bind the runtime's ACG request rewrite to a scope. */
+  bindScope(scopeHandle: ScopeHandle): void;
+  /** Build cache request facts for an annotated LLM request. */
+  buildCacheRequestFacts(options: CacheRequestFactsOptions): CacheRequestFacts | null;
 }
 
 export declare const ADAPTIVE_PLUGIN_KIND: 'adaptive';
@@ -172,3 +262,9 @@ export declare function ComponentSpec(
     enabled?: boolean;
   },
 ): ComponentSpec;
+/** Validate an adaptive config document without constructing a runtime. */
+export declare function validateConfig(config: Config): ConfigReport;
+/** Build one adaptive cache telemetry event from normalized usage. */
+export declare function buildCacheTelemetryEvent(options: CacheTelemetryEventOptions): CacheTelemetryEvent | null;
+/** Set manual latency sensitivity on the current scope. */
+export declare function setLatencySensitivity(value: number): void;

--- a/crates/node/adaptive.js
+++ b/crates/node/adaptive.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+const lib = require('./index.js');
 const plugin = require('./plugin.js');
 
 const ADAPTIVE_PLUGIN_KIND = 'adaptive';
@@ -164,7 +165,38 @@ function ComponentSpec(config, { enabled = true } = {}) {
   });
 }
 
+/**
+ * Validate an adaptive config document without constructing a runtime.
+ *
+ * @param {object} config - Adaptive runtime configuration document.
+ * @returns {object} A structured validation report with diagnostics.
+ */
+function validateConfig(config) {
+  return lib.validateAdaptiveConfig(config);
+}
+
+/**
+ * Build one adaptive cache telemetry event from normalized usage.
+ *
+ * @param {object} options - Cache telemetry event inputs.
+ * @returns {object|null} A telemetry event, or `null` when usage lacks prompt tokens.
+ */
+function buildCacheTelemetryEvent(options) {
+  return lib.buildCacheTelemetryEvent(options) ?? null;
+}
+
+/**
+ * Set manual latency sensitivity on the current scope.
+ *
+ * @param {number} value - Positive sensitivity value to store on the current scope.
+ * @returns {void} Nothing.
+ */
+function setLatencySensitivity(value) {
+  return lib.setLatencySensitivity(value);
+}
+
 module.exports = {
+  AdaptiveRuntime: lib.AdaptiveRuntime,
   ADAPTIVE_PLUGIN_KIND,
   defaultConfig,
   inMemoryBackend,
@@ -174,4 +206,7 @@ module.exports = {
   toolParallelismConfig,
   acgConfig,
   ComponentSpec,
+  validateConfig,
+  buildCacheTelemetryEvent,
+  setLatencySensitivity,
 };

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -3347,6 +3347,12 @@ impl AdaptiveRuntime {
     }
 
     /// Register all configured adaptive runtime features.
+    ///
+    /// `register()` and `shutdown()` both temporarily take ownership of the
+    /// runtime state, so concurrent calls are mutually exclusive by design.
+    /// Once either operation takes the state, another concurrent registration or
+    /// shutdown attempt fails with "adaptive runtime already shut down". This
+    /// prevents double-registration and shutdown-during-registration races.
     #[napi(ts_return_type = "Promise<void>")]
     pub fn register(&self, env: Env) -> napi::Result<JsObject> {
         let inner = self.inner.clone();

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -18,10 +18,12 @@ use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use chrono::{DateTime, Utc};
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{JsFunction, JsObject, JsUnknown, NapiRaw, NapiValue};
 use napi_derive::napi;
+use serde::Deserialize;
 use serde_json::Value as Json;
 use tokio_stream::StreamExt;
 
@@ -39,6 +41,8 @@ use nemo_relay::api::scope::ScopeAttributes;
 use nemo_relay::api::subscriber as core_subscriber_api;
 use nemo_relay::api::tool as core_tool_api;
 use nemo_relay::api::tool::ToolAttributes;
+use nemo_relay::codec::request::AnnotatedLlmRequest;
+use nemo_relay::codec::response::Usage;
 use nemo_relay::error::{FlowError, Result as FlowResult};
 use nemo_relay::plugin::{
     ConfigDiagnostic, DiagnosticLevel, Plugin, PluginConfig, PluginError, PluginRegistration,
@@ -49,7 +53,12 @@ use nemo_relay::plugin::{
     validate_plugin_config as validate_plugin_config_impl,
 };
 use nemo_relay::shared_runtime::initialize_shared_runtime_binding;
+use nemo_relay_adaptive::acg::{
+    AgentIdentity, CacheRequestFacts, CacheTelemetryEvent, CacheTelemetryProvider,
+};
+use nemo_relay_adaptive::context_helpers::set_latency_sensitivity as adaptive_set_latency_sensitivity;
 use nemo_relay_adaptive::plugin_component::register_adaptive_component;
+use nemo_relay_adaptive::{AdaptiveConfig, AdaptiveRuntime as CoreAdaptiveRuntime};
 use nemo_relay_pii_redaction::component::register_pii_redaction_component;
 
 use crate::callable;
@@ -3269,6 +3278,357 @@ impl OpenInferenceSubscriber {
             .shutdown()
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheTelemetryOptions {
+    provider: String,
+    #[serde(alias = "request_id")]
+    request_id: String,
+    usage: Option<Json>,
+    #[serde(default, alias = "request_facts")]
+    request_facts: Option<Json>,
+    #[serde(alias = "agent_id")]
+    agent_id: String,
+    #[serde(alias = "template_version")]
+    template_version: String,
+    #[serde(alias = "toolset_hash")]
+    toolset_hash: String,
+    #[serde(alias = "model_family")]
+    model_family: String,
+    #[serde(alias = "tenant_scope")]
+    tenant_scope: String,
+    timestamp: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheRequestFactsOptions {
+    provider: String,
+    #[serde(alias = "request_id")]
+    request_id: String,
+    #[serde(alias = "annotated_request")]
+    annotated_request: Json,
+    #[serde(alias = "agent_id")]
+    agent_id: String,
+    timestamp: Option<String>,
+}
+
+enum NodeAdaptiveRuntimeState {
+    Pending {
+        config: AdaptiveConfig,
+        report: nemo_relay::plugin::ConfigReport,
+    },
+    Ready(CoreAdaptiveRuntime),
+}
+
+/// Owned adaptive runtime that can register adaptive features outside the plugin system.
+#[napi]
+pub struct AdaptiveRuntime {
+    inner: Arc<tokio::sync::Mutex<Option<NodeAdaptiveRuntimeState>>>,
+}
+
+#[napi]
+impl AdaptiveRuntime {
+    /// Create an adaptive runtime wrapper from config.
+    ///
+    /// The runtime is constructed lazily when `register()` is awaited.
+    #[napi(constructor)]
+    pub fn new(config: Json) -> napi::Result<Self> {
+        let config: AdaptiveConfig = serde_json::from_value(config)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        let report = validate_adaptive_config_or_err(&config)?;
+        Ok(Self {
+            inner: Arc::new(tokio::sync::Mutex::new(Some(
+                NodeAdaptiveRuntimeState::Pending { config, report },
+            ))),
+        })
+    }
+
+    /// Register all configured adaptive runtime features.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn register(&self, env: Env) -> napi::Result<JsObject> {
+        let inner = self.inner.clone();
+        env.execute_tokio_future(
+            async move {
+                let state = {
+                    let mut guard = inner.lock().await;
+                    guard.take().ok_or_else(|| {
+                        napi::Error::from_reason("adaptive runtime already shut down")
+                    })?
+                };
+
+                let (result, next_state) = match state {
+                    NodeAdaptiveRuntimeState::Pending { config, report } => {
+                        match CoreAdaptiveRuntime::new(config.clone()).await {
+                            Ok(mut runtime) => {
+                                let result = runtime
+                                    .register()
+                                    .await
+                                    .map_err(|error| napi::Error::from_reason(error.to_string()));
+                                (result, Some(NodeAdaptiveRuntimeState::Ready(runtime)))
+                            }
+                            Err(error) => (
+                                Err(napi::Error::from_reason(error.to_string())),
+                                Some(NodeAdaptiveRuntimeState::Pending { config, report }),
+                            ),
+                        }
+                    }
+                    NodeAdaptiveRuntimeState::Ready(mut runtime) => {
+                        let result = runtime
+                            .register()
+                            .await
+                            .map_err(|error| napi::Error::from_reason(error.to_string()));
+                        (result, Some(NodeAdaptiveRuntimeState::Ready(runtime)))
+                    }
+                };
+
+                let mut guard = inner.lock().await;
+                *guard = next_state;
+                result
+            },
+            |env, _| env.get_undefined(),
+        )
+    }
+
+    /// Deregister all previously registered adaptive runtime features.
+    #[napi]
+    pub fn deregister(&self) -> napi::Result<()> {
+        let mut guard = self.inner.try_lock().map_err(|_| {
+            napi::Error::from_reason(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_mut()
+            .ok_or_else(|| napi::Error::from_reason("adaptive runtime already shut down"))?;
+        match state {
+            NodeAdaptiveRuntimeState::Pending { .. } => Ok(()),
+            NodeAdaptiveRuntimeState::Ready(runtime) => runtime
+                .deregister()
+                .map_err(|error| napi::Error::from_reason(error.to_string())),
+        }
+    }
+
+    /// Shut down the adaptive runtime and consume its Rust runtime state.
+    #[napi(ts_return_type = "Promise<void>")]
+    pub fn shutdown(&self, env: Env) -> napi::Result<JsObject> {
+        let inner = self.inner.clone();
+        env.execute_tokio_future(
+            async move {
+                let state = {
+                    let mut guard = inner.lock().await;
+                    guard.take().ok_or_else(|| {
+                        napi::Error::from_reason("adaptive runtime already shut down")
+                    })?
+                };
+                match state {
+                    NodeAdaptiveRuntimeState::Pending { .. } => Ok(()),
+                    NodeAdaptiveRuntimeState::Ready(runtime) => runtime
+                        .shutdown()
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string())),
+                }
+            },
+            |env, _| env.get_undefined(),
+        )
+    }
+
+    /// Block until the telemetry drain has processed pending events.
+    #[napi(js_name = "waitForIdle")]
+    pub fn wait_for_idle(&self) -> napi::Result<()> {
+        let guard = self.inner.try_lock().map_err(|_| {
+            napi::Error::from_reason(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("adaptive runtime already shut down"))?;
+        match state {
+            NodeAdaptiveRuntimeState::Pending { .. } => Ok(()),
+            NodeAdaptiveRuntimeState::Ready(runtime) => {
+                runtime.wait_for_idle();
+                Ok(())
+            }
+        }
+    }
+
+    /// Return the validation report captured during runtime construction.
+    #[napi]
+    pub fn report(&self) -> napi::Result<Json> {
+        let guard = self.inner.try_lock().map_err(|_| {
+            napi::Error::from_reason(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("adaptive runtime already shut down"))?;
+        let report = match state {
+            NodeAdaptiveRuntimeState::Pending { report, .. } => report,
+            NodeAdaptiveRuntimeState::Ready(runtime) => runtime.report(),
+        };
+        serde_json::to_value(report).map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Bind the runtime's ACG request rewrite to a scope.
+    #[napi(js_name = "bindScope")]
+    pub fn bind_scope(&self, scope_handle: &ScopeHandle) -> napi::Result<()> {
+        let mut guard = self.inner.try_lock().map_err(|_| {
+            napi::Error::from_reason(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_mut()
+            .ok_or_else(|| napi::Error::from_reason("adaptive runtime already shut down"))?;
+        match state {
+            NodeAdaptiveRuntimeState::Pending { .. } => Err(napi::Error::from_reason(
+                "adaptive runtime must be registered before binding ACG request intercepts",
+            )),
+            NodeAdaptiveRuntimeState::Ready(runtime) => runtime
+                .bind_scope(scope_handle.inner.uuid)
+                .map_err(|error| napi::Error::from_reason(error.to_string())),
+        }
+    }
+
+    /// Build cache request facts for an annotated LLM request.
+    #[napi(js_name = "buildCacheRequestFacts")]
+    pub fn build_cache_request_facts(&self, options: Json) -> napi::Result<Option<Json>> {
+        let options: CacheRequestFactsOptions = serde_json::from_value(options)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        let _request_id = parse_cache_telemetry_request_id(&options.request_id)?;
+        let _timestamp = parse_cache_telemetry_timestamp(options.timestamp.as_deref())?;
+        let annotated_request: AnnotatedLlmRequest =
+            serde_json::from_value(options.annotated_request).map_err(|error| {
+                napi::Error::from_reason(format!("invalid annotatedRequest: {error}"))
+            })?;
+        let guard = self.inner.try_lock().map_err(|_| {
+            napi::Error::from_reason(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("adaptive runtime already shut down"))?;
+        match state {
+            NodeAdaptiveRuntimeState::Pending { .. } => Err(napi::Error::from_reason(
+                "adaptive runtime must be registered before building cache request facts",
+            )),
+            NodeAdaptiveRuntimeState::Ready(runtime) => Ok(runtime
+                .build_cache_request_facts(&options.agent_id, &options.provider, &annotated_request)
+                .map(|facts| serde_json::to_value(&facts))
+                .transpose()
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?),
+        }
+    }
+}
+
+fn validate_adaptive_config_or_err(
+    config: &AdaptiveConfig,
+) -> napi::Result<nemo_relay::plugin::ConfigReport> {
+    let report = CoreAdaptiveRuntime::validate_config(config);
+    if report.has_errors() {
+        let joined = report
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.level == DiagnosticLevel::Error)
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(napi::Error::from_reason(joined));
+    }
+    Ok(report)
+}
+
+fn parse_cache_telemetry_provider(provider: &str) -> napi::Result<CacheTelemetryProvider> {
+    match provider {
+        "anthropic" => Ok(CacheTelemetryProvider::Anthropic),
+        "openai" => Ok(CacheTelemetryProvider::OpenAI),
+        other => Err(napi::Error::from_reason(format!(
+            "unsupported provider: {other}",
+        ))),
+    }
+}
+
+fn parse_cache_telemetry_request_id(request_id: &str) -> napi::Result<uuid::Uuid> {
+    uuid::Uuid::parse_str(request_id)
+        .map_err(|error| napi::Error::from_reason(format!("invalid requestId UUID: {error}")))
+}
+
+fn parse_cache_telemetry_timestamp(timestamp: Option<&str>) -> napi::Result<DateTime<Utc>> {
+    match timestamp {
+        Some(value) => DateTime::parse_from_rfc3339(value)
+            .map(|value| value.with_timezone(&Utc))
+            .map_err(|error| napi::Error::from_reason(format!("invalid timestamp: {error}"))),
+        None => Ok(Utc::now()),
+    }
+}
+
+fn parse_cache_request_facts(value: Option<Json>) -> napi::Result<Option<CacheRequestFacts>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|error| napi::Error::from_reason(format!("invalid requestFacts: {error}")))
+}
+
+/// Validate an adaptive config document without constructing a runtime.
+#[napi(js_name = "validateAdaptiveConfig")]
+pub fn validate_adaptive_config(config: Json) -> napi::Result<Json> {
+    let config: AdaptiveConfig = serde_json::from_value(config)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    serde_json::to_value(CoreAdaptiveRuntime::validate_config(&config))
+        .map_err(|error| napi::Error::from_reason(error.to_string()))
+}
+
+/// Build one adaptive cache telemetry event from normalized usage.
+#[napi(js_name = "buildCacheTelemetryEvent")]
+pub fn build_cache_telemetry_event(options: Json) -> napi::Result<Option<Json>> {
+    let options: CacheTelemetryOptions = serde_json::from_value(options)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    let provider = parse_cache_telemetry_provider(&options.provider)?;
+    let request_id = parse_cache_telemetry_request_id(&options.request_id)?;
+    let timestamp = parse_cache_telemetry_timestamp(options.timestamp.as_deref())?;
+    let Some(usage_json) = options.usage else {
+        return Ok(None);
+    };
+    let usage: Usage = serde_json::from_value(usage_json)
+        .map_err(|error| napi::Error::from_reason(format!("invalid usage: {error}")))?;
+    let request_facts = parse_cache_request_facts(options.request_facts)?;
+    let agent_identity = AgentIdentity {
+        agent_id: options.agent_id,
+        template_version: options.template_version,
+        toolset_hash: options.toolset_hash,
+        model_family: options.model_family,
+        tenant_scope: options.tenant_scope,
+    };
+    CacheTelemetryEvent::from_usage(
+        request_id,
+        agent_identity,
+        provider,
+        &usage,
+        timestamp,
+        request_facts.as_ref(),
+    )
+    .map(|event| serde_json::to_value(&event))
+    .transpose()
+    .map_err(|error| napi::Error::from_reason(error.to_string()))
+}
+
+/// Set manual latency sensitivity on the current scope.
+#[napi(js_name = "setLatencySensitivity")]
+pub fn set_latency_sensitivity(value: u32) -> napi::Result<()> {
+    if value == 0 {
+        return Err(napi::Error::from_reason(
+            "sensitivity must be positive (> 0)",
+        ));
+    }
+    adaptive_set_latency_sensitivity(value)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))
 }
 
 /// Validate a plugin config document and return a structured diagnostics report.

--- a/crates/node/tests/adaptive_runtime_tests.mjs
+++ b/crates/node/tests/adaptive_runtime_tests.mjs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const adaptive = require('../adaptive.js');
+
+function acgRuntimeConfig(provider = 'anthropic') {
+  return {
+    version: 1,
+    agent_id: `node-adaptive-${provider}`,
+    state: {
+      backend: adaptive.inMemoryBackend(),
+    },
+    acg: adaptive.acgConfig({
+      provider,
+    }),
+  };
+}
+
+describe('adaptive runtime bridge', () => {
+  it('validates config through the native adaptive runtime', () => {
+    assert.deepEqual(adaptive.validateConfig(adaptive.defaultConfig()).diagnostics, []);
+  });
+
+  it('builds cache telemetry events from one options object', () => {
+    const event = adaptive.buildCacheTelemetryEvent({
+      provider: 'openai',
+      requestId: '00000000-0000-0000-0000-000000000201',
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 10,
+        cache_read_tokens: 25,
+      },
+      agentId: 'node-agent',
+      templateVersion: 'v1',
+      toolsetHash: 'tools',
+      modelFamily: 'gpt',
+      tenantScope: 'tenant',
+      timestamp: '2026-06-15T00:00:00Z',
+    });
+
+    assert.equal(event.provider, 'openai');
+    assert.equal(event.request_id, '00000000-0000-0000-0000-000000000201');
+    assert.equal(event.cache_read_tokens, 25);
+    assert.equal(event.total_prompt_tokens, 100);
+    assert.equal(event.hit_rate, 0.25);
+    assert.equal(event.agent_identity.agent_id, 'node-agent');
+  });
+
+  it('returns null when cache telemetry lacks prompt tokens', () => {
+    assert.equal(
+      adaptive.buildCacheTelemetryEvent({
+        provider: 'openai',
+        requestId: '00000000-0000-0000-0000-000000000202',
+        usage: {
+          completion_tokens: 10,
+        },
+        agentId: 'node-agent',
+        templateVersion: 'v1',
+        toolsetHash: 'tools',
+        modelFamily: 'gpt',
+        tenantScope: 'tenant',
+      }),
+      null,
+    );
+  });
+
+  it('registers an owned runtime and builds cache request facts', async () => {
+    const runtime = new adaptive.AdaptiveRuntime(acgRuntimeConfig('openai'));
+    await runtime.register();
+    try {
+      assert.deepEqual(runtime.report().diagnostics, []);
+      const facts = runtime.buildCacheRequestFacts({
+        provider: 'openai',
+        requestId: '00000000-0000-0000-0000-000000000203',
+        annotatedRequest: {
+          messages: [
+            {
+              role: 'user',
+              content: 'Find sources about caching',
+            },
+          ],
+          model: 'gpt-4.1-mini',
+        },
+        agentId: 'node-adaptive-openai',
+      });
+
+      assert.deepEqual(facts, {
+        missing_facts: ['acg_stability_unavailable'],
+        provider: 'openai',
+        stable_prefix_length: 0,
+      });
+      runtime.waitForIdle();
+      runtime.deregister();
+    } finally {
+      await runtime.shutdown().catch(() => {});
+    }
+  });
+
+  it('rejects invalid latency sensitivity values', () => {
+    assert.throws(() => adaptive.setLatencySensitivity(0), /positive/);
+  });
+});

--- a/crates/wasm/src/api/mod.rs
+++ b/crates/wasm/src/api/mod.rs
@@ -23,11 +23,14 @@
 //! All functions use `JsValue` for JSON payloads and return `Result<T, JsValue>`
 //! where errors are thrown as JavaScript exceptions.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use chrono::{DateTime, Utc};
 use js_sys::{Function, Reflect};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
@@ -50,6 +53,8 @@ use nemo_relay::api::scope::{ScopeAttributes, ScopeHandle as CoreScopeHandle};
 use nemo_relay::api::subscriber as relay_subscriber_api;
 use nemo_relay::api::tool as relay_tool_api;
 use nemo_relay::api::tool::ToolAttributes;
+use nemo_relay::codec::request::AnnotatedLlmRequest;
+use nemo_relay::codec::response::Usage;
 use nemo_relay::error::{FlowError, Result as FlowResult};
 use nemo_relay::plugin::{
     ConfigDiagnostic, DiagnosticLevel, Plugin, PluginConfig, PluginError,
@@ -60,7 +65,12 @@ use nemo_relay::plugin::{
     list_plugin_kinds as list_plugin_kinds_impl, register_plugin as register_plugin_impl,
     validate_plugin_config as validate_plugin_config_impl,
 };
+use nemo_relay_adaptive::acg::{
+    AgentIdentity, CacheRequestFacts, CacheTelemetryEvent, CacheTelemetryProvider,
+};
+use nemo_relay_adaptive::context_helpers::set_latency_sensitivity as adaptive_set_latency_sensitivity;
 use nemo_relay_adaptive::plugin_component::register_adaptive_component;
+use nemo_relay_adaptive::{AdaptiveConfig, AdaptiveRuntime as CoreAdaptiveRuntime};
 use nemo_relay_pii_redaction::component::register_pii_redaction_component;
 
 use crate::callable;
@@ -2201,6 +2211,368 @@ fn ensure_adaptive_component_registered() -> Result<(), JsValue> {
 
 fn ensure_pii_redaction_component_registered() -> Result<(), JsValue> {
     register_pii_redaction_component().map_err(to_js_err)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheTelemetryOptions {
+    provider: String,
+    #[serde(alias = "request_id")]
+    request_id: String,
+    usage: Option<Json>,
+    #[serde(default, alias = "request_facts")]
+    request_facts: Option<Json>,
+    #[serde(alias = "agent_id")]
+    agent_id: String,
+    #[serde(alias = "template_version")]
+    template_version: String,
+    #[serde(alias = "toolset_hash")]
+    toolset_hash: String,
+    #[serde(alias = "model_family")]
+    model_family: String,
+    #[serde(alias = "tenant_scope")]
+    tenant_scope: String,
+    timestamp: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheRequestFactsOptions {
+    provider: String,
+    #[serde(alias = "request_id")]
+    request_id: String,
+    #[serde(alias = "annotated_request")]
+    annotated_request: Json,
+    #[serde(alias = "agent_id")]
+    agent_id: String,
+    timestamp: Option<String>,
+}
+
+enum WasmAdaptiveRuntimeState {
+    Pending {
+        config: AdaptiveConfig,
+        report: nemo_relay::plugin::ConfigReport,
+    },
+    Ready(CoreAdaptiveRuntime),
+}
+
+/// Owned adaptive runtime that can register adaptive features outside the plugin system.
+#[wasm_bindgen(js_name = AdaptiveRuntime)]
+pub struct AdaptiveRuntime {
+    inner: Rc<RefCell<Option<WasmAdaptiveRuntimeState>>>,
+}
+
+#[wasm_bindgen(js_class = AdaptiveRuntime)]
+impl AdaptiveRuntime {
+    /// Create an adaptive runtime wrapper from config.
+    ///
+    /// The runtime is constructed lazily when `register()` is awaited.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        #[wasm_bindgen(unchecked_param_type = "Json")] config: JsValue,
+    ) -> Result<Self, JsValue> {
+        let config_json = js_to_json(&config)?;
+        let config: AdaptiveConfig = serde_json::from_value(config_json)
+            .map_err(|error| JsValue::from_str(&error.to_string()))?;
+        let report = validate_adaptive_config_or_err(&config)?;
+        Ok(Self {
+            inner: Rc::new(RefCell::new(Some(WasmAdaptiveRuntimeState::Pending {
+                config,
+                report,
+            }))),
+        })
+    }
+
+    /// Register all configured adaptive runtime features.
+    pub fn register(&self) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let state = inner
+                .try_borrow_mut()
+                .map_err(|_| JsValue::from_str("adaptive runtime is locked"))?
+                .take()
+                .ok_or_else(|| JsValue::from_str("adaptive runtime already shut down"))?;
+
+            let (result, next_state) = match state {
+                WasmAdaptiveRuntimeState::Pending { config, report } => {
+                    match CoreAdaptiveRuntime::new(config.clone()).await {
+                        Ok(mut runtime) => {
+                            let result = runtime
+                                .register()
+                                .await
+                                .map_err(|error| JsValue::from_str(&error.to_string()));
+                            (result, Some(WasmAdaptiveRuntimeState::Ready(runtime)))
+                        }
+                        Err(error) => (
+                            Err(JsValue::from_str(&error.to_string())),
+                            Some(WasmAdaptiveRuntimeState::Pending { config, report }),
+                        ),
+                    }
+                }
+                WasmAdaptiveRuntimeState::Ready(mut runtime) => {
+                    let result = runtime
+                        .register()
+                        .await
+                        .map_err(|error| JsValue::from_str(&error.to_string()));
+                    (result, Some(WasmAdaptiveRuntimeState::Ready(runtime)))
+                }
+            };
+
+            *inner
+                .try_borrow_mut()
+                .map_err(|_| JsValue::from_str("adaptive runtime is locked"))? = next_state;
+            result.map(|_| JsValue::UNDEFINED)
+        })
+    }
+
+    /// Deregister all previously registered adaptive runtime features.
+    pub fn deregister(&self) -> Result<(), JsValue> {
+        let mut guard = self.inner.try_borrow_mut().map_err(|_| {
+            JsValue::from_str(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("adaptive runtime already shut down"))?;
+        match state {
+            WasmAdaptiveRuntimeState::Pending { .. } => Ok(()),
+            WasmAdaptiveRuntimeState::Ready(runtime) => runtime
+                .deregister()
+                .map_err(|error| JsValue::from_str(&error.to_string())),
+        }
+    }
+
+    /// Shut down the adaptive runtime and consume its Rust runtime state.
+    pub fn shutdown(&self) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let state = inner
+                .try_borrow_mut()
+                .map_err(|_| JsValue::from_str("adaptive runtime is locked"))?
+                .take()
+                .ok_or_else(|| JsValue::from_str("adaptive runtime already shut down"))?;
+            match state {
+                WasmAdaptiveRuntimeState::Pending { .. } => Ok(JsValue::UNDEFINED),
+                WasmAdaptiveRuntimeState::Ready(runtime) => runtime
+                    .shutdown()
+                    .await
+                    .map(|_| JsValue::UNDEFINED)
+                    .map_err(|error| JsValue::from_str(&error.to_string())),
+            }
+        })
+    }
+
+    /// Block until the telemetry drain has processed pending events.
+    #[wasm_bindgen(js_name = "waitForIdle")]
+    pub fn wait_for_idle(&self) -> Result<(), JsValue> {
+        let guard = self.inner.try_borrow().map_err(|_| {
+            JsValue::from_str(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| JsValue::from_str("adaptive runtime already shut down"))?;
+        match state {
+            WasmAdaptiveRuntimeState::Pending { .. } => Ok(()),
+            WasmAdaptiveRuntimeState::Ready(runtime) => {
+                runtime.wait_for_idle();
+                Ok(())
+            }
+        }
+    }
+
+    /// Return the validation report captured during runtime construction.
+    #[wasm_bindgen(unchecked_return_type = "Json")]
+    pub fn report(&self) -> Result<JsValue, JsValue> {
+        let guard = self.inner.try_borrow().map_err(|_| {
+            JsValue::from_str(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| JsValue::from_str("adaptive runtime already shut down"))?;
+        let report = match state {
+            WasmAdaptiveRuntimeState::Pending { report, .. } => report,
+            WasmAdaptiveRuntimeState::Ready(runtime) => runtime.report(),
+        };
+        serde_wasm_bindgen::to_value(report).map_err(|error| JsValue::from_str(&error.to_string()))
+    }
+
+    /// Bind the runtime's ACG request rewrite to a scope.
+    #[wasm_bindgen(js_name = "bindScope")]
+    pub fn bind_scope(&self, scope_handle: &ScopeHandle) -> Result<(), JsValue> {
+        let mut guard = self.inner.try_borrow_mut().map_err(|_| {
+            JsValue::from_str(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("adaptive runtime already shut down"))?;
+        match state {
+            WasmAdaptiveRuntimeState::Pending { .. } => Err(JsValue::from_str(
+                "adaptive runtime must be registered before binding ACG request intercepts",
+            )),
+            WasmAdaptiveRuntimeState::Ready(runtime) => runtime
+                .bind_scope(scope_handle.inner.uuid)
+                .map_err(|error| JsValue::from_str(&error.to_string())),
+        }
+    }
+
+    /// Build cache request facts for an annotated LLM request.
+    #[wasm_bindgen(
+        js_name = "buildCacheRequestFacts",
+        unchecked_return_type = "Json | null"
+    )]
+    pub fn build_cache_request_facts(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "Json")] options: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let options: CacheRequestFactsOptions = serde_wasm_bindgen::from_value(options)
+            .map_err(|error| JsValue::from_str(&error.to_string()))?;
+        let _request_id = parse_cache_telemetry_request_id(&options.request_id)?;
+        let _timestamp = parse_cache_telemetry_timestamp(options.timestamp.as_deref())?;
+        let annotated_request: AnnotatedLlmRequest =
+            serde_json::from_value(options.annotated_request).map_err(|error| {
+                JsValue::from_str(&format!("invalid annotatedRequest: {error}"))
+            })?;
+        let guard = self.inner.try_borrow().map_err(|_| {
+            JsValue::from_str(
+                "adaptive runtime is locked by an async operation; try again after await completes",
+            )
+        })?;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| JsValue::from_str("adaptive runtime already shut down"))?;
+        match state {
+            WasmAdaptiveRuntimeState::Pending { .. } => Err(JsValue::from_str(
+                "adaptive runtime must be registered before building cache request facts",
+            )),
+            WasmAdaptiveRuntimeState::Ready(runtime) => {
+                match runtime.build_cache_request_facts(
+                    &options.agent_id,
+                    &options.provider,
+                    &annotated_request,
+                ) {
+                    Some(facts) => serde_wasm_bindgen::to_value(&facts)
+                        .map_err(|error| JsValue::from_str(&error.to_string())),
+                    None => Ok(JsValue::NULL),
+                }
+            }
+        }
+    }
+}
+
+fn validate_adaptive_config_or_err(
+    config: &AdaptiveConfig,
+) -> Result<nemo_relay::plugin::ConfigReport, JsValue> {
+    let report = CoreAdaptiveRuntime::validate_config(config);
+    if report.has_errors() {
+        let joined = report
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.level == DiagnosticLevel::Error)
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(JsValue::from_str(&joined));
+    }
+    Ok(report)
+}
+
+fn parse_cache_telemetry_provider(provider: &str) -> Result<CacheTelemetryProvider, JsValue> {
+    match provider {
+        "anthropic" => Ok(CacheTelemetryProvider::Anthropic),
+        "openai" => Ok(CacheTelemetryProvider::OpenAI),
+        other => Err(JsValue::from_str(&format!("unsupported provider: {other}"))),
+    }
+}
+
+fn parse_cache_telemetry_request_id(request_id: &str) -> Result<Uuid, JsValue> {
+    Uuid::parse_str(request_id)
+        .map_err(|error| JsValue::from_str(&format!("invalid requestId UUID: {error}")))
+}
+
+fn parse_cache_telemetry_timestamp(timestamp: Option<&str>) -> Result<DateTime<Utc>, JsValue> {
+    match timestamp {
+        Some(value) => DateTime::parse_from_rfc3339(value)
+            .map(|value| value.with_timezone(&Utc))
+            .map_err(|error| JsValue::from_str(&format!("invalid timestamp: {error}"))),
+        None => Ok(Utc::now()),
+    }
+}
+
+fn parse_cache_request_facts(value: Option<Json>) -> Result<Option<CacheRequestFacts>, JsValue> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|error| JsValue::from_str(&format!("invalid requestFacts: {error}")))
+}
+
+/// Validate an adaptive config document without constructing a runtime.
+#[wasm_bindgen(js_name = "validateAdaptiveConfig", unchecked_return_type = "Json")]
+pub fn validate_adaptive_config(
+    #[wasm_bindgen(unchecked_param_type = "Json")] config: JsValue,
+) -> Result<JsValue, JsValue> {
+    let config_json = js_to_json(&config)?;
+    let config: AdaptiveConfig = serde_json::from_value(config_json)
+        .map_err(|error| JsValue::from_str(&error.to_string()))?;
+    serde_wasm_bindgen::to_value(&CoreAdaptiveRuntime::validate_config(&config))
+        .map_err(|error| JsValue::from_str(&error.to_string()))
+}
+
+/// Build one adaptive cache telemetry event from normalized usage.
+#[wasm_bindgen(
+    js_name = "buildCacheTelemetryEvent",
+    unchecked_return_type = "Json | null"
+)]
+pub fn build_cache_telemetry_event(
+    #[wasm_bindgen(unchecked_param_type = "Json")] options: JsValue,
+) -> Result<JsValue, JsValue> {
+    let options: CacheTelemetryOptions = serde_wasm_bindgen::from_value(options)
+        .map_err(|error| JsValue::from_str(&error.to_string()))?;
+    let provider = parse_cache_telemetry_provider(&options.provider)?;
+    let request_id = parse_cache_telemetry_request_id(&options.request_id)?;
+    let timestamp = parse_cache_telemetry_timestamp(options.timestamp.as_deref())?;
+    let Some(usage_json) = options.usage else {
+        return Ok(JsValue::NULL);
+    };
+    let usage: Usage = serde_json::from_value(usage_json)
+        .map_err(|error| JsValue::from_str(&format!("invalid usage: {error}")))?;
+    let request_facts = parse_cache_request_facts(options.request_facts)?;
+    let agent_identity = AgentIdentity {
+        agent_id: options.agent_id,
+        template_version: options.template_version,
+        toolset_hash: options.toolset_hash,
+        model_family: options.model_family,
+        tenant_scope: options.tenant_scope,
+    };
+    match CacheTelemetryEvent::from_usage(
+        request_id,
+        agent_identity,
+        provider,
+        &usage,
+        timestamp,
+        request_facts.as_ref(),
+    ) {
+        Some(event) => serde_wasm_bindgen::to_value(&event)
+            .map_err(|error| JsValue::from_str(&error.to_string())),
+        None => Ok(JsValue::NULL),
+    }
+}
+
+/// Set manual latency sensitivity on the current scope.
+#[wasm_bindgen(js_name = "setLatencySensitivity")]
+pub fn set_latency_sensitivity(value: u32) -> Result<(), JsValue> {
+    if value == 0 {
+        return Err(JsValue::from_str("sensitivity must be positive (> 0)"));
+    }
+    adaptive_set_latency_sensitivity(value).map_err(|error| JsValue::from_str(&error))
 }
 
 /// Validate a plugin config document and return a structured diagnostics report.

--- a/crates/wasm/tests-js/adaptive_tests.mjs
+++ b/crates/wasm/tests-js/adaptive_tests.mjs
@@ -82,3 +82,77 @@ test('WebAssembly adaptive wrappers build adaptive component specs', () => {
     },
   );
 });
+
+test('WebAssembly adaptive wrappers validate config through the native runtime', () => {
+  assert.deepEqual(adaptive.validateConfig(adaptive.defaultConfig()).diagnostics, []);
+});
+
+test('WebAssembly adaptive wrappers build cache telemetry events from options', () => {
+  const event = adaptive.buildCacheTelemetryEvent({
+    provider: 'openai',
+    requestId: '00000000-0000-0000-0000-000000000301',
+    usage: {
+      prompt_tokens: 100,
+      completion_tokens: 10,
+      cache_read_tokens: 25,
+    },
+    agentId: 'wasm-agent',
+    templateVersion: 'v1',
+    toolsetHash: 'tools',
+    modelFamily: 'gpt',
+    tenantScope: 'tenant',
+    timestamp: '2026-06-15T00:00:00Z',
+  });
+
+  assert.equal(event.provider, 'openai');
+  assert.equal(event.cache_read_tokens, 25);
+  assert.equal(event.total_prompt_tokens, 100);
+  assert.equal(event.hit_rate, 0.25);
+  assert.equal(event.agent_identity.agent_id, 'wasm-agent');
+});
+
+test('WebAssembly adaptive runtime registers and builds cache request facts', async () => {
+  const runtime = new adaptive.AdaptiveRuntime({
+    version: 1,
+    agent_id: 'wasm-adaptive-openai',
+    state: {
+      backend: adaptive.inMemoryBackend(),
+    },
+    acg: adaptive.acgConfig({
+      provider: 'openai',
+    }),
+  });
+
+  await runtime.register();
+  try {
+    assert.deepEqual(runtime.report().diagnostics, []);
+    const facts = runtime.buildCacheRequestFacts({
+      provider: 'openai',
+      requestId: '00000000-0000-0000-0000-000000000302',
+      annotatedRequest: {
+        messages: [
+          {
+            role: 'user',
+            content: 'Find sources about caching',
+          },
+        ],
+        model: 'gpt-4.1-mini',
+      },
+      agentId: 'wasm-adaptive-openai',
+    });
+
+    assert.deepEqual(facts, {
+      missing_facts: ['acg_stability_unavailable'],
+      provider: 'openai',
+      stable_prefix_length: 0,
+    });
+    runtime.waitForIdle();
+    runtime.deregister();
+  } finally {
+    await runtime.shutdown().catch(() => {});
+  }
+});
+
+test('WebAssembly adaptive wrappers reject invalid latency sensitivity values', () => {
+  assert.throws(() => adaptive.setLatencySensitivity(0), /positive/);
+});

--- a/crates/wasm/wrappers/esm/adaptive.d.ts
+++ b/crates/wasm/wrappers/esm/adaptive.d.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ConfigPolicy, ConfigDiagnostic, ConfigReport } from './plugin.js';
+import type { ScopeHandle } from './index.js';
 import type { JsonObject } from './typed.js';
 
 export { ConfigPolicy, ConfigDiagnostic, ConfigReport };
@@ -69,6 +70,96 @@ export interface ComponentSpec {
   kind: 'adaptive';
   enabled?: boolean;
   config: Config;
+}
+
+/** Normalized LLM token usage for cache telemetry. */
+export interface CacheUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  cost?: JsonObject;
+}
+
+/** Identity of the agent associated with cache telemetry. */
+export interface AgentIdentity {
+  agent_id: string;
+  template_version: string;
+  toolset_hash: string;
+  model_family: string;
+  tenant_scope: string;
+}
+
+/** Input for building cache request facts. */
+export interface CacheRequestFactsOptions {
+  provider: string;
+  requestId: string;
+  annotatedRequest: JsonObject;
+  agentId: string;
+  timestamp?: string;
+}
+
+/** Request-time facts used to classify cache misses. */
+export interface CacheRequestFacts {
+  provider: string;
+  stable_prefix_length: number;
+  stable_prefix_tokens?: number;
+  required_min_tokens?: number;
+  first_mismatch_span_id?: string;
+  first_mismatch_sequence_index?: number;
+  expected_hash_prefix?: string;
+  actual_hash_prefix?: string;
+  retention_window_secs?: number;
+  observed_gap_secs?: number;
+  missing_facts?: string[];
+}
+
+/** Input for building cache telemetry events. */
+export interface CacheTelemetryEventOptions {
+  provider: 'anthropic' | 'openai' | string;
+  requestId: string;
+  usage?: CacheUsage | null;
+  requestFacts?: CacheRequestFacts | null;
+  agentId: string;
+  templateVersion: string;
+  toolsetHash: string;
+  modelFamily: string;
+  tenantScope: string;
+  timestamp?: string;
+}
+
+/** Normalized adaptive cache telemetry event. */
+export interface CacheTelemetryEvent {
+  request_id: string;
+  agent_identity: AgentIdentity;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_prompt_tokens: number;
+  hit_rate: number;
+  miss_reason?: JsonObject;
+  miss_diagnosis?: JsonObject;
+  provider: string;
+  timestamp: string;
+}
+
+/** Owned adaptive runtime outside the generic plugin system. */
+export declare class AdaptiveRuntime {
+  constructor(config: Config);
+  /** Register all configured adaptive runtime features. */
+  register(): Promise<void>;
+  /** Deregister all previously registered adaptive runtime features. */
+  deregister(): void;
+  /** Shut down the adaptive runtime and consume its Rust runtime state. */
+  shutdown(): Promise<void>;
+  /** Block until adaptive telemetry has processed pending events. */
+  waitForIdle(): void;
+  /** Return the validation report captured during construction. */
+  report(): ConfigReport;
+  /** Bind the runtime's ACG request rewrite to a scope. */
+  bindScope(scopeHandle: ScopeHandle): void;
+  /** Build cache request facts for an annotated LLM request. */
+  buildCacheRequestFacts(options: CacheRequestFactsOptions): CacheRequestFacts | null;
 }
 
 export declare const ADAPTIVE_PLUGIN_KIND: 'adaptive';
@@ -172,3 +263,9 @@ export declare function ComponentSpec(
     enabled?: boolean;
   },
 ): import('./plugin.js').ComponentSpec;
+/** Validate an adaptive config document without constructing a runtime. */
+export declare function validateConfig(config: Config): ConfigReport;
+/** Build one adaptive cache telemetry event from normalized usage. */
+export declare function buildCacheTelemetryEvent(options: CacheTelemetryEventOptions): CacheTelemetryEvent | null;
+/** Set manual latency sensitivity on the current scope. */
+export declare function setLatencySensitivity(value: number): void;

--- a/crates/wasm/wrappers/esm/adaptive.js
+++ b/crates/wasm/wrappers/esm/adaptive.js
@@ -2,8 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as plugin from './plugin.js';
+import {
+  AdaptiveRuntime,
+  buildCacheTelemetryEvent as nativeBuildCacheTelemetryEvent,
+  setLatencySensitivity as nativeSetLatencySensitivity,
+  validateAdaptiveConfig,
+} from './pkg/index.js';
 
 export const ADAPTIVE_PLUGIN_KIND = 'adaptive';
+export { AdaptiveRuntime };
 
 /**
  * Create a default adaptive component config.
@@ -160,4 +167,34 @@ export function ComponentSpec(config, { enabled = true } = {}) {
   return plugin.ComponentSpec(ADAPTIVE_PLUGIN_KIND, config, {
     enabled,
   });
+}
+
+/**
+ * Validate an adaptive config document without constructing a runtime.
+ *
+ * @param {object} config - Adaptive runtime configuration document.
+ * @returns {object} A structured validation report with diagnostics.
+ */
+export function validateConfig(config) {
+  return validateAdaptiveConfig(config);
+}
+
+/**
+ * Build one adaptive cache telemetry event from normalized usage.
+ *
+ * @param {object} options - Cache telemetry event inputs.
+ * @returns {object|null} A telemetry event, or `null` when usage lacks prompt tokens.
+ */
+export function buildCacheTelemetryEvent(options) {
+  return nativeBuildCacheTelemetryEvent(options);
+}
+
+/**
+ * Set manual latency sensitivity on the current scope.
+ *
+ * @param {number} value - Positive sensitivity value to store on the current scope.
+ * @returns {void} Nothing.
+ */
+export function setLatencySensitivity(value) {
+  return nativeSetLatencySensitivity(value);
 }

--- a/crates/wasm/wrappers/nodejs/adaptive.js
+++ b/crates/wasm/wrappers/nodejs/adaptive.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+const lib = require('./nemo_relay_wasm.js');
 const plugin = require('./plugin.js');
 
 const ADAPTIVE_PLUGIN_KIND = 'adaptive';
@@ -164,6 +165,37 @@ function ComponentSpec(config, { enabled = true } = {}) {
   });
 }
 
+/**
+ * Validate an adaptive config document without constructing a runtime.
+ *
+ * @param {object} config - Adaptive runtime configuration document.
+ * @returns {object} A structured validation report with diagnostics.
+ */
+function validateConfig(config) {
+  return lib.validateAdaptiveConfig(config);
+}
+
+/**
+ * Build one adaptive cache telemetry event from normalized usage.
+ *
+ * @param {object} options - Cache telemetry event inputs.
+ * @returns {object|null} A telemetry event, or `null` when usage lacks prompt tokens.
+ */
+function buildCacheTelemetryEvent(options) {
+  return lib.buildCacheTelemetryEvent(options);
+}
+
+/**
+ * Set manual latency sensitivity on the current scope.
+ *
+ * @param {number} value - Positive sensitivity value to store on the current scope.
+ * @returns {void} Nothing.
+ */
+function setLatencySensitivity(value) {
+  return lib.setLatencySensitivity(value);
+}
+
+exports.AdaptiveRuntime = lib.AdaptiveRuntime;
 exports.ADAPTIVE_PLUGIN_KIND = ADAPTIVE_PLUGIN_KIND;
 exports.defaultConfig = defaultConfig;
 exports.inMemoryBackend = inMemoryBackend;
@@ -173,3 +205,6 @@ exports.adaptiveHintsConfig = adaptiveHintsConfig;
 exports.toolParallelismConfig = toolParallelismConfig;
 exports.acgConfig = acgConfig;
 exports.ComponentSpec = ComponentSpec;
+exports.validateConfig = validateConfig;
+exports.buildCacheTelemetryEvent = buildCacheTelemetryEvent;
+exports.setLatencySensitivity = setLatencySensitivity;

--- a/go/nemo_relay/adaptive/adaptive.go
+++ b/go/nemo_relay/adaptive/adaptive.go
@@ -28,6 +28,9 @@ type Config = nemo_relay.AdaptiveConfig
 // ComponentSpec wraps adaptive config as a top-level adaptive component.
 type ComponentSpec = nemo_relay.AdaptiveComponentSpec
 
+// Runtime owns adaptive runtime registrations outside the plugin system.
+type Runtime = nemo_relay.AdaptiveRuntime
+
 // StateConfig selects the adaptive state backend.
 type StateConfig = nemo_relay.AdaptiveStateConfig
 
@@ -48,6 +51,24 @@ type AcgStabilityThresholds = nemo_relay.AcgStabilityThresholds
 
 // AcgConfig configures the adaptive cache governor.
 type AcgConfig = nemo_relay.AcgConfig
+
+// CacheUsage is normalized LLM token usage for cache telemetry.
+type CacheUsage = nemo_relay.CacheUsage
+
+// AgentIdentity identifies the agent associated with cache telemetry.
+type AgentIdentity = nemo_relay.AgentIdentity
+
+// CacheRequestFactsInput is the typed input for building cache request facts.
+type CacheRequestFactsInput = nemo_relay.CacheRequestFactsInput
+
+// CacheRequestFacts describes request-time facts used to classify cache misses.
+type CacheRequestFacts = nemo_relay.CacheRequestFacts
+
+// CacheTelemetryEventInput is the typed input for building cache telemetry events.
+type CacheTelemetryEventInput = nemo_relay.CacheTelemetryEventInput
+
+// CacheTelemetryEvent is the normalized adaptive cache telemetry event.
+type CacheTelemetryEvent = nemo_relay.CacheTelemetryEvent
 
 // PluginKind is the top-level plugin kind used by the adaptive component.
 const PluginKind = nemo_relay.AdaptivePluginKind
@@ -100,4 +121,24 @@ func NewComponentSpec(config Config) ComponentSpec {
 // Component converts adaptive config directly into the shared plugin shape.
 func Component(config Config) nemo_relay.PluginComponentSpec {
 	return nemo_relay.AdaptiveComponent(config)
+}
+
+// ValidateConfig validates an adaptive runtime config without constructing a runtime.
+func ValidateConfig(config Config) (nemo_relay.ConfigReport, error) {
+	return nemo_relay.ValidateAdaptiveConfig(config)
+}
+
+// NewRuntime creates an owned adaptive runtime from config.
+func NewRuntime(config Config) (*Runtime, error) {
+	return nemo_relay.NewAdaptiveRuntime(config)
+}
+
+// BuildCacheTelemetryEvent builds one cache telemetry event from normalized usage.
+func BuildCacheTelemetryEvent(input CacheTelemetryEventInput) (*CacheTelemetryEvent, error) {
+	return nemo_relay.BuildCacheTelemetryEvent(input)
+}
+
+// SetLatencySensitivity sets manual latency sensitivity on the current scope.
+func SetLatencySensitivity(value uint32) error {
+	return nemo_relay.SetLatencySensitivity(value)
 }

--- a/go/nemo_relay/adaptive/runtime_test.go
+++ b/go/nemo_relay/adaptive/runtime_test.go
@@ -18,6 +18,7 @@ func TestAdaptivePackageRuntimeHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRuntime failed: %v", err)
 	}
+	defer runtime.Shutdown()
 	if err := runtime.Register(); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}

--- a/go/nemo_relay/adaptive/runtime_test.go
+++ b/go/nemo_relay/adaptive/runtime_test.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package adaptive
+
+import "testing"
+
+func TestAdaptivePackageRuntimeHelpers(t *testing.T) {
+	report, err := ValidateConfig(NewConfig())
+	if err != nil {
+		t.Fatalf("ValidateConfig failed: %v", err)
+	}
+	if len(report.Diagnostics) != 0 {
+		t.Fatalf("expected clean report, got %#v", report.Diagnostics)
+	}
+
+	runtime, err := NewRuntime(NewConfig())
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+	if err := runtime.Register(); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	if err := runtime.Shutdown(); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+}

--- a/go/nemo_relay/adaptive_runtime.go
+++ b/go/nemo_relay/adaptive_runtime.go
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nemo_relay
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct FfiAdaptiveRuntime FfiAdaptiveRuntime;
+typedef struct FfiScopeHandle FfiScopeHandle;
+
+extern int32_t nemo_relay_adaptive_validate_config(const char* config_json, char** out_json);
+extern int32_t nemo_relay_adaptive_runtime_create(const char* config_json, FfiAdaptiveRuntime** out);
+extern int32_t nemo_relay_adaptive_runtime_register(FfiAdaptiveRuntime* runtime);
+extern int32_t nemo_relay_adaptive_runtime_deregister(FfiAdaptiveRuntime* runtime);
+extern int32_t nemo_relay_adaptive_runtime_shutdown(FfiAdaptiveRuntime* runtime);
+extern int32_t nemo_relay_adaptive_runtime_wait_for_idle(FfiAdaptiveRuntime* runtime);
+extern int32_t nemo_relay_adaptive_runtime_report_json(FfiAdaptiveRuntime* runtime, char** out_json);
+extern int32_t nemo_relay_adaptive_runtime_bind_scope(FfiAdaptiveRuntime* runtime, const FfiScopeHandle* scope);
+extern int32_t nemo_relay_adaptive_runtime_build_cache_request_facts(FfiAdaptiveRuntime* runtime, const char* options_json, char** out_json);
+extern int32_t nemo_relay_adaptive_build_cache_telemetry_event(const char* options_json, char** out_json);
+extern int32_t nemo_relay_adaptive_set_latency_sensitivity(uint32_t value);
+extern void nemo_relay_adaptive_runtime_free(FfiAdaptiveRuntime* ptr);
+extern void nemo_relay_string_free(char* ptr);
+*/
+import "C"
+
+import (
+	"encoding/json"
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+// AdaptiveRuntime owns adaptive runtime registrations outside the generic plugin system.
+type AdaptiveRuntime struct {
+	ptr *C.FfiAdaptiveRuntime
+}
+
+// CacheUsage is normalized LLM token usage used to build adaptive cache telemetry.
+type CacheUsage struct {
+	PromptTokens     *uint64         `json:"prompt_tokens,omitempty"`
+	CompletionTokens *uint64         `json:"completion_tokens,omitempty"`
+	TotalTokens      *uint64         `json:"total_tokens,omitempty"`
+	CacheReadTokens  *uint64         `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens *uint64         `json:"cache_write_tokens,omitempty"`
+	Cost             json.RawMessage `json:"cost,omitempty"`
+}
+
+// AgentIdentity identifies the agent associated with cache telemetry.
+type AgentIdentity struct {
+	AgentID         string `json:"agent_id"`
+	TemplateVersion string `json:"template_version"`
+	ToolsetHash     string `json:"toolset_hash"`
+	ModelFamily     string `json:"model_family"`
+	TenantScope     string `json:"tenant_scope"`
+}
+
+// CacheRequestFactsInput is the typed input for building cache request facts.
+type CacheRequestFactsInput struct {
+	Provider         string          `json:"provider"`
+	RequestID        string          `json:"request_id"`
+	AnnotatedRequest json.RawMessage `json:"annotated_request"`
+	AgentID          string          `json:"agent_id"`
+	Timestamp        string          `json:"timestamp,omitempty"`
+}
+
+// CacheRequestFacts describes request-time facts used to classify cache misses.
+type CacheRequestFacts struct {
+	Provider                   string   `json:"provider"`
+	StablePrefixLength         uint64   `json:"stable_prefix_length"`
+	StablePrefixTokens         *uint32  `json:"stable_prefix_tokens,omitempty"`
+	RequiredMinTokens          *uint32  `json:"required_min_tokens,omitempty"`
+	FirstMismatchSpanID        *string  `json:"first_mismatch_span_id,omitempty"`
+	FirstMismatchSequenceIndex *uint32  `json:"first_mismatch_sequence_index,omitempty"`
+	ExpectedHashPrefix         *string  `json:"expected_hash_prefix,omitempty"`
+	ActualHashPrefix           *string  `json:"actual_hash_prefix,omitempty"`
+	RetentionWindowSecs        *float64 `json:"retention_window_secs,omitempty"`
+	ObservedGapSecs            *float64 `json:"observed_gap_secs,omitempty"`
+	MissingFacts               []string `json:"missing_facts,omitempty"`
+}
+
+// CacheTelemetryEventInput is the typed input for building cache telemetry events.
+type CacheTelemetryEventInput struct {
+	Provider        string             `json:"provider"`
+	RequestID       string             `json:"request_id"`
+	Usage           *CacheUsage        `json:"usage,omitempty"`
+	RequestFacts    *CacheRequestFacts `json:"request_facts,omitempty"`
+	AgentID         string             `json:"agent_id"`
+	TemplateVersion string             `json:"template_version"`
+	ToolsetHash     string             `json:"toolset_hash"`
+	ModelFamily     string             `json:"model_family"`
+	TenantScope     string             `json:"tenant_scope"`
+	Timestamp       string             `json:"timestamp,omitempty"`
+}
+
+// CacheTelemetryEvent is the normalized adaptive cache telemetry event.
+type CacheTelemetryEvent struct {
+	RequestID           string         `json:"request_id"`
+	AgentIdentity       AgentIdentity  `json:"agent_identity"`
+	CacheReadTokens     uint64         `json:"cache_read_tokens"`
+	CacheCreationTokens uint64         `json:"cache_creation_tokens"`
+	TotalPromptTokens   uint64         `json:"total_prompt_tokens"`
+	HitRate             float64        `json:"hit_rate"`
+	MissReason          map[string]any `json:"miss_reason,omitempty"`
+	MissDiagnosis       map[string]any `json:"miss_diagnosis,omitempty"`
+	Provider            string         `json:"provider"`
+	Timestamp           string         `json:"timestamp"`
+}
+
+func adaptiveConfigCString(config AdaptiveConfig) (*C.char, error) {
+	payload, err := jsonMarshal(config)
+	if err != nil {
+		return nil, err
+	}
+	return C.CString(string(payload)), nil
+}
+
+func adaptiveOptionsCString(value any) (*C.char, error) {
+	payload, err := jsonMarshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return C.CString(string(payload)), nil
+}
+
+func adaptiveJSONString(status C.int32_t, out *C.char) (string, error) {
+	return checkedJSONString(int32(status), func() string { return C.GoString(out) }, func() {
+		C.nemo_relay_string_free(out)
+	})
+}
+
+// ValidateAdaptiveConfig validates an adaptive runtime config without constructing a runtime.
+func ValidateAdaptiveConfig(config AdaptiveConfig) (ConfigReport, error) {
+	cConfig, err := adaptiveConfigCString(config)
+	if err != nil {
+		return ConfigReport{}, err
+	}
+	defer C.free(unsafe.Pointer(cConfig))
+
+	var out *C.char
+	raw, err := adaptiveJSONString(C.nemo_relay_adaptive_validate_config(cConfig, &out), out)
+	if err != nil {
+		return ConfigReport{}, err
+	}
+	var report ConfigReport
+	if err := jsonUnmarshal([]byte(raw), &report); err != nil {
+		return ConfigReport{}, err
+	}
+	return report, nil
+}
+
+// NewAdaptiveRuntime creates an owned adaptive runtime from config.
+func NewAdaptiveRuntime(config AdaptiveConfig) (*AdaptiveRuntime, error) {
+	cConfig, err := adaptiveConfigCString(config)
+	if err != nil {
+		return nil, err
+	}
+	defer C.free(unsafe.Pointer(cConfig))
+
+	var out *C.FfiAdaptiveRuntime
+	if err := checkStatus(C.nemo_relay_adaptive_runtime_create(cConfig, &out)); err != nil {
+		return nil, err
+	}
+	r := &AdaptiveRuntime{ptr: out}
+	runtime.SetFinalizer(r, func(r *AdaptiveRuntime) {
+		if r.ptr != nil {
+			C.nemo_relay_adaptive_runtime_free(r.ptr)
+			r.ptr = nil
+		}
+	})
+	return r, nil
+}
+
+// Register activates all configured adaptive runtime features.
+func (r *AdaptiveRuntime) Register() error {
+	if r == nil || r.ptr == nil {
+		return errNilAdaptiveRuntime()
+	}
+	return checkStatus(C.nemo_relay_adaptive_runtime_register(r.ptr))
+}
+
+// Deregister removes all adaptive runtime registrations owned by this runtime.
+func (r *AdaptiveRuntime) Deregister() error {
+	if r == nil || r.ptr == nil {
+		return errNilAdaptiveRuntime()
+	}
+	return checkStatus(C.nemo_relay_adaptive_runtime_deregister(r.ptr))
+}
+
+// Shutdown deregisters the adaptive runtime and consumes its Rust runtime state.
+func (r *AdaptiveRuntime) Shutdown() error {
+	if r == nil || r.ptr == nil {
+		return errNilAdaptiveRuntime()
+	}
+	err := checkStatus(C.nemo_relay_adaptive_runtime_shutdown(r.ptr))
+	C.nemo_relay_adaptive_runtime_free(r.ptr)
+	r.ptr = nil
+	runtime.SetFinalizer(r, nil)
+	return err
+}
+
+// WaitForIdle blocks until adaptive telemetry has processed pending events.
+func (r *AdaptiveRuntime) WaitForIdle() error {
+	if r == nil || r.ptr == nil {
+		return errNilAdaptiveRuntime()
+	}
+	return checkStatus(C.nemo_relay_adaptive_runtime_wait_for_idle(r.ptr))
+}
+
+// Report returns the runtime validation report captured during construction.
+func (r *AdaptiveRuntime) Report() (ConfigReport, error) {
+	if r == nil || r.ptr == nil {
+		return ConfigReport{}, errNilAdaptiveRuntime()
+	}
+	var out *C.char
+	raw, err := adaptiveJSONString(C.nemo_relay_adaptive_runtime_report_json(r.ptr, &out), out)
+	if err != nil {
+		return ConfigReport{}, err
+	}
+	var report ConfigReport
+	if err := jsonUnmarshal([]byte(raw), &report); err != nil {
+		return ConfigReport{}, err
+	}
+	return report, nil
+}
+
+// BindScope binds the runtime's ACG request rewrite to an active scope.
+func (r *AdaptiveRuntime) BindScope(scope *ScopeHandle) error {
+	if r == nil || r.ptr == nil {
+		return errNilAdaptiveRuntime()
+	}
+	if scope == nil || scope.ptr == nil {
+		return errNilScopeHandle()
+	}
+	return checkStatus(C.nemo_relay_adaptive_runtime_bind_scope(
+		r.ptr,
+		(*C.FfiScopeHandle)(unsafe.Pointer(scope.ptr)),
+	))
+}
+
+// BuildCacheRequestFacts derives cache request facts from an annotated request.
+func (r *AdaptiveRuntime) BuildCacheRequestFacts(input CacheRequestFactsInput) (*CacheRequestFacts, error) {
+	if r == nil || r.ptr == nil {
+		return nil, errNilAdaptiveRuntime()
+	}
+	cOptions, err := adaptiveOptionsCString(input)
+	if err != nil {
+		return nil, err
+	}
+	defer C.free(unsafe.Pointer(cOptions))
+
+	var out *C.char
+	raw, err := adaptiveJSONString(C.nemo_relay_adaptive_runtime_build_cache_request_facts(r.ptr, cOptions, &out), out)
+	if err != nil {
+		return nil, err
+	}
+	if raw == "null" {
+		return nil, nil
+	}
+	var facts CacheRequestFacts
+	if err := jsonUnmarshal([]byte(raw), &facts); err != nil {
+		return nil, err
+	}
+	return &facts, nil
+}
+
+// BuildCacheTelemetryEvent builds one cache telemetry event from normalized usage.
+func BuildCacheTelemetryEvent(input CacheTelemetryEventInput) (*CacheTelemetryEvent, error) {
+	cOptions, err := adaptiveOptionsCString(input)
+	if err != nil {
+		return nil, err
+	}
+	defer C.free(unsafe.Pointer(cOptions))
+
+	var out *C.char
+	raw, err := adaptiveJSONString(C.nemo_relay_adaptive_build_cache_telemetry_event(cOptions, &out), out)
+	if err != nil {
+		return nil, err
+	}
+	if raw == "null" {
+		return nil, nil
+	}
+	var event CacheTelemetryEvent
+	if err := jsonUnmarshal([]byte(raw), &event); err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// SetLatencySensitivity sets manual latency sensitivity on the current scope.
+func SetLatencySensitivity(value uint32) error {
+	return checkStatus(C.nemo_relay_adaptive_set_latency_sensitivity(C.uint32_t(value)))
+}
+
+func errNilAdaptiveRuntime() error {
+	return errors.New("adaptive runtime is nil or shut down")
+}
+
+func errNilScopeHandle() error {
+	return errors.New("scope handle is nil")
+}

--- a/go/nemo_relay/adaptive_runtime_test.go
+++ b/go/nemo_relay/adaptive_runtime_test.go
@@ -37,6 +37,7 @@ func TestValidateAdaptiveConfigAndOwnedRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewAdaptiveRuntime failed: %v", err)
 	}
+	defer runtime.Shutdown()
 	if err := runtime.Register(); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}

--- a/go/nemo_relay/adaptive_runtime_test.go
+++ b/go/nemo_relay/adaptive_runtime_test.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nemo_relay
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func testAdaptiveRuntimeConfig(provider string) AdaptiveConfig {
+	config := NewAdaptiveConfig()
+	config.AgentID = "go-adaptive-" + provider
+	config.State = &AdaptiveStateConfig{
+		Backend: NewInMemoryAdaptiveBackend(),
+	}
+	config.Acg = &AcgConfig{
+		Provider: provider,
+	}
+	return config
+}
+
+func uint64Ptr(value uint64) *uint64 {
+	return &value
+}
+
+func TestValidateAdaptiveConfigAndOwnedRuntime(t *testing.T) {
+	report, err := ValidateAdaptiveConfig(NewAdaptiveConfig())
+	if err != nil {
+		t.Fatalf("ValidateAdaptiveConfig failed: %v", err)
+	}
+	if len(report.Diagnostics) != 0 {
+		t.Fatalf("expected clean report, got %#v", report.Diagnostics)
+	}
+
+	runtime, err := NewAdaptiveRuntime(NewAdaptiveConfig())
+	if err != nil {
+		t.Fatalf("NewAdaptiveRuntime failed: %v", err)
+	}
+	if err := runtime.Register(); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	runtime.WaitForIdle()
+	if report, err := runtime.Report(); err != nil || len(report.Diagnostics) != 0 {
+		t.Fatalf("unexpected runtime report: %#v err=%v", report, err)
+	}
+	if err := runtime.Deregister(); err != nil {
+		t.Fatalf("Deregister failed: %v", err)
+	}
+	if err := runtime.Shutdown(); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+}
+
+func TestBuildCacheTelemetryEvent(t *testing.T) {
+	event, err := BuildCacheTelemetryEvent(CacheTelemetryEventInput{
+		Provider:  "openai",
+		RequestID: "00000000-0000-0000-0000-000000000401",
+		Usage: &CacheUsage{
+			PromptTokens:     uint64Ptr(100),
+			CompletionTokens: uint64Ptr(10),
+			CacheReadTokens:  uint64Ptr(25),
+		},
+		AgentID:         "go-agent",
+		TemplateVersion: "v1",
+		ToolsetHash:     "tools",
+		ModelFamily:     "gpt",
+		TenantScope:     "tenant",
+		Timestamp:       "2026-06-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("BuildCacheTelemetryEvent failed: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected cache telemetry event")
+	}
+	if event.Provider != "openai" || event.CacheReadTokens != 25 || event.TotalPromptTokens != 100 || event.HitRate != 0.25 {
+		t.Fatalf("unexpected event: %#v", event)
+	}
+	if event.AgentIdentity.AgentID != "go-agent" {
+		t.Fatalf("unexpected agent identity: %#v", event.AgentIdentity)
+	}
+
+	empty, err := BuildCacheTelemetryEvent(CacheTelemetryEventInput{
+		Provider:  "openai",
+		RequestID: "00000000-0000-0000-0000-000000000402",
+		Usage: &CacheUsage{
+			CompletionTokens: uint64Ptr(10),
+		},
+		AgentID:         "go-agent",
+		TemplateVersion: "v1",
+		ToolsetHash:     "tools",
+		ModelFamily:     "gpt",
+		TenantScope:     "tenant",
+	})
+	if err != nil {
+		t.Fatalf("BuildCacheTelemetryEvent without prompt tokens failed: %v", err)
+	}
+	if empty != nil {
+		t.Fatalf("expected nil event without prompt tokens, got %#v", empty)
+	}
+}
+
+func TestAdaptiveRuntimeBuildCacheRequestFacts(t *testing.T) {
+	runtime, err := NewAdaptiveRuntime(testAdaptiveRuntimeConfig("openai"))
+	if err != nil {
+		t.Fatalf("NewAdaptiveRuntime failed: %v", err)
+	}
+	if err := runtime.Register(); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	defer func() {
+		_ = runtime.Shutdown()
+	}()
+
+	annotated, err := json.Marshal(map[string]any{
+		"messages": []map[string]any{
+			{
+				"role":    "user",
+				"content": "Find sources about caching",
+			},
+		},
+		"model": "gpt-4.1-mini",
+	})
+	if err != nil {
+		t.Fatalf("marshal annotated request: %v", err)
+	}
+
+	facts, err := runtime.BuildCacheRequestFacts(CacheRequestFactsInput{
+		Provider:         "openai",
+		RequestID:        "00000000-0000-0000-0000-000000000403",
+		AnnotatedRequest: annotated,
+		AgentID:          "go-adaptive-openai",
+	})
+	if err != nil {
+		t.Fatalf("BuildCacheRequestFacts failed: %v", err)
+	}
+	if facts == nil {
+		t.Fatal("expected cache request facts")
+	}
+	if facts.Provider != "openai" || facts.StablePrefixLength != 0 || len(facts.MissingFacts) != 1 {
+		t.Fatalf("unexpected cache request facts: %#v", facts)
+	}
+	if facts.MissingFacts[0] != "acg_stability_unavailable" {
+		t.Fatalf("unexpected missing facts: %#v", facts.MissingFacts)
+	}
+}
+
+func TestSetLatencySensitivityRejectsInvalidValue(t *testing.T) {
+	if err := SetLatencySensitivity(0); err == nil {
+		t.Fatal("expected SetLatencySensitivity(0) to fail")
+	}
+}


### PR DESCRIPTION
#### Overview

Adds adaptive runtime binding parity across Node.js, WebAssembly, and Go by exposing runtime lifecycle, telemetry, scope binding, and cache helper surfaces backed by a new FFI bridge.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds FFI adaptive runtime functions for validation, registration, deregistration, shutdown, idle wait, report, scope binding, cache request facts, telemetry events, and latency sensitivity.
- Exposes Node.js and WebAssembly `AdaptiveRuntime` APIs plus `validateConfig`, `buildCacheTelemetryEvent`, and `setLatencySensitivity`.
- Adds Go `AdaptiveRuntime` APIs and adaptive convenience-package aliases.
- Updates generated FFI header and binding tests for the new surfaces.
- Validation: `cargo fmt --all`, `cargo check -p nemo-relay-ffi -p nemo-relay-node -p nemo-relay-wasm`, `just build-go`, `just test-go`, `just test-node`, `just test-wasm`, `cargo clippy --workspace --all-targets -- -D warnings`, `just test-rust`, and `uv run pre-commit run --files <changed files...>`.

#### Where should the reviewer start?

Start with `crates/ffi/src/api/adaptive.rs` for the shared FFI contract, then review `go/nemo_relay/adaptive_runtime.go` and `crates/node/src/api/mod.rs` for the binding-facing runtime APIs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adaptive runtime support across FFI, Node.js, WebAssembly, and Go bindings
  * Exposes adaptive config validation, cache telemetry event building, and cache request facts generation from annotated requests
  * Provides full runtime lifecycle controls (register/deregister/shutdown/wait-for-idle), diagnostics reporting, scope binding, and manual latency sensitivity tuning
* **Tests**
  * Added coverage for adaptive config validation, telemetry/event/facts generation, runtime lifecycle flows, and latency sensitivity input validation (Node, WASM, and Go)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->