### PR TITLE
chore: update Fern CLI to 5.57.0

### DIFF
--- a/ATTRIBUTIONS-Node.md
+++ b/ATTRIBUTIONS-Node.md
@@ -6432,7 +6432,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.```
 
-## fern-api - 5.37.10
+## fern-api - 5.57.0
 **Repository URL**: https://github.com/fern-api/fern
 **License Type(s)**: Apache*
 ### License: https://opensource.org/licenses/

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.37.10"
+  "version": "5.57.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "integrations/openclaw"
       ],
       "devDependencies": {
-        "fern-api": "5.37.10",
+        "fern-api": "5.57.0",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -1144,9 +1144,9 @@
       }
     },
     "node_modules/fern-api": {
-      "version": "5.37.10",
-      "resolved": "https://registry.npmjs.org/fern-api/-/fern-api-5.37.10.tgz",
-      "integrity": "sha512-GQ/lrHsB2nw0ZkuUas/nWLtxd/SSwX0Sj6QFwLSMPAImeVrN/m8871EH3pXH+Ht8cuSSxHUWlEU4buPtznwavA==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/fern-api/-/fern-api-5.57.0.tgz",
+      "integrity": "sha512-B1eQKKDtTT6YaHT4+mbK3Zpnk0IlNk74Y6ny/EAqOnd8C8t1WtmkmXJg7zFuvbd0te1vC+pG1YTk304I5x/uQg==",
       "dev": true,
       "bin": {
         "fern": "cli.cjs"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "integrations/openclaw"
   ],
   "devDependencies": {
-    "fern-api": "5.37.10",
+    "fern-api": "5.57.0",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
#### Overview

Update the pinned Fern CLI from 5.37.10 to 5.57.0 so local documentation builds and CI publishing use the requested Fern release consistently.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update `fern/fern.config.json` and the root `fern-api` development dependency to 5.57.0.
- Refresh `package-lock.json` with the 5.57.0 package URL and integrity hash.
- Regenerate `ATTRIBUTIONS-Node.md` from the updated lockfile.
- Validate with `npm ci --ignore-scripts`, `npm exec -- fern --version`, `just docs`, targeted pre-commit hooks, and `git diff --check`.
- The full pre-commit suite passed all relevant hooks; its repository-wide `ty` hook still reports unrelated generated-protobuf errors from the pre-existing untracked `python/plugin/` worktree.

#### Where should the reviewer start?

Start with `fern/fern.config.json` and `package.json` to verify the Fern pins match, then review the lockfile and generated attribution updates.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes: RELAY-377


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s versioned third-party attribution entry to the latest release.
  * Bumped the configured tool/version setting to match the newer release.
  * Updated the development dependency version for improved consistency with the current setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->