### PR TITLE
docs: include PII redaction Rust API reference

### DIFF
--- a/scripts/docs/fern_cleanup.py
+++ b/scripts/docs/fern_cleanup.py
@@ -30,9 +30,9 @@ SUPPORT_API_REFERENCE_TEXT = (
     "[Node.js Library Reference](/reference/api/nodejs-library-reference), and\n"
     "[Rust Library Reference](/reference/api/rust-library-reference) for generated\n"
     "symbol-level documentation. The Rust reference includes `nemo-relay`,\n"
-    "`nemo-relay-adaptive`, and `nemo-relay-ffi`. For Go and WebAssembly surfaces, use\n"
-    "the source directories, tests, and task-focused guides when you need exact\n"
-    "behavior."
+    "`nemo-relay-adaptive`, `nemo-relay-pii-redaction`, and `nemo-relay-ffi`.\n"
+    "For Go and WebAssembly surfaces, use the source directories, tests, and\n"
+    "task-focused guides when you need exact behavior."
 )
 ASSISTANT_SYMBOL_REFERENCE_TEXT = (
     "For symbol-level work, assistants should use the source directories, tests, and\n"

--- a/scripts/docs/generate_rust_library_reference.py
+++ b/scripts/docs/generate_rust_library_reference.py
@@ -23,10 +23,14 @@ from reference_common import escape_mdx_text, frontmatter, reset_output_dir
 CRATES = (
     ("nemo-relay", "nemo_relay", "Core Rust runtime APIs for NeMo Relay."),
     ("nemo-relay-adaptive", "nemo_relay_adaptive", "Adaptive runtime primitives and plugin components."),
+    ("nemo-relay-pii-redaction", "nemo_relay_pii_redaction", "PII redaction plugin components for NeMo Relay."),
     ("nemo-relay-ffi", "nemo_relay_ffi", "C-compatible FFI surface for NeMo Relay."),
 )
 BASE_URL = "/reference/api/rust-library-reference"
-GENERATED_BY = "Generated from `cargo doc --no-deps -p nemo-relay -p nemo-relay-adaptive -p nemo-relay-ffi`."
+GENERATED_BY = (
+    "Generated from `cargo doc --no-deps -p nemo-relay -p nemo-relay-adaptive "
+    "-p nemo-relay-pii-redaction -p nemo-relay-ffi`."
+)
 TRANSLATION_TABLE = str.maketrans(
     {
         "\xa0": " ",
@@ -156,6 +160,8 @@ def _run_cargo_doc(repo_root: Path) -> None:
             "nemo-relay",
             "-p",
             "nemo-relay-adaptive",
+            "-p",
+            "nemo-relay-pii-redaction",
             "-p",
             "nemo-relay-ffi",
         ],


### PR DESCRIPTION
#### Overview

Add the `nemo-relay-pii-redaction` crate to the generated Fern Rust library reference so the Rust API docs include the first-party PII redaction plugin surface.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Added `nemo-relay-pii-redaction` to the Rust API reference generator crate list.
- Included the crate in the `cargo doc --no-deps` invocation and generated-source label.
- Updated Fern cleanup copy that enumerates the Rust crates covered by the generated reference.

#### Where should the reviewer start?

Start with `scripts/docs/generate_rust_library_reference.py`; it is the durable source for the ignored generated Fern Rust API pages.

Validation:

- `just docs-api-reference`
- `npx fern check --warnings` (passed with the existing FDR redirects 403 warning)
- `npx fern docs broken-links --strict`
- `git diff --check`
- Commit hook checks for the staged files

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended Rust API reference documentation to include the `nemo-relay-pii-redaction` library, providing developers with comprehensive reference materials alongside existing NeMo Relay crates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->