### PR TITLE
fix: make native dynamic plugin example satisfy trust policy

### DIFF
--- a/crates/cli/tests/coverage/plugins_lifecycle_tests.rs
+++ b/crates/cli/tests/coverage/plugins_lifecycle_tests.rs
@@ -351,6 +351,60 @@ symbol = "nemo_relay_fixture_native_plugin"
     manifest_path
 }
 
+fn materialize_native_example_manifest(dir: &Path) -> PathBuf {
+    let artifact_name = "libnemo_relay_rust_native_plugin_example.so";
+    let artifact_relative = Path::new("target").join("debug").join(artifact_name);
+    let artifact_path = dir.join(&artifact_relative);
+    std::fs::create_dir_all(artifact_path.parent().unwrap()).unwrap();
+    let artifact_body = b"native plugin example fixture";
+    std::fs::write(&artifact_path, artifact_body).unwrap();
+    let digest = Sha256::digest(artifact_body)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+
+    let repository_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let template = std::fs::read_to_string(
+        repository_root.join("examples/rust-native-plugin/relay-plugin.toml"),
+    )
+    .unwrap();
+    let manifest = template
+        .replace("<platform-library-file>", artifact_name)
+        .replace("<artifact-sha256>", &digest);
+    let manifest_path = dir.join("relay-plugin.toml");
+    std::fs::write(&manifest_path, manifest).unwrap();
+    manifest_path
+}
+
+#[test]
+fn tracked_native_plugin_example_satisfies_default_trust_policy() {
+    let temp = tempfile::tempdir().unwrap();
+    let _env = EnvScope::hermetic(&temp);
+    let _cwd = CurrentDirGuard::enter(temp.path());
+    let plugin_dir = temp.path().join("plugins").join("native-example");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    materialize_native_example_manifest(&plugin_dir);
+
+    add(
+        PluginsAddCommand {
+            scope: PluginsScopeArgs {
+                project: true,
+                ..PluginsScopeArgs::default()
+            },
+            path: plugin_dir,
+        },
+        &ServerArgs::default(),
+    )
+    .unwrap();
+
+    let resolved = resolve_plugins_config(None).unwrap();
+    assert_eq!(resolved.dynamic_plugins.len(), 1);
+    assert_eq!(
+        resolved.dynamic_plugins[0].plugin_id,
+        "examples.rust_native_policy"
+    );
+}
+
 #[test]
 fn add_registers_dynamic_plugin_in_project_plugins_toml() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/cli/tests/coverage/plugins_lifecycle_tests.rs
+++ b/crates/cli/tests/coverage/plugins_lifecycle_tests.rs
@@ -406,6 +406,52 @@ fn tracked_native_plugin_example_satisfies_default_trust_policy() {
 }
 
 #[test]
+fn tracked_native_plugin_example_rejects_tampered_artifact() {
+    let temp = tempfile::tempdir().unwrap();
+    let _env = EnvScope::hermetic(&temp);
+    let _cwd = CurrentDirGuard::enter(temp.path());
+    let plugin_dir = temp.path().join("plugins").join("native-example");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    materialize_native_example_manifest(&plugin_dir);
+    std::fs::write(
+        plugin_dir
+            .join("target")
+            .join("debug")
+            .join("libnemo_relay_rust_native_plugin_example.so"),
+        b"tampered native plugin example fixture",
+    )
+    .unwrap();
+
+    let error = add(
+        PluginsAddCommand {
+            scope: PluginsScopeArgs {
+                project: true,
+                ..PluginsScopeArgs::default()
+            },
+            path: plugin_dir,
+        },
+        &ServerArgs::default(),
+    )
+    .unwrap_err();
+
+    match error {
+        CliError::PluginLifecycle {
+            kind: PluginLifecycleFailureKind::Refused,
+            code: Some("integrity_failed"),
+            message,
+            ..
+        } => assert!(message.contains("failed integrity verification")),
+        other => panic!("unexpected integrity add error: {other}"),
+    }
+    assert!(
+        resolve_plugins_config(None)
+            .unwrap()
+            .dynamic_plugins
+            .is_empty()
+    );
+}
+
+#[test]
 fn add_registers_dynamic_plugin_in_project_plugins_toml() {
     let temp = tempfile::tempdir().unwrap();
     let _env = EnvScope::hermetic(&temp);

--- a/crates/cli/tests/coverage/plugins_lifecycle_tests.rs
+++ b/crates/cli/tests/coverage/plugins_lifecycle_tests.rs
@@ -351,9 +351,13 @@ symbol = "nemo_relay_fixture_native_plugin"
     manifest_path
 }
 
-fn materialize_native_example_manifest(dir: &Path) -> PathBuf {
-    let artifact_name = "libnemo_relay_rust_native_plugin_example.so";
-    let artifact_relative = Path::new("target").join("debug").join(artifact_name);
+fn materialize_native_example_manifest(dir: &Path) -> (PathBuf, PathBuf) {
+    let artifact_name = format!(
+        "{}nemo_relay_rust_native_plugin_example{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    );
+    let artifact_relative = Path::new("target").join("debug").join(&artifact_name);
     let artifact_path = dir.join(&artifact_relative);
     std::fs::create_dir_all(artifact_path.parent().unwrap()).unwrap();
     let artifact_body = b"native plugin example fixture";
@@ -369,11 +373,11 @@ fn materialize_native_example_manifest(dir: &Path) -> PathBuf {
     )
     .unwrap();
     let manifest = template
-        .replace("<platform-library-file>", artifact_name)
+        .replace("<platform-library-file>", &artifact_name)
         .replace("<artifact-sha256>", &digest);
     let manifest_path = dir.join("relay-plugin.toml");
     std::fs::write(&manifest_path, manifest).unwrap();
-    manifest_path
+    (manifest_path, artifact_path)
 }
 
 #[test]
@@ -412,15 +416,8 @@ fn tracked_native_plugin_example_rejects_tampered_artifact() {
     let _cwd = CurrentDirGuard::enter(temp.path());
     let plugin_dir = temp.path().join("plugins").join("native-example");
     std::fs::create_dir_all(&plugin_dir).unwrap();
-    materialize_native_example_manifest(&plugin_dir);
-    std::fs::write(
-        plugin_dir
-            .join("target")
-            .join("debug")
-            .join("libnemo_relay_rust_native_plugin_example.so"),
-        b"tampered native plugin example fixture",
-    )
-    .unwrap();
+    let (_, artifact_path) = materialize_native_example_manifest(&plugin_dir);
+    std::fs::write(artifact_path, b"tampered native plugin example fixture").unwrap();
 
     let error = add(
         PluginsAddCommand {

--- a/examples/rust-native-plugin/README.md
+++ b/examples/rust-native-plugin/README.md
@@ -71,7 +71,7 @@ emit_isolated_scope = true
 Start the gateway normally after the dynamic record is enabled:
 
 ```bash
-nemo-relay gateway
+nemo-relay --bind 127.0.0.1:4040
 ```
 
 ## What the Example Registers

--- a/examples/rust-native-plugin/README.md
+++ b/examples/rust-native-plugin/README.md
@@ -22,9 +22,9 @@ Run this command from the example directory:
 cargo build
 ```
 
-Before you register the plugin, replace `<platform-library-file>` in
-`relay-plugin.toml` with the file name that `cargo build` creates for your
-platform:
+Before you register the plugin, copy `relay-plugin.toml` to a local manifest and
+replace both occurrences of `<platform-library-file>` with the file name that
+`cargo build` creates for your platform:
 
 | Platform | Library path |
 |---|---|
@@ -32,12 +32,26 @@ platform:
 | Linux | `target/debug/libnemo_relay_rust_native_plugin_example.so` |
 | Windows | `target/debug/nemo_relay_rust_native_plugin_example.dll` |
 
+The copied manifest must use the same relative path for `source.artifact` and
+`load.library`. Calculate the library's SHA-256 digest and replace
+`<artifact-sha256>` with the lowercase hexadecimal value:
+
+| Platform | Digest command |
+|---|---|
+| macOS | `shasum -a 256 <library-path>` |
+| Linux | `sha256sum <library-path>` |
+| Windows PowerShell | `(Get-FileHash <library-path> -Algorithm SHA256).Hash.ToLower()` |
+
+Keep the `sha256:` prefix in the manifest. For example, a digest of `abc123`
+is written as `sha256:abc123`.
+
 ## Register With Relay
 
-After updating `load.library`, run these commands from the repository root:
+After materializing the library path and digest, run these commands from the
+repository root using the copied manifest path:
 
 ```bash
-nemo-relay plugins add ./examples/rust-native-plugin/relay-plugin.toml
+nemo-relay plugins add ./examples/rust-native-plugin/relay-plugin.local.toml
 nemo-relay plugins enable examples.rust_native_policy
 ```
 
@@ -45,7 +59,7 @@ You can also reference the manifest manually from `plugins.toml`:
 
 ```toml
 [[plugins.dynamic]]
-manifest = "./examples/rust-native-plugin/relay-plugin.toml"
+manifest = "./examples/rust-native-plugin/relay-plugin.local.toml"
 
 [plugins.dynamic.config]
 tag = "demo"

--- a/examples/rust-native-plugin/relay-plugin.toml
+++ b/examples/rust-native-plugin/relay-plugin.toml
@@ -17,6 +17,14 @@ enabled = false
 [capabilities]
 items = ["plugin_native"]
 
+[source]
+# Keep this path aligned with `load.library` when materializing the manifest.
+artifact = "target/debug/<platform-library-file>"
+
+[integrity]
+# Replace this placeholder with the SHA-256 digest of `source.artifact`.
+sha256 = "sha256:<artifact-sha256>"
+
 [load]
 # Replace `<platform-library-file>` with the file built by `cargo build` for
 # your platform. Refer to README.md for the expected debug artifact names.


### PR DESCRIPTION
#### Overview

Relay runs a native Rust plugin by loading its compiled `.so`, `.dylib`, or `.dll` file into the Relay process. This PR updates the official example so Relay verifies that exact compiled file before it is accepted and loaded.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

The example previously declared only `load.library`. That told Relay which file to execute, but it did not identify an artifact for the default integrity policy to verify or provide the artifact's expected digest. As a result, the documented `plugins add` flow was rejected before the plugin could be enabled.

This change adds the missing pieces:

- `source.artifact` identifies the compiled plugin file Relay should verify.
- `integrity.sha256` records the expected fingerprint of that file.
- `load.library` points to the same file, ensuring the verified artifact is the artifact Relay executes.
- The README explains how to build the plugin, calculate the platform-specific digest, and create a local manifest.
- A CLI lifecycle test materializes the tracked example manifest with an artifact and matching digest, then verifies that `plugins add` succeeds under the default trust policy.
- A companion test tampers the generated artifact, verifies `plugins add` returns `integrity_failed`, and confirms the plugin is not registered.

The digest must be generated after compilation because the library bytes vary by platform and build. This is the expected packaging flow for native dynamic plugins whether they are maintained in this repository or built and distributed by another contributing project.

This PR does not weaken the trust policy, change the native ABI, or change the example plugin's runtime behavior.

#### Where should the reviewer start?

Start with `examples/rust-native-plugin/relay-plugin.toml`, then review the lifecycle regression in `crates/cli/tests/coverage/plugins_lifecycle_tests.rs`.

#### Testing

- `cargo test -p nemo-relay-cli`
- `cargo fmt --all -- --check`
- `cargo clippy -p nemo-relay-cli --all-targets -- -D warnings`
- `pre-commit run --from-ref github/main --to-ref HEAD`

Manual native-example E2E on macOS arm64:

1. Built `examples/rust-native-plugin` into the real Mach-O `.dylib`.
2. Copied the example manifest, substituted the platform filename, and inserted the library's computed SHA-256 digest.
3. Ran `plugins add`, `plugins validate`, and `plugins enable` in an isolated user configuration. Validation reported `policy_state: valid` and `integrity_state: valid`.
4. Started the gateway with the enabled plugin and confirmed `/healthz` returned `{"status":"ok"}`.
5. Routed an OpenAI-compatible request through the gateway to a local mock upstream. The upstream received `native_llm_request_intercept: true` and `native_llm_execution_request: true`, confirming the compiled example loaded and registered live middleware.

The manual run also caught and corrected the example's stale `nemo-relay gateway` command; daemon startup now uses the supported `nemo-relay --bind 127.0.0.1:4040` form.

The repository-wide `pre-commit run --all-files` also completed all checks except the existing `attributions-rust` drift, which rewrites the unrelated `md-5` license entry. That generated change is not included here.

#### Breaking changes

None.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #302


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native plugin setup now supports local manifests that require an explicit SHA-256 integrity check for the referenced artifact.

* **Documentation**
  * Updated the Rust native plugin README with clearer local-manifest steps, platform-specific library path substitution, and how to supply the `sha256:` digest.
  * Updated the example commands to bind the gateway to `127.0.0.1:4040` and to use the local manifest (`relay-plugin.local.toml`).

* **Tests**
  * Added end-to-end coverage for accepting the default-trust native plugin example.
  * Added coverage to verify tampered artifacts are rejected with an integrity failure and no dynamic plugins are loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
