### PR TITLE
feat: add ATIF storage binding helpers

### DIFF
--- a/crates/wasm/tests-js/observability_tests.mjs
+++ b/crates/wasm/tests-js/observability_tests.mjs
@@ -31,6 +31,27 @@ test('WebAssembly observability wrappers expose helper defaults', () => {
   });
 });
 
+test('WebAssembly observability wrappers pass through ATIF remote storage config', () => {
+  const s3 = {
+    type: 's3',
+    bucket: 'archive',
+    key_prefix: 'runs/',
+  };
+  const http = {
+    type: 'http',
+    endpoint: 'https://example.com/atif',
+    headers: { 'x-static': 'value' },
+    header_env: { authorization: 'NEMO_RELAY_ATIF_HTTP_AUTH' },
+    timeout_millis: 1500,
+  };
+  const config = observability.atifConfig({
+    enabled: true,
+    storage: [s3, http],
+  });
+
+  assert.deepEqual(config.storage, [s3, http]);
+});
+
 test('WebAssembly observability wrappers build component specs and validate file sinks', () => {
   assert.equal(plugin.listKinds().includes(observability.OBSERVABILITY_PLUGIN_KIND), true);
 

--- a/crates/wasm/tests-js/observability_tests.mjs
+++ b/crates/wasm/tests-js/observability_tests.mjs
@@ -50,6 +50,12 @@ test('WebAssembly observability wrappers pass through ATIF remote storage config
   });
 
   assert.deepEqual(config.storage, [s3, http]);
+
+  const singleConfig = observability.atifConfig({
+    enabled: true,
+    storage: s3,
+  });
+  assert.deepEqual(singleConfig.storage, s3);
 });
 
 test('WebAssembly observability wrappers build component specs and validate file sinks', () => {

--- a/crates/wasm/wrappers/esm/observability.d.ts
+++ b/crates/wasm/wrappers/esm/observability.d.ts
@@ -21,6 +21,26 @@ export interface AtofEndpointConfig {
   timeout_millis?: number;
 }
 
+export interface S3StorageConfig {
+  type: 's3';
+  bucket: string;
+  key_prefix?: string;
+  access_key_id?: string;
+  secret_access_key_var?: string;
+  session_token_var?: string;
+  region?: string;
+  endpoint_url?: string;
+  allow_http?: boolean;
+}
+
+export interface HttpStorageConfig {
+  type: 'http';
+  endpoint: string;
+  headers?: Record<string, string>;
+  header_env?: Record<string, string>;
+  timeout_millis?: number;
+}
+
 export interface AtifConfig {
   enabled?: boolean;
   agent_name?: string;
@@ -30,6 +50,7 @@ export interface AtifConfig {
   extra?: JsonObject;
   output_directory?: string;
   filename_template?: string;
+  storage?: S3StorageConfig | HttpStorageConfig | Array<S3StorageConfig | HttpStorageConfig>;
 }
 
 export interface OtlpConfig {

--- a/go/nemo_relay/observability_plugin.go
+++ b/go/nemo_relay/observability_plugin.go
@@ -3,6 +3,8 @@
 
 package nemo_relay
 
+import "encoding/json"
+
 // ObservabilityPluginKind is the top-level plugin kind used by the core observability component.
 const ObservabilityPluginKind = "observability"
 
@@ -35,14 +37,88 @@ type ObservabilityAtofEndpoint struct {
 
 // ObservabilityAtifConfig configures per-top-level-agent ATIF file export.
 type ObservabilityAtifConfig struct {
-	Enabled          bool             `json:"enabled,omitempty"`
-	AgentName        string           `json:"agent_name,omitempty"`
-	AgentVersion     string           `json:"agent_version,omitempty"`
-	ModelName        string           `json:"model_name,omitempty"`
-	ToolDefinitions  []map[string]any `json:"tool_definitions,omitempty"`
-	Extra            map[string]any   `json:"extra,omitempty"`
-	OutputDirectory  string           `json:"output_directory,omitempty"`
-	FilenameTemplate string           `json:"filename_template,omitempty"`
+	Enabled          bool                             `json:"enabled,omitempty"`
+	AgentName        string                           `json:"agent_name,omitempty"`
+	AgentVersion     string                           `json:"agent_version,omitempty"`
+	ModelName        string                           `json:"model_name,omitempty"`
+	ToolDefinitions  []map[string]any                 `json:"tool_definitions,omitempty"`
+	Extra            map[string]any                   `json:"extra,omitempty"`
+	OutputDirectory  string                           `json:"output_directory,omitempty"`
+	FilenameTemplate string                           `json:"filename_template,omitempty"`
+	Storage          []ObservabilityAtifStorageConfig `json:"storage,omitempty"`
+}
+
+// ObservabilityAtifStorageConfig is one remote ATIF trajectory storage destination.
+type ObservabilityAtifStorageConfig interface {
+	atifStorageConfig()
+}
+
+// ObservabilityS3StorageConfig configures S3-compatible ATIF trajectory upload.
+type ObservabilityS3StorageConfig struct {
+	Bucket             string `json:"bucket"`
+	KeyPrefix          string `json:"key_prefix,omitempty"`
+	AccessKeyID        string `json:"access_key_id,omitempty"`
+	SecretAccessKeyVar string `json:"secret_access_key_var,omitempty"`
+	SessionTokenVar    string `json:"session_token_var,omitempty"`
+	Region             string `json:"region,omitempty"`
+	EndpointURL        string `json:"endpoint_url,omitempty"`
+	AllowHTTP          *bool  `json:"allow_http,omitempty"`
+}
+
+func (ObservabilityS3StorageConfig) atifStorageConfig() {}
+
+// MarshalJSON serializes the S3 config with the core plugin's fixed type discriminator.
+func (config ObservabilityS3StorageConfig) MarshalJSON() ([]byte, error) {
+	type s3StorageJSON struct {
+		Type               string `json:"type"`
+		Bucket             string `json:"bucket"`
+		KeyPrefix          string `json:"key_prefix,omitempty"`
+		AccessKeyID        string `json:"access_key_id,omitempty"`
+		SecretAccessKeyVar string `json:"secret_access_key_var,omitempty"`
+		SessionTokenVar    string `json:"session_token_var,omitempty"`
+		Region             string `json:"region,omitempty"`
+		EndpointURL        string `json:"endpoint_url,omitempty"`
+		AllowHTTP          *bool  `json:"allow_http,omitempty"`
+	}
+	return json.Marshal(s3StorageJSON{
+		Type:               "s3",
+		Bucket:             config.Bucket,
+		KeyPrefix:          config.KeyPrefix,
+		AccessKeyID:        config.AccessKeyID,
+		SecretAccessKeyVar: config.SecretAccessKeyVar,
+		SessionTokenVar:    config.SessionTokenVar,
+		Region:             config.Region,
+		EndpointURL:        config.EndpointURL,
+		AllowHTTP:          config.AllowHTTP,
+	})
+}
+
+// ObservabilityHttpStorageConfig configures HTTP ATIF trajectory upload.
+type ObservabilityHttpStorageConfig struct {
+	Endpoint      string            `json:"endpoint"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	HeaderEnv     map[string]string `json:"header_env,omitempty"`
+	TimeoutMillis uint64            `json:"timeout_millis,omitempty"`
+}
+
+func (ObservabilityHttpStorageConfig) atifStorageConfig() {}
+
+// MarshalJSON serializes the HTTP config with the core plugin's fixed type discriminator.
+func (config ObservabilityHttpStorageConfig) MarshalJSON() ([]byte, error) {
+	type httpStorageJSON struct {
+		Type          string            `json:"type"`
+		Endpoint      string            `json:"endpoint"`
+		Headers       map[string]string `json:"headers,omitempty"`
+		HeaderEnv     map[string]string `json:"header_env,omitempty"`
+		TimeoutMillis uint64            `json:"timeout_millis,omitempty"`
+	}
+	return json.Marshal(httpStorageJSON{
+		Type:          "http",
+		Endpoint:      config.Endpoint,
+		Headers:       config.Headers,
+		HeaderEnv:     config.HeaderEnv,
+		TimeoutMillis: config.TimeoutMillis,
+	})
 }
 
 // ObservabilityOtlpConfig configures OpenTelemetry or OpenInference OTLP export.
@@ -84,6 +160,16 @@ func NewObservabilityAtifConfig() ObservabilityAtifConfig {
 		ModelName:        "unknown",
 		FilenameTemplate: "nemo-relay-atif-{session_id}.json",
 	}
+}
+
+// NewObservabilityS3StorageConfig returns an S3-compatible ATIF storage destination.
+func NewObservabilityS3StorageConfig(bucket string) ObservabilityS3StorageConfig {
+	return ObservabilityS3StorageConfig{Bucket: bucket}
+}
+
+// NewObservabilityHttpStorageConfig returns an HTTP ATIF storage destination.
+func NewObservabilityHttpStorageConfig(endpoint string) ObservabilityHttpStorageConfig {
+	return ObservabilityHttpStorageConfig{Endpoint: endpoint}
 }
 
 // NewObservabilityOtlpConfig returns disabled OTLP settings with core defaults.

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -67,6 +67,26 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 		httpStorage.TimeoutMillis != 1500 {
 		t.Fatalf("unexpected HTTP constructor values: %#v", httpStorage)
 	}
+	s3Serialized := marshalStorageConfig(t, s3Storage)
+	if s3Serialized["type"] != "s3" ||
+		s3Serialized["bucket"] != "archive" ||
+		s3Serialized["key_prefix"] != "runs/" ||
+		s3Serialized["access_key_id"] != "test-access-key" ||
+		s3Serialized["secret_access_key_var"] != "NEMO_RELAY_TEST_SECRET" ||
+		s3Serialized["region"] != "us-west-2" ||
+		s3Serialized["allow_http"] != false {
+		t.Fatalf("unexpected serialized S3 storage config: %#v", s3Serialized)
+	}
+	httpSerialized := marshalStorageConfig(t, httpStorage)
+	httpHeaders := httpSerialized["headers"].(map[string]any)
+	httpHeaderEnv := httpSerialized["header_env"].(map[string]any)
+	if httpSerialized["type"] != "http" ||
+		httpSerialized["endpoint"] != "https://example.com/atif" ||
+		httpSerialized["timeout_millis"] != float64(1500) ||
+		httpHeaders["x-static"] != "value" ||
+		httpHeaderEnv["authorization"] != "NEMO_RELAY_ATIF_HTTP_AUTH" {
+		t.Fatalf("unexpected serialized HTTP storage config: %#v", httpSerialized)
+	}
 	atif.Storage = []ObservabilityAtifStorageConfig{
 		s3Storage,
 		httpStorage,
@@ -102,6 +122,19 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 	if http["type"] != "http" || http["endpoint"] != "https://example.com/atif" || http["timeout_millis"] != float64(1500) {
 		t.Fatalf("unexpected HTTP storage config: %#v", http)
 	}
+}
+
+func marshalStorageConfig(t *testing.T, config ObservabilityAtifStorageConfig) map[string]any {
+	t.Helper()
+	payload, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal storage config: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		t.Fatalf("unmarshal storage config: %v", err)
+	}
+	return parsed
 }
 
 func TestObservabilityPluginAtofAndAtifFiles(t *testing.T) {

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -42,21 +42,34 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 		t.Fatalf("unexpected ATIF defaults: %#v", atif)
 	}
 	allowHTTP := false
+	s3Storage := NewObservabilityS3StorageConfig("archive")
+	s3Storage.KeyPrefix = "runs/"
+	s3Storage.AccessKeyID = "test-access-key"
+	s3Storage.SecretAccessKeyVar = "NEMO_RELAY_TEST_SECRET"
+	s3Storage.Region = "us-west-2"
+	s3Storage.AllowHTTP = &allowHTTP
+	httpStorage := NewObservabilityHttpStorageConfig("https://example.com/atif")
+	httpStorage.Headers = map[string]string{"x-static": "value"}
+	httpStorage.HeaderEnv = map[string]string{"authorization": "NEMO_RELAY_ATIF_HTTP_AUTH"}
+	httpStorage.TimeoutMillis = 1500
+	if s3Storage.Bucket != "archive" ||
+		s3Storage.KeyPrefix != "runs/" ||
+		s3Storage.AccessKeyID != "test-access-key" ||
+		s3Storage.SecretAccessKeyVar != "NEMO_RELAY_TEST_SECRET" ||
+		s3Storage.Region != "us-west-2" ||
+		s3Storage.AllowHTTP == nil ||
+		*s3Storage.AllowHTTP {
+		t.Fatalf("unexpected S3 constructor values: %#v", s3Storage)
+	}
+	if httpStorage.Endpoint != "https://example.com/atif" ||
+		httpStorage.Headers["x-static"] != "value" ||
+		httpStorage.HeaderEnv["authorization"] != "NEMO_RELAY_ATIF_HTTP_AUTH" ||
+		httpStorage.TimeoutMillis != 1500 {
+		t.Fatalf("unexpected HTTP constructor values: %#v", httpStorage)
+	}
 	atif.Storage = []ObservabilityAtifStorageConfig{
-		ObservabilityS3StorageConfig{
-			Bucket:             "archive",
-			KeyPrefix:          "runs/",
-			AccessKeyID:        "test-access-key",
-			SecretAccessKeyVar: "NEMO_RELAY_TEST_SECRET",
-			Region:             "us-west-2",
-			AllowHTTP:          &allowHTTP,
-		},
-		ObservabilityHttpStorageConfig{
-			Endpoint:      "https://example.com/atif",
-			Headers:       map[string]string{"x-static": "value"},
-			HeaderEnv:     map[string]string{"authorization": "NEMO_RELAY_ATIF_HTTP_AUTH"},
-			TimeoutMillis: 1500,
-		},
+		s3Storage,
+		httpStorage,
 	}
 	otlp := NewObservabilityOtlpConfig()
 	if otlp.Enabled || otlp.Transport != "http_binary" || otlp.ServiceName != "nemo-relay" || otlp.TimeoutMillis != 3000 {

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -41,12 +41,30 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 	if atif.Enabled || atif.AgentName != "NeMo Relay" || atif.ModelName != "unknown" || atif.FilenameTemplate != "nemo-relay-atif-{session_id}.json" {
 		t.Fatalf("unexpected ATIF defaults: %#v", atif)
 	}
+	allowHTTP := false
+	atif.Storage = []ObservabilityAtifStorageConfig{
+		ObservabilityS3StorageConfig{
+			Bucket:             "archive",
+			KeyPrefix:          "runs/",
+			AccessKeyID:        "test-access-key",
+			SecretAccessKeyVar: "NEMO_RELAY_TEST_SECRET",
+			Region:             "us-west-2",
+			AllowHTTP:          &allowHTTP,
+		},
+		ObservabilityHttpStorageConfig{
+			Endpoint:      "https://example.com/atif",
+			Headers:       map[string]string{"x-static": "value"},
+			HeaderEnv:     map[string]string{"authorization": "NEMO_RELAY_ATIF_HTTP_AUTH"},
+			TimeoutMillis: 1500,
+		},
+	}
 	otlp := NewObservabilityOtlpConfig()
 	if otlp.Enabled || otlp.Transport != "http_binary" || otlp.ServiceName != "nemo-relay" || otlp.TimeoutMillis != 3000 {
 		t.Fatalf("unexpected OTLP defaults: %#v", otlp)
 	}
 
 	config.Atof = &atof
+	config.Atif = &atif
 	wrapped := ObservabilityComponent(config)
 	if wrapped.Kind != ObservabilityPluginKind || !wrapped.Enabled {
 		t.Fatalf("unexpected component wrapper: %#v", wrapped)
@@ -57,6 +75,19 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 	atofConfig := wrapped.Config["atof"].(map[string]any)
 	if _, ok := atofConfig["endpoints"].([]any); !ok {
 		t.Fatalf("expected serialized ATOF endpoints, got %#v", atofConfig)
+	}
+	atifConfig := wrapped.Config["atif"].(map[string]any)
+	storage := atifConfig["storage"].([]any)
+	if len(storage) != 2 {
+		t.Fatalf("expected two ATIF storage destinations, got %#v", storage)
+	}
+	s3 := storage[0].(map[string]any)
+	if s3["type"] != "s3" || s3["bucket"] != "archive" || s3["key_prefix"] != "runs/" || s3["allow_http"] != false {
+		t.Fatalf("unexpected S3 storage config: %#v", s3)
+	}
+	http := storage[1].(map[string]any)
+	if http["type"] != "http" || http["endpoint"] != "https://example.com/atif" || http["timeout_millis"] != float64(1500) {
+		t.Fatalf("unexpected HTTP storage config: %#v", http)
 	}
 }
 


### PR DESCRIPTION
#### Overview

Adds typed binding support for ATIF remote storage helper configuration so Go and WebAssembly callers can configure S3 and HTTP storage without hand-writing discriminator objects.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds Go `ObservabilityAtifStorageConfig` typed helpers for S3 and HTTP storage with fixed JSON `type` discriminators.
- Adds WebAssembly TypeScript declarations for `S3StorageConfig`, `HttpStorageConfig`, and `AtifConfig.storage`.
- Extends Go and WebAssembly tests to cover mixed ATIF storage config serialization.
- Validation: `just test-go`, `just test-wasm`, and `uv run pre-commit run --files <changed files...>`.

#### Where should the reviewer start?

Start with `go/nemo_relay/observability_plugin.go` for the Go helper shape, then `crates/wasm/wrappers/esm/observability.d.ts` for the WebAssembly declaration parity.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observability plugin now supports configuring ATIF storage backends for S3 and HTTP destinations.
  * Multiple mixed storage backends can be provided in a single configuration.

* **Type Updates**
  * Updated ESM public type definitions to add optional `storage` support for S3/HTTP (single or array forms).

* **Tests**
  * Added Node.js test coverage to verify provided storage configuration is forwarded unchanged (single object and array forms).
  * Extended Go tests to validate correct serialization of S3 and HTTP storage entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->