### PR TITLE
fix: guard FFI request intercept output pointers

### DIFF
--- a/crates/ffi/src/api/mod.rs
+++ b/crates/ffi/src/api/mod.rs
@@ -123,6 +123,12 @@ pub unsafe extern "C" fn nemo_relay_tool_request_intercepts(
     out: *mut *mut c_char,
 ) -> NemoRelayStatus {
     clear_last_error();
+    if out.is_null() {
+        set_last_error("out pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    unsafe { *out = std::ptr::null_mut() };
+
     let name = match c_str_to_string(name) {
         Ok(s) => s,
         Err(status) => return status,
@@ -201,6 +207,12 @@ pub unsafe extern "C" fn nemo_relay_llm_request_intercepts(
     out: *mut *mut c_char,
 ) -> NemoRelayStatus {
     clear_last_error();
+    if out.is_null() {
+        set_last_error("out pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    unsafe { *out = std::ptr::null_mut() };
+
     let name_str = if name.is_null() {
         ""
     } else {

--- a/crates/ffi/tests/unit/api/registry_tests.rs
+++ b/crates/ffi/tests/unit/api/registry_tests.rs
@@ -321,20 +321,31 @@ fn test_ffi_helper_rejection_and_null_name_paths() {
         let invalid_json = cstring("{");
         let tool_name = cstring("tool");
         let llm_name = cstring("llm");
-        let mut null_llm_out = ptr::null_mut();
+        let mut tool_out = ptr::null_mut();
+        let mut llm_error_out = ptr::null_mut();
 
         assert_eq!(
-            nemo_relay_tool_request_intercepts(ptr::null(), args.as_ptr(), ptr::null_mut()),
+            nemo_relay_tool_request_intercepts(tool_name.as_ptr(), args.as_ptr(), ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert!(
+            read_last_error()
+                .unwrap_or_default()
+                .contains("out pointer is null")
+        );
+        assert_eq!(
+            nemo_relay_tool_request_intercepts(ptr::null(), args.as_ptr(), &mut tool_out),
             NemoRelayStatus::NullPointer
         );
         assert_eq!(
             nemo_relay_tool_request_intercepts(
                 tool_name.as_ptr(),
                 invalid_json.as_ptr(),
-                ptr::null_mut()
+                &mut tool_out
             ),
             NemoRelayStatus::InvalidJson
         );
+        assert!(tool_out.is_null());
         assert_eq!(
             nemo_relay_tool_conditional_execution(ptr::null(), args.as_ptr()),
             NemoRelayStatus::NullPointer
@@ -373,13 +384,23 @@ fn test_ffi_helper_rejection_and_null_name_paths() {
         assert_eq!(llm_json["content"]["model"], json!("ffi-model"));
 
         assert_eq!(
+            nemo_relay_llm_request_intercepts(llm_name.as_ptr(), request.as_ptr(), ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert!(
+            read_last_error()
+                .unwrap_or_default()
+                .contains("out pointer is null")
+        );
+        assert_eq!(
             nemo_relay_llm_request_intercepts(
                 llm_name.as_ptr(),
                 invalid_json.as_ptr(),
-                &mut null_llm_out
+                &mut llm_error_out
             ),
             NemoRelayStatus::InvalidJson
         );
+        assert!(llm_error_out.is_null());
         assert_eq!(
             nemo_relay_llm_conditional_execution(invalid_json.as_ptr()),
             NemoRelayStatus::InvalidJson


### PR DESCRIPTION
#### Overview

The standalone FFI request intercept helpers now validate their output pointer before writing through it, so invalid C ABI callers receive `NemoRelayStatus::NullPointer` instead of crashing the process.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Added early `out.is_null()` checks to `nemo_relay_tool_request_intercepts` and `nemo_relay_llm_request_intercepts`.
- Set the FFI last-error message to `out pointer is null` before returning `NemoRelayStatus::NullPointer`.
- Initialize `*out` to null on non-null output pointers before parsing or middleware execution, so later error paths do not leave stale output pointers.
- Added FFI regression coverage for null output pointers and invalid JSON paths.

Validation:

- `cargo test -p nemo-relay-ffi test_ffi_helper_rejection_and_null_name_paths -- --nocapture`
- `cargo test -p nemo-relay-ffi`
- `cargo fmt --all --check`
- `git diff --check`
- `just test-rust`

#### Where should the reviewer start?

Start with `crates/ffi/src/api/mod.rs`, then check `crates/ffi/tests/unit/api/registry_tests.rs` for the null pointer coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parameter validation for API calls with improved error detection and reporting when invalid or null parameters are provided.
  * Prevents potential issues and crashes from incorrect parameter usage.
  * Provides clearer error messages to help identify configuration issues.

* **Tests**
  * Strengthened test coverage for API error handling scenarios to ensure robust error path validation and proper error message generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->