### PR TITLE
refactor: align exporter cost fallback with normalized responses

### DIFF
--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -22,6 +22,31 @@ pub mod otel;
 pub mod plugin_component;
 
 #[cfg(any(feature = "otel", feature = "openinference"))]
+pub(crate) fn estimate_cost_for_response_or_requested_model(
+    event: &crate::api::event::Event,
+    response_model: Option<&str>,
+    usage: &crate::codec::response::Usage,
+) -> Option<crate::codec::response::CostEstimate> {
+    // Prefer the provider-echoed model, but fall back to the requested model
+    // when pricing does not recognize the echoed model alias.
+    if let Some(model_name) = response_model
+        && let Some(cost) = crate::codec::response::estimate_cost_for_provider(
+            Some(event.name()),
+            model_name,
+            usage,
+        )
+    {
+        return Some(cost);
+    }
+
+    let event_model = event.model_name()?;
+    if response_model == Some(event_model) {
+        return None;
+    }
+    crate::codec::response::estimate_cost_for_provider(Some(event.name()), event_model, usage)
+}
+
+#[cfg(any(feature = "otel", feature = "openinference"))]
 pub(crate) fn set_span_status_from_event_metadata<S>(span: &mut S, event: &crate::api::event::Event)
 where
     S: opentelemetry::trace::Span,

--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use super::manual;
+use super::{estimate_cost_for_response_or_requested_model, manual};
 use crate::api::event::{Event, ScopeCategory};
 use crate::api::runtime::EventSubscriberFn;
 use crate::api::scope::ScopeType;
@@ -1194,9 +1194,10 @@ fn cost_total_from_llm_event(
         if let Some(cost) = usage.cost.as_ref() {
             return cost.total_or_component_sum_for_currency("USD");
         }
-        if let Some(model_name) = response.model.as_deref().or_else(|| event.model_name()) {
-            return estimate_cost_for_provider(Some(event.name()), model_name, usage)
-                .and_then(|cost| cost.total_for_currency("USD"));
+        if let Some(cost) =
+            estimate_cost_for_response_or_requested_model(event, response.model.as_deref(), usage)
+        {
+            return cost.total_for_currency("USD");
         }
     }
 

--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -776,7 +776,10 @@ fn end_attributes(event: &Event) -> Vec<KeyValue> {
     if is_llm {
         push_llm_usage_attributes(&mut attributes, usage.as_ref());
     }
-    if is_llm && let Some(cost_total) = cost_total_from_llm_event(event, fallback_usage.as_ref()) {
+    if is_llm
+        && let Some(cost_total) =
+            cost_total_from_llm_event(event, normalized.as_deref(), fallback_usage.as_ref())
+    {
         attributes.push(KeyValue::new(oi::llm::cost::TOTAL, cost_total));
     }
     if is_llm {
@@ -1174,14 +1177,18 @@ fn finish_reason_value(reason: &FinishReason) -> String {
     }
 }
 
-fn cost_total_from_llm_event(event: &Event, fallback_usage: Option<&Usage>) -> Option<f64> {
+fn cost_total_from_llm_event(
+    event: &Event,
+    normalized_response: Option<&AnnotatedLlmResponse>,
+    fallback_usage: Option<&Usage>,
+) -> Option<f64> {
     if let Some(cost) =
         manual::cost_from_manual_llm_output(event.output(), true).map(|(total, _)| total)
     {
         return Some(cost);
     }
 
-    if let Some(response) = event.annotated_response()
+    if let Some(response) = normalized_response
         && let Some(usage) = response.usage.as_ref()
     {
         if let Some(cost) = usage.cost.as_ref() {

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use super::manual;
+use super::{estimate_cost_for_response_or_requested_model, manual};
 use crate::api::event::Event;
 use crate::api::event::ScopeCategory;
 use crate::api::runtime::EventSubscriberFn;
@@ -722,9 +722,12 @@ fn cost_from_llm_event(event: &Event) -> Option<(f64, String)> {
             if let Some(cost) = usage.cost.as_ref() {
                 return cost_total_and_currency(cost);
             }
-            if let Some(model_name) = response.model.as_deref().or_else(|| event.model_name()) {
-                return estimate_cost_for_provider(Some(event.name()), model_name, usage)
-                    .and_then(|cost| cost_total_and_currency(&cost));
+            if let Some(cost) = estimate_cost_for_response_or_requested_model(
+                event,
+                response.model.as_deref(),
+                usage,
+            ) {
+                return cost_total_and_currency(&cost);
             }
         }
     }

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -716,15 +716,16 @@ fn cost_from_llm_event(event: &Event) -> Option<(f64, String)> {
     if let Some(cost) = manual::cost_from_manual_llm_output(event.output(), false) {
         return Some(cost);
     }
-    if let Some(response) = event.annotated_response()
-        && let Some(usage) = response.usage.as_ref()
-    {
-        if let Some(cost) = usage.cost.as_ref() {
-            return cost_total_and_currency(cost);
-        }
-        if let Some(model_name) = response.model.as_deref().or_else(|| event.model_name()) {
-            return estimate_cost_for_provider(Some(event.name()), model_name, usage)
-                .and_then(|cost| cost_total_and_currency(&cost));
+    if let Some(response) = event.normalized_llm_response() {
+        let response = response.as_ref();
+        if let Some(usage) = response.usage.as_ref() {
+            if let Some(cost) = usage.cost.as_ref() {
+                return cost_total_and_currency(cost);
+            }
+            if let Some(model_name) = response.model.as_deref().or_else(|| event.model_name()) {
+                return estimate_cost_for_provider(Some(event.name()), model_name, usage)
+                    .and_then(|cost| cost_total_and_currency(&cost));
+            }
         }
     }
     let usage = manual::usage_from_manual_llm_output(event.output())?;

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -2739,6 +2739,24 @@ fn llm_end_with_unannotated_openai_response_uses_codec_cost_attribute() {
 }
 
 #[test]
+fn llm_end_with_unannotated_openai_response_without_usage_omits_cost_attribute() {
+    let _pricing_guard = pricing_test_mutex().lock().unwrap();
+    reset_active_pricing_resolver().unwrap();
+    let _reset_guard = ResetPricingResolverGuard;
+
+    let mut output = openai_chat_provider_response("priced-model");
+    output.as_object_mut().unwrap().remove("usage");
+    let event = make_end_event(Uuid::now_v7(), None, "openai", ScopeType::Llm, Some(output));
+
+    assert!(event.annotated_response().is_none());
+    let normalized = event.normalized_llm_response().unwrap();
+    assert!(normalized.usage.is_none());
+
+    let attributes = attr_map(&end_attributes(&event));
+    assert!(!attributes.contains_key("llm.cost.total"));
+}
+
+#[test]
 fn llm_end_with_manual_usage_and_output_model_emits_derived_cost_attribute() {
     let _pricing_guard = pricing_test_mutex().lock().unwrap();
     install_test_pricing("priced-model");

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -158,6 +158,65 @@ fn install_test_pricing(model_id: &str) {
     set_active_pricing_resolver(PricingResolver::from_catalogs(vec![catalog])).unwrap();
 }
 
+fn install_openai_disambiguation_pricing(model_id: &str) {
+    let catalog = PricingCatalog::from_json_str(
+        &json!({
+            "version": 1,
+            "entries": [
+                {
+                    "provider": "other",
+                    "model_id": model_id,
+                    "pricing_as_of": "2026-06-05",
+                    "pricing_source": "test",
+                    "rates": {
+                        "input_per_million": 1000.0,
+                        "output_per_million": 1000.0
+                    },
+                    "prompt_cache": {
+                        "read_accounting": "included_in_prompt_tokens"
+                    }
+                },
+                {
+                    "provider": "openai",
+                    "model_id": model_id,
+                    "pricing_as_of": "2026-06-05",
+                    "pricing_source": "test",
+                    "rates": {
+                        "input_per_million": 0.15,
+                        "output_per_million": 0.60,
+                        "cache_read_per_million": 0.075
+                    },
+                    "prompt_cache": {
+                        "read_accounting": "included_in_prompt_tokens"
+                    }
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    set_active_pricing_resolver(PricingResolver::from_catalogs(vec![catalog])).unwrap();
+}
+
+fn openai_chat_provider_response(model_id: &str) -> Json {
+    json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": model_id,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "hello"},
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 1_000,
+            "completion_tokens": 500,
+            "total_tokens": 1_500,
+            "prompt_tokens_details": {"cached_tokens": 200}
+        }
+    })
+}
+
 fn sample_openinference_annotated_request() -> AnnotatedLlmRequest {
     AnnotatedLlmRequest {
         messages: vec![
@@ -2649,6 +2708,30 @@ fn llm_end_with_known_model_usage_emits_derived_cost_attribute() {
 
     let spans = exporter.get_finished_spans().unwrap();
     let attributes = attr_map(&spans[0].attributes);
+    assert_eq!(
+        attributes.get("llm.cost.total"),
+        Some(&"0.000435".to_string())
+    );
+}
+
+#[test]
+fn llm_end_with_unannotated_openai_response_uses_codec_cost_attribute() {
+    let _pricing_guard = pricing_test_mutex().lock().unwrap();
+    install_openai_disambiguation_pricing("priced-model");
+    let _reset_guard = ResetPricingResolverGuard;
+
+    let event = make_end_event(
+        Uuid::now_v7(),
+        None,
+        "other",
+        ScopeType::Llm,
+        Some(openai_chat_provider_response("priced-model")),
+    );
+
+    assert!(event.annotated_response().is_none());
+    assert!(event.normalized_llm_response().is_some());
+
+    let attributes = attr_map(&end_attributes(&event));
     assert_eq!(
         attributes.get("llm.cost.total"),
         Some(&"0.000435".to_string())

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -2739,6 +2739,37 @@ fn llm_end_with_unannotated_openai_response_uses_codec_cost_attribute() {
 }
 
 #[test]
+fn llm_end_with_unpriced_response_model_uses_requested_model_cost_attribute() {
+    let _pricing_guard = pricing_test_mutex().lock().unwrap();
+    install_openai_disambiguation_pricing("priced-model");
+    let _reset_guard = ResetPricingResolverGuard;
+
+    let event = make_scope_event_with_profile(
+        ScopeCategory::End,
+        Uuid::now_v7(),
+        None,
+        "openai",
+        ScopeType::Llm,
+        Some(openai_chat_provider_response("api-echoed-model")),
+        Some(
+            CategoryProfile::builder()
+                .model_name("priced-model")
+                .build(),
+        ),
+    );
+
+    assert!(event.annotated_response().is_none());
+    let normalized = event.normalized_llm_response().unwrap();
+    assert_eq!(normalized.model.as_deref(), Some("api-echoed-model"));
+
+    let attributes = attr_map(&end_attributes(&event));
+    assert_eq!(
+        attributes.get("llm.cost.total"),
+        Some(&"0.000435".to_string())
+    );
+}
+
+#[test]
 fn llm_end_with_unannotated_openai_response_without_usage_omits_cost_attribute() {
     let _pricing_guard = pricing_test_mutex().lock().unwrap();
     reset_active_pricing_resolver().unwrap();

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -972,6 +972,41 @@ fn llm_end_with_unannotated_openai_response_uses_codec_cost() {
 }
 
 #[test]
+fn llm_end_with_unpriced_response_model_uses_requested_model_cost() {
+    let _pricing_guard = pricing_test_mutex().lock().unwrap();
+    install_openai_disambiguation_pricing("priced-model");
+    let _reset_guard = ResetPricingResolverGuard;
+
+    let event = make_scope_event_with_profile(
+        ScopeCategory::End,
+        Uuid::now_v7(),
+        None,
+        "openai",
+        ScopeType::Llm,
+        Some(openai_chat_provider_response("api-echoed-model")),
+        Some(
+            CategoryProfile::builder()
+                .model_name("priced-model")
+                .build(),
+        ),
+    );
+
+    assert!(event.annotated_response().is_none());
+    let normalized = event.normalized_llm_response().unwrap();
+    assert_eq!(normalized.model.as_deref(), Some("api-echoed-model"));
+
+    let attributes = attr_map(&end_attributes(&event));
+    assert_eq!(
+        attributes.get("nemo_relay.llm.cost.total"),
+        Some(&"0.000435".to_string())
+    );
+    assert_eq!(
+        attributes.get("nemo_relay.llm.cost.currency"),
+        Some(&"USD".to_string())
+    );
+}
+
+#[test]
 fn llm_end_with_unannotated_openai_response_without_usage_omits_cost() {
     let _pricing_guard = pricing_test_mutex().lock().unwrap();
     reset_active_pricing_resolver().unwrap();

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -972,6 +972,25 @@ fn llm_end_with_unannotated_openai_response_uses_codec_cost() {
 }
 
 #[test]
+fn llm_end_with_unannotated_openai_response_without_usage_omits_cost() {
+    let _pricing_guard = pricing_test_mutex().lock().unwrap();
+    reset_active_pricing_resolver().unwrap();
+    let _reset_guard = ResetPricingResolverGuard;
+
+    let mut output = openai_chat_provider_response("priced-model");
+    output.as_object_mut().unwrap().remove("usage");
+    let event = make_end_event(Uuid::now_v7(), None, "openai", ScopeType::Llm, Some(output));
+
+    assert!(event.annotated_response().is_none());
+    let normalized = event.normalized_llm_response().unwrap();
+    assert!(normalized.usage.is_none());
+
+    let attributes = attr_map(&end_attributes(&event));
+    assert!(!attributes.contains_key("nemo_relay.llm.cost.total"));
+    assert!(!attributes.contains_key("nemo_relay.llm.cost.currency"));
+}
+
+#[test]
 fn helper_functions_cover_additional_otel_branches() {
     let function_end = make_end_event(Uuid::now_v7(), None, "fn-scope", ScopeType::Function, None);
     assert_eq!(span_name(&function_end), "fn-scope");

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -78,6 +78,14 @@ fn install_test_pricing(model_id: &str) {
 }
 
 fn install_provider_disambiguation_pricing(model_id: &str) {
+    install_disambiguation_pricing(model_id, "test");
+}
+
+fn install_openai_disambiguation_pricing(model_id: &str) {
+    install_disambiguation_pricing(model_id, "openai");
+}
+
+fn install_disambiguation_pricing(model_id: &str, preferred_provider: &str) {
     let catalog = PricingCatalog::from_json_str(
         &json!({
             "version": 1,
@@ -96,7 +104,7 @@ fn install_provider_disambiguation_pricing(model_id: &str) {
                     }
                 },
                 {
-                    "provider": "test",
+                    "provider": preferred_provider,
                     "model_id": model_id,
                     "pricing_as_of": "2026-06-05",
                     "pricing_source": "test",
@@ -115,6 +123,25 @@ fn install_provider_disambiguation_pricing(model_id: &str) {
     )
     .unwrap();
     set_active_pricing_resolver(PricingResolver::from_catalogs(vec![catalog])).unwrap();
+}
+
+fn openai_chat_provider_response(model_id: &str) -> Json {
+    json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": model_id,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "hello"},
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 1_000,
+            "completion_tokens": 500,
+            "total_tokens": 1_500,
+            "prompt_tokens_details": {"cached_tokens": 200}
+        }
+    })
 }
 
 fn reset_global() {
@@ -913,6 +940,34 @@ fn pre_epoch_timestamps_round_trip_through_system_time() {
     assert_eq!(
         to_system_time(timestamp),
         UNIX_EPOCH - Duration::new(1, 500_000_000)
+    );
+}
+
+#[test]
+fn llm_end_with_unannotated_openai_response_uses_codec_cost() {
+    let _pricing_guard = pricing_test_mutex().lock().unwrap();
+    install_openai_disambiguation_pricing("priced-model");
+    let _reset_guard = ResetPricingResolverGuard;
+
+    let event = make_end_event(
+        Uuid::now_v7(),
+        None,
+        "other",
+        ScopeType::Llm,
+        Some(openai_chat_provider_response("priced-model")),
+    );
+
+    assert!(event.annotated_response().is_none());
+    assert!(event.normalized_llm_response().is_some());
+
+    let attributes = attr_map(&end_attributes(&event));
+    assert_eq!(
+        attributes.get("nemo_relay.llm.cost.total"),
+        Some(&"0.000435".to_string())
+    );
+    assert_eq!(
+        attributes.get("nemo_relay.llm.cost.currency"),
+        Some(&"USD".to_string())
     );
 }
 


### PR DESCRIPTION
#### Overview

Aligns OTel and OpenInference cost fallback extraction with normalized LLM responses, so provider-shaped responses can use the codec-normalized path before falling back to raw/manual parsing.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Uses `normalized_llm_response()` for OTel and OpenInference cost fallback where available.
- Keeps exporter-specific projection and schema logic local.
- Preserves manual/raw fallback behavior when normalized response data is unavailable.
- Falls back to the requested model when the normalized/provider-echoed model is not present in pricing, preventing silent cost loss for aliased model names.
- Adds regression coverage for unannotated OpenAI-shaped responses to ensure provider-aware normalized cost extraction is used instead of event-name-only fallback behavior.
- Adds negative coverage for normalized provider-shaped responses without usage, so exporters do not fabricate cost attributes.
- Does not change ATIF projection, usage/token extraction, model-name extraction, tool-call naming, or exporter output schemas.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p nemo-relay unannotated_openai_response -- --nocapture`
- `cargo test -p nemo-relay unpriced_response_model -- --nocapture`
- `cargo test -p nemo-relay observability::otel::tests -- --nocapture`
- `cargo test -p nemo-relay observability::openinference::tests -- --nocapture`
- `cargo check -p nemo-relay --no-default-features`
- `cargo check -p nemo-relay --no-default-features --features otel`
- `cargo check -p nemo-relay --no-default-features --features openinference`
- `cargo llvm-cov test --no-report -p nemo-relay observability::otel::tests`
- `cargo llvm-cov test --no-report -p nemo-relay observability::openinference::tests`
- Targeted `cargo llvm-cov` report confirmed all added production lines in `otel.rs` and `openinference.rs` are hit.
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start with the shared fallback helper in `crates/core/src/observability/mod.rs`, then review its use in `crates/core/src/observability/otel.rs` and `crates/core/src/observability/openinference.rs`. The focused regression coverage is in the matching observability test files.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

No public issue.
