### PR TITLE
feat: provider-aware ACG request-surface resolution

### DIFF
--- a/crates/adaptive/src/acg/request_surfaces/mod.rs
+++ b/crates/adaptive/src/acg/request_surfaces/mod.rs
@@ -16,7 +16,7 @@ pub(crate) mod openai_responses;
 use std::collections::HashSet;
 
 use nemo_relay::api::llm::LlmRequest;
-use nemo_relay::codec::resolve::{ProviderSurface, detect_request_surface};
+use nemo_relay::codec::resolve::{ProviderSurface, detect_request_surface_with_hint};
 use serde_json::Value;
 
 use crate::acg::prompt_ir::PromptIR;
@@ -79,8 +79,9 @@ impl RequestSurface {
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn resolve_request_surface_from_request(
     request: &LlmRequest,
+    provider_hint: Option<&str>,
 ) -> crate::acg::Result<RequestSurface> {
-    detect_request_surface(&request.content)
+    detect_request_surface_with_hint(&request.content, provider_hint)
         .map(RequestSurface::from_provider_surface)
         .ok_or_else(|| {
             crate::acg::AcgError::Internal(
@@ -94,7 +95,7 @@ pub(crate) fn resolve_request_surface(
     provider: &str,
     request: &LlmRequest,
 ) -> crate::acg::Result<RequestSurface> {
-    let surface = resolve_request_surface_from_request(request)?;
+    let surface = resolve_request_surface_from_request(request, Some(provider))?;
     if surface.supports_provider(provider) {
         Ok(surface)
     } else {

--- a/crates/adaptive/src/acg_component.rs
+++ b/crates/adaptive/src/acg_component.rs
@@ -108,8 +108,11 @@ fn decode_request_for_surface(
     }
 }
 
-fn build_semantic_request_view(request: &LlmRequest) -> Result<SemanticRequestView> {
-    let request_surface = resolve_request_surface_from_request(request)
+fn build_semantic_request_view(
+    request: &LlmRequest,
+    provider: &str,
+) -> Result<SemanticRequestView> {
+    let request_surface = resolve_request_surface_from_request(request, Some(provider))
         .map_err(|error| AdaptiveError::Internal(error.to_string()))?;
     let annotated_request = decode_request_for_surface(request_surface, request)?;
 
@@ -387,7 +390,7 @@ fn translate_request(
     hot_cache: &Arc<RwLock<HotCache>>,
 ) -> Option<LlmRequest> {
     // Response codecs stay on the observability path after provider execution.
-    let semantic_request_view = match build_semantic_request_view(request) {
+    let semantic_request_view = match build_semantic_request_view(request, provider) {
         Ok(view) => view,
         Err(error) => {
             acg_debug::emit(

--- a/crates/adaptive/tests/integration/runtime_integration_tests.rs
+++ b/crates/adaptive/tests/integration/runtime_integration_tests.rs
@@ -294,16 +294,20 @@ fn sample_run_with_requests(
 }
 
 #[test]
-fn acg_component_source_resolves_request_surfaces_instead_of_decoding_from_provider() {
+fn acg_component_source_resolves_request_surfaces_shape_first_with_provider_hint() {
     let source = include_str!("../../src/acg_component.rs");
 
     assert!(
-        source.contains("resolve_request_surface_from_request"),
-        "acg_component should resolve request surfaces independently from provider selection",
+        source.contains("decode_request_for_surface"),
+        "acg_component should decode by the resolved request surface",
     );
     assert!(
         !source.contains("decode_request_for_provider"),
-        "acg_component should no longer decode semantic requests from the configured provider",
+        "acg_component should not decode semantic requests directly from the configured provider",
+    );
+    assert!(
+        source.contains("build_semantic_request_view(request, provider)"),
+        "acg_component should pass the provider as a disambiguation hint to surface resolution",
     );
 }
 

--- a/crates/adaptive/tests/integration/runtime_integration_tests.rs
+++ b/crates/adaptive/tests/integration/runtime_integration_tests.rs
@@ -305,8 +305,10 @@ fn acg_component_source_resolves_request_surfaces_shape_first_with_provider_hint
         !source.contains("decode_request_for_provider"),
         "acg_component should not decode semantic requests directly from the configured provider",
     );
+    // Whitespace-stripped so a rustfmt reflow of the call's arguments doesn't break this.
+    let source_no_ws: String = source.chars().filter(|c| !c.is_whitespace()).collect();
     assert!(
-        source.contains("build_semantic_request_view(request, provider)"),
+        source_no_ws.contains("build_semantic_request_view(request,provider"),
         "acg_component should pass the provider as a disambiguation hint to surface resolution",
     );
 }

--- a/crates/adaptive/tests/unit/acg/request_surface_tests.rs
+++ b/crates/adaptive/tests/unit/acg/request_surface_tests.rs
@@ -290,24 +290,29 @@ fn test_request_surface_resolution_and_passthrough_support_cover_matrix() {
     assert!(RequestSurface::OpenAIChat.supports_provider("passthrough"));
     assert!(!RequestSurface::OpenAIChat.supports_provider("unknown"));
     assert_eq!(
-        super::resolve_request_surface_from_request(&chat_request).unwrap(),
+        super::resolve_request_surface_from_request(&chat_request, None).unwrap(),
         RequestSurface::OpenAIChat
     );
     assert_eq!(
-        super::resolve_request_surface_from_request(&responses_request).unwrap(),
+        super::resolve_request_surface_from_request(&responses_request, None).unwrap(),
         RequestSurface::OpenAIResponses
     );
     assert_eq!(
-        super::resolve_request_surface_from_request(&anthropic_request).unwrap(),
+        super::resolve_request_surface_from_request(&anthropic_request, None).unwrap(),
         RequestSurface::AnthropicMessages
     );
     assert!(matches!(
-        super::resolve_request_surface_from_request(&invalid_request),
+        super::resolve_request_surface_from_request(&invalid_request, None),
         Err(crate::acg::AcgError::Internal(message))
             if message.contains("unable to resolve request surface")
     ));
+    // `resolve_request_surface` is the plugin-facade path, not the live translate path.
+    assert_eq!(
+        super::resolve_request_surface("anthropic", &chat_request).unwrap(),
+        RequestSurface::AnthropicMessages
+    );
     assert!(matches!(
-        super::resolve_request_surface("anthropic", &chat_request),
+        super::resolve_request_surface("anthropic", &responses_request),
         Err(crate::acg::AcgError::Internal(message))
             if message.contains("does not support resolved request surface")
     ));

--- a/crates/adaptive/tests/unit/acg_component_tests.rs
+++ b/crates/adaptive/tests/unit/acg_component_tests.rs
@@ -19,7 +19,9 @@ use crate::storage::traits::StorageBackendDyn;
 use nemo_relay::api::llm::LlmRequest;
 use nemo_relay::api::runtime::LlmExecutionNextFn;
 use nemo_relay::api::runtime::LlmStreamExecutionNextFn;
+use nemo_relay::codec::anthropic::AnthropicMessagesCodec;
 use nemo_relay::codec::request::{AnnotatedLlmRequest, Message, MessageContent};
+use nemo_relay::codec::traits::LlmCodec;
 use serde_json::{Value, json};
 use tokio_stream::StreamExt;
 
@@ -406,7 +408,8 @@ impl StorageBackendDyn for FailingStabilityBackend {
 
 #[test]
 fn acg_component_translate_request_degrades_when_provider_semantics_do_not_match_request_surface() {
-    let request = sample_openai_chat_request();
+    // A Responses shape (`input`) genuinely diverges from "anthropic"; the hint can't override it.
+    let request = sample_openai_responses_request();
     let hot_cache = sample_hot_cache();
     let plugin = build_provider_plugin("anthropic").expect("anthropic plugin should build");
 
@@ -581,8 +584,8 @@ fn rewrite_request_with_hot_cache_adaptive_placement_differs_by_state() {
 #[test]
 fn acg_component_translate_request_uses_learning_key_for_profile_lookup() {
     let request = sample_layered_anthropic_request();
-    let semantic_request_view =
-        build_semantic_request_view(&request).expect("anthropic request should decode");
+    let semantic_request_view = build_semantic_request_view(&request, "anthropic")
+        .expect("anthropic request should decode");
     let learning_key = crate::acg_profile::derive_acg_learning_key(
         "agent-1",
         &semantic_request_view.annotated_request,
@@ -812,18 +815,19 @@ fn acg_component_build_provider_plugin_supports_passthrough_and_rejects_unknown(
 #[test]
 fn acg_component_build_semantic_request_view_decodes_supported_surfaces_and_rejects_unknown_shape()
 {
-    let anthropic = build_semantic_request_view(&sample_anthropic_request()).unwrap();
+    let anthropic = build_semantic_request_view(&sample_anthropic_request(), "anthropic").unwrap();
     assert_eq!(anthropic.request_surface, RequestSurface::AnthropicMessages);
     assert_eq!(
         anthropic.annotated_request.model.as_deref(),
         Some("claude-sonnet-4-20250514")
     );
 
-    let chat = build_semantic_request_view(&sample_openai_chat_request()).unwrap();
+    let chat = build_semantic_request_view(&sample_openai_chat_request(), "openai").unwrap();
     assert_eq!(chat.request_surface, RequestSurface::OpenAIChat);
     assert_eq!(chat.annotated_request.model.as_deref(), Some("gpt-4o"));
 
-    let responses = build_semantic_request_view(&sample_openai_responses_request()).unwrap();
+    let responses =
+        build_semantic_request_view(&sample_openai_responses_request(), "openai").unwrap();
     assert_eq!(responses.request_surface, RequestSurface::OpenAIResponses);
     assert_eq!(
         responses.annotated_request.model.as_deref(),
@@ -835,9 +839,91 @@ fn acg_component_build_semantic_request_view_decodes_supported_surfaces_and_reje
         content: json!({"model": "unknown"}),
     };
     assert!(matches!(
-        build_semantic_request_view(&invalid),
+        build_semantic_request_view(&invalid, "passthrough"),
         Err(AdaptiveError::Internal(message)) if message.contains("unable to resolve request surface")
     ));
+}
+
+fn sample_system_less_anthropic_request() -> LlmRequest {
+    LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [
+                {"role": "user", "content": long_text(1500)},
+                {"role": "user", "content": long_text(1600)},
+                {"role": "user", "content": long_text(1700)}
+            ]
+        }),
+    }
+}
+
+#[test]
+fn acg_component_build_semantic_request_view_uses_provider_hint_for_system_less_anthropic() {
+    let request = sample_system_less_anthropic_request();
+
+    // Without the anthropic hint, the system-less shape stays OpenAI Chat.
+    for provider in ["openai", "passthrough"] {
+        assert_eq!(
+            build_semantic_request_view(&request, provider)
+                .unwrap()
+                .request_surface,
+            RequestSurface::OpenAIChat,
+        );
+    }
+
+    // The "anthropic" hint disambiguates it to Anthropic Messages.
+    assert_eq!(
+        build_semantic_request_view(&request, "anthropic")
+            .unwrap()
+            .request_surface,
+        RequestSurface::AnthropicMessages,
+    );
+}
+
+#[test]
+fn acg_component_translate_request_optimizes_system_less_anthropic_with_provider_hint() {
+    let request = sample_system_less_anthropic_request();
+    let view = build_semantic_request_view(&request, "anthropic").unwrap();
+
+    // The subscriber keys profiles off the Anthropic codec annotation; the hint makes
+    // translate-time decode match it, so the learned profile is found.
+    let learning_key =
+        crate::acg_profile::derive_acg_learning_key("agent-1", &view.annotated_request);
+    assert_eq!(
+        learning_key,
+        crate::acg_profile::derive_acg_learning_key(
+            "agent-1",
+            &AnthropicMessagesCodec.decode(&request).unwrap(),
+        ),
+    );
+
+    let plugin = build_provider_plugin("anthropic").unwrap();
+    let hot_cache = Arc::new(RwLock::new(HotCache {
+        plan: None,
+        trie: None,
+        agent_hints_default: None,
+        acg_profiles: std::collections::HashMap::from([(
+            learning_key.clone(),
+            layered_stability_result(6),
+        )]),
+        acg_profile_observation_counts: std::collections::HashMap::from([(learning_key, 6)]),
+        acg_stability: None,
+        acg_observation_count: 0,
+    }));
+
+    let translated = translate_request(
+        &request,
+        "agent-1",
+        "anthropic",
+        plugin.as_ref(),
+        &hot_cache,
+    )
+    .expect("system-less anthropic request should translate under the anthropic hint");
+    assert!(
+        translated.content.to_string().contains("cache_control"),
+        "anthropic cache_control breakpoints should be applied",
+    );
 }
 
 #[test]
@@ -945,7 +1031,7 @@ fn acg_component_resolve_model_family_capabilities_prefers_longest_prefix() {
 #[test]
 fn acg_component_build_hint_translation_and_apply_hint_translation_cover_passthrough_and_errors() {
     let request = sample_openai_chat_request();
-    let semantic_view = build_semantic_request_view(&request).unwrap();
+    let semantic_view = build_semantic_request_view(&request, "openai").unwrap();
     let prompt_ir =
         crate::acg::ir_builder::build_prompt_ir(&semantic_view.annotated_request).unwrap();
     let plugin = build_provider_plugin("openai").unwrap();
@@ -992,7 +1078,7 @@ fn acg_component_build_hint_translation_and_apply_hint_translation_cover_passthr
 fn acg_component_translate_request_uses_profile_specific_stability_and_fails_open_without_any_stability()
  {
     let request = sample_openai_responses_request();
-    let semantic_view = build_semantic_request_view(&request).unwrap();
+    let semantic_view = build_semantic_request_view(&request, "openai").unwrap();
     let learning_key = crate::acg_profile::derive_acg_learning_key(
         "agent-profile",
         &semantic_view.annotated_request,
@@ -1137,7 +1223,7 @@ fn acg_component_decode_request_for_surface_reports_codec_specific_errors() {
 #[test]
 fn acg_component_build_hint_translation_succeeds_for_openai_and_anthropic() {
     let openai_request = sample_openai_chat_request();
-    let openai_view = build_semantic_request_view(&openai_request).unwrap();
+    let openai_view = build_semantic_request_view(&openai_request, "openai").unwrap();
     let openai_prompt_ir =
         crate::acg::ir_builder::build_prompt_ir(&openai_view.annotated_request).unwrap();
     let openai_plugin = build_provider_plugin("openai").unwrap();
@@ -1178,7 +1264,7 @@ fn acg_component_build_hint_translation_succeeds_for_openai_and_anthropic() {
     );
 
     let anthropic_request = sample_layered_anthropic_request();
-    let anthropic_view = build_semantic_request_view(&anthropic_request).unwrap();
+    let anthropic_view = build_semantic_request_view(&anthropic_request, "anthropic").unwrap();
     let anthropic_prompt_ir =
         crate::acg::ir_builder::build_prompt_ir(&anthropic_view.annotated_request).unwrap();
     let anthropic_plugin = build_provider_plugin("anthropic").unwrap();


### PR DESCRIPTION
#### Overview

Wire the (previously unwired) provider-hint capability from #301 into the ACG (adaptive cache governor) request-surface resolution. ACG now passes the configured `provider` as a disambiguation hint, so a system-less Anthropic request — `messages` with no top-level `system`, which is shape-identical to OpenAI Chat — resolves to `AnthropicMessages` under provider `"anthropic"` and receives Anthropic cache-hint translation instead of passing through unoptimized. Adaptive-only change; the core hint API and the `provider` config surface are unchanged.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- **`request_surfaces::resolve_request_surface_from_request`** now takes a `provider_hint: Option<&str>` and calls core `detect_request_surface_with_hint`. Both consumers — the live `build_semantic_request_view` path and the plugin-facade `resolve_request_surface` path — pass the configured provider, so surface resolution stays consistent across them.
- **`build_semantic_request_view(request, provider)`** threads the configured provider (already in scope in `translate_request`) into resolution.
- **Behavior:** only the ambiguous `messages`-only-under-`"anthropic"` case changes. Shape stays authoritative — a strong `input`/`instructions`/`system` signal is never overridden by the hint, so genuine provider/surface mismatches still pass through unchanged (`unwrap_or(request)`). `"openai"`/`"passthrough"` are unaffected.
- **Learn↔translate key alignment:** the learning key is derived from the normalized `AnnotatedLlmRequest`; the observation path keys off the provider codec's annotation (`event.annotated_request()`). The hint makes translate-time decode use the same (Anthropic) codec, so the learned profile is found at translate time — verified by a dedicated assertion.
- **Tests:** updated the request-surface matrix (system-less + `"anthropic"` now resolves Anthropic; added a strong-signal Responses mismatch case that still errors), added a behavior test and an **end-to-end** test that seeds a learned profile and asserts `cache_control` is actually applied, and rewrote the source guard to the new contract (shape-first; decode by the resolved surface; provider only as a hint — still never provider-first).
- **`detect_request_surface` (no-hint):** this PR removes its last in-tree caller. It is intentionally kept in core as the shape-only public counterpart to `detect_request_surface_with_hint` (both added in #301); no core change here.

Local validation: `cargo test -p nemo-relay-adaptive` (all pass), `cargo clippy -p nemo-relay-adaptive --all-targets` clean, `cargo fmt --check` clean. Core is untouched; full cross-language matrix left to CI. (Note: `runtime::features::tests::registration_context_registers_all_supported_callback_types` is a pre-existing flaky test unrelated to this change.)

#### Where should the reviewer start?

`crates/adaptive/src/acg/request_surfaces/mod.rs` (the hint-aware shared resolver) and `crates/adaptive/src/acg_component.rs` (`build_semantic_request_view` threading the provider). Then the end-to-end test `acg_component_translate_request_optimizes_system_less_anthropic_with_provider_hint` in `acg_component_tests.rs` — it proves the feature actually fires (`cache_control` applied) and that the learn/translate keys align.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to RELAY-362 (deferred follow-up to #301)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request detection now uses the selected provider as a hint, improving how similar request formats are interpreted for both request decoding and semantic request views.
* **Bug Fixes**
  * Improved provider-specific translation behavior for Anthropic and OpenAI request styles, including better handling of ambiguous system-less Anthropic requests and fewer misclassifications.
* **Tests**
  * Updated integration and unit tests to validate provider-aware surface resolution and corrected expectations for provider routing and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->