### PR TITLE
fix(cli): parse codex `plugin list` text output instead of --json

### DIFF
--- a/crates/cli/src/plugin_install/host.rs
+++ b/crates/cli/src/plugin_install/host.rs
@@ -220,8 +220,7 @@ fn codex_plugin_registered(
     options: &PluginInstallOptions,
     runner: &dyn CommandRunner,
 ) -> Result<bool, String> {
-    // Codex `plugin list` has no `--json` flag, so parse its text table the same way
-    // `codex_marketplace_registered` parses `plugin marketplace list`.
+    // Codex `plugin list` has no `--json` flag (unlike Claude Code).
     let output = run_capture_command("codex", &["plugin".into(), "list".into()], options, runner)?;
     let plugin_id = format!("{PLUGIN_NAME}@{MARKETPLACE_NAME}");
     Ok(output
@@ -230,9 +229,6 @@ fn codex_plugin_registered(
         .any(|line| codex_plugin_line_installed(line, &plugin_id)))
 }
 
-// Codex `plugin list` rows are `<id>  <status>  <version>  <path>`. An installed
-// plugin's status starts with `installed` (e.g. `installed, enabled`), while an
-// available-but-uninstalled one is `not installed`.
 fn codex_plugin_line_installed(line: &str, plugin_id: &str) -> bool {
     let mut columns = line.split_whitespace();
     if columns.next() != Some(plugin_id) {

--- a/crates/cli/src/plugin_install/host.rs
+++ b/crates/cli/src/plugin_install/host.rs
@@ -220,17 +220,27 @@ fn codex_plugin_registered(
     options: &PluginInstallOptions,
     runner: &dyn CommandRunner,
 ) -> Result<bool, String> {
-    let output = run_capture_command(
-        "codex",
-        &["plugin".into(), "list".into(), "--json".into()],
-        options,
-        runner,
-    )?;
-    let plugins = parse_json_command_output("codex plugin list --json", output)?;
-    Ok(plugins
-        .get("installed")
-        .and_then(Value::as_array)
-        .is_some_and(|plugins| plugins.iter().any(plugin_entry_matches)))
+    // Codex `plugin list` has no `--json` flag, so parse its text table the same way
+    // `codex_marketplace_registered` parses `plugin marketplace list`.
+    let output = run_capture_command("codex", &["plugin".into(), "list".into()], options, runner)?;
+    let plugin_id = format!("{PLUGIN_NAME}@{MARKETPLACE_NAME}");
+    Ok(output
+        .stdout
+        .lines()
+        .any(|line| codex_plugin_line_installed(line, &plugin_id)))
+}
+
+// Codex `plugin list` rows are `<id>  <status>  <version>  <path>`. An installed
+// plugin's status starts with `installed` (e.g. `installed, enabled`), while an
+// available-but-uninstalled one is `not installed`.
+fn codex_plugin_line_installed(line: &str, plugin_id: &str) -> bool {
+    let mut columns = line.split_whitespace();
+    if columns.next() != Some(plugin_id) {
+        return false;
+    }
+    columns
+        .next()
+        .is_some_and(|status| status.starts_with("installed"))
 }
 
 fn codex_marketplace_registered(

--- a/crates/cli/tests/coverage/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/plugin_install_tests.rs
@@ -559,21 +559,17 @@ fn host_command_helpers_cover_dry_run_missing_failure_and_reporting() {
     );
 
     let runner = MockRunner::default()
-        .with_executable("codex", "/bin/codex")
-        .with_capture_output("/bin/codex plugin list --json", "not json")
-        .with_capture_output("/bin/codex plugin marketplace list", "");
+        .with_executable("claude", "/bin/claude")
+        .with_capture_output("/bin/claude plugin list --json", "not json");
     assert!(
-        host_registration_report(PluginHost::Codex, &normal, &runner)
+        host_registration_report(PluginHost::ClaudeCode, &normal, &runner)
             .unwrap_err()
             .contains("failed to parse")
     );
 
     let runner = MockRunner::default()
         .with_executable("codex", "/bin/codex")
-        .with_capture_output(
-            "/bin/codex plugin list --json",
-            json!({"installed": []}).to_string(),
-        )
+        .with_capture_output("/bin/codex plugin list", "PLUGIN  STATUS  VERSION  PATH\n")
         .with_capture_output("/bin/codex plugin marketplace list", "MARKETPLACE ROOT\n");
     let error = validate_host_registration(PluginHost::Codex, &normal, &runner).unwrap_err();
     assert!(
@@ -618,30 +614,41 @@ fn host_registration_report_accepts_claude_and_codex_shape_variants() {
         assert!(report.host_marketplace_registered);
     }
 
-    for plugin_entry in [
-        json!({"id": plugin_id.clone()}),
-        json!({"pluginId": plugin_id.clone()}),
-        json!({"name": PLUGIN_NAME, "marketplaceName": MARKETPLACE_NAME}),
-    ] {
-        let runner = MockRunner::default()
-            .with_executable("codex", "/bin/codex")
-            .with_capture_output(
-                "/bin/codex plugin list --json",
-                json!({"installed": [plugin_entry]}).to_string(),
-            )
-            .with_capture_output(
-                "/bin/codex plugin marketplace list",
-                format!("{MARKETPLACE_NAME} /tmp/nemo-relay-local\n"),
-            );
-        let report = host_registration_report(PluginHost::Codex, &normal, &runner).unwrap();
-        assert!(report.ok());
-    }
-
+    // Codex `plugin list` is a text table; an installed row registers the plugin.
     let runner = MockRunner::default()
         .with_executable("codex", "/bin/codex")
         .with_capture_output(
-            "/bin/codex plugin list --json",
-            json!({"installed": [{"name": PLUGIN_NAME, "marketplaceName": "other"}]}).to_string(),
+            "/bin/codex plugin list",
+            format!("{plugin_id}  installed, enabled  0.4.0  /tmp/nemo-relay-plugin\n"),
+        )
+        .with_capture_output(
+            "/bin/codex plugin marketplace list",
+            format!("{MARKETPLACE_NAME} /tmp/nemo-relay-local\n"),
+        );
+    let report = host_registration_report(PluginHost::Codex, &normal, &runner).unwrap();
+    assert!(report.ok());
+
+    // A row that is present but `not installed` must not count as registered.
+    let runner = MockRunner::default()
+        .with_executable("codex", "/bin/codex")
+        .with_capture_output(
+            "/bin/codex plugin list",
+            format!("{plugin_id}  not installed\n"),
+        )
+        .with_capture_output(
+            "/bin/codex plugin marketplace list",
+            format!("{MARKETPLACE_NAME} /tmp/nemo-relay-local\n"),
+        );
+    let report = host_registration_report(PluginHost::Codex, &normal, &runner).unwrap();
+    assert!(!report.host_plugin_registered);
+    assert!(report.host_marketplace_registered);
+
+    // A plugin installed under a different marketplace id must not match.
+    let runner = MockRunner::default()
+        .with_executable("codex", "/bin/codex")
+        .with_capture_output(
+            "/bin/codex plugin list",
+            format!("{PLUGIN_NAME}@other  installed, enabled  0.4.0  /tmp/other\n"),
         )
         .with_capture_output("/bin/codex plugin marketplace list", "other /tmp/other\n");
     let report = host_registration_report(PluginHost::Codex, &normal, &runner).unwrap();
@@ -1328,13 +1335,9 @@ fn doctor_json_uses_quiet_plugin_report() {
         .with_executable("nemo-relay", "/bin/nemo-relay")
         .with_executable("codex", "/bin/codex")
         .with_capture_output(
-            "/bin/codex plugin list --json",
-            json!({
-                "installed": [
-                    { "pluginId": "nemo-relay-plugin@nemo-relay-local" }
-                ]
-            })
-            .to_string(),
+            "/bin/codex plugin list",
+            "PLUGIN                              STATUS              VERSION  PATH\n\
+             nemo-relay-plugin@nemo-relay-local  installed, enabled  0.4.0    /tmp/nemo-relay-plugin\n",
         )
         .with_capture_output(
             "/bin/codex plugin marketplace list",
@@ -1357,7 +1360,7 @@ fn doctor_json_uses_quiet_plugin_report() {
     assert_eq!(
         runner.capture_commands(),
         vec![
-            "/bin/codex plugin list --json",
+            "/bin/codex plugin list",
             "/bin/codex plugin marketplace list"
         ]
     );

--- a/crates/cli/tests/coverage/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/plugin_install_tests.rs
@@ -559,15 +559,6 @@ fn host_command_helpers_cover_dry_run_missing_failure_and_reporting() {
     );
 
     let runner = MockRunner::default()
-        .with_executable("claude", "/bin/claude")
-        .with_capture_output("/bin/claude plugin list --json", "not json");
-    assert!(
-        host_registration_report(PluginHost::ClaudeCode, &normal, &runner)
-            .unwrap_err()
-            .contains("failed to parse")
-    );
-
-    let runner = MockRunner::default()
         .with_executable("codex", "/bin/codex")
         .with_capture_output("/bin/codex plugin list", "PLUGIN  STATUS  VERSION  PATH\n")
         .with_capture_output("/bin/codex plugin marketplace list", "MARKETPLACE ROOT\n");
@@ -661,6 +652,17 @@ fn host_registration_report_accepts_claude_and_codex_shape_variants() {
 fn host_registration_report_surfaces_capture_status_and_stderr_variants() {
     let dir = tempdir().unwrap();
     let normal = options(dir.path());
+
+    // Non-JSON `claude plugin list` output surfaces a parse error. Codex no longer
+    // has a JSON path, so this only applies to the host that still uses `--json`.
+    let runner = MockRunner::default()
+        .with_executable("claude", "/bin/claude")
+        .with_capture_output("/bin/claude plugin list --json", "not json");
+    assert!(
+        host_registration_report(PluginHost::ClaudeCode, &normal, &runner)
+            .unwrap_err()
+            .contains("failed to parse")
+    );
 
     let runner = MockRunner::default()
         .with_executable("claude", "/bin/claude")

--- a/crates/cli/tests/coverage/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/plugin_install_tests.rs
@@ -605,7 +605,6 @@ fn host_registration_report_accepts_claude_and_codex_shape_variants() {
         assert!(report.host_marketplace_registered);
     }
 
-    // Codex `plugin list` is a text table; an installed row registers the plugin.
     let runner = MockRunner::default()
         .with_executable("codex", "/bin/codex")
         .with_capture_output(
@@ -619,7 +618,6 @@ fn host_registration_report_accepts_claude_and_codex_shape_variants() {
     let report = host_registration_report(PluginHost::Codex, &normal, &runner).unwrap();
     assert!(report.ok());
 
-    // A row that is present but `not installed` must not count as registered.
     let runner = MockRunner::default()
         .with_executable("codex", "/bin/codex")
         .with_capture_output(
@@ -634,7 +632,6 @@ fn host_registration_report_accepts_claude_and_codex_shape_variants() {
     assert!(!report.host_plugin_registered);
     assert!(report.host_marketplace_registered);
 
-    // A plugin installed under a different marketplace id must not match.
     let runner = MockRunner::default()
         .with_executable("codex", "/bin/codex")
         .with_capture_output(
@@ -653,8 +650,6 @@ fn host_registration_report_surfaces_capture_status_and_stderr_variants() {
     let dir = tempdir().unwrap();
     let normal = options(dir.path());
 
-    // Non-JSON `claude plugin list` output surfaces a parse error. Codex no longer
-    // has a JSON path, so this only applies to the host that still uses `--json`.
     let runner = MockRunner::default()
         .with_executable("claude", "/bin/claude")
         .with_capture_output("/bin/claude plugin list --json", "not json");


### PR DESCRIPTION
#### Overview

`nemo-relay doctor --plugin codex` (and `--plugin all`) fails on Codex CLI 0.136.0 with `error: unexpected argument '--json' found`. The codex plugin host-registration probe calls `codex plugin list --json`, but current Codex `plugin list` has no `--json` flag (only `-c`, `-m/--marketplace`, `--enable`, `--disable`).

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- `codex_plugin_registered` now runs `codex plugin list` (no `--json`) and parses the text table, mirroring the existing `codex_marketplace_registered` text parsing. A small helper `codex_plugin_line_installed` matches the row whose first column is `nemo-relay-plugin@nemo-relay-local` and whose status column starts with `installed` (so `installed, enabled` matches but `not installed` does not).
- Claude Code is unchanged and still uses `--json`, since its CLI supports it.
- Updated `plugin_install` tests to mock the Codex text output, added not-installed and wrong-marketplace negative cases, and moved the JSON parse-error assertion to the Claude path (Codex no longer has a JSON parse path).

Validation (isolated worktree off `main`):
- `cargo test -p nemo-relay-cli plugin_install` — 34 passed
- `cargo clippy -p nemo-relay-cli --all-targets` — clean
- `cargo fmt -- --check` — clean
- pre-commit hooks passed on commit

#### Where should the reviewer start?

`crates/cli/src/plugin_install/host.rs` — `codex_plugin_registered` and the new `codex_plugin_line_installed` helper.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex plugin registration detection by reading the standard (non-JSON) plugin list table output instead of relying on JSON parsing.
  * Strengthened matching to require the correct plugin name and marketplace pairing, reducing incorrect registrations.
  * Updated behavior when the plugin list output format can’t be parsed, so errors are surfaced as expected.

* **Tests**
  * Revised plugin installation and coverage tests to mock the text table output and validate installed, not installed, and mismatched marketplace scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->