### PR TITLE
fix(atof): create ATOF output directory before opening JSONL output file

### DIFF
--- a/crates/cli/src/launcher.rs
+++ b/crates/cli/src/launcher.rs
@@ -155,8 +155,9 @@ async fn execute_live_run(
     let running_server = RunningGateway::start(listener, gateway_config);
     if let Err(error) = wait_for_health(gateway_url).await {
         let restore = prepared.restore();
-        let _ = running_server.stop().await;
+        let server_result = running_server.stop().await;
         restore?;
+        server_result?;
         return Err(error);
     }
     let status = prepared.spawn_and_wait().await;

--- a/crates/cli/tests/coverage/launcher_tests.rs
+++ b/crates/cli/tests/coverage/launcher_tests.rs
@@ -1134,6 +1134,49 @@ async fn wait_for_health_reports_unready_gateway() {
 }
 
 #[tokio::test]
+async fn execute_live_run_reports_gateway_startup_error_when_health_check_fails() {
+    let resolved = ResolvedConfig {
+        gateway: GatewayConfig::default(),
+        agents: AgentConfigs::default(),
+    };
+    let prepared = PreparedRun::new(
+        CodingAgent::ClaudeCode,
+        vec!["claude".into()],
+        "http://127.0.0.1:1234",
+        &resolved,
+        false,
+    )
+    .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let gateway_url = format!("http://{}", listener.local_addr().unwrap());
+    let gateway_config = GatewayConfig {
+        plugin_config: Some(json!({
+            "version": 1,
+            "components": [{
+                "kind": OBSERVABILITY_PLUGIN_KIND,
+                "enabled": true,
+                "config": {
+                    "version": 1,
+                    "atof": {
+                        "enabled": true,
+                        "mode": "invalid"
+                    }
+                }
+            }]
+        })),
+        ..GatewayConfig::default()
+    };
+
+    let error = execute_live_run(listener, gateway_config, &gateway_url, prepared)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("ATOF mode"));
+    assert!(!error.contains("gateway did not become ready"));
+}
+
+#[tokio::test]
 async fn execute_live_run_restores_hermes_hooks_when_health_check_fails() {
     let temp = tempfile::tempdir().unwrap();
     let hooks_path = temp.path().join("hermes-home/config.yaml");

--- a/crates/core/src/observability/atof.rs
+++ b/crates/core/src/observability/atof.rs
@@ -9,7 +9,7 @@
 //! one JSON object per JSONL line.
 
 use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
+use std::fs::{File, OpenOptions, create_dir_all};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, mpsc as std_mpsc};
@@ -263,6 +263,10 @@ impl AtofExporter {
     /// Create a new exporter from config and open its output file.
     pub fn new(config: AtofExporterConfig) -> Result<Self> {
         let path = config.path();
+        create_dir_all(&config.output_directory).map_err(|source| AtofExporterError::OpenFile {
+            path: path.clone(),
+            source,
+        })?;
         let file = open_file(&path, config.mode)?;
         let endpoints = start_endpoint_workers(&config.endpoints)?;
         Ok(Self {

--- a/crates/core/tests/unit/observability/atof_tests.rs
+++ b/crates/core/tests/unit/observability/atof_tests.rs
@@ -1202,6 +1202,24 @@ fn invalid_output_path_errors_cleanly() {
 }
 
 #[test]
+fn missing_output_directory_is_created() {
+    let dir = temp_dir("atof-missing-output-dir");
+    let output_dir = dir.join("nested/atof");
+
+    let exporter = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(&output_dir)
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+
+    let output_path = output_dir.join("events.jsonl");
+    assert_eq!(exporter.path(), output_path.as_path());
+    assert!(output_dir.is_dir());
+    assert!(output_path.exists());
+}
+
+#[test]
 fn invalid_filename_errors_cleanly() {
     let dir = temp_dir("atof-invalid-filename");
 


### PR DESCRIPTION
#### Overview

Fixes the transparent gateway startup failure seen when a fresh README-style observability setup enables local ATOF output before the `.nemo-relay/atof` directory exists.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Create the configured ATOF output directory before opening the JSONL output file.
- Preserve the real gateway startup error in transparent run mode instead of masking startup failures as a `/healthz` timeout.
- Add regression coverage for missing ATOF output directories and gateway startup error reporting.

#### Where should the reviewer start?

Start with `crates/core/src/observability/atof.rs`, then review the launcher error-path test in `crates/cli/tests/coverage/launcher_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-359


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when a gateway health check fails, so shutdown problems are no longer hidden.
  * Ensured observability output setup creates missing parent directories automatically before writing logs.
* **Tests**
  * Added coverage for gateway health-check failures caused by invalid observability settings.
  * Added a unit test verifying nested output directories are created and output files are written correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->