### PR TITLE
fix: enable tokio time for core package builds

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -83,7 +83,7 @@ schemars = { version = "0.8", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 bitflags = { version = "2", features = ["serde"] }
 thiserror = "2"
-tokio = { version = "1", default-features = false, features = ["rt", "macros", "sync"] }
+tokio = { version = "1", default-features = false, features = ["rt", "macros", "sync", "time"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
 typed-builder = "0.23.2"
 futures-util = { version = "0.3", optional = true }


### PR DESCRIPTION
#### Overview

Enable Tokio's `time` feature in the core crate so packaged builds compile when downstream crates depend on `nemo-relay` with default features disabled.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Added `time` to the direct Tokio feature list in `crates/core/Cargo.toml`.
- This matches the unconditional use of `tokio::time::timeout` in the local NeMo Guardrails worker path.
- This fixes package verification for feature-minimal consumers such as `nemo-relay-pii-redaction`.
- Breaking changes: none.

Validation run:

- `cargo check -p nemo-relay-pii-redaction --no-default-features`
- `cargo check -p nemo-relay --no-default-features`
- `cargo package -p nemo-relay --allow-dirty`
- `cargo package -p nemo-relay-pii-redaction --allow-dirty --config 'patch.crates-io.nemo-relay.path="crates/core"'`
- `cargo fmt --all`
- `just test-rust`
- `cargo clippy --workspace --all-targets -- -D warnings`

#### Where should the reviewer start?

Start with `crates/core/Cargo.toml`; the only source change is the Tokio feature list for the core crate.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime environment dependencies to enable additional timekeeping features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->