### PR TITLE
fix: enable runtime features in distributed packages

### DIFF
--- a/crates/adaptive/src/lib.rs
+++ b/crates/adaptive/src/lib.rs
@@ -9,6 +9,11 @@
 //! This crate provides the adaptive runtime, persistence abstractions, learner
 //! implementations, and Adaptive Cache Governor (ACG) analysis types used to
 //! derive and apply runtime hints from observed NeMo Relay executions.
+
+#[cfg(test)]
+pub(crate) static TEST_GLOBAL_CONTEXT_MUTEX: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 pub mod acg;
 pub mod acg_component;
 pub mod acg_learner;

--- a/crates/adaptive/tests/unit/plugin_component_tests.rs
+++ b/crates/adaptive/tests/unit/plugin_component_tests.rs
@@ -5,8 +5,6 @@
 
 use super::*;
 
-use std::sync::{Mutex, OnceLock};
-
 use nemo_relay::api::llm::LlmRequest;
 use nemo_relay::api::llm::llm_request_intercepts;
 use nemo_relay::api::runtime::NemoRelayContextState;
@@ -14,15 +12,6 @@ use nemo_relay::api::runtime::global_context;
 use nemo_relay::plugin::{DiagnosticLevel, UnsupportedBehavior, clear_plugin_configuration};
 use nemo_relay::plugin::{Plugin, PluginRegistrationContext, rollback_registrations};
 use serde_json::json;
-use tokio::sync::Mutex as AsyncMutex;
-
-static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-static ASYNC_TEST_MUTEX: AsyncMutex<()> = AsyncMutex::const_new(());
-
-fn test_mutex() -> &'static Mutex<()> {
-    TEST_MUTEX.get_or_init(|| Mutex::new(()))
-}
-
 fn reset_global() {
     let _ = clear_plugin_configuration();
     let _ = deregister_adaptive_component();
@@ -89,9 +78,9 @@ fn validate_adaptive_plugin_config_reports_unknown_fields_and_backend_errors() {
     );
 }
 
-#[test]
-fn register_adaptive_component_is_idempotent_and_deregisters_cleanly() {
-    let _guard = test_mutex().lock().unwrap();
+#[tokio::test(flavor = "current_thread")]
+async fn register_adaptive_component_is_idempotent_and_deregisters_cleanly() {
+    let _guard = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     let _ = clear_plugin_configuration();
     let _ = deregister_adaptive_component();
 
@@ -351,7 +340,7 @@ fn validate_adaptive_plugin_config_reports_component_specific_unknown_fields() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn adaptive_plugin_registers_runtime_and_rolls_back_registration() {
-    let _guard = ASYNC_TEST_MUTEX.lock().await;
+    let _guard = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let plugin = AdaptivePlugin;

--- a/crates/adaptive/tests/unit/runtime_features_tests.rs
+++ b/crates/adaptive/tests/unit/runtime_features_tests.rs
@@ -7,6 +7,16 @@ use super::*;
 
 use std::sync::Arc;
 
+use crate::acg::profile::{BlockStabilityScore, StabilityClass};
+use crate::acg::prompt_ir::SpanId;
+use crate::acg::stability::StabilityAnalysisResult;
+use crate::config::{BackendSpec, StateConfig};
+use crate::intercepts::AGENT_HINTS_HEADER_KEY;
+use crate::trie::accumulator::AccumulatorState;
+use crate::trie::serialization::TrieEnvelope;
+use crate::types::metadata::{AgentHints, MetadataEnvelope, ParallelHint};
+use crate::types::plan::{ExecutionPlan, ParallelGroup};
+use crate::types::records::RunRecord;
 use nemo_relay::api::llm::{
     LlmCallExecuteParams, LlmRequest, LlmStreamCallExecuteParams, llm_call_execute,
     llm_request_intercepts, llm_stream_call_execute,
@@ -28,21 +38,7 @@ use nemo_relay::error::FlowError;
 use nemo_relay::plugin::{ConfigPolicy, DiagnosticLevel, UnsupportedBehavior};
 use nemo_relay::plugin::{clear_plugin_configuration, rollback_registrations};
 use serde_json::json;
-use tokio::sync::Mutex;
-
-use crate::acg::profile::{BlockStabilityScore, StabilityClass};
-use crate::acg::prompt_ir::SpanId;
-use crate::acg::stability::StabilityAnalysisResult;
-use crate::config::{BackendSpec, StateConfig};
-use crate::intercepts::AGENT_HINTS_HEADER_KEY;
-use crate::trie::accumulator::AccumulatorState;
-use crate::trie::serialization::TrieEnvelope;
-use crate::types::metadata::{AgentHints, MetadataEnvelope, ParallelHint};
-use crate::types::plan::{ExecutionPlan, ParallelGroup};
-use crate::types::records::RunRecord;
 use tokio_stream::StreamExt;
-
-static TEST_MUTEX: Mutex<()> = Mutex::const_new(());
 
 fn reset_global() {
     let _ = clear_plugin_configuration();
@@ -427,7 +423,7 @@ async fn adaptive_runtime_new_rejects_invalid_configs_with_joined_errors() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn registration_context_take_event_receiver_only_allows_one_consumer() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig::default())
@@ -444,7 +440,7 @@ async fn registration_context_take_event_receiver_only_allows_one_consumer() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn telemetry_feature_registers_subscriber_and_starts_drain_task() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig {
@@ -484,7 +480,7 @@ async fn telemetry_feature_registers_subscriber_and_starts_drain_task() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn telemetry_feature_requires_backend() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig::default())
@@ -506,7 +502,7 @@ async fn telemetry_feature_requires_backend() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn adaptive_hints_feature_registers_request_intercept() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig::default())
@@ -562,7 +558,7 @@ async fn adaptive_hints_feature_registers_request_intercept() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn tool_parallelism_feature_registers_execution_intercept() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig::default())
@@ -611,7 +607,7 @@ async fn tool_parallelism_feature_registers_execution_intercept() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn adaptive_runtime_register_survives_hot_cache_seed_failures() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let config = AdaptiveConfig {
@@ -653,7 +649,7 @@ async fn adaptive_runtime_register_survives_hot_cache_seed_failures() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn adaptive_runtime_register_is_idempotent_for_active_features() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig {
@@ -678,7 +674,7 @@ async fn adaptive_runtime_register_is_idempotent_for_active_features() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn adaptive_runtime_register_rolls_back_when_telemetry_receiver_is_missing() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig {
@@ -702,7 +698,7 @@ async fn adaptive_runtime_register_rolls_back_when_telemetry_receiver_is_missing
 
 #[tokio::test(flavor = "current_thread")]
 async fn registration_context_registers_all_supported_callback_types() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig::default())
@@ -811,7 +807,7 @@ async fn adaptive_runtime_helper_methods_cover_report_wait_for_idle_and_feature_
 
 #[tokio::test(flavor = "current_thread")]
 async fn acg_feature_registers_execution_and_stream_intercepts() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig::default())
@@ -918,7 +914,7 @@ async fn acg_feature_registers_execution_and_stream_intercepts() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn adaptive_runtime_register_feature_rolls_back_partial_registrations_and_abort_handle() {
-    let _lock = TEST_MUTEX.lock().await;
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_global();
 
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig::default())

--- a/crates/adaptive/tests/unit/runtime_tests.rs
+++ b/crates/adaptive/tests/unit/runtime_tests.rs
@@ -581,6 +581,7 @@ async fn adaptive_runtime_build_cache_request_facts_keeps_missing_stability_sema
 
 #[tokio::test(flavor = "current_thread")]
 async fn adaptive_runtime_bind_scope_requires_registration_and_passes_through_without_state() {
+    let _guard = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
     reset_runtime_context();
     let mut runtime = AdaptiveRuntime::new(AdaptiveConfig {
         agent_id: Some("agent-1".to_string()),

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,7 +25,7 @@ default = ["atof-streaming"]
 atof-streaming = ["nemo-relay/atof-streaming"]
 
 [dependencies]
-nemo-relay = { workspace = true, features = ["guardrails-remote", "object-store", "openinference", "worker-grpc"] }
+nemo-relay = { workspace = true, features = ["guardrails-remote", "object-store", "otel", "openinference", "worker-grpc"] }
 nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }
 nemo-relay-pii-redaction.workspace = true
 async-stream = "0.3"

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 test = false
 
 [dependencies]
-nemo-relay = { workspace = true, features = ["atof-streaming", "otel", "openinference"] }
+nemo-relay = { workspace = true, features = ["atof-streaming", "guardrails-remote", "object-store", "otel", "openinference", "worker-grpc"] }
 nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }
 nemo-relay-pii-redaction.workspace = true
 chrono = "0.4"

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -18,7 +18,7 @@ name = "_native"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-nemo-relay = { workspace = true, features = ["atof-streaming", "otel", "openinference"] }
+nemo-relay = { workspace = true, features = ["atof-streaming", "guardrails-remote", "object-store", "otel", "openinference", "worker-grpc"] }
 nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }
 nemo-relay-pii-redaction.workspace = true
 pyo3 = { version = "0.28.2", features = ["abi3", "abi3-py311", "experimental-inspect", "macros"] }


### PR DESCRIPTION
#### Overview

Enable the complete native runtime feature set in the published Python and Node packages, add the missing OpenTelemetry feature to the CLI, and eliminate a parallel adaptive-test race discovered during validation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Enable object storage, remote guardrails, and gRPC worker plugins in Python and Node native builds.
- Enable the OpenTelemetry feature in the CLI build.
- Serialize adaptive tests that mutate the process-global Relay context with one crate-wide test mutex.
- Validate the adaptive race fix with 25 consecutive parallel suite runs.
- Validate Rust, Python, Go, Node.js, WebAssembly, Clippy, formatting, dependency policy, and repository pre-commit checks.

#### Where should the reviewer start?

Start with `crates/python/Cargo.toml` for RELAY-394 and `crates/adaptive/src/lib.rs` plus `crates/adaptive/tests/unit/runtime_features_tests.rs` for the shared test-isolation lock.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes [RELAY-394](https://linear.app/nvidia/issue/RELAY-394/object-storage-feature-missing-in-nemo-relay-python-wheels)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded platform support in the CLI, node, and Python packages to include additional telemetry and runtime capabilities.
* **Bug Fixes**
  * Improved test isolation by using a shared async lock, reducing flaky failures from concurrent test execution.
  * Updated one runtime test to run asynchronously for more reliable coordination with shared state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->