### PR TITLE
ci: publish pii redaction crate from GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,7 +262,7 @@ publish:artifactory:cargo:
       artifactory = { index = "sparse+${NEMO_RELAY_CI_ARTIFACTORY_CARGO_URL}" }
       EOF
       export CARGO_REGISTRIES_ARTIFACTORY_TOKEN="Bearer ${NEMO_RELAY_CI_ARTIFACTORY_KEY}"
-      export NEMO_RELAY_ARTIFACTORY_CRATE_DIRS="core adaptive ffi cli"
+      export NEMO_RELAY_ARTIFACTORY_CRATE_DIRS="core adaptive pii-redaction ffi cli"
 
       crates="$(
         uv run --no-project python - <<'PY'


### PR DESCRIPTION
#### Overview

Publish the missing `nemo-relay-pii-redaction` crate from the GitLab Artifactory Cargo publishing job.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `pii-redaction` to `NEMO_RELAY_ARTIFACTORY_CRATE_DIRS` so the existing GitLab publish script rewrites its workspace registry entry and publishes `nemo-relay-pii-redaction` with the other Cargo crates.

#### Where should the reviewer start?

`.gitlab-ci.yml`, in the `publish:artifactory:cargo` job.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD pipeline configuration to expand automated publishing scope.

---

**Note:** This is an internal infrastructure change with no direct user-visible impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->