### PR TITLE
chore: address current Sonar findings

### DIFF
--- a/crates/wasm/wrappers/esm/adaptive.js
+++ b/crates/wasm/wrappers/esm/adaptive.js
@@ -3,14 +3,13 @@
 
 import * as plugin from './plugin.js';
 import {
-  AdaptiveRuntime,
   buildCacheTelemetryEvent as nativeBuildCacheTelemetryEvent,
   setLatencySensitivity as nativeSetLatencySensitivity,
   validateAdaptiveConfig,
 } from './pkg/index.js';
 
 export const ADAPTIVE_PLUGIN_KIND = 'adaptive';
-export { AdaptiveRuntime };
+export { AdaptiveRuntime } from './pkg/index.js';
 
 /**
  * Create a default adaptive component config.

--- a/go/nemo_relay/adaptive_runtime_test.go
+++ b/go/nemo_relay/adaptive_runtime_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+const testAgentID = "go-agent"
+
 func testAdaptiveRuntimeConfig(provider string) AdaptiveConfig {
 	config := NewAdaptiveConfig()
 	config.AgentID = "go-adaptive-" + provider
@@ -62,7 +64,7 @@ func TestBuildCacheTelemetryEvent(t *testing.T) {
 			CompletionTokens: uint64Ptr(10),
 			CacheReadTokens:  uint64Ptr(25),
 		},
-		AgentID:         "go-agent",
+		AgentID:         testAgentID,
 		TemplateVersion: "v1",
 		ToolsetHash:     "tools",
 		ModelFamily:     "gpt",
@@ -78,7 +80,7 @@ func TestBuildCacheTelemetryEvent(t *testing.T) {
 	if event.Provider != "openai" || event.CacheReadTokens != 25 || event.TotalPromptTokens != 100 || event.HitRate != 0.25 {
 		t.Fatalf("unexpected event: %#v", event)
 	}
-	if event.AgentIdentity.AgentID != "go-agent" {
+	if event.AgentIdentity.AgentID != testAgentID {
 		t.Fatalf("unexpected agent identity: %#v", event.AgentIdentity)
 	}
 
@@ -88,7 +90,7 @@ func TestBuildCacheTelemetryEvent(t *testing.T) {
 		Usage: &CacheUsage{
 			CompletionTokens: uint64Ptr(10),
 		},
-		AgentID:         "go-agent",
+		AgentID:         testAgentID,
 		TemplateVersion: "v1",
 		ToolsetHash:     "tools",
 		ModelFamily:     "gpt",
@@ -148,7 +150,7 @@ func TestAdaptiveRuntimeBuildCacheRequestFacts(t *testing.T) {
 }
 
 func TestSetLatencySensitivityRejectsInvalidValue(t *testing.T) {
-	if err := SetLatencySensitivity(0); err == nil {
+	if SetLatencySensitivity(0) == nil {
 		t.Fatal("expected SetLatencySensitivity(0) to fail")
 	}
 }

--- a/go/nemo_relay/observability_plugin.go
+++ b/go/nemo_relay/observability_plugin.go
@@ -37,19 +37,19 @@ type ObservabilityAtofEndpoint struct {
 
 // ObservabilityAtifConfig configures per-top-level-agent ATIF file export.
 type ObservabilityAtifConfig struct {
-	Enabled          bool                             `json:"enabled,omitempty"`
-	AgentName        string                           `json:"agent_name,omitempty"`
-	AgentVersion     string                           `json:"agent_version,omitempty"`
-	ModelName        string                           `json:"model_name,omitempty"`
-	ToolDefinitions  []map[string]any                 `json:"tool_definitions,omitempty"`
-	Extra            map[string]any                   `json:"extra,omitempty"`
-	OutputDirectory  string                           `json:"output_directory,omitempty"`
-	FilenameTemplate string                           `json:"filename_template,omitempty"`
-	Storage          []ObservabilityAtifStorageConfig `json:"storage,omitempty"`
+	Enabled          bool                                 `json:"enabled,omitempty"`
+	AgentName        string                               `json:"agent_name,omitempty"`
+	AgentVersion     string                               `json:"agent_version,omitempty"`
+	ModelName        string                               `json:"model_name,omitempty"`
+	ToolDefinitions  []map[string]any                     `json:"tool_definitions,omitempty"`
+	Extra            map[string]any                       `json:"extra,omitempty"`
+	OutputDirectory  string                               `json:"output_directory,omitempty"`
+	FilenameTemplate string                               `json:"filename_template,omitempty"`
+	Storage          []ObservabilityAtifStorageConfigurer `json:"storage,omitempty"`
 }
 
-// ObservabilityAtifStorageConfig is one remote ATIF trajectory storage destination.
-type ObservabilityAtifStorageConfig interface {
+// ObservabilityAtifStorageConfigurer is one remote ATIF trajectory storage destination.
+type ObservabilityAtifStorageConfigurer interface {
 	atifStorageConfig()
 }
 
@@ -65,7 +65,9 @@ type ObservabilityS3StorageConfig struct {
 	AllowHTTP          *bool  `json:"allow_http,omitempty"`
 }
 
-func (ObservabilityS3StorageConfig) atifStorageConfig() {}
+func (ObservabilityS3StorageConfig) atifStorageConfig() {
+	// Marker method: S3 storage is serialized by MarshalJSON.
+}
 
 // MarshalJSON serializes the S3 config with the core plugin's fixed type discriminator.
 func (config ObservabilityS3StorageConfig) MarshalJSON() ([]byte, error) {
@@ -101,7 +103,9 @@ type ObservabilityHttpStorageConfig struct {
 	TimeoutMillis uint64            `json:"timeout_millis,omitempty"`
 }
 
-func (ObservabilityHttpStorageConfig) atifStorageConfig() {}
+func (ObservabilityHttpStorageConfig) atifStorageConfig() {
+	// Marker method: HTTP storage is serialized by MarshalJSON.
+}
 
 // MarshalJSON serializes the HTTP config with the core plugin's fixed type discriminator.
 func (config ObservabilityHttpStorageConfig) MarshalJSON() ([]byte, error) {

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -18,6 +18,10 @@ const (
 	FirstAgentName                 = "go-first-agent"
 	NestedAgentName                = "go-nested-agent"
 	SecondAgentName                = "go-second-agent"
+	testAccessKeyID                = "test-access-key"
+	testAtifEndpoint               = "https://example.com/atif"
+	testRegion                     = "us-west-2"
+	testStaticHeader               = "x-static"
 	fatalErrorFormat               = "%s: %v"
 	failedSuffix                   = " failed"
 )
@@ -44,50 +48,17 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 	allowHTTP := false
 	s3Storage := NewObservabilityS3StorageConfig("archive")
 	s3Storage.KeyPrefix = "runs/"
-	s3Storage.AccessKeyID = "test-access-key"
+	s3Storage.AccessKeyID = testAccessKeyID
 	s3Storage.SecretAccessKeyVar = "NEMO_RELAY_TEST_SECRET"
-	s3Storage.Region = "us-west-2"
+	s3Storage.Region = testRegion
 	s3Storage.AllowHTTP = &allowHTTP
-	httpStorage := NewObservabilityHttpStorageConfig("https://example.com/atif")
-	httpStorage.Headers = map[string]string{"x-static": "value"}
+	httpStorage := NewObservabilityHttpStorageConfig(testAtifEndpoint)
+	httpStorage.Headers = map[string]string{testStaticHeader: "value"}
 	httpStorage.HeaderEnv = map[string]string{"authorization": "NEMO_RELAY_ATIF_HTTP_AUTH"}
 	httpStorage.TimeoutMillis = 1500
-	if s3Storage.Bucket != "archive" ||
-		s3Storage.KeyPrefix != "runs/" ||
-		s3Storage.AccessKeyID != "test-access-key" ||
-		s3Storage.SecretAccessKeyVar != "NEMO_RELAY_TEST_SECRET" ||
-		s3Storage.Region != "us-west-2" ||
-		s3Storage.AllowHTTP == nil ||
-		*s3Storage.AllowHTTP {
-		t.Fatalf("unexpected S3 constructor values: %#v", s3Storage)
-	}
-	if httpStorage.Endpoint != "https://example.com/atif" ||
-		httpStorage.Headers["x-static"] != "value" ||
-		httpStorage.HeaderEnv["authorization"] != "NEMO_RELAY_ATIF_HTTP_AUTH" ||
-		httpStorage.TimeoutMillis != 1500 {
-		t.Fatalf("unexpected HTTP constructor values: %#v", httpStorage)
-	}
-	s3Serialized := marshalStorageConfig(t, s3Storage)
-	if s3Serialized["type"] != "s3" ||
-		s3Serialized["bucket"] != "archive" ||
-		s3Serialized["key_prefix"] != "runs/" ||
-		s3Serialized["access_key_id"] != "test-access-key" ||
-		s3Serialized["secret_access_key_var"] != "NEMO_RELAY_TEST_SECRET" ||
-		s3Serialized["region"] != "us-west-2" ||
-		s3Serialized["allow_http"] != false {
-		t.Fatalf("unexpected serialized S3 storage config: %#v", s3Serialized)
-	}
-	httpSerialized := marshalStorageConfig(t, httpStorage)
-	httpHeaders := httpSerialized["headers"].(map[string]any)
-	httpHeaderEnv := httpSerialized["header_env"].(map[string]any)
-	if httpSerialized["type"] != "http" ||
-		httpSerialized["endpoint"] != "https://example.com/atif" ||
-		httpSerialized["timeout_millis"] != float64(1500) ||
-		httpHeaders["x-static"] != "value" ||
-		httpHeaderEnv["authorization"] != "NEMO_RELAY_ATIF_HTTP_AUTH" {
-		t.Fatalf("unexpected serialized HTTP storage config: %#v", httpSerialized)
-	}
-	atif.Storage = []ObservabilityAtifStorageConfig{
+	assertS3StorageConfig(t, s3Storage)
+	assertHTTPStorageConfig(t, httpStorage)
+	atif.Storage = []ObservabilityAtifStorageConfigurer{
 		s3Storage,
 		httpStorage,
 	}
@@ -109,7 +80,56 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 	if _, ok := atofConfig["endpoints"].([]any); !ok {
 		t.Fatalf("expected serialized ATOF endpoints, got %#v", atofConfig)
 	}
-	atifConfig := wrapped.Config["atif"].(map[string]any)
+	assertWrappedAtifStorageConfig(t, wrapped.Config["atif"].(map[string]any))
+}
+
+func assertS3StorageConfig(t *testing.T, storage ObservabilityS3StorageConfig) {
+	t.Helper()
+	if storage.Bucket != "archive" ||
+		storage.KeyPrefix != "runs/" ||
+		storage.AccessKeyID != testAccessKeyID ||
+		storage.SecretAccessKeyVar != "NEMO_RELAY_TEST_SECRET" ||
+		storage.Region != testRegion ||
+		storage.AllowHTTP == nil ||
+		*storage.AllowHTTP {
+		t.Fatalf("unexpected S3 constructor values: %#v", storage)
+	}
+
+	serialized := marshalStorageConfig(t, storage)
+	if serialized["type"] != "s3" ||
+		serialized["bucket"] != "archive" ||
+		serialized["key_prefix"] != "runs/" ||
+		serialized["access_key_id"] != testAccessKeyID ||
+		serialized["secret_access_key_var"] != "NEMO_RELAY_TEST_SECRET" ||
+		serialized["region"] != testRegion ||
+		serialized["allow_http"] != false {
+		t.Fatalf("unexpected serialized S3 storage config: %#v", serialized)
+	}
+}
+
+func assertHTTPStorageConfig(t *testing.T, storage ObservabilityHttpStorageConfig) {
+	t.Helper()
+	if storage.Endpoint != testAtifEndpoint ||
+		storage.Headers[testStaticHeader] != "value" ||
+		storage.HeaderEnv["authorization"] != "NEMO_RELAY_ATIF_HTTP_AUTH" ||
+		storage.TimeoutMillis != 1500 {
+		t.Fatalf("unexpected HTTP constructor values: %#v", storage)
+	}
+
+	serialized := marshalStorageConfig(t, storage)
+	headers := serialized["headers"].(map[string]any)
+	headerEnv := serialized["header_env"].(map[string]any)
+	if serialized["type"] != "http" ||
+		serialized["endpoint"] != testAtifEndpoint ||
+		serialized["timeout_millis"] != float64(1500) ||
+		headers[testStaticHeader] != "value" ||
+		headerEnv["authorization"] != "NEMO_RELAY_ATIF_HTTP_AUTH" {
+		t.Fatalf("unexpected serialized HTTP storage config: %#v", serialized)
+	}
+}
+
+func assertWrappedAtifStorageConfig(t *testing.T, atifConfig map[string]any) {
+	t.Helper()
 	storage := atifConfig["storage"].([]any)
 	if len(storage) != 2 {
 		t.Fatalf("expected two ATIF storage destinations, got %#v", storage)
@@ -119,12 +139,12 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 		t.Fatalf("unexpected S3 storage config: %#v", s3)
 	}
 	http := storage[1].(map[string]any)
-	if http["type"] != "http" || http["endpoint"] != "https://example.com/atif" || http["timeout_millis"] != float64(1500) {
+	if http["type"] != "http" || http["endpoint"] != testAtifEndpoint || http["timeout_millis"] != float64(1500) {
 		t.Fatalf("unexpected HTTP storage config: %#v", http)
 	}
 }
 
-func marshalStorageConfig(t *testing.T, config ObservabilityAtifStorageConfig) map[string]any {
+func marshalStorageConfig(t *testing.T, config ObservabilityAtifStorageConfigurer) map[string]any {
 	t.Helper()
 	payload, err := json.Marshal(config)
 	if err != nil {

--- a/go/nemo_relay/pricing.go
+++ b/go/nemo_relay/pricing.go
@@ -24,11 +24,11 @@ const (
 
 // PricingConfig is the canonical Go shape for the pricing plugin config document.
 type PricingConfig struct {
-	Sources []PricingSourceConfig `json:"sources,omitempty"`
+	Sources []PricingSourceConfigurer `json:"sources,omitempty"`
 }
 
-// PricingSourceConfig is implemented by pricing source config structs.
-type PricingSourceConfig interface {
+// PricingSourceConfigurer is implemented by pricing source config structs.
+type PricingSourceConfigurer interface {
 	pricingSourceConfig()
 }
 
@@ -37,7 +37,9 @@ type PricingInlineSourceConfig struct {
 	Catalog PricingCatalog `json:"catalog"`
 }
 
-func (PricingInlineSourceConfig) pricingSourceConfig() {}
+func (PricingInlineSourceConfig) pricingSourceConfig() {
+	// Marker method: inline sources are serialized by MarshalJSON.
+}
 
 // MarshalJSON serializes the inline source with the canonical type discriminator.
 func (source PricingInlineSourceConfig) MarshalJSON() ([]byte, error) {
@@ -56,7 +58,9 @@ type PricingFileSourceConfig struct {
 	Path string `json:"path"`
 }
 
-func (PricingFileSourceConfig) pricingSourceConfig() {}
+func (PricingFileSourceConfig) pricingSourceConfig() {
+	// Marker method: file sources are serialized by MarshalJSON.
+}
 
 // MarshalJSON serializes the file source with the canonical type discriminator.
 func (source PricingFileSourceConfig) MarshalJSON() ([]byte, error) {
@@ -136,7 +140,7 @@ type PricingComponentSpec struct {
 
 // NewPricingConfig returns an empty pricing config.
 func NewPricingConfig() PricingConfig {
-	return PricingConfig{Sources: []PricingSourceConfig{}}
+	return PricingConfig{Sources: []PricingSourceConfigurer{}}
 }
 
 // NewPricingInlineSource returns an inline pricing catalog source.

--- a/go/nemo_relay/pricing/pricing.go
+++ b/go/nemo_relay/pricing/pricing.go
@@ -9,7 +9,7 @@ import nemo_relay "github.com/NVIDIA/NeMo-Relay/go/nemo_relay"
 type Config = nemo_relay.PricingConfig
 
 // SourceConfig is implemented by pricing source config structs.
-type SourceConfig = nemo_relay.PricingSourceConfig
+type SourceConfig = nemo_relay.PricingSourceConfigurer
 
 // InlineSourceConfig embeds a pricing catalog directly in plugin config.
 type InlineSourceConfig = nemo_relay.PricingInlineSourceConfig

--- a/go/nemo_relay/pricing_test.go
+++ b/go/nemo_relay/pricing_test.go
@@ -19,7 +19,7 @@ func TestPricingConfigHelpers(t *testing.T) {
 	entry.Rates = &rates
 
 	config := NewPricingConfig()
-	config.Sources = []PricingSourceConfig{
+	config.Sources = []PricingSourceConfigurer{
 		NewPricingInlineSource(NewPricingCatalog(entry)),
 		NewPricingFileSource("/tmp/pricing.json"),
 	}
@@ -91,7 +91,7 @@ func TestValidatePricingConfig(t *testing.T) {
 	entry.Rates = &rates
 
 	report, err := ValidatePricingConfig(PricingConfig{
-		Sources: []PricingSourceConfig{
+		Sources: []PricingSourceConfigurer{
 			NewPricingInlineSource(NewPricingCatalog(entry)),
 		},
 	})
@@ -105,7 +105,7 @@ func TestValidatePricingConfig(t *testing.T) {
 	rates.InputPerMillion = -1
 	entry.Rates = &rates
 	invalid, err := ValidatePricingConfig(PricingConfig{
-		Sources: []PricingSourceConfig{
+		Sources: []PricingSourceConfigurer{
 			NewPricingInlineSource(NewPricingCatalog(entry)),
 		},
 	})


### PR DESCRIPTION
#### Overview

Addresses the current Sonar scan findings across the Go binding tests/config helpers and the WebAssembly ESM adaptive wrapper.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Rename Go single-method marker interfaces to convention-compliant `Configurer` names and update Go aliases/tests.
- Add explicit comments to intentional marker-method bodies.
- Reduce observability helper test complexity and replace duplicated literals with constants.
- Clean up adaptive runtime test literals and simplify the invalid latency assertion.
- Re-export `AdaptiveRuntime` directly from the WASM ESM wrapper.

Validation:

- `just test-go`
- `node --check crates/wasm/wrappers/esm/adaptive.js`
- `git diff --check`
- Sonar snippet analysis returned zero issues for the edited snippets.
- Commit-time hooks passed for the changed files.

#### Where should the reviewer start?

Start with `go/nemo_relay/observability_plugin.go` for the exported marker-interface rename, then `go/nemo_relay/observability_plugin_test.go` for the test complexity cleanup.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to configuration interfaces and test infrastructure for the adaptive runtime, observability, and pricing modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->