### PR TITLE
feat: add Go PII redaction helpers

### DIFF
--- a/go/nemo_relay/pii_redaction.go
+++ b/go/nemo_relay/pii_redaction.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nemo_relay
+
+// PiiRedactionPluginKind is the top-level plugin kind used by the built-in PII redaction component.
+const PiiRedactionPluginKind = "pii_redaction"
+
+// PiiRedactionBuiltinConfig configures deterministic built-in redaction.
+type PiiRedactionBuiltinConfig struct {
+	Action         string   `json:"action,omitempty"`
+	TargetPaths    []string `json:"target_paths,omitempty"`
+	Pattern        string   `json:"pattern,omitempty"`
+	Detector       string   `json:"detector,omitempty"`
+	Replacement    string   `json:"replacement,omitempty"`
+	MaskChar       string   `json:"mask_char,omitempty"`
+	UnmaskedPrefix *int32   `json:"unmasked_prefix,omitempty"`
+	UnmaskedSuffix *int32   `json:"unmasked_suffix,omitempty"`
+}
+
+// PiiRedactionLocalModelConfig configures the future local-model redaction backend.
+type PiiRedactionLocalModelConfig struct {
+	Backend         string `json:"backend,omitempty"`
+	ModelID         string `json:"model_id,omitempty"`
+	DetectorProfile string `json:"detector_profile,omitempty"`
+	AllowNetwork    *bool  `json:"allow_network,omitempty"`
+	MaxLatencyMS    *int32 `json:"max_latency_ms,omitempty"`
+}
+
+// PiiRedactionConfig is the canonical Go shape for the PII redaction plugin config document.
+type PiiRedactionConfig struct {
+	Version    uint32                        `json:"version,omitempty"`
+	Mode       string                        `json:"mode,omitempty"`
+	Input      bool                          `json:"input"`
+	Output     bool                          `json:"output"`
+	ToolInput  bool                          `json:"tool_input"`
+	ToolOutput bool                          `json:"tool_output"`
+	Priority   int32                         `json:"priority,omitempty"`
+	Codec      string                        `json:"codec,omitempty"`
+	Builtin    *PiiRedactionBuiltinConfig    `json:"builtin,omitempty"`
+	Local      *PiiRedactionLocalModelConfig `json:"local,omitempty"`
+	Policy     *ConfigPolicy                 `json:"policy,omitempty"`
+}
+
+// PiiRedactionComponentSpec wraps one PII redaction config as a top-level plugin component.
+type PiiRedactionComponentSpec struct {
+	Enabled bool               `json:"enabled,omitempty"`
+	Config  PiiRedactionConfig `json:"config"`
+}
+
+// NewPiiRedactionConfig returns a default PII redaction config with version 1.
+func NewPiiRedactionConfig() PiiRedactionConfig {
+	return PiiRedactionConfig{
+		Version:    1,
+		Mode:       "builtin",
+		Input:      true,
+		Output:     true,
+		ToolInput:  true,
+		ToolOutput: true,
+		Priority:   100,
+	}
+}
+
+// NewPiiRedactionBuiltinConfig returns default built-in redaction settings.
+func NewPiiRedactionBuiltinConfig() PiiRedactionBuiltinConfig {
+	return PiiRedactionBuiltinConfig{
+		Action:      "remove",
+		TargetPaths: []string{},
+	}
+}
+
+// NewPiiRedactionLocalModelConfig returns default local-model redaction settings.
+func NewPiiRedactionLocalModelConfig() PiiRedactionLocalModelConfig {
+	return PiiRedactionLocalModelConfig{}
+}
+
+// NewPiiRedactionComponentSpec wraps PII redaction config as an enabled component.
+func NewPiiRedactionComponentSpec(config PiiRedactionConfig) PiiRedactionComponentSpec {
+	return PiiRedactionComponentSpec{
+		Enabled: true,
+		Config:  config,
+	}
+}
+
+// PluginComponent converts the PII redaction wrapper into the shared plugin shape.
+func (spec PiiRedactionComponentSpec) PluginComponent() PluginComponentSpec {
+	return PluginComponentSpec{
+		Kind:    PiiRedactionPluginKind,
+		Enabled: spec.Enabled,
+		Config:  mustConfigMap(spec.Config),
+	}
+}
+
+// PiiRedactionComponent converts PII redaction config directly into a shared plugin component.
+func PiiRedactionComponent(config PiiRedactionConfig) PluginComponentSpec {
+	return NewPiiRedactionComponentSpec(config).PluginComponent()
+}
+
+// ValidatePiiRedactionConfig validates a PII redaction config without activating it.
+func ValidatePiiRedactionConfig(config PiiRedactionConfig) (ConfigReport, error) {
+	return ValidatePluginConfig(PluginConfig{
+		Version:    1,
+		Components: []PluginComponentSpec{PiiRedactionComponent(config)},
+	})
+}

--- a/go/nemo_relay/pii_redaction.go
+++ b/go/nemo_relay/pii_redaction.go
@@ -50,6 +50,7 @@ type PiiRedactionComponentSpec struct {
 
 // NewPiiRedactionConfig returns a default PII redaction config with version 1.
 func NewPiiRedactionConfig() PiiRedactionConfig {
+	builtin := NewPiiRedactionBuiltinConfig()
 	return PiiRedactionConfig{
 		Version:    1,
 		Mode:       "builtin",
@@ -58,6 +59,7 @@ func NewPiiRedactionConfig() PiiRedactionConfig {
 		ToolInput:  true,
 		ToolOutput: true,
 		Priority:   100,
+		Builtin:    &builtin,
 	}
 }
 

--- a/go/nemo_relay/pii_redaction/pii_redaction.go
+++ b/go/nemo_relay/pii_redaction/pii_redaction.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package pii_redaction
+
+import nemo_relay "github.com/NVIDIA/NeMo-Relay/go/nemo_relay"
+
+// Config is the canonical PII redaction config document.
+type Config = nemo_relay.PiiRedactionConfig
+
+// BuiltinConfig configures deterministic built-in redaction.
+type BuiltinConfig = nemo_relay.PiiRedactionBuiltinConfig
+
+// LocalModelConfig configures the future local-model redaction backend.
+type LocalModelConfig = nemo_relay.PiiRedactionLocalModelConfig
+
+// ComponentSpec wraps PII redaction config as a top-level plugin component.
+type ComponentSpec = nemo_relay.PiiRedactionComponentSpec
+
+// ConfigPolicy controls how PII redaction validation handles unsupported input.
+type ConfigPolicy = nemo_relay.ConfigPolicy
+
+// ConfigReport is the validation report returned by PII redaction helpers.
+type ConfigReport = nemo_relay.ConfigReport
+
+// PluginKind is the top-level plugin kind used by the PII redaction component.
+const PluginKind = nemo_relay.PiiRedactionPluginKind
+
+// NewConfig returns a default PII redaction config with version 1.
+func NewConfig() Config {
+	return nemo_relay.NewPiiRedactionConfig()
+}
+
+// NewBuiltinConfig returns default built-in redaction settings.
+func NewBuiltinConfig() BuiltinConfig {
+	return nemo_relay.NewPiiRedactionBuiltinConfig()
+}
+
+// NewLocalModelConfig returns default local-model redaction settings.
+func NewLocalModelConfig() LocalModelConfig {
+	return nemo_relay.NewPiiRedactionLocalModelConfig()
+}
+
+// NewComponentSpec wraps PII redaction config as an enabled component.
+func NewComponentSpec(config Config) ComponentSpec {
+	return nemo_relay.NewPiiRedactionComponentSpec(config)
+}
+
+// Component converts PII redaction config directly into the shared plugin shape.
+func Component(config Config) nemo_relay.PluginComponentSpec {
+	return nemo_relay.PiiRedactionComponent(config)
+}
+
+// ValidateConfig validates a PII redaction config without activating it.
+func ValidateConfig(config Config) (ConfigReport, error) {
+	return nemo_relay.ValidatePiiRedactionConfig(config)
+}

--- a/go/nemo_relay/pii_redaction/pii_redaction_test.go
+++ b/go/nemo_relay/pii_redaction/pii_redaction_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package pii_redaction
+
+import "testing"
+
+func TestPiiRedactionShorthandHelpers(t *testing.T) {
+	config := NewConfig()
+	config.Codec = "openai_chat"
+	builtin := NewBuiltinConfig()
+	config.Builtin = &builtin
+
+	component := Component(config)
+	if component.Kind != PluginKind || !component.Enabled {
+		t.Fatalf("unexpected PII redaction component: %#v", component)
+	}
+	report, err := ValidateConfig(config)
+	if err != nil {
+		t.Fatalf("ValidateConfig failed: %v", err)
+	}
+	if len(report.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", report.Diagnostics)
+	}
+}

--- a/go/nemo_relay/pii_redaction_test.go
+++ b/go/nemo_relay/pii_redaction_test.go
@@ -10,6 +10,9 @@ func TestPiiRedactionConfigHelpers(t *testing.T) {
 	if config.Version != 1 || config.Mode != "builtin" || !config.Input || !config.Output || !config.ToolInput || !config.ToolOutput || config.Priority != 100 {
 		t.Fatalf("unexpected PII redaction defaults: %#v", config)
 	}
+	if config.Builtin == nil || config.Builtin.Action != "remove" || len(config.Builtin.TargetPaths) != 0 {
+		t.Fatalf("unexpected default built-in redaction config: %#v", config.Builtin)
+	}
 	builtin := NewPiiRedactionBuiltinConfig()
 	if builtin.Action != "remove" || len(builtin.TargetPaths) != 0 {
 		t.Fatalf("unexpected built-in redaction defaults: %#v", builtin)

--- a/go/nemo_relay/pii_redaction_test.go
+++ b/go/nemo_relay/pii_redaction_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nemo_relay
+
+import "testing"
+
+func TestPiiRedactionConfigHelpers(t *testing.T) {
+	config := NewPiiRedactionConfig()
+	if config.Version != 1 || config.Mode != "builtin" || !config.Input || !config.Output || !config.ToolInput || !config.ToolOutput || config.Priority != 100 {
+		t.Fatalf("unexpected PII redaction defaults: %#v", config)
+	}
+	builtin := NewPiiRedactionBuiltinConfig()
+	if builtin.Action != "remove" || len(builtin.TargetPaths) != 0 {
+		t.Fatalf("unexpected built-in redaction defaults: %#v", builtin)
+	}
+	local := NewPiiRedactionLocalModelConfig()
+	if local != (PiiRedactionLocalModelConfig{}) {
+		t.Fatalf("unexpected local model defaults: %#v", local)
+	}
+
+	config.Builtin = &builtin
+	component := PiiRedactionComponent(config)
+	if component.Kind != PiiRedactionPluginKind || !component.Enabled {
+		t.Fatalf("unexpected PII redaction component: %#v", component)
+	}
+	if component.Config["mode"] != "builtin" || component.Config["priority"] != float64(100) {
+		t.Fatalf("unexpected serialized config: %#v", component.Config)
+	}
+	serializedBuiltin, ok := component.Config["builtin"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected serialized builtin object, got %#v", component.Config["builtin"])
+	}
+	if serializedBuiltin["action"] != "remove" {
+		t.Fatalf("unexpected serialized builtin config: %#v", serializedBuiltin)
+	}
+}
+
+func TestPiiRedactionValidationRejectsBadValues(t *testing.T) {
+	config := NewPiiRedactionConfig()
+	config.Input = false
+	config.Output = false
+	builtin := NewPiiRedactionBuiltinConfig()
+	builtin.Action = "mask"
+	builtin.Detector = "not_a_detector"
+	config.Builtin = &builtin
+
+	report, err := ValidatePiiRedactionConfig(config)
+	if err != nil {
+		t.Fatalf("ValidatePiiRedactionConfig failed: %v", err)
+	}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Field != nil && *diagnostic.Field == "builtin.detector" {
+			return
+		}
+	}
+	t.Fatalf("expected builtin.detector diagnostic, got %#v", report.Diagnostics)
+}
+
+func TestPiiRedactionListKindIsAutomatic(t *testing.T) {
+	kinds, err := ListPluginKinds()
+	if err != nil {
+		t.Fatalf("ListPluginKinds failed: %v", err)
+	}
+	for _, kind := range kinds {
+		if kind == PiiRedactionPluginKind {
+			return
+		}
+	}
+	t.Fatalf("expected %q in registered kinds: %#v", PiiRedactionPluginKind, kinds)
+}


### PR DESCRIPTION
#### Overview

Adds Go PII redaction helper parity for the existing built-in plugin, including a top-level API and convenience subpackage.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds top-level Go PII redaction config structs, constructors, component helper, and validation helper.
- Adds `go/nemo_relay/pii_redaction` convenience package mirroring the existing Go helper style.
- Preserves documented defaults: builtin mode, all input/output flags enabled, priority 100, builtin remove action, and `pii_redaction` plugin kind.
- Validation: `just test-go` and `uv run pre-commit run --files <changed files...>`.

#### Where should the reviewer start?

Start with `go/nemo_relay/pii_redaction.go` for the public helper API and `go/nemo_relay/pii_redaction/pii_redaction.go` for the convenience package aliases.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PII redaction plugin configuration support, including an explicit plugin kind for easy identification.
  * Provided helper constructors to create default built-in and local-model redaction configurations and wrap them into enabled component specifications.
  * Added configuration validation to report setup issues early.
* **Tests**
  * Added unit tests covering shorthand helpers, default values, config serialization, and validation diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->