### PR TITLE
fix(cli): use forward slashes in transparent hook executable path

### DIFF
--- a/crates/cli/src/launcher.rs
+++ b/crates/cli/src/launcher.rs
@@ -823,7 +823,18 @@ fn eprint_border_line(left: char, right: char, inner_width: usize, color: bool) 
 fn transparent_hook_executable() -> String {
     std::env::current_exe()
         .ok()
-        .and_then(|path| path.to_str().map(str::to_owned))
+        .and_then(|path| {
+            path.to_str().map(|s| {
+                #[cfg(windows)]
+                {
+                    s.replace('\\', "/")
+                }
+                #[cfg(not(windows))]
+                {
+                    s.to_owned()
+                }
+            })
+        })
         .unwrap_or_else(|| "nemo-relay".to_string())
 }
 


### PR DESCRIPTION
On Windows, std::env::current_exe() returns a path with backslashes
(e.g. C:\Users\...\.cargo\bin\nemo-relay.exe). This path is written into
the generated hooks.json and later executed by the agent's hook runner via
bash, which interprets backslashes as escape sequences, corrupting the path.

Replace backslashes with forward slashes — valid on both Windows cmd and
Git Bash, and already the convention on Linux/macOS.

---

#### Overview

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

One-line change in `crates/cli/src/launcher.rs:826`:

```diff
- .and_then(|path| path.to_str().map(str::to_owned))
+ .and_then(|path| path.to_str().map(|s| s.replace('\\', "/")))
```

`std::env::current_exe()` on Windows returns paths with backslashes. When
this path is embedded into the hook command and executed by bash (Claude
Code's hook runner), bash interprets the backslashes as escape sequences
(`\U`, `\1`, `\c`, `\b`, `\n`), mangling the path into something like
`C:Users16611.cargobinnemo-relay.exe`.

Forward slashes (`C:/Users/.../.cargo/bin/nemo-relay.exe`) work correctly
on both Windows `cmd` and Git Bash.

#### Where should the reviewer start?

`crates/cli/src/launcher.rs:826` — `transparent_hook_executable()`

#### Related Issues

- Closes #319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook executable path formatting on Windows by converting backslashes to forward slashes for consistent injection.
  * Kept existing fallback behavior unchanged when the current executable path can’t be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->