### PR TITLE
ci: use sticky comments for license and docs updates

### DIFF
--- a/.github/workflows/ci_license_diff.yml
+++ b/.github/workflows/ci_license_diff.yml
@@ -100,13 +100,12 @@ jobs:
           cat license-diff.status >&2
           cat license-diff.md
 
-      - name: Upsert PR comment
+      - name: Build PR comment
+        id: comment
         if: ${{ steps.compare.outcome == 'success' }}
         env:
           COMPARE_REF: ${{ steps.compare.outputs.compare_ref }}
           DIFF_STATUS: ${{ steps.compare.outputs.diff_status }}
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -115,10 +114,9 @@ jobs:
             echo "::warning title=License diff comment skipped::Unable to derive a PR number from ref '${GITHUB_REF_NAME}'."
             exit 0
           fi
+          printf 'pr_number=%s\n' "$pr_number" >> "$GITHUB_OUTPUT"
 
-          marker="<!-- nemo-relay-license-diff -->"
           {
-            echo "$marker"
             echo "## License Diff"
             echo
             echo "Compared against \`${COMPARE_REF}\`."
@@ -146,24 +144,10 @@ jobs:
             echo "</details>"
           } > license-diff-comment.md
 
-          comment_id=""
-          if ! comment_id="$(
-            gh api "repos/{owner}/{repo}/issues/${pr_number}/comments" --paginate \
-              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- nemo-relay-license-diff -->"))) | .id' \
-              | tail -n 1
-          )"; then
-            echo "::warning title=License diff comment failed::Unable to list comments on PR #${pr_number}."
-            exit 0
-          fi
-
-          if [[ -n "$comment_id" ]]; then
-            if gh api --method PATCH "repos/{owner}/{repo}/issues/comments/${comment_id}" --field body=@license-diff-comment.md --silent; then
-              echo "Updated license diff comment on PR #${pr_number}."
-            else
-              echo "::warning title=License diff comment failed::Unable to update license diff comment on PR #${pr_number}."
-            fi
-          elif gh api --method POST "repos/{owner}/{repo}/issues/${pr_number}/comments" --field body=@license-diff-comment.md --silent; then
-            echo "Created license diff comment on PR #${pr_number}."
-          else
-            echo "::warning title=License diff comment failed::Unable to create license diff comment on PR #${pr_number}."
-          fi
+      - name: Upsert PR comment
+        if: ${{ steps.comment.outputs.pr_number != '' }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: nemo-relay-license-diff
+          number: ${{ steps.comment.outputs.pr_number }}
+          path: license-diff-comment.md

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -151,6 +151,7 @@ jobs:
         run: |
           set -euo pipefail
           pr_number="${GITHUB_REF_NAME#pull-request/}"
+          printf 'pr_number=%s\n' "$pr_number" >> "$GITHUB_OUTPUT"
           preview_id="pull-request-${pr_number}"
           if OUTPUT="$("$GITHUB_WORKSPACE/source-checkout/node_modules/.bin/fern" generate --docs --preview --id "$preview_id" 2>&1)"; then
             fern_exit=0
@@ -169,15 +170,11 @@ jobs:
 
       - name: Comment preview URL on PR
         if: ${{ steps.preview.outputs.url != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          pr_number="${GITHUB_REF_NAME#pull-request/}"
-          gh pr comment "https://github.com/${{ github.repository }}/pull/${pr_number}" \
-            --edit-last \
-            --create-if-none \
-            --body "Fern docs preview: ${{ steps.preview.outputs.url }}"
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: nemo-relay-fern-preview
+          number: ${{ steps.preview.outputs.pr_number }}
+          message: 'Fern docs preview: ${{ steps.preview.outputs.url }}'
 
   cleanup-preview-docs:
     name: Clean up docs preview


### PR DESCRIPTION
#### Overview

Use stable sticky PR comments for license diffs and Fern documentation preview links so repeated workflow runs update the same comment in place.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace the manual license-diff comment lookup and patch logic with a pinned sticky-pull-request-comment action.
- Replace Fern preview edit-last behavior with an independently keyed sticky comment.
- Preserve the existing minimum pull-requests write permissions and pass explicit PR numbers for push-triggered workflows.
- Pin marocchino/sticky-pull-request-comment v3.0.4 to its full commit SHA.

Validation:

- YAML parsing for all workflow files
- Targeted pre-commit checks for both changed workflows
- Full uv run pre-commit run --all-files

#### Where should the reviewer start?

Start with .github/workflows/ci_license_diff.yml and compare its new keyed sticky-comment step with the equivalent Fern preview step in .github/workflows/fern-docs.yml.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-380](https://linear.app/nvidia/issue/RELAY-380/use-sticky-github-comments-for-license-and-docs-updates)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how pull request comments are created and updated in automated checks.
  * Preview documentation comments now reliably use the correct pull request number and include the generated preview link.
  * License diff comments now persist more consistently with a fixed comment header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->