### PR TITLE
test: improve Go and FFI coverage

### DIFF
--- a/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
@@ -727,3 +727,432 @@ fn test_ffi_scope_registry_invalid_utf8_scope_and_name_sweeps() {
         nemo_relay_scope_stack_free(stack);
     }
 }
+
+#[test]
+fn test_ffi_adaptive_and_observability_entry_points_from_integration_binary() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let config = cstring(
+            &json!({
+                "version": 1,
+                "agent_id": "ffi-adaptive-integration",
+                "state": {
+                    "backend": {
+                        "kind": "in_memory",
+                        "config": {}
+                    }
+                },
+                "acg": {
+                    "provider": "openai"
+                }
+            })
+            .to_string(),
+        );
+        let invalid_json = cstring("{");
+        let mut out_json = ptr::null_mut();
+
+        assert_eq!(
+            nemo_relay_adaptive_validate_config(config.as_ptr(), &mut out_json),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json)["diagnostics"], json!([]));
+        assert_eq!(
+            nemo_relay_adaptive_validate_config(config.as_ptr(), ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_validate_config(invalid_json.as_ptr(), &mut out_json),
+            NemoRelayStatus::InvalidJson
+        );
+
+        let mut runtime = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_adaptive_runtime_create(config.as_ptr(), ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_create(invalid_json.as_ptr(), &mut runtime),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_create(config.as_ptr(), &mut runtime),
+            NemoRelayStatus::Ok
+        );
+        assert!(!runtime.is_null());
+        assert_eq!(
+            nemo_relay_adaptive_runtime_register(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_register(runtime),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_wait_for_idle(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_wait_for_idle(runtime),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_report_json(runtime, ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_report_json(runtime, &mut out_json),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json)["diagnostics"], json!([]));
+
+        let stack = fresh_scope_stack();
+        let scope_name = cstring("ffi_adaptive_integration_scope");
+        let mut scope = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Agent,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut scope,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_bind_scope(runtime, scope),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_bind_scope(runtime, ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+
+        let cache_options = cstring(
+            &json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000701",
+                "annotated_request": {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Cache this"
+                        }
+                    ],
+                    "model": "gpt-4.1-mini"
+                },
+                "agent_id": "ffi-adaptive-integration"
+            })
+            .to_string(),
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_build_cache_request_facts(
+                runtime,
+                cache_options.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let facts = returned_json(out_json);
+        assert_eq!(facts["provider"], json!("openai"));
+        assert_eq!(
+            nemo_relay_adaptive_runtime_build_cache_request_facts(
+                runtime,
+                cache_options.as_ptr(),
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        for options in [
+            json!({
+                "provider": "openai",
+                "request_id": "not-a-uuid",
+                "annotated_request": {},
+                "agent_id": "ffi-adaptive-integration"
+            }),
+            json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000703",
+                "annotated_request": {},
+                "agent_id": "ffi-adaptive-integration",
+                "timestamp": "not-a-timestamp"
+            }),
+            json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000704",
+                "annotated_request": "bad",
+                "agent_id": "ffi-adaptive-integration"
+            }),
+            json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000705"
+            }),
+        ] {
+            let options = cstring(&options.to_string());
+            assert!(
+                matches!(
+                    nemo_relay_adaptive_runtime_build_cache_request_facts(
+                        runtime,
+                        options.as_ptr(),
+                        &mut out_json,
+                    ),
+                    NemoRelayStatus::InvalidArg | NemoRelayStatus::InvalidJson
+                ),
+                "expected invalid cache facts options to fail"
+            );
+        }
+
+        let telemetry_options = cstring(
+            &json!({
+                "provider": "anthropic",
+                "request_id": "00000000-0000-0000-0000-000000000702",
+                "usage": {
+                    "prompt_tokens": 50,
+                    "cache_read_tokens": 10
+                },
+                "agent_id": "ffi-adaptive-integration",
+                "template_version": "v1",
+                "toolset_hash": "tools",
+                "model_family": "claude",
+                "tenant_scope": "tenant"
+            })
+            .to_string(),
+        );
+        assert_eq!(
+            nemo_relay_adaptive_build_cache_telemetry_event(
+                telemetry_options.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let event = returned_json(out_json);
+        assert_eq!(event["cache_read_tokens"], json!(10));
+        assert_eq!(event["hit_rate"], json!(10.0 / 60.0));
+        assert_eq!(
+            nemo_relay_adaptive_build_cache_telemetry_event(
+                telemetry_options.as_ptr(),
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        let no_usage_options = cstring(
+            &json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000706",
+                "agent_id": "ffi-adaptive-integration",
+                "template_version": "v1",
+                "toolset_hash": "tools",
+                "model_family": "gpt",
+                "tenant_scope": "tenant"
+            })
+            .to_string(),
+        );
+        assert_eq!(
+            nemo_relay_adaptive_build_cache_telemetry_event(
+                no_usage_options.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json), Json::Null);
+        for (options, expected) in [
+            (
+                json!({
+                    "provider": "unsupported",
+                    "request_id": "00000000-0000-0000-0000-000000000707",
+                    "usage": {},
+                    "agent_id": "ffi-adaptive-integration",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant"
+                }),
+                NemoRelayStatus::InvalidArg,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "not-a-uuid",
+                    "usage": {},
+                    "agent_id": "ffi-adaptive-integration",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant"
+                }),
+                NemoRelayStatus::InvalidArg,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "00000000-0000-0000-0000-000000000708",
+                    "usage": {},
+                    "agent_id": "ffi-adaptive-integration",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant",
+                    "timestamp": "not-a-timestamp"
+                }),
+                NemoRelayStatus::InvalidArg,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "00000000-0000-0000-0000-000000000709",
+                    "usage": "bad",
+                    "agent_id": "ffi-adaptive-integration",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant"
+                }),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "00000000-0000-0000-0000-000000000710",
+                    "usage": {},
+                    "request_facts": "bad",
+                    "agent_id": "ffi-adaptive-integration",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant"
+                }),
+                NemoRelayStatus::InvalidJson,
+            ),
+        ] {
+            let options = cstring(&options.to_string());
+            assert_eq!(
+                nemo_relay_adaptive_build_cache_telemetry_event(options.as_ptr(), &mut out_json),
+                expected
+            );
+        }
+        assert_eq!(
+            nemo_relay_adaptive_build_cache_telemetry_event(invalid_json.as_ptr(), &mut out_json,),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_build_cache_request_facts(
+                ptr::null_mut(),
+                cache_options.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_set_latency_sensitivity(0),
+            NemoRelayStatus::InvalidArg
+        );
+
+        assert_eq!(
+            nemo_relay_adaptive_runtime_deregister(runtime),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_deregister(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_shutdown(runtime),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_shutdown(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_report_json(runtime, &mut out_json),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_eq!(
+            nemo_relay_pop_scope(scope, ptr::null()),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_scope_handle_free(scope);
+        nemo_relay_scope_stack_free(stack);
+        types::nemo_relay_adaptive_runtime_free(runtime);
+
+        assert_eq!(
+            nemo_relay_observability_default_config_json(&mut out_json),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json)["version"], json!(1));
+        assert_eq!(
+            nemo_relay_observability_default_config_json(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_observability_component_spec_json(ptr::null(), true, &mut out_json),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json)["kind"], json!("observability"));
+        assert_eq!(
+            nemo_relay_observability_component_spec_json(
+                invalid_json.as_ptr(),
+                true,
+                &mut out_json,
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+
+        let append = cstring("append");
+        let bad_mode = cstring("bad-mode");
+        let filename = cstring("events.jsonl");
+        let invalid_utf8 = [0xffu8, 0];
+        let invalid = invalid_utf8.as_ptr() as *const c_char;
+        let mut atof = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_atof_exporter_create(
+                ptr::null(),
+                append.as_ptr(),
+                filename.as_ptr(),
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_create(
+                ptr::null(),
+                bad_mode.as_ptr(),
+                filename.as_ptr(),
+                &mut atof,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_create(invalid, append.as_ptr(), filename.as_ptr(), &mut atof),
+            NemoRelayStatus::InvalidUtf8
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_create(ptr::null(), invalid, filename.as_ptr(), &mut atof),
+            NemoRelayStatus::InvalidUtf8
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_create(ptr::null(), append.as_ptr(), invalid, &mut atof),
+            NemoRelayStatus::InvalidUtf8
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_register(ptr::null(), filename.as_ptr()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_force_flush(ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_shutdown(ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_path(ptr::null(), &mut out_json),
+            NemoRelayStatus::NullPointer
+        );
+    }
+}

--- a/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
@@ -1105,6 +1105,50 @@ fn test_ffi_adaptive_and_observability_entry_points_from_integration_binary() {
         let append = cstring("append");
         let bad_mode = cstring("bad-mode");
         let filename = cstring("events.jsonl");
+        let happy_dir = temp_dir("ffi-atof-happy");
+        let happy_dir_text = happy_dir.to_string_lossy().into_owned();
+        let happy_dir = cstring(&happy_dir_text);
+        let happy_filename = cstring("happy-events.jsonl");
+        let happy_name = cstring(&unique_name("ffi_atof_happy"));
+        let mut happy_atof = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_atof_exporter_create(
+                happy_dir.as_ptr(),
+                append.as_ptr(),
+                happy_filename.as_ptr(),
+                &mut happy_atof,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert!(!happy_atof.is_null());
+        let mut path_ptr = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_atof_exporter_path(happy_atof, &mut path_ptr),
+            NemoRelayStatus::Ok
+        );
+        let path = take_string(path_ptr).expect("expected ATOF exporter path");
+        assert!(
+            path.ends_with("happy-events.jsonl"),
+            "unexpected ATOF exporter path: {path}"
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_register(happy_atof, happy_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_force_flush(happy_atof),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_shutdown(happy_atof),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_deregister(happy_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_atof_exporter_free(happy_atof);
+
         let invalid_utf8 = [0xffu8, 0];
         let invalid = invalid_utf8.as_ptr() as *const c_char;
         let mut atof = ptr::null_mut();

--- a/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
@@ -2653,3 +2653,483 @@ fn test_ffi_llm_execute_and_stream_additional_input_paths() {
         nemo_relay_scope_stack_free(stack);
     }
 }
+
+#[test]
+fn test_ffi_adaptive_runtime_and_cache_helper_paths() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let config = cstring(
+            &json!({
+                "version": 1,
+                "agent_id": "ffi-adaptive-openai",
+                "state": {
+                    "backend": {
+                        "kind": "in_memory",
+                        "config": {}
+                    }
+                },
+                "acg": {
+                    "provider": "openai"
+                }
+            })
+            .to_string(),
+        );
+        let invalid_json = cstring("{");
+        let mut out_json = ptr::null_mut();
+
+        assert_eq!(
+            nemo_relay_adaptive_validate_config(ptr::null(), &mut out_json),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_adaptive_validate_config(config.as_ptr(), ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_validate_config(invalid_json.as_ptr(), &mut out_json),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_adaptive_validate_config(config.as_ptr(), &mut out_json),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json)["diagnostics"], json!([]));
+
+        let mut runtime = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_adaptive_runtime_create(config.as_ptr(), ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_create(invalid_json.as_ptr(), &mut runtime),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_create(config.as_ptr(), &mut runtime),
+            NemoRelayStatus::Ok
+        );
+        assert!(!runtime.is_null());
+
+        assert_eq!(
+            nemo_relay_adaptive_runtime_report_json(runtime, ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_report_json(runtime, &mut out_json),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json)["diagnostics"], json!([]));
+        assert_eq!(
+            nemo_relay_adaptive_runtime_register(runtime),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_wait_for_idle(runtime),
+            NemoRelayStatus::Ok
+        );
+
+        let stack = fresh_scope_stack();
+        let scope_name = cstring("ffi_adaptive_bound_scope");
+        let mut scope = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Agent,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut scope,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_bind_scope(runtime, ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_bind_scope(runtime, scope),
+            NemoRelayStatus::Ok
+        );
+
+        let cache_facts_options = cstring(
+            &json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000601",
+                "annotated_request": {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Find cache evidence"
+                        }
+                    ],
+                    "model": "gpt-4.1-mini"
+                },
+                "agent_id": "ffi-adaptive-openai",
+                "timestamp": "2026-06-24T12:00:00Z"
+            })
+            .to_string(),
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_build_cache_request_facts(
+                runtime,
+                cache_facts_options.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let facts = returned_json(out_json);
+        assert_eq!(facts["provider"], "openai");
+        assert_eq!(facts["missing_facts"][0], "acg_stability_unavailable");
+
+        for options in [
+            json!({
+                "provider": "openai",
+                "request_id": "not-a-uuid",
+                "annotated_request": {},
+                "agent_id": "ffi-adaptive-openai"
+            }),
+            json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000602",
+                "annotated_request": {},
+                "agent_id": "ffi-adaptive-openai",
+                "timestamp": "not-a-timestamp"
+            }),
+            json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000603",
+                "annotated_request": "bad",
+                "agent_id": "ffi-adaptive-openai"
+            }),
+        ] {
+            let options = cstring(&options.to_string());
+            assert!(
+                matches!(
+                    nemo_relay_adaptive_runtime_build_cache_request_facts(
+                        runtime,
+                        options.as_ptr(),
+                        &mut out_json,
+                    ),
+                    NemoRelayStatus::InvalidArg | NemoRelayStatus::InvalidJson
+                ),
+                "expected invalid cache facts options to fail"
+            );
+        }
+        assert_eq!(
+            nemo_relay_adaptive_runtime_build_cache_request_facts(
+                runtime,
+                invalid_json.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_build_cache_request_facts(
+                runtime,
+                cache_facts_options.as_ptr(),
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+
+        let telemetry_options = cstring(
+            &json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000604",
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 8,
+                    "cache_read_tokens": 25
+                },
+                "request_facts": facts,
+                "agent_id": "ffi-adaptive-openai",
+                "template_version": "v1",
+                "toolset_hash": "tools",
+                "model_family": "gpt",
+                "tenant_scope": "tenant",
+                "timestamp": "2026-06-24T12:00:01Z"
+            })
+            .to_string(),
+        );
+        assert_eq!(
+            nemo_relay_adaptive_build_cache_telemetry_event(
+                telemetry_options.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let event = returned_json(out_json);
+        assert_eq!(event["cache_read_tokens"], json!(25));
+        assert_eq!(event["hit_rate"], json!(0.25));
+
+        let no_usage_options = cstring(
+            &json!({
+                "provider": "openai",
+                "request_id": "00000000-0000-0000-0000-000000000605",
+                "agent_id": "ffi-adaptive-openai",
+                "template_version": "v1",
+                "toolset_hash": "tools",
+                "model_family": "gpt",
+                "tenant_scope": "tenant"
+            })
+            .to_string(),
+        );
+        assert_eq!(
+            nemo_relay_adaptive_build_cache_telemetry_event(
+                no_usage_options.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json), Json::Null);
+
+        for (options, expected) in [
+            (
+                json!({
+                    "provider": "unsupported",
+                    "request_id": "00000000-0000-0000-0000-000000000606",
+                    "usage": {},
+                    "agent_id": "ffi-adaptive-openai",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant"
+                }),
+                NemoRelayStatus::InvalidArg,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "not-a-uuid",
+                    "usage": {},
+                    "agent_id": "ffi-adaptive-openai",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant"
+                }),
+                NemoRelayStatus::InvalidArg,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "00000000-0000-0000-0000-000000000607",
+                    "usage": {},
+                    "agent_id": "ffi-adaptive-openai",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant",
+                    "timestamp": "not-a-timestamp"
+                }),
+                NemoRelayStatus::InvalidArg,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "00000000-0000-0000-0000-000000000608",
+                    "usage": "bad",
+                    "agent_id": "ffi-adaptive-openai",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant"
+                }),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "00000000-0000-0000-0000-000000000609",
+                    "usage": {},
+                    "request_facts": "bad",
+                    "agent_id": "ffi-adaptive-openai",
+                    "template_version": "v1",
+                    "toolset_hash": "tools",
+                    "model_family": "gpt",
+                    "tenant_scope": "tenant"
+                }),
+                NemoRelayStatus::InvalidJson,
+            ),
+        ] {
+            let options = cstring(&options.to_string());
+            assert_eq!(
+                nemo_relay_adaptive_build_cache_telemetry_event(options.as_ptr(), &mut out_json),
+                expected
+            );
+        }
+        assert_eq!(
+            nemo_relay_adaptive_build_cache_telemetry_event(
+                telemetry_options.as_ptr(),
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_adaptive_build_cache_telemetry_event(invalid_json.as_ptr(), &mut out_json),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_adaptive_set_latency_sensitivity(0),
+            NemoRelayStatus::InvalidArg
+        );
+
+        assert_eq!(
+            nemo_relay_adaptive_runtime_deregister(runtime),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_shutdown(runtime),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_shutdown(runtime),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_eq!(
+            nemo_relay_adaptive_runtime_register(runtime),
+            NemoRelayStatus::InvalidArg
+        );
+
+        assert_eq!(
+            nemo_relay_pop_scope(scope, ptr::null()),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_scope_handle_free(scope);
+        nemo_relay_scope_stack_free(stack);
+        types::nemo_relay_adaptive_runtime_free(runtime);
+    }
+}
+
+#[test]
+fn test_ffi_observability_component_and_constructor_error_paths() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let mut out_json = ptr::null_mut();
+        let invalid_json = cstring("{");
+        let invalid_config = cstring(r#"{"version":"bad"}"#);
+        let explicit_config = cstring(
+            &json!({
+                "version": 1,
+                "atof": {
+                    "enabled": false
+                }
+            })
+            .to_string(),
+        );
+
+        assert_eq!(
+            nemo_relay_observability_default_config_json(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_observability_component_spec_json(ptr::null(), true, ptr::null_mut(),),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_observability_component_spec_json(
+                invalid_json.as_ptr(),
+                true,
+                &mut out_json,
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_observability_component_spec_json(
+                invalid_config.as_ptr(),
+                true,
+                &mut out_json,
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_eq!(
+            nemo_relay_observability_component_spec_json(
+                explicit_config.as_ptr(),
+                false,
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let component = returned_json(out_json);
+        assert_eq!(component["kind"], "observability");
+        assert_eq!(component["enabled"], false);
+
+        let invalid_utf8 = [0xffu8, 0];
+        let invalid = invalid_utf8.as_ptr() as *const c_char;
+        let append = cstring("append");
+        let filename = cstring("events.jsonl");
+        let bad_mode = cstring("bad-mode");
+        let mut atof = ptr::null_mut();
+
+        assert_eq!(
+            nemo_relay_atof_exporter_create(
+                ptr::null(),
+                append.as_ptr(),
+                filename.as_ptr(),
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_create(
+                ptr::null(),
+                bad_mode.as_ptr(),
+                filename.as_ptr(),
+                &mut atof,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_create(invalid, append.as_ptr(), filename.as_ptr(), &mut atof,),
+            NemoRelayStatus::InvalidUtf8
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_create(ptr::null(), invalid, filename.as_ptr(), &mut atof,),
+            NemoRelayStatus::InvalidUtf8
+        );
+        assert_eq!(
+            nemo_relay_atof_exporter_create(ptr::null(), append.as_ptr(), invalid, &mut atof,),
+            NemoRelayStatus::InvalidUtf8
+        );
+
+        let invalid_map_shape = cstring(r#"["not-an-object"]"#);
+        let mut otel = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_otel_subscriber_create(
+                ptr::null(),
+                ptr::null(),
+                invalid_map_shape.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                &mut otel,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        let mut openinference = ptr::null_mut();
+        assert_eq!(
+            nemo_relay_openinference_subscriber_create(
+                ptr::null(),
+                ptr::null(),
+                invalid_map_shape.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                &mut openinference,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+    }
+}

--- a/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
@@ -2785,38 +2785,44 @@ fn test_ffi_adaptive_runtime_and_cache_helper_paths() {
         assert_eq!(facts["provider"], "openai");
         assert_eq!(facts["missing_facts"][0], "acg_stability_unavailable");
 
-        for options in [
-            json!({
-                "provider": "openai",
-                "request_id": "not-a-uuid",
-                "annotated_request": {},
-                "agent_id": "ffi-adaptive-openai"
-            }),
-            json!({
-                "provider": "openai",
-                "request_id": "00000000-0000-0000-0000-000000000602",
-                "annotated_request": {},
-                "agent_id": "ffi-adaptive-openai",
-                "timestamp": "not-a-timestamp"
-            }),
-            json!({
-                "provider": "openai",
-                "request_id": "00000000-0000-0000-0000-000000000603",
-                "annotated_request": "bad",
-                "agent_id": "ffi-adaptive-openai"
-            }),
+        for (options, expected) in [
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "not-a-uuid",
+                    "annotated_request": {},
+                    "agent_id": "ffi-adaptive-openai"
+                }),
+                NemoRelayStatus::InvalidArg,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "00000000-0000-0000-0000-000000000602",
+                    "annotated_request": {},
+                    "agent_id": "ffi-adaptive-openai",
+                    "timestamp": "not-a-timestamp"
+                }),
+                NemoRelayStatus::InvalidArg,
+            ),
+            (
+                json!({
+                    "provider": "openai",
+                    "request_id": "00000000-0000-0000-0000-000000000603",
+                    "annotated_request": "bad",
+                    "agent_id": "ffi-adaptive-openai"
+                }),
+                NemoRelayStatus::InvalidJson,
+            ),
         ] {
             let options = cstring(&options.to_string());
-            assert!(
-                matches!(
-                    nemo_relay_adaptive_runtime_build_cache_request_facts(
-                        runtime,
-                        options.as_ptr(),
-                        &mut out_json,
-                    ),
-                    NemoRelayStatus::InvalidArg | NemoRelayStatus::InvalidJson
+            assert_eq!(
+                nemo_relay_adaptive_runtime_build_cache_request_facts(
+                    runtime,
+                    options.as_ptr(),
+                    &mut out_json,
                 ),
-                "expected invalid cache facts options to fail"
+                expected
             );
         }
         assert_eq!(

--- a/crates/ffi/tests/unit/types_tests.rs
+++ b/crates/ffi/tests/unit/types_tests.rs
@@ -245,6 +245,12 @@ fn test_llm_request_null_inputs_event_null_guards_and_free_nulls() {
     assert!(unsafe { nemo_relay_event_tool_call_id(std::ptr::null()) }.is_null());
     assert!(unsafe { nemo_relay_event_parent_uuid(std::ptr::null()) }.is_null());
     assert!(unsafe { nemo_relay_event_scope_type(std::ptr::null()) }.is_null());
+    assert!(unsafe { nemo_relay_event_atof_version(std::ptr::null()) }.is_null());
+    assert!(unsafe { nemo_relay_event_scope_category(std::ptr::null()) }.is_null());
+    assert!(unsafe { nemo_relay_event_category(std::ptr::null()) }.is_null());
+    assert!(unsafe { nemo_relay_event_attributes_json(std::ptr::null()) }.is_null());
+    assert!(unsafe { nemo_relay_event_category_profile(std::ptr::null()) }.is_null());
+    assert!(unsafe { nemo_relay_event_data_schema(std::ptr::null()) }.is_null());
 
     unsafe {
         nemo_relay_scope_handle_free(std::ptr::null_mut());
@@ -256,6 +262,7 @@ fn test_llm_request_null_inputs_event_null_guards_and_free_nulls() {
         nemo_relay_atif_exporter_free(std::ptr::null_mut());
         nemo_relay_otel_subscriber_free(std::ptr::null_mut());
         nemo_relay_openinference_subscriber_free(std::ptr::null_mut());
+        nemo_relay_adaptive_runtime_free(std::ptr::null_mut());
     }
 }
 
@@ -329,6 +336,9 @@ fn test_valid_free_functions_and_none_backed_accessors() {
         ),
     )));
     unsafe { nemo_relay_atif_exporter_free(exporter_ptr) };
+
+    let adaptive_ptr = Box::into_raw(Box::new(FfiAdaptiveRuntime(std::sync::Mutex::new(None))));
+    unsafe { nemo_relay_adaptive_runtime_free(adaptive_ptr) };
 }
 
 #[test]
@@ -387,8 +397,24 @@ fn test_llm_request_and_event_accessors() {
         Some("start".into())
     );
     assert_eq!(
+        take_string(unsafe { nemo_relay_event_atof_version(&ffi_event) }),
+        Some("0.1".into())
+    );
+    assert_eq!(
         take_string(unsafe { nemo_relay_event_category(&ffi_event) }),
         Some("guardrail".into())
+    );
+    assert_eq!(
+        take_string(unsafe { nemo_relay_event_attributes_json(&ffi_event) }),
+        Some("[]".into())
+    );
+    assert_eq!(
+        take_string(unsafe { nemo_relay_event_category_profile(&ffi_event) }),
+        None
+    );
+    assert_eq!(
+        take_string(unsafe { nemo_relay_event_data_schema(&ffi_event) }),
+        None
     );
     assert_eq!(
         take_string(unsafe { nemo_relay_event_uuid(&ffi_event) }),
@@ -464,6 +490,10 @@ fn test_llm_request_and_event_accessors() {
         take_string(unsafe { nemo_relay_event_model_name(&ffi_llm_event) }),
         Some("model".into())
     );
+    let llm_profile = take_string(unsafe { nemo_relay_event_category_profile(&ffi_llm_event) })
+        .expect("expected category profile");
+    let llm_profile: serde_json::Value = serde_json::from_str(&llm_profile).unwrap();
+    assert_eq!(llm_profile["model_name"], json!("model"));
     assert_eq!(
         take_string(unsafe { nemo_relay_event_scope_type(&ffi_llm_event) }),
         Some("llm".into())
@@ -505,6 +535,22 @@ fn test_llm_request_and_event_accessors() {
     let ffi_mark_event = FfiEvent(mark_event);
     assert_eq!(
         take_string(unsafe { nemo_relay_event_scope_type(&ffi_mark_event) }),
+        None
+    );
+    assert_eq!(
+        take_string(unsafe { nemo_relay_event_atof_version(&ffi_mark_event) }),
+        Some("0.1".into())
+    );
+    assert_eq!(
+        take_string(unsafe { nemo_relay_event_scope_category(&ffi_mark_event) }),
+        None
+    );
+    assert_eq!(
+        take_string(unsafe { nemo_relay_event_category(&ffi_mark_event) }),
+        None
+    );
+    assert_eq!(
+        take_string(unsafe { nemo_relay_event_attributes_json(&ffi_mark_event) }),
         None
     );
     assert_eq!(unsafe { nemo_relay_event_attributes(&ffi_mark_event) }, 0);

--- a/go/nemo_relay/adaptive/optimizer_test.go
+++ b/go/nemo_relay/adaptive/optimizer_test.go
@@ -102,7 +102,7 @@ func TestAdaptivePackageTelemetryAndLatencyHelpers(t *testing.T) {
 		t.Fatalf("unexpected cache telemetry event: %#v", event)
 	}
 
-	if err := SetLatencySensitivity(0); err == nil {
+	if SetLatencySensitivity(0) == nil {
 		t.Fatal("expected SetLatencySensitivity to reject zero")
 	}
 }

--- a/go/nemo_relay/adaptive/optimizer_test.go
+++ b/go/nemo_relay/adaptive/optimizer_test.go
@@ -4,8 +4,9 @@
 package adaptive
 
 import (
-	nemo_relay "github.com/NVIDIA/NeMo-Relay/go/nemo_relay"
 	"testing"
+
+	nemo_relay "github.com/NVIDIA/NeMo-Relay/go/nemo_relay"
 )
 
 func TestConfigBuilders(t *testing.T) {
@@ -75,5 +76,33 @@ func TestRedisBackendAndComponentSpecBuilders(t *testing.T) {
 	}
 	if acgConfig["provider"] != "openai" {
 		t.Fatalf("expected wrapped config to preserve acg provider, got %#v", acgConfig["provider"])
+	}
+}
+
+func TestAdaptivePackageTelemetryAndLatencyHelpers(t *testing.T) {
+	promptTokens := uint64(40)
+	cacheReadTokens := uint64(10)
+	event, err := BuildCacheTelemetryEvent(CacheTelemetryEventInput{
+		Provider:  "openai",
+		RequestID: "00000000-0000-0000-0000-000000000501",
+		Usage: &CacheUsage{
+			PromptTokens:    &promptTokens,
+			CacheReadTokens: &cacheReadTokens,
+		},
+		AgentID:         "go-adaptive-wrapper",
+		TemplateVersion: "v1",
+		ToolsetHash:     "tools",
+		ModelFamily:     "gpt",
+		TenantScope:     "tenant",
+	})
+	if err != nil {
+		t.Fatalf("BuildCacheTelemetryEvent failed: %v", err)
+	}
+	if event == nil || event.HitRate != 0.25 {
+		t.Fatalf("unexpected cache telemetry event: %#v", event)
+	}
+
+	if err := SetLatencySensitivity(0); err == nil {
+		t.Fatal("expected SetLatencySensitivity to reject zero")
 	}
 }

--- a/go/nemo_relay/adaptive_runtime_test.go
+++ b/go/nemo_relay/adaptive_runtime_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 )
 
-const testAgentID = "go-agent"
+const (
+	testAgentID                 = "go-agent"
+	newAdaptiveRuntimeFailedMsg = "NewAdaptiveRuntime failed: %v"
+)
 
 func testAdaptiveRuntimeConfig(provider string) AdaptiveConfig {
 	config := NewAdaptiveConfig()
@@ -37,7 +40,7 @@ func TestValidateAdaptiveConfigAndOwnedRuntime(t *testing.T) {
 
 	runtime, err := NewAdaptiveRuntime(NewAdaptiveConfig())
 	if err != nil {
-		t.Fatalf("NewAdaptiveRuntime failed: %v", err)
+		t.Fatalf(newAdaptiveRuntimeFailedMsg, err)
 	}
 	defer runtime.Shutdown()
 	if err := runtime.Register(); err != nil {
@@ -107,7 +110,7 @@ func TestBuildCacheTelemetryEvent(t *testing.T) {
 func TestAdaptiveRuntimeBuildCacheRequestFacts(t *testing.T) {
 	runtime, err := NewAdaptiveRuntime(testAdaptiveRuntimeConfig("openai"))
 	if err != nil {
-		t.Fatalf("NewAdaptiveRuntime failed: %v", err)
+		t.Fatalf(newAdaptiveRuntimeFailedMsg, err)
 	}
 	if err := runtime.Register(); err != nil {
 		t.Fatalf("Register failed: %v", err)
@@ -152,11 +155,11 @@ func TestAdaptiveRuntimeBuildCacheRequestFacts(t *testing.T) {
 func TestAdaptiveRuntimeBindScopeRejectsNilScope(t *testing.T) {
 	runtime, err := NewAdaptiveRuntime(testAdaptiveRuntimeConfig("openai"))
 	if err != nil {
-		t.Fatalf("NewAdaptiveRuntime failed: %v", err)
+		t.Fatalf(newAdaptiveRuntimeFailedMsg, err)
 	}
 	defer runtime.Shutdown()
 
-	if err := runtime.BindScope(nil); err == nil {
+	if runtime.BindScope(nil) == nil {
 		t.Fatal("expected BindScope to reject nil scope")
 	}
 }

--- a/go/nemo_relay/adaptive_runtime_test.go
+++ b/go/nemo_relay/adaptive_runtime_test.go
@@ -149,6 +149,18 @@ func TestAdaptiveRuntimeBuildCacheRequestFacts(t *testing.T) {
 	}
 }
 
+func TestAdaptiveRuntimeBindScopeRejectsNilScope(t *testing.T) {
+	runtime, err := NewAdaptiveRuntime(testAdaptiveRuntimeConfig("openai"))
+	if err != nil {
+		t.Fatalf("NewAdaptiveRuntime failed: %v", err)
+	}
+	defer runtime.Shutdown()
+
+	if err := runtime.BindScope(nil); err == nil {
+		t.Fatal("expected BindScope to reject nil scope")
+	}
+}
+
 func TestSetLatencySensitivityRejectsInvalidValue(t *testing.T) {
 	if SetLatencySensitivity(0) == nil {
 		t.Fatal("expected SetLatencySensitivity(0) to fail")

--- a/go/nemo_relay/pii_redaction/pii_redaction_test.go
+++ b/go/nemo_relay/pii_redaction/pii_redaction_test.go
@@ -23,3 +23,17 @@ func TestPiiRedactionShorthandHelpers(t *testing.T) {
 		t.Fatalf("unexpected diagnostics: %#v", report.Diagnostics)
 	}
 }
+
+func TestPiiRedactionComponentSpecAndLocalModelHelpers(t *testing.T) {
+	config := NewConfig()
+	local := NewLocalModelConfig()
+	local.Backend = "local"
+	local.ModelID = "pii-model"
+	config.Mode = "local"
+	config.Local = &local
+
+	spec := NewComponentSpec(config)
+	if !spec.Enabled || spec.Config.Local == nil || spec.Config.Local.ModelID != "pii-model" {
+		t.Fatalf("unexpected PII redaction component spec: %#v", spec)
+	}
+}

--- a/go/nemo_relay/pricing/pricing_test.go
+++ b/go/nemo_relay/pricing/pricing_test.go
@@ -53,8 +53,10 @@ func TestPricingPackageSourceAndRateHelpers(t *testing.T) {
 	}
 
 	minTokens := uint64(256)
+	maxTokens := uint64(1024)
 	tier := NewTokenRateTier(NewTokenRates(3, 4))
 	tier.MinPromptTokens = &minTokens
+	tier.MaxPromptTokens = &maxTokens
 	schedule := NewPromptTokenThresholdRateSchedule(tier)
 	schedulePayload, err := json.Marshal(schedule)
 	if err != nil {
@@ -66,6 +68,24 @@ func TestPricingPackageSourceAndRateHelpers(t *testing.T) {
 	}
 	if parsedSchedule["type"] != "prompt_token_threshold" || parsedSchedule["applies_to"] != "full_request" {
 		t.Fatalf("unexpected rate schedule: %#v", parsedSchedule)
+	}
+	tiers, ok := parsedSchedule["tiers"].([]any)
+	if !ok || len(tiers) != 1 {
+		t.Fatalf("unexpected rate schedule tiers: %#v", parsedSchedule["tiers"])
+	}
+	parsedTier, ok := tiers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected rate schedule tier: %#v", tiers[0])
+	}
+	if parsedTier["min_prompt_tokens"] != float64(minTokens) || parsedTier["max_prompt_tokens"] != float64(maxTokens) {
+		t.Fatalf("unexpected token bounds: %#v", parsedTier)
+	}
+	rates, ok := parsedTier["rates"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected tier rates: %#v", parsedTier["rates"])
+	}
+	if rates["input_per_million"] != float64(3) || rates["output_per_million"] != float64(4) {
+		t.Fatalf("unexpected tier rate values: %#v", rates)
 	}
 
 	config := NewConfig()

--- a/go/nemo_relay/pricing/pricing_test.go
+++ b/go/nemo_relay/pricing/pricing_test.go
@@ -3,7 +3,10 @@
 
 package pricing
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestPricingPackageHelpers(t *testing.T) {
 	entry := NewModelPricing("test", "priced-model")
@@ -27,5 +30,47 @@ func TestPricingPackageHelpers(t *testing.T) {
 	}
 	if len(report.Diagnostics) != 0 {
 		t.Fatalf("expected clean report, got %#v", report.Diagnostics)
+	}
+}
+
+func TestPricingPackageSourceAndRateHelpers(t *testing.T) {
+	fileSource := NewFileSource("/tmp/pricing.json")
+	payload, err := json.Marshal(fileSource)
+	if err != nil {
+		t.Fatalf("marshal file source: %v", err)
+	}
+	var parsedSource map[string]any
+	if err := json.Unmarshal(payload, &parsedSource); err != nil {
+		t.Fatalf("unmarshal file source: %v", err)
+	}
+	if parsedSource["type"] != "file" || parsedSource["path"] != "/tmp/pricing.json" {
+		t.Fatalf("unexpected file source: %#v", parsedSource)
+	}
+
+	promptCache := NewPromptCacheConfig()
+	if promptCache.ReadAccounting != CacheReadIncludedInPromptTokens {
+		t.Fatalf("unexpected prompt cache defaults: %#v", promptCache)
+	}
+
+	minTokens := uint64(256)
+	tier := NewTokenRateTier(NewTokenRates(3, 4))
+	tier.MinPromptTokens = &minTokens
+	schedule := NewPromptTokenThresholdRateSchedule(tier)
+	schedulePayload, err := json.Marshal(schedule)
+	if err != nil {
+		t.Fatalf("marshal rate schedule: %v", err)
+	}
+	var parsedSchedule map[string]any
+	if err := json.Unmarshal(schedulePayload, &parsedSchedule); err != nil {
+		t.Fatalf("unmarshal rate schedule: %v", err)
+	}
+	if parsedSchedule["type"] != "prompt_token_threshold" || parsedSchedule["applies_to"] != "full_request" {
+		t.Fatalf("unexpected rate schedule: %#v", parsedSchedule)
+	}
+
+	config := NewConfig()
+	component := Component(config)
+	if component.Kind != PluginKind || !component.Enabled {
+		t.Fatalf("unexpected pricing component: %#v", component)
 	}
 }

--- a/go/nemo_relay/subscribers/subscribers_test.go
+++ b/go/nemo_relay/subscribers/subscribers_test.go
@@ -36,8 +36,8 @@ func countScopedMarks(t *testing.T, handle *nemo_relay.ScopeHandle) int {
 	if err := nemo_relay.EmitEvent("first-mark"); err != nil {
 		t.Fatalf("EmitEvent failed: %v", err)
 	}
-	if err := nemo_relay.FlushSubscribers(); err != nil {
-		t.Fatalf("FlushSubscribers failed: %v", err)
+	if err := subscriberspkg.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
 	}
 	if err := subscriberspkg.ScopeDeregister(handle.UUID(), "subs_local"); err != nil {
 		t.Fatalf("ScopeDeregister failed: %v", err)
@@ -75,8 +75,8 @@ func TestSubscriberShorthands(t *testing.T) {
 	if err := subscriberspkg.Deregister("subs_global"); err != nil {
 		t.Fatalf("Deregister failed: %v", err)
 	}
-	if err := nemo_relay.FlushSubscribers(); err != nil {
-		t.Fatalf("FlushSubscribers failed: %v", err)
+	if err := subscriberspkg.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
 	}
 
 	mu.Lock()


### PR DESCRIPTION
#### Overview

Adds focused Go and FFI test coverage for previously under-covered binding surfaces.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Covers Go shorthand/helper packages that were below coverage expectations, including adaptive, pricing, PII redaction, and subscribers.
- Adds FFI adaptive runtime lifecycle, cache request facts, cache telemetry, and error-path coverage.
- Extends FFI observability and type accessor coverage for ATOF/exporter and event helper paths.
- Leaves runtime behavior unchanged; this is test-only coverage improvement.

Validation:
- `just --set ci true test-go`
- `cargo fmt --all`
- `cargo test -p nemo-relay-ffi`
- `cargo llvm-cov test -p nemo-relay-ffi --all-targets --ignore-filename-regex '.*/tests/.*\\.rs$' --summary-only`
- `git diff --check`
- Commit pre-commit hooks, including Cargo checks, Go formatting, and Go vet

#### Where should the reviewer start?

Start with `crates/ffi/tests/unit/api/coverage_sweeps_tests.rs` for the adaptive FFI coverage expansion, then `crates/ffi/tests/integration/api/coverage_sweeps_tests.rs` for the integration-side FFI coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Rust FFI coverage with new end-to-end and unit tests for adaptive runtime, cache-facts, cache telemetry (including hit-rate), observability config/spec, and AToF exporter flows.
  * Added stronger validation for null pointers, invalid JSON/UTF-8, unsupported inputs, and adaptive runtime lifecycle teardown/error paths.
  * Extended event accessor assertions and updated free/cleanup coverage.
  * Added Go helper tests for telemetry/latency sensitivity, rejected nil scope binding, PII redaction local specs, and pricing JSON round-tripping; adjusted subscriber flush behavior in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->