### PR TITLE
fix: implement worker invocation cancellation

### DIFF
--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -16,12 +16,12 @@ use nemo_relay_worker_proto::v1::relay_host_runtime_server::{
     RelayHostRuntime, RelayHostRuntimeServer,
 };
 use nemo_relay_worker_proto::v1::{
-    CreateScopeStackRequest, CreateScopeStackResponse, DropScopeStackRequest, EmitMarkRequest,
-    GuardrailResult, HandshakeRequest, HealthRequest, HostAck, InvokeRequest, InvokeResponse,
-    JsonEnvelope, JsonResult, LlmInvocation, LlmNextRequest, LlmStreamNextRequest, PopScopeRequest,
-    PushScopeRequest, PushScopeResponse, RegisterRequest, RegisterResponse, Registration,
-    RegistrationSurface, ScopeContext, ShutdownRequest, StreamChunk, ToolInvocation,
-    ToolNextRequest, ValidateRequest, WorkerError,
+    CancelInvocationRequest, CreateScopeStackRequest, CreateScopeStackResponse,
+    DropScopeStackRequest, EmitMarkRequest, GuardrailResult, HandshakeRequest, HealthRequest,
+    HostAck, InvokeRequest, InvokeResponse, JsonEnvelope, JsonResult, LlmInvocation,
+    LlmNextRequest, LlmStreamNextRequest, PopScopeRequest, PushScopeRequest, PushScopeResponse,
+    RegisterRequest, RegisterResponse, Registration, RegistrationSurface, ScopeContext,
+    ShutdownRequest, StreamChunk, ToolInvocation, ToolNextRequest, ValidateRequest, WorkerError,
 };
 use nemo_relay_worker_proto::{WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, json_envelope};
 use semver::{Version, VersionReq};
@@ -982,6 +982,83 @@ struct WorkerPluginCallback {
     host_state: Arc<WorkerHostRuntimeState>,
 }
 
+struct WorkerInvocationGuard {
+    runtime: tokio::runtime::Handle,
+    client: PluginWorkerClient<Channel>,
+    host_state: Arc<WorkerHostRuntimeState>,
+    activation_id: String,
+    auth_token: String,
+    invocation_id: String,
+    continuation_id: String,
+    scope_stack_id: String,
+    cancel_on_drop: bool,
+    cleaned: bool,
+}
+
+impl WorkerInvocationGuard {
+    fn new(callback: &WorkerPluginCallback, request: &InvokeRequest) -> Self {
+        Self {
+            runtime: callback.runtime.clone(),
+            client: callback.client.clone(),
+            host_state: callback.host_state.clone(),
+            activation_id: request.activation_id.clone(),
+            auth_token: request.auth_token.clone(),
+            invocation_id: request.invocation_id.clone(),
+            continuation_id: request.continuation_id.clone(),
+            scope_stack_id: request
+                .scope
+                .as_ref()
+                .map(|scope| scope.scope_stack_id.clone())
+                .unwrap_or_default(),
+            cancel_on_drop: true,
+            cleaned: false,
+        }
+    }
+
+    fn cancel(&mut self, reason: impl Into<String>) {
+        if !self.cancel_on_drop {
+            return;
+        }
+        self.cancel_on_drop = false;
+        let mut client = self.client.clone();
+        let request = CancelInvocationRequest {
+            activation_id: self.activation_id.clone(),
+            invocation_id: self.invocation_id.clone(),
+            auth_token: self.auth_token.clone(),
+            reason: reason.into(),
+        };
+        self.runtime.spawn(async move {
+            let _ = worker_rpc(client.cancel_invocation(worker_rpc_request(request))).await;
+        });
+    }
+
+    fn finish(&mut self) {
+        self.cancel_on_drop = false;
+        self.cleanup();
+    }
+
+    fn cleanup(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        self.cleaned = true;
+        if !self.continuation_id.is_empty() {
+            self.host_state.remove_continuation(&self.continuation_id);
+        }
+        if !self.scope_stack_id.is_empty() {
+            self.host_state
+                .remove_invocation_scope_stack(&self.scope_stack_id);
+        }
+    }
+}
+
+impl Drop for WorkerInvocationGuard {
+    fn drop(&mut self) {
+        self.cancel("host caller cancelled the worker invocation");
+        self.cleanup();
+    }
+}
+
 impl WorkerPluginCallback {
     fn invoke_subscriber(&self, registration_name: &str, event: &Event) -> FlowResult<()> {
         let request = self.base_request(
@@ -1042,20 +1119,13 @@ impl WorkerPluginCallback {
         let continuation_id = self
             .host_state
             .insert_continuation(Continuation::Tool(next))?;
-        let callback = self.clone();
-        let registration_name = registration_name.to_string();
-        let tool_name = tool_name.to_string();
-        tokio::task::spawn_blocking(move || {
-            callback.invoke_tool_json(
-                &registration_name,
-                RegistrationSurface::ToolExecutionIntercept,
-                &tool_name,
-                value,
-                Some(continuation_id.clone()),
-            )
-        })
-        .await
-        .map_err(|err| FlowError::Internal(format!("worker task join failed: {err}")))?
+        let request = self.base_request(
+            registration_name,
+            RegistrationSurface::ToolExecutionIntercept,
+            Some(continuation_id),
+            Some(invoke_request_payload_tool(tool_name, value)),
+        );
+        json_from_invoke_response(self.invoke_async(request).await?)
     }
 
     fn invoke_llm_request_json(
@@ -1178,25 +1248,18 @@ impl WorkerPluginCallback {
         let continuation_id = self
             .host_state
             .insert_continuation(Continuation::Llm(next))?;
-        let callback = self.clone();
-        let registration_name = registration_name.to_string();
-        let model_name = model_name.to_string();
-        tokio::task::spawn_blocking(move || {
-            let invoke = callback.base_request(
-                &registration_name,
-                RegistrationSurface::LlmExecutionIntercept,
-                Some(continuation_id),
-                Some(invoke_request_payload_llm(
-                    &model_name,
-                    Some(request),
-                    None,
-                    None,
-                )),
-            );
-            json_from_invoke_response(callback.invoke_blocking(invoke)?)
-        })
-        .await
-        .map_err(|err| FlowError::Internal(format!("worker task join failed: {err}")))?
+        let invoke = self.base_request(
+            registration_name,
+            RegistrationSurface::LlmExecutionIntercept,
+            Some(continuation_id),
+            Some(invoke_request_payload_llm(
+                model_name,
+                Some(request),
+                None,
+                None,
+            )),
+        );
+        json_from_invoke_response(self.invoke_async(invoke).await?)
     }
 
     async fn invoke_llm_stream_execution(
@@ -1220,20 +1283,32 @@ impl WorkerPluginCallback {
                 None,
             )),
         );
-        let scope_stack_id = invoke
-            .scope
-            .as_ref()
-            .map(|scope| scope.scope_stack_id.clone())
-            .unwrap_or_default();
         let mut client = self.client.clone();
-        let host_state = self.host_state.clone();
+        let mut guard = WorkerInvocationGuard::new(self, &invoke);
         let (tx, rx) = mpsc::channel(16);
         self.runtime.spawn(async move {
-            let result = worker_rpc(client.invoke_stream(worker_rpc_request(invoke))).await;
+            let result = tokio::select! {
+                result = worker_rpc(client.invoke_stream(worker_rpc_request(invoke))) => result,
+                _ = tx.closed() => {
+                    guard.cancel("host stopped consuming the worker stream");
+                    guard.finish();
+                    return;
+                }
+            };
             match result {
                 Ok(response) => {
                     let mut stream = response.into_inner();
-                    while let Some(item) = stream.next().await {
+                    loop {
+                        let item = tokio::select! {
+                            item = stream.next() => item,
+                            _ = tx.closed() => {
+                                guard.cancel("host stopped consuming the worker stream");
+                                break;
+                            }
+                        };
+                        let Some(item) = item else {
+                            break;
+                        };
                         let result = match item {
                             Ok(chunk) => json_from_stream_chunk(chunk),
                             Err(err) => Err(FlowError::Internal(format!(
@@ -1241,22 +1316,27 @@ impl WorkerPluginCallback {
                             ))),
                         };
                         if tx.send(result).await.is_err() {
+                            guard.cancel("host stopped consuming the worker stream");
                             break;
                         }
                     }
                 }
                 Err(err) => {
+                    let reason = if err.code() == tonic::Code::DeadlineExceeded {
+                        "worker stream invocation timed out"
+                    } else {
+                        "worker stream transport failed"
+                    };
+                    guard.cancel(reason);
                     let _ = tx
-                        .send(Err(FlowError::Internal(format!(
-                            "worker stream invoke failed: {err}"
-                        ))))
+                        .send(Err(worker_status_to_flow(
+                            "worker stream invoke failed",
+                            err,
+                        )))
                         .await;
                 }
             }
-            host_state.remove_continuation(&continuation_id);
-            if !scope_stack_id.is_empty() {
-                host_state.remove_invocation_scope_stack(&scope_stack_id);
-            }
+            guard.finish();
         });
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
@@ -1287,26 +1367,33 @@ impl WorkerPluginCallback {
     }
 
     fn invoke_blocking(&self, request: InvokeRequest) -> FlowResult<InvokeResponse> {
-        let scope_stack_id = request
-            .scope
-            .as_ref()
-            .map(|scope| scope.scope_stack_id.clone())
-            .unwrap_or_default();
-        let continuation_id = request.continuation_id.clone();
+        block_on_handle(&self.runtime, self.invoke_async(request))
+    }
+
+    async fn invoke_async(&self, request: InvokeRequest) -> FlowResult<InvokeResponse> {
+        self.invoke_async_with_timeout(request, WORKER_RPC_TIMEOUT)
+            .await
+    }
+
+    async fn invoke_async_with_timeout(
+        &self,
+        request: InvokeRequest,
+        timeout: Duration,
+    ) -> FlowResult<InvokeResponse> {
+        let mut guard = WorkerInvocationGuard::new(self, &request);
         let mut client = self.client.clone();
-        let result = block_on_handle(&self.runtime, async move {
-            worker_rpc(client.invoke(worker_rpc_request(request))).await
-        })
-        .map(|response| response.into_inner())
-        .map_err(|err| FlowError::Internal(format!("worker invoke failed: {err}")));
-        if !continuation_id.is_empty() {
-            self.host_state.remove_continuation(&continuation_id);
+        let result =
+            worker_rpc_with_timeout(timeout, client.invoke(worker_rpc_request(request))).await;
+        if result
+            .as_ref()
+            .is_err_and(|err| err.code() == tonic::Code::DeadlineExceeded)
+        {
+            guard.cancel("worker invocation timed out");
         }
-        if !scope_stack_id.is_empty() {
-            self.host_state
-                .remove_invocation_scope_stack(&scope_stack_id);
-        }
+        guard.finish();
         result
+            .map(|response| response.into_inner())
+            .map_err(|err| worker_status_to_flow("worker invoke failed", err))
     }
 }
 
@@ -1405,11 +1492,18 @@ async fn worker_rpc<T, F>(future: F) -> Result<Response<T>, Status>
 where
     F: Future<Output = Result<Response<T>, Status>>,
 {
-    match tokio::time::timeout(WORKER_RPC_TIMEOUT, future).await {
+    worker_rpc_with_timeout(WORKER_RPC_TIMEOUT, future).await
+}
+
+async fn worker_rpc_with_timeout<T, F>(timeout: Duration, future: F) -> Result<Response<T>, Status>
+where
+    F: Future<Output = Result<Response<T>, Status>>,
+{
+    match tokio::time::timeout(timeout, future).await {
         Ok(result) => result,
         Err(_) => Err(Status::deadline_exceeded(format!(
-            "worker RPC timed out after {}s",
-            WORKER_RPC_TIMEOUT.as_secs()
+            "worker RPC timed out after {}ms",
+            timeout.as_millis()
         ))),
     }
 }
@@ -1923,7 +2017,23 @@ fn flow_error_to_worker(err: FlowError) -> WorkerError {
 }
 
 fn worker_error_to_flow(error: WorkerError) -> FlowError {
-    FlowError::Internal(format!("{}: {}", error.code, error.message))
+    if error.code == "worker.cancelled" {
+        FlowError::Internal(format!("worker invocation cancelled: {}", error.message))
+    } else {
+        FlowError::Internal(format!("{}: {}", error.code, error.message))
+    }
+}
+
+fn worker_status_to_flow(context: &str, error: Status) -> FlowError {
+    match error.code() {
+        tonic::Code::DeadlineExceeded => {
+            FlowError::Internal(format!("worker invocation timed out: {error}"))
+        }
+        tonic::Code::Cancelled => {
+            FlowError::Internal(format!("worker invocation cancelled: {error}"))
+        }
+        _ => FlowError::Internal(format!("{context}: {error}")),
+    }
 }
 
 fn worker_error_to_plugin(error: WorkerError, fallback: &str) -> PluginError {

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -1047,7 +1047,7 @@ impl WorkerInvocationGuard {
         }
         if !self.scope_stack_id.is_empty() {
             self.host_state
-                .remove_invocation_scope_stack(&self.scope_stack_id);
+                .cleanup_invocation_scope_stack(&self.scope_stack_id);
         }
     }
 }
@@ -1546,9 +1546,20 @@ where
 struct WorkerHostRuntimeState {
     activation_id: String,
     auth_token: String,
-    scope_stacks: Mutex<HashMap<String, crate::api::runtime::ScopeStackHandle>>,
+    scope_stacks: Mutex<HashMap<String, StoredScopeStack>>,
+    pending_scope_cleanups: Mutex<Vec<PendingScopeCleanup>>,
     scope_handles: Mutex<HashMap<String, StoredScopeHandle>>,
     continuations: Mutex<HashMap<String, Continuation>>,
+}
+
+struct StoredScopeStack {
+    handle: crate::api::runtime::ScopeStackHandle,
+    invocation_base_depth: Option<usize>,
+}
+
+struct PendingScopeCleanup {
+    handle: crate::api::runtime::ScopeStackHandle,
+    base_depth: usize,
 }
 
 struct StoredScopeHandle {
@@ -1562,6 +1573,7 @@ impl WorkerHostRuntimeState {
             activation_id,
             auth_token,
             scope_stacks: Mutex::new(HashMap::new()),
+            pending_scope_cleanups: Mutex::new(Vec::new()),
             scope_handles: Mutex::new(HashMap::new()),
             continuations: Mutex::new(HashMap::new()),
         }
@@ -1580,14 +1592,84 @@ impl WorkerHostRuntimeState {
     ) -> String {
         let id = format!("invoke-{}", Uuid::now_v7());
         if let Ok(mut stacks) = self.scope_stacks.lock() {
-            stacks.insert(id.clone(), stack);
+            let invocation_base_depth = stack
+                .read()
+                .expect("scope stack lock poisoned")
+                .scopes()
+                .len();
+            stacks.insert(
+                id.clone(),
+                StoredScopeStack {
+                    handle: stack,
+                    invocation_base_depth: Some(invocation_base_depth),
+                },
+            );
         }
         id
     }
 
-    fn remove_invocation_scope_stack(&self, id: &str) {
-        if let Ok(mut stacks) = self.scope_stacks.lock() {
-            stacks.remove(id);
+    fn cleanup_invocation_scope_stack(&self, id: &str) {
+        let Ok(mut stacks) = self.scope_stacks.lock() else {
+            return;
+        };
+        let Some(stored) = stacks.remove(id) else {
+            return;
+        };
+        if let Some(mut base_depth) = stored.invocation_base_depth {
+            let has_active_alias = stacks.values().any(|candidate| {
+                candidate.invocation_base_depth.is_some()
+                    && Arc::ptr_eq(&candidate.handle, &stored.handle)
+            });
+            if let Ok(mut pending) = self.pending_scope_cleanups.lock() {
+                if has_active_alias {
+                    pending.push(PendingScopeCleanup {
+                        handle: stored.handle,
+                        base_depth,
+                    });
+                } else {
+                    pending.retain(|cleanup| {
+                        if Arc::ptr_eq(&cleanup.handle, &stored.handle) {
+                            base_depth = base_depth.min(cleanup.base_depth);
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    Self::unwind_scope_stack(&stored.handle, base_depth);
+                }
+            } else if !has_active_alias {
+                Self::unwind_scope_stack(&stored.handle, base_depth);
+            }
+        }
+        if let Ok(mut handles) = self.scope_handles.lock() {
+            handles.retain(|_, handle| handle.scope_stack_id != id);
+        }
+    }
+
+    fn unwind_scope_stack(stack: &crate::api::runtime::ScopeStackHandle, base_depth: usize) {
+        loop {
+            let top_uuid = {
+                let Ok(stack) = stack.read() else {
+                    return;
+                };
+                if stack.scopes().len() <= base_depth {
+                    return;
+                }
+                stack.top().uuid
+            };
+            let popped = with_scope_stack(stack.clone(), || {
+                pop_scope(PopScopeParams::builder().handle_uuid(&top_uuid).build())
+            })
+            .is_ok();
+            if popped {
+                continue;
+            }
+            let Ok(mut stack) = stack.write() else {
+                return;
+            };
+            if stack.remove(&top_uuid).is_err() {
+                return;
+            }
         }
     }
 
@@ -1624,7 +1706,7 @@ impl WorkerHostRuntimeState {
             .lock()
             .map_err(|err| Status::internal(format!("scope stack lock poisoned: {err}")))?
             .get(id)
-            .cloned()
+            .map(|stored| stored.handle.clone())
             .map(Some)
             .ok_or_else(|| Status::not_found("scope stack not found"))
     }
@@ -1759,7 +1841,13 @@ impl RelayHostRuntime for WorkerHostRuntimeService {
             .scope_stacks
             .lock()
             .map_err(|err| Status::internal(format!("scope stack lock poisoned: {err}")))?
-            .insert(id.clone(), crate::api::runtime::create_scope_stack());
+            .insert(
+                id.clone(),
+                StoredScopeStack {
+                    handle: crate::api::runtime::create_scope_stack(),
+                    invocation_base_depth: None,
+                },
+            );
         Ok(Response::new(CreateScopeStackResponse {
             scope_stack_id: id,
             error: None,

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
 use nemo_relay_worker_proto::v1::plugin_worker_client::PluginWorkerClient;
@@ -1548,6 +1548,8 @@ struct WorkerHostRuntimeState {
     auth_token: String,
     scope_stacks: Mutex<HashMap<String, StoredScopeStack>>,
     pending_scope_cleanups: Mutex<Vec<PendingScopeCleanup>>,
+    scope_stack_cleanups: Mutex<Vec<crate::api::runtime::ScopeStackHandle>>,
+    scope_stack_cleanup_complete: Condvar,
     scope_handles: Mutex<HashMap<String, StoredScopeHandle>>,
     continuations: Mutex<HashMap<String, Continuation>>,
 }
@@ -1567,6 +1569,20 @@ struct StoredScopeHandle {
     scope_stack_id: String,
 }
 
+struct ScopeStackCleanupGuard<'a> {
+    state: &'a WorkerHostRuntimeState,
+    handle: crate::api::runtime::ScopeStackHandle,
+}
+
+impl Drop for ScopeStackCleanupGuard<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut cleanups) = self.state.scope_stack_cleanups.lock() {
+            cleanups.retain(|handle| !Arc::ptr_eq(handle, &self.handle));
+            self.state.scope_stack_cleanup_complete.notify_all();
+        }
+    }
+}
+
 impl WorkerHostRuntimeState {
     fn new(activation_id: String, auth_token: String) -> Self {
         Self {
@@ -1574,6 +1590,8 @@ impl WorkerHostRuntimeState {
             auth_token,
             scope_stacks: Mutex::new(HashMap::new()),
             pending_scope_cleanups: Mutex::new(Vec::new()),
+            scope_stack_cleanups: Mutex::new(Vec::new()),
+            scope_stack_cleanup_complete: Condvar::new(),
             scope_handles: Mutex::new(HashMap::new()),
             continuations: Mutex::new(HashMap::new()),
         }
@@ -1591,31 +1609,52 @@ impl WorkerHostRuntimeState {
         stack: crate::api::runtime::ScopeStackHandle,
     ) -> String {
         let id = format!("invoke-{}", Uuid::now_v7());
-        if let Ok(mut stacks) = self.scope_stacks.lock() {
-            let invocation_base_depth = stack
-                .read()
-                .expect("scope stack lock poisoned")
-                .scopes()
-                .len();
-            stacks.insert(
-                id.clone(),
-                StoredScopeStack {
-                    handle: stack,
-                    invocation_base_depth: Some(invocation_base_depth),
-                },
-            );
+        let Ok(mut stacks) = self.scope_stacks.lock() else {
+            return id;
+        };
+        loop {
+            let Ok(cleanups) = self.scope_stack_cleanups.lock() else {
+                return id;
+            };
+            if !cleanups.iter().any(|handle| Arc::ptr_eq(handle, &stack)) {
+                break;
+            }
+            drop(stacks);
+            let Ok(guard) = self.scope_stack_cleanup_complete.wait(cleanups) else {
+                return id;
+            };
+            drop(guard);
+            let Ok(guard) = self.scope_stacks.lock() else {
+                return id;
+            };
+            stacks = guard;
         }
+        let Ok(stack_guard) = stack.read() else {
+            return id;
+        };
+        let invocation_base_depth = stack_guard.scopes().len();
+        drop(stack_guard);
+        stacks.insert(
+            id.clone(),
+            StoredScopeStack {
+                handle: stack,
+                invocation_base_depth: Some(invocation_base_depth),
+            },
+        );
         id
     }
 
     fn cleanup_invocation_scope_stack(&self, id: &str) {
-        let Ok(mut stacks) = self.scope_stacks.lock() else {
-            return;
-        };
-        let Some(stored) = stacks.remove(id) else {
-            return;
-        };
-        if let Some(mut base_depth) = stored.invocation_base_depth {
+        let unwind = {
+            let Ok(mut stacks) = self.scope_stacks.lock() else {
+                return;
+            };
+            let Some(stored) = stacks.remove(id) else {
+                return;
+            };
+            let Some(mut base_depth) = stored.invocation_base_depth else {
+                return;
+            };
             let has_active_alias = stacks.values().any(|candidate| {
                 candidate.invocation_base_depth.is_some()
                     && Arc::ptr_eq(&candidate.handle, &stored.handle)
@@ -1626,6 +1665,7 @@ impl WorkerHostRuntimeState {
                         handle: stored.handle,
                         base_depth,
                     });
+                    None
                 } else {
                     pending.retain(|cleanup| {
                         if Arc::ptr_eq(&cleanup.handle, &stored.handle) {
@@ -1635,11 +1675,23 @@ impl WorkerHostRuntimeState {
                             true
                         }
                     });
-                    Self::unwind_scope_stack(&stored.handle, base_depth);
+                    if let Ok(mut cleanups) = self.scope_stack_cleanups.lock() {
+                        cleanups.push(stored.handle.clone());
+                        Some((stored.handle, base_depth))
+                    } else {
+                        None
+                    }
                 }
-            } else if !has_active_alias {
-                Self::unwind_scope_stack(&stored.handle, base_depth);
+            } else {
+                None
             }
+        };
+        if let Some((handle, base_depth)) = unwind {
+            let _cleanup = ScopeStackCleanupGuard {
+                state: self,
+                handle: handle.clone(),
+            };
+            Self::unwind_scope_stack(&handle, base_depth);
         }
         if let Ok(mut handles) = self.scope_handles.lock() {
             handles.retain(|_, handle| handle.scope_stack_id != id);

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -231,6 +231,61 @@ async fn rust_worker_registers_and_invokes_all_current_surfaces() {
 }
 
 #[tokio::test]
+async fn host_cancellation_reaches_rust_worker_invocation() {
+    let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
+    let loaded = load_and_initialize_fixture(Map::new()).await;
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+    let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+    let dropped_tx = Arc::new(Mutex::new(Some(dropped_tx)));
+
+    let execution = tokio::spawn(tool_call_execute(
+        ToolCallExecuteParams::builder()
+            .name("worker-fixture-cancelled-tool")
+            .args(json!({ "input": "cancel" }))
+            .func(Arc::new(move |_| {
+                let started = started_tx
+                    .lock()
+                    .expect("started lock")
+                    .take()
+                    .expect("callback should run once");
+                let dropped = dropped_tx
+                    .lock()
+                    .expect("dropped lock")
+                    .take()
+                    .expect("callback should run once");
+                Box::pin(async move {
+                    struct DropSignal(Option<tokio::sync::oneshot::Sender<()>>);
+                    impl Drop for DropSignal {
+                        fn drop(&mut self) {
+                            if let Some(sender) = self.0.take() {
+                                let _ = sender.send(());
+                            }
+                        }
+                    }
+
+                    let _drop_signal = DropSignal(Some(dropped));
+                    let _ = started.send(());
+                    std::future::pending::<FlowResult<Json>>().await
+                })
+            }))
+            .build(),
+    ));
+    started_rx
+        .await
+        .expect("worker should call the host continuation");
+
+    execution.abort();
+    let _ = execution.await;
+    tokio::time::timeout(std::time::Duration::from_secs(2), dropped_rx)
+        .await
+        .expect("worker cancellation should drop the host continuation")
+        .expect("host continuation drop signal should be delivered");
+
+    loaded.clear();
+}
+
+#[tokio::test]
 async fn worker_request_intercept_callback_error_surfaces_to_host() {
     let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
     let loaded =

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -271,8 +271,9 @@ async fn host_cancellation_reaches_rust_worker_invocation() {
             }))
             .build(),
     ));
-    started_rx
+    tokio::time::timeout(std::time::Duration::from_secs(2), started_rx)
         .await
+        .expect("worker should call the host continuation before cancellation")
         .expect("worker should call the host continuation");
 
     execution.abort();

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -512,7 +512,7 @@ async fn callback_stream_stops_when_host_receiver_is_dropped() {
     )
     .await;
 
-    let stream = callback
+    let mut stream = callback
         .invoke_llm_stream_execution(
             "stream_receiver_drop",
             "model",
@@ -523,14 +523,180 @@ async fn callback_stream_stops_when_host_receiver_is_dropped() {
         )
         .await
         .expect("host stream should be returned");
-    drop(stream);
     yield_tx
         .send(())
         .expect("worker stream yield signal should be delivered");
+    stream
+        .next()
+        .await
+        .expect("worker stream should yield before it is abandoned")
+        .expect("worker stream chunk should be valid");
+    drop(stream);
     tokio::time::timeout(std::time::Duration::from_secs(1), stream_dropped_rx)
         .await
         .expect("worker stream should be dropped after host receiver is dropped")
         .expect("worker stream drop signal should be delivered");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn callback_timeout_sends_explicit_worker_cancellation() {
+    let (started_tx, started_rx) = oneshot::channel();
+    let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+    let (callback, _shutdown, mut cancel_rx) = fake_callback_service_with_handlers(
+        {
+            let started_tx = started_tx.clone();
+            move |_| {
+                let started_tx = started_tx.clone();
+                Box::pin(async move {
+                    if let Some(started) = started_tx.lock().expect("started lock").take() {
+                        let _ = started.send(());
+                    }
+                    std::future::pending::<InvokeResponse>().await
+                })
+            }
+        },
+        |_| Box::pin(tokio_stream::empty()),
+    )
+    .await;
+    let request = callback.base_request(
+        "timeout",
+        RegistrationSurface::ToolRequestIntercept,
+        None,
+        Some(invoke_request_payload_tool("tool", json!({}))),
+    );
+    let invocation_id = request.invocation_id.clone();
+
+    let result = callback
+        .invoke_async_with_timeout(request, std::time::Duration::from_millis(10))
+        .await;
+    started_rx.await.expect("worker invocation should start");
+    let cancellation = tokio::time::timeout(std::time::Duration::from_secs(1), cancel_rx.recv())
+        .await
+        .expect("host should send cancellation after timeout")
+        .expect("cancellation channel should remain open");
+
+    assert!(
+        result
+            .expect_err("worker invocation should time out")
+            .to_string()
+            .contains("worker invocation timed out")
+    );
+    assert_eq!(cancellation.invocation_id, invocation_id);
+    assert!(cancellation.reason.contains("timed out"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dropping_callback_future_cancels_worker_and_cleans_host_state() {
+    let (started_tx, started_rx) = oneshot::channel();
+    let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+    let (callback, _shutdown, mut cancel_rx) = fake_callback_service_with_handlers(
+        {
+            let started_tx = started_tx.clone();
+            move |_| {
+                let started_tx = started_tx.clone();
+                Box::pin(async move {
+                    if let Some(started) = started_tx.lock().expect("started lock").take() {
+                        let _ = started.send(());
+                    }
+                    std::future::pending::<InvokeResponse>().await
+                })
+            }
+        },
+        |_| Box::pin(tokio_stream::empty()),
+    )
+    .await;
+    let continuation_id = callback
+        .host_state
+        .insert_continuation(Continuation::Tool(Arc::new(|value| {
+            Box::pin(async move { Ok(value) })
+        })))
+        .expect("continuation should insert");
+    let request = callback.base_request(
+        "cancel",
+        RegistrationSurface::ToolExecutionIntercept,
+        Some(continuation_id),
+        Some(invoke_request_payload_tool("tool", json!({}))),
+    );
+    let invocation_id = request.invocation_id.clone();
+    let callback_task = callback.clone();
+    let task = tokio::spawn(async move { callback_task.invoke_async(request).await });
+    started_rx.await.expect("worker invocation should start");
+
+    task.abort();
+    let _ = task.await;
+    let cancellation = tokio::time::timeout(std::time::Duration::from_secs(1), cancel_rx.recv())
+        .await
+        .expect("host should send cancellation when caller drops")
+        .expect("cancellation channel should remain open");
+
+    assert_eq!(cancellation.invocation_id, invocation_id);
+    assert!(cancellation.reason.contains("caller cancelled"));
+    assert!(
+        callback
+            .host_state
+            .continuations
+            .lock()
+            .expect("continuation lock")
+            .is_empty()
+    );
+    assert!(
+        callback
+            .host_state
+            .scope_stacks
+            .lock()
+            .expect("scope lock")
+            .is_empty()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dropping_host_stream_sends_explicit_worker_cancellation() {
+    let (yield_tx, yield_rx) = oneshot::channel();
+    let yield_rx = Arc::new(Mutex::new(Some(yield_rx)));
+    let (callback, _shutdown, mut cancel_rx) = fake_callback_service_with_handlers(
+        |_| {
+            Box::pin(async {
+                InvokeResponse {
+                    result: Some(InvokeResult::Empty(EmptyResult {})),
+                }
+            })
+        },
+        {
+            let yield_rx = yield_rx.clone();
+            move |_| {
+                let yield_rx = yield_rx
+                    .lock()
+                    .expect("yield lock")
+                    .take()
+                    .expect("stream should be created once");
+                Box::pin(SignalChunkThenPendingStream {
+                    yield_rx,
+                    dropped: None,
+                    yielded: false,
+                })
+            }
+        },
+    )
+    .await;
+    let stream = callback
+        .invoke_llm_stream_execution(
+            "cancel_stream",
+            "model",
+            valid_llm_request(),
+            Arc::new(|_request| {
+                Box::pin(async { Ok(Box::pin(tokio_stream::empty()) as LlmJsonStream) })
+            }),
+        )
+        .await
+        .expect("host stream should be returned");
+    drop(stream);
+    yield_tx.send(()).expect("stream should advance after drop");
+
+    let cancellation = tokio::time::timeout(std::time::Duration::from_secs(1), cancel_rx.recv())
+        .await
+        .expect("host should cancel abandoned stream")
+        .expect("cancellation channel should remain open");
+    assert!(cancellation.reason.contains("stopped consuming"));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -987,6 +1153,20 @@ async fn fake_callback_service_with_stream(
     callback_for_client(client, shutdown_tx)
 }
 
+async fn fake_callback_service_with_handlers(
+    invoke: impl Fn(InvokeRequest) -> FakeInvokeFuture + Send + Sync + 'static,
+    invoke_stream: impl Fn(InvokeRequest) -> FakeInvokeStream + Send + Sync + 'static,
+) -> (
+    WorkerPluginCallback,
+    oneshot::Sender<()>,
+    mpsc::UnboundedReceiver<CancelInvocationRequest>,
+) {
+    let (client, shutdown_tx, cancel_rx) =
+        fake_worker_client_with_handlers(invoke, invoke_stream).await;
+    let (callback, shutdown_tx) = callback_for_client(client, shutdown_tx);
+    (callback, shutdown_tx, cancel_rx)
+}
+
 fn callback_for_client(
     client: PluginWorkerClient<Channel>,
     shutdown_tx: oneshot::Sender<()>,
@@ -1056,6 +1236,26 @@ async fn fake_worker_client_with_stream(
     invoke: impl Fn(InvokeRequest) -> InvokeResponse + Send + Sync + 'static,
     invoke_stream: impl Fn(InvokeRequest) -> FakeInvokeStream + Send + Sync + 'static,
 ) -> (PluginWorkerClient<Channel>, oneshot::Sender<()>) {
+    let invoke = Arc::new(invoke);
+    let (client, shutdown_tx, _cancel_rx) = fake_worker_client_with_handlers(
+        move |request| {
+            let invoke = invoke.clone();
+            Box::pin(async move { invoke(request) })
+        },
+        invoke_stream,
+    )
+    .await;
+    (client, shutdown_tx)
+}
+
+async fn fake_worker_client_with_handlers(
+    invoke: impl Fn(InvokeRequest) -> FakeInvokeFuture + Send + Sync + 'static,
+    invoke_stream: impl Fn(InvokeRequest) -> FakeInvokeStream + Send + Sync + 'static,
+) -> (
+    PluginWorkerClient<Channel>,
+    oneshot::Sender<()>,
+    mpsc::UnboundedReceiver<CancelInvocationRequest>,
+) {
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
         .await
         .expect("fake worker listener should bind");
@@ -1063,11 +1263,13 @@ async fn fake_worker_client_with_stream(
         .local_addr()
         .expect("fake worker listener address should be available");
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (cancel_tx, cancel_rx) = mpsc::unbounded_channel();
     tokio::spawn(
         Server::builder()
             .add_service(PluginWorkerServer::new(FakePluginWorker {
                 invoke: Arc::new(invoke),
                 invoke_stream: Arc::new(invoke_stream),
+                cancel_tx,
             }))
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                 let _ = shutdown_rx.await;
@@ -1076,7 +1278,7 @@ async fn fake_worker_client_with_stream(
     let client = PluginWorkerClient::connect(format!("http://{addr}"))
         .await
         .expect("fake worker client should connect");
-    (client, shutdown_tx)
+    (client, shutdown_tx, cancel_rx)
 }
 
 fn registration(surface: RegistrationSurface, local_name: &str) -> Registration {
@@ -1093,10 +1295,12 @@ fn poison_mutex(f: impl FnOnce() + std::panic::UnwindSafe) {
 }
 
 struct FakePluginWorker {
-    invoke: Arc<dyn Fn(InvokeRequest) -> InvokeResponse + Send + Sync>,
+    invoke: Arc<dyn Fn(InvokeRequest) -> FakeInvokeFuture + Send + Sync>,
     invoke_stream: Arc<dyn Fn(InvokeRequest) -> FakeInvokeStream + Send + Sync>,
+    cancel_tx: mpsc::UnboundedSender<CancelInvocationRequest>,
 }
 
+type FakeInvokeFuture = Pin<Box<dyn Future<Output = InvokeResponse> + Send>>;
 type FakeInvokeStream =
     Pin<Box<dyn tokio_stream::Stream<Item = std::result::Result<StreamChunk, Status>> + Send>>;
 
@@ -1198,7 +1402,9 @@ impl PluginWorker for FakePluginWorker {
         &self,
         request: Request<InvokeRequest>,
     ) -> std::result::Result<tonic::Response<InvokeResponse>, tonic::Status> {
-        Ok(tonic::Response::new((self.invoke)(request.into_inner())))
+        Ok(tonic::Response::new(
+            (self.invoke)(request.into_inner()).await,
+        ))
     }
 
     type InvokeStreamStream =
@@ -1215,11 +1421,12 @@ impl PluginWorker for FakePluginWorker {
 
     async fn cancel_invocation(
         &self,
-        _request: Request<CancelInvocationRequest>,
+        request: Request<CancelInvocationRequest>,
     ) -> std::result::Result<tonic::Response<WorkerAck>, tonic::Status> {
+        let _ = self.cancel_tx.send(request.into_inner());
         Ok(tonic::Response::new(WorkerAck {
-            accepted: false,
-            message: "not implemented".into(),
+            accepted: true,
+            message: "cancelled".into(),
         }))
     }
 

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -526,10 +526,10 @@ async fn callback_stream_stops_when_host_receiver_is_dropped() {
     yield_tx
         .send(())
         .expect("worker stream yield signal should be delivered");
-    stream
-        .next()
+    tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
         .await
-        .expect("worker stream should yield before it is abandoned")
+        .expect("worker stream should yield before timing out")
+        .expect("worker stream ended before yielding a chunk")
         .expect("worker stream chunk should be valid");
     drop(stream);
     tokio::time::timeout(std::time::Duration::from_secs(1), stream_dropped_rx)
@@ -766,6 +766,71 @@ async fn dropping_callback_future_cancels_worker_and_cleans_host_state() {
             .expect("invocation scope stack lock")
             .scopes()
             .len(),
+        baseline_depth
+    );
+}
+
+#[test]
+fn invocation_cleanup_releases_host_state_locks_before_unwinding() {
+    let state = Arc::new(WorkerHostRuntimeState::new(
+        ACTIVATION_ID.into(),
+        AUTH_TOKEN.into(),
+    ));
+    let stack = crate::api::runtime::create_scope_stack();
+    let baseline_depth = stack.read().expect("scope stack lock").scopes().len();
+    let scope_stack_id = state.insert_invocation_scope_stack(stack.clone());
+    with_scope_stack(stack.clone(), || {
+        push_scope(
+            PushScopeParams::builder()
+                .name("cleanup-lock-test")
+                .scope_type(ScopeType::Custom)
+                .build(),
+        )
+    })
+    .expect("worker scope should push");
+
+    let stack_guard = stack.write().expect("scope stack lock");
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    let cleanup_state = state.clone();
+    let cleanup = std::thread::spawn(move || {
+        cleanup_state.cleanup_invocation_scope_stack(&scope_stack_id);
+        let _ = done_tx.send(());
+    });
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    loop {
+        let cleanup_registered = state
+            .scope_stack_cleanups
+            .lock()
+            .expect("scope cleanup lock")
+            .iter()
+            .any(|handle| Arc::ptr_eq(handle, &stack));
+        if cleanup_registered {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "scope cleanup should register before unwinding"
+        );
+        std::thread::yield_now();
+    }
+
+    assert!(state.scope_stacks.try_lock().is_ok());
+    assert!(state.pending_scope_cleanups.try_lock().is_ok());
+    drop(stack_guard);
+    done_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("scope cleanup thread should finish before timing out");
+    cleanup.join().expect("scope cleanup thread should finish");
+
+    assert!(
+        state
+            .scope_stack_cleanups
+            .lock()
+            .expect("scope cleanup lock")
+            .is_empty()
+    );
+    assert_eq!(
+        stack.read().expect("scope stack lock").scopes().len(),
         baseline_depth
     );
 }

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -627,6 +627,56 @@ async fn dropping_callback_future_cancels_worker_and_cleans_host_state() {
         Some(continuation_id),
         Some(invoke_request_payload_tool("tool", json!({}))),
     );
+    let scope_stack_id = request
+        .scope
+        .as_ref()
+        .expect("worker invocation should have a scope stack")
+        .scope_stack_id
+        .clone();
+    let invocation_stack = callback
+        .host_state
+        .stack(&scope_stack_id)
+        .expect("invocation scope stack lookup should succeed")
+        .expect("invocation scope stack should exist");
+    let baseline_depth = invocation_stack
+        .read()
+        .expect("invocation scope stack lock")
+        .scopes()
+        .len();
+    let host_runtime = WorkerHostRuntimeService {
+        state: callback.host_state.clone(),
+    };
+    for name in ["cancelled-outer", "cancelled-inner"] {
+        let pushed = host_runtime
+            .push_scope(Request::new(PushScopeRequest {
+                activation_id: ACTIVATION_ID.into(),
+                auth_token: AUTH_TOKEN.into(),
+                scope: Some(ScopeContext {
+                    scope_stack_id: scope_stack_id.clone(),
+                    parent_scope_id: String::new(),
+                }),
+                name: name.into(),
+                scope_type: ProtoScopeType::Custom as i32,
+                data: None,
+                metadata: None,
+                input: None,
+            }))
+            .await
+            .expect("worker scope should push")
+            .into_inner();
+        assert!(pushed.error.is_none());
+    }
+    assert_eq!(
+        invocation_stack
+            .read()
+            .expect("invocation scope stack lock")
+            .scopes()
+            .len(),
+        baseline_depth + 2
+    );
+    let overlapping_scope_stack_id = callback
+        .host_state
+        .insert_invocation_scope_stack(invocation_stack.clone());
     let invocation_id = request.invocation_id.clone();
     let callback_task = callback.clone();
     let task = tokio::spawn(async move { callback_task.invoke_async(request).await });
@@ -655,10 +705,68 @@ async fn dropping_callback_future_cancels_worker_and_cleans_host_state() {
     assert!(
         callback
             .host_state
+            .scope_handles
+            .lock()
+            .expect("scope handle lock")
+            .is_empty()
+    );
+    assert_eq!(
+        callback
+            .host_state
+            .scope_stacks
+            .lock()
+            .expect("scope lock")
+            .len(),
+        1
+    );
+    assert_eq!(
+        invocation_stack
+            .read()
+            .expect("invocation scope stack lock")
+            .scopes()
+            .len(),
+        baseline_depth + 2
+    );
+    callback
+        .host_state
+        .cleanup_invocation_scope_stack(&overlapping_scope_stack_id);
+    assert!(
+        callback
+            .host_state
             .scope_stacks
             .lock()
             .expect("scope lock")
             .is_empty()
+    );
+    assert!(
+        callback
+            .host_state
+            .pending_scope_cleanups
+            .lock()
+            .expect("pending cleanup lock")
+            .is_empty()
+    );
+    assert_eq!(
+        invocation_stack
+            .read()
+            .expect("invocation scope stack lock")
+            .scopes()
+            .len(),
+        baseline_depth
+    );
+    callback
+        .host_state
+        .cleanup_invocation_scope_stack(&scope_stack_id);
+    callback
+        .host_state
+        .cleanup_invocation_scope_stack(&overlapping_scope_stack_id);
+    assert_eq!(
+        invocation_stack
+            .read()
+            .expect("invocation scope stack lock")
+            .scopes()
+            .len(),
+        baseline_depth
     );
 }
 

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -566,10 +566,20 @@ async fn callback_timeout_sends_explicit_worker_cancellation() {
     );
     let invocation_id = request.invocation_id.clone();
 
-    let result = callback
-        .invoke_async_with_timeout(request, std::time::Duration::from_millis(10))
-        .await;
-    started_rx.await.expect("worker invocation should start");
+    let callback_task = callback.clone();
+    let task = tokio::spawn(async move {
+        callback_task
+            .invoke_async_with_timeout(request, std::time::Duration::from_millis(10))
+            .await
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(1), started_rx)
+        .await
+        .expect("worker invocation should start before timeout assertion")
+        .expect("worker invocation should start");
+    let result = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+        .await
+        .expect("timed out invocation should complete")
+        .expect("timed out invocation task should join");
     let cancellation = tokio::time::timeout(std::time::Duration::from_secs(1), cancel_rx.recv())
         .await
         .expect("host should send cancellation after timeout")
@@ -620,7 +630,10 @@ async fn dropping_callback_future_cancels_worker_and_cleans_host_state() {
     let invocation_id = request.invocation_id.clone();
     let callback_task = callback.clone();
     let task = tokio::spawn(async move { callback_task.invoke_async(request).await });
-    started_rx.await.expect("worker invocation should start");
+    tokio::time::timeout(std::time::Duration::from_secs(1), started_rx)
+        .await
+        .expect("worker invocation should start before caller abort")
+        .expect("worker invocation should start");
 
     task.abort();
     let _ = task.await;
@@ -678,7 +691,7 @@ async fn dropping_host_stream_sends_explicit_worker_cancellation() {
         },
     )
     .await;
-    let stream = callback
+    let mut stream = callback
         .invoke_llm_stream_execution(
             "cancel_stream",
             "model",
@@ -689,8 +702,15 @@ async fn dropping_host_stream_sends_explicit_worker_cancellation() {
         )
         .await
         .expect("host stream should be returned");
+    yield_tx
+        .send(())
+        .expect("worker stream yield signal should be delivered");
+    tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+        .await
+        .expect("worker stream should yield before abandonment")
+        .expect("worker stream should yield before abandonment")
+        .expect("worker stream chunk should be valid");
     drop(stream);
-    yield_tx.send(()).expect("stream should advance after drop");
 
     let cancellation = tokio::time::timeout(std::time::Duration::from_secs(1), cancel_rx.recv())
         .await

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -4,6 +4,19 @@
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 
 //! Rust SDK for NeMo Relay out-of-process gRPC worker plugins.
+//!
+//! # Invocation cancellation
+//!
+//! The `grpc-v1` service tracks active unary and streaming callbacks by the
+//! host-provided invocation ID. Relay sends `CancelInvocation` when a managed
+//! caller is cancelled, an invocation times out, or a host stream is abandoned.
+//! The SDK aborts the matching async callback task and reports
+//! `worker.cancelled`; cancellation of an unknown, completed, or already
+//! cancelled ID returns a negative acknowledgment.
+//!
+//! Cancellation is cooperative. Dropping an async callback future releases its
+//! Rust-owned resources, but an accepted acknowledgment does not prove that
+//! arbitrary blocking work started by the callback has stopped.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -13,6 +26,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
@@ -40,7 +54,7 @@ use nemo_relay_worker_proto::{WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, jso
 use tokio::net::TcpListener;
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, mpsc};
 use tokio_stream::wrappers::TcpListenerStream;
 #[cfg(unix)]
 use tokio_stream::wrappers::UnixListenerStream;
@@ -740,6 +754,8 @@ async fn serve_plugin_arc_with_endpoint_file(
         plugin,
         runtime,
         handlers: Arc::new(Mutex::new(WorkerHandlers::default())),
+        active_invocations: Arc::new(Mutex::new(HashMap::new())),
+        next_invocation_generation: Arc::new(AtomicU64::new(1)),
     };
     serve_worker_service(service, &config.worker_endpoint, endpoint_file.as_deref()).await
 }
@@ -801,10 +817,71 @@ async fn serve_tcp_worker_service(
         .map_err(|err| WorkerSdkError::Transport(err.to_string()))
 }
 
+#[derive(Clone)]
 struct WorkerService {
     plugin: Arc<dyn WorkerPlugin>,
     runtime: PluginRuntime,
     handlers: Arc<Mutex<WorkerHandlers>>,
+    active_invocations: Arc<Mutex<HashMap<String, ActiveInvocation>>>,
+    next_invocation_generation: Arc<AtomicU64>,
+}
+
+struct ActiveInvocation {
+    generation: u64,
+    abort_handle: tokio::task::AbortHandle,
+    stream_tx: Option<mpsc::Sender<std::result::Result<StreamChunk, Status>>>,
+}
+
+struct ActiveInvocationGuard {
+    active_invocations: Arc<Mutex<HashMap<String, ActiveInvocation>>>,
+    invocation_id: String,
+    generation: u64,
+    armed: bool,
+}
+
+impl ActiveInvocationGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ActiveInvocationGuard {
+    fn drop(&mut self) {
+        if self.armed
+            && let Ok(mut active) = self.active_invocations.lock()
+            && active
+                .get(&self.invocation_id)
+                .is_some_and(|entry| entry.generation == self.generation)
+        {
+            active.remove(&self.invocation_id);
+        }
+    }
+}
+
+struct AbortTaskOnDrop {
+    abort_handle: tokio::task::AbortHandle,
+    armed: bool,
+}
+
+impl AbortTaskOnDrop {
+    fn new(abort_handle: tokio::task::AbortHandle) -> Self {
+        Self {
+            abort_handle,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for AbortTaskOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.abort_handle.abort();
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -910,7 +987,38 @@ impl PluginWorker for WorkerService {
     ) -> std::result::Result<Response<InvokeResponse>, Status> {
         let request = request.into_inner();
         self.authorize(&request.activation_id, &request.auth_token)?;
-        let response = self.invoke_inner(request).await;
+        let invocation_id = request.invocation_id.clone();
+        let service = self.clone();
+        let task = tokio::spawn(async move { service.invoke_inner(request).await });
+        let abort_handle = task.abort_handle();
+        let generation = match self.track_invocation(&invocation_id, abort_handle.clone(), None) {
+            Ok(generation) => generation,
+            Err(err) => {
+                task.abort();
+                return Err(err);
+            }
+        };
+        let _active_guard = ActiveInvocationGuard {
+            active_invocations: self.active_invocations.clone(),
+            invocation_id,
+            generation,
+            armed: true,
+        };
+        let mut abort_on_drop = AbortTaskOnDrop::new(abort_handle);
+        let response = match task.await {
+            Ok(response) => response,
+            Err(err) if err.is_cancelled() => cancelled_invoke_response(),
+            Err(err) => InvokeResponse {
+                result: Some(nemo_relay_worker_proto::v1::invoke_response::Result::Error(
+                    WorkerError {
+                        code: "worker.error".into(),
+                        message: format!("worker invocation task failed: {err}"),
+                        retryable: false,
+                    },
+                )),
+            },
+        };
+        abort_on_drop.disarm();
         Ok(Response::new(response))
     }
 
@@ -923,6 +1031,7 @@ impl PluginWorker for WorkerService {
     ) -> std::result::Result<Response<Self::InvokeStreamStream>, Status> {
         let request = request.into_inner();
         self.authorize(&request.activation_id, &request.auth_token)?;
+        let invocation_id = request.invocation_id.clone();
         let scope = invocation_scope_context(request.scope.as_ref());
         let surface = RegistrationSurface::try_from(request.surface)
             .map_err(|_| Status::invalid_argument("unknown registration surface"))?;
@@ -946,29 +1055,119 @@ impl PluginWorker for WorkerService {
             runtime: self.runtime.clone(),
             continuation_id: request.continuation_id,
         };
-        let stream = TASK_SCOPE_CONTEXT
-            .scope(scope.clone(), async {
-                let future =
-                    with_thread_scope(&scope, || handler(&payload.model_name, request_value, next));
-                future.await
-            })
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-        let stream = ScopedJsonStream::new(stream, scope);
-        let mapped = stream.map(|item| match item {
-            Ok(value) => Ok(StreamChunk {
-                item: Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Value(
-                    json_envelope("nemo.relay.Json@1", &value)
-                        .map_err(|err| Status::internal(err.to_string()))?,
-                )),
-            }),
-            Err(err) => Ok(StreamChunk {
-                item: Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Error(
-                    sdk_error_to_worker(err),
-                )),
-            }),
+        let model_name = payload.model_name;
+        let open_scope = scope.clone();
+        let open_task = tokio::spawn(async move {
+            TASK_SCOPE_CONTEXT
+                .scope(open_scope.clone(), async {
+                    let future = with_thread_scope(&open_scope, || {
+                        handler(&model_name, request_value, next)
+                    });
+                    future.await
+                })
+                .await
         });
-        Ok(Response::new(Box::pin(mapped)))
+        let open_abort_handle = open_task.abort_handle();
+        let generation =
+            match self.track_invocation(&invocation_id, open_abort_handle.clone(), None) {
+                Ok(generation) => generation,
+                Err(err) => {
+                    open_task.abort();
+                    return Err(err);
+                }
+            };
+        let mut active_guard = ActiveInvocationGuard {
+            active_invocations: self.active_invocations.clone(),
+            invocation_id: invocation_id.clone(),
+            generation,
+            armed: true,
+        };
+        let mut abort_on_drop = AbortTaskOnDrop::new(open_abort_handle);
+        let stream = match open_task.await {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(err)) => {
+                abort_on_drop.disarm();
+                return Err(Status::internal(err.to_string()));
+            }
+            Err(err) if err.is_cancelled() => {
+                abort_on_drop.disarm();
+                return Err(Status::cancelled("worker invocation was cancelled"));
+            }
+            Err(err) => {
+                abort_on_drop.disarm();
+                return Err(Status::internal(format!(
+                    "worker stream invocation task failed: {err}"
+                )));
+            }
+        };
+        abort_on_drop.disarm();
+        let (tx, rx) = mpsc::channel(16);
+        let active_invocations = self.active_invocations.clone();
+        let task_invocation_id = invocation_id.clone();
+        let task_tx = tx.clone();
+        let task = tokio::spawn(async move {
+            let _active_guard = ActiveInvocationGuard {
+                active_invocations,
+                invocation_id: task_invocation_id,
+                generation,
+                armed: true,
+            };
+            let mut stream = ScopedJsonStream::new(stream, scope);
+            loop {
+                let item = tokio::select! {
+                    item = stream.next() => item,
+                    _ = task_tx.closed() => return,
+                };
+                let Some(item) = item else {
+                    return;
+                };
+                let chunk = match item {
+                    Ok(value) => StreamChunk {
+                        item: Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Value(
+                            match json_envelope("nemo.relay.Json@1", &value) {
+                                Ok(value) => value,
+                                Err(err) => {
+                                    let _ =
+                                        task_tx.send(Err(Status::internal(err.to_string()))).await;
+                                    return;
+                                }
+                            },
+                        )),
+                    },
+                    Err(err) => StreamChunk {
+                        item: Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Error(
+                            sdk_error_to_worker(err),
+                        )),
+                    },
+                };
+                if task_tx.send(Ok(chunk)).await.is_err() {
+                    return;
+                }
+            }
+        });
+        let replaced = self.replace_invocation(
+            &invocation_id,
+            generation,
+            ActiveInvocation {
+                generation,
+                abort_handle: task.abort_handle(),
+                stream_tx: Some(tx),
+            },
+        );
+        match replaced {
+            Ok(true) => active_guard.disarm(),
+            Ok(false) => {
+                task.abort();
+                return Err(Status::cancelled("worker invocation was cancelled"));
+            }
+            Err(err) => {
+                task.abort();
+                return Err(err);
+            }
+        }
+        Ok(Response::new(Box::pin(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )))
     }
 
     async fn cancel_invocation(
@@ -977,9 +1176,30 @@ impl PluginWorker for WorkerService {
     ) -> std::result::Result<Response<WorkerAck>, Status> {
         let request = request.into_inner();
         self.authorize(&request.activation_id, &request.auth_token)?;
+        let active = {
+            let mut invocations = self
+                .active_invocations
+                .lock()
+                .map_err(|err| Status::internal(format!("invocation lock poisoned: {err}")))?;
+            invocations.remove(&request.invocation_id)
+        };
+        let Some(active) = active else {
+            return Ok(Response::new(WorkerAck {
+                accepted: false,
+                message: "invocation is not active".into(),
+            }));
+        };
+        if let Some(tx) = active.stream_tx {
+            let _ = tx.try_send(Ok(cancelled_stream_chunk()));
+        }
+        active.abort_handle.abort();
         Ok(Response::new(WorkerAck {
-            accepted: false,
-            message: "cancel invocation is not implemented by the Rust worker SDK yet".into(),
+            accepted: true,
+            message: if request.reason.is_empty() {
+                "cancellation accepted".into()
+            } else {
+                format!("cancellation accepted: {}", request.reason)
+            },
         }))
     }
 
@@ -1005,6 +1225,67 @@ impl WorkerService {
             return Err(Status::permission_denied("invalid worker token"));
         }
         Ok(())
+    }
+
+    fn track_invocation(
+        &self,
+        invocation_id: &str,
+        abort_handle: tokio::task::AbortHandle,
+        stream_tx: Option<mpsc::Sender<std::result::Result<StreamChunk, Status>>>,
+    ) -> std::result::Result<u64, Status> {
+        let generation = self
+            .next_invocation_generation
+            .fetch_add(1, Ordering::Relaxed);
+        self.insert_invocation(
+            invocation_id,
+            ActiveInvocation {
+                generation,
+                abort_handle,
+                stream_tx,
+            },
+        )?;
+        Ok(generation)
+    }
+
+    fn insert_invocation(
+        &self,
+        invocation_id: &str,
+        invocation: ActiveInvocation,
+    ) -> std::result::Result<(), Status> {
+        if invocation_id.is_empty() {
+            return Err(Status::invalid_argument("invocation_id must not be empty"));
+        }
+        let mut active = self
+            .active_invocations
+            .lock()
+            .map_err(|err| Status::internal(format!("invocation lock poisoned: {err}")))?;
+        if active.contains_key(invocation_id) {
+            return Err(Status::already_exists(format!(
+                "invocation '{invocation_id}' is already active"
+            )));
+        }
+        active.insert(invocation_id.to_string(), invocation);
+        Ok(())
+    }
+
+    fn replace_invocation(
+        &self,
+        invocation_id: &str,
+        generation: u64,
+        invocation: ActiveInvocation,
+    ) -> std::result::Result<bool, Status> {
+        let mut active = self
+            .active_invocations
+            .lock()
+            .map_err(|err| Status::internal(format!("invocation lock poisoned: {err}")))?;
+        if active
+            .get(invocation_id)
+            .is_none_or(|entry| entry.generation != generation)
+        {
+            return Ok(false);
+        }
+        active.insert(invocation_id.to_string(), invocation);
+        Ok(true)
     }
 
     async fn invoke_inner(&self, request: InvokeRequest) -> InvokeResponse {
@@ -1423,6 +1704,30 @@ fn sdk_error_to_worker(error: WorkerSdkError) -> WorkerError {
         code: "worker.error".into(),
         message: error.to_string(),
         retryable: false,
+    }
+}
+
+fn cancelled_worker_error() -> WorkerError {
+    WorkerError {
+        code: "worker.cancelled".into(),
+        message: "worker invocation was cancelled".into(),
+        retryable: false,
+    }
+}
+
+fn cancelled_invoke_response() -> InvokeResponse {
+    InvokeResponse {
+        result: Some(nemo_relay_worker_proto::v1::invoke_response::Result::Error(
+            cancelled_worker_error(),
+        )),
+    }
+}
+
+fn cancelled_stream_chunk() -> StreamChunk {
+    StreamChunk {
+        item: Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Error(
+            cancelled_worker_error(),
+        )),
     }
 }
 

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -54,7 +54,7 @@ use nemo_relay_worker_proto::{WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, jso
 use tokio::net::TcpListener;
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::{OnceCell, mpsc};
+use tokio::sync::{OnceCell, mpsc, watch};
 use tokio_stream::wrappers::TcpListenerStream;
 #[cfg(unix)]
 use tokio_stream::wrappers::UnixListenerStream;
@@ -829,7 +829,7 @@ struct WorkerService {
 struct ActiveInvocation {
     generation: u64,
     abort_handle: tokio::task::AbortHandle,
-    stream_tx: Option<mpsc::Sender<std::result::Result<StreamChunk, Status>>>,
+    stream_cancel: Option<watch::Sender<bool>>,
 }
 
 struct ActiveInvocationGuard {
@@ -1056,6 +1056,8 @@ impl PluginWorker for WorkerService {
             continuation_id: request.continuation_id,
         };
         let model_name = payload.model_name;
+        let (tx, rx) = mpsc::channel(16);
+        let (stream_cancel_tx, stream_cancel_rx) = watch::channel(false);
         let open_scope = scope.clone();
         let open_task = tokio::spawn(async move {
             TASK_SCOPE_CONTEXT
@@ -1068,14 +1070,17 @@ impl PluginWorker for WorkerService {
                 .await
         });
         let open_abort_handle = open_task.abort_handle();
-        let generation =
-            match self.track_invocation(&invocation_id, open_abort_handle.clone(), None) {
-                Ok(generation) => generation,
-                Err(err) => {
-                    open_task.abort();
-                    return Err(err);
-                }
-            };
+        let generation = match self.track_invocation(
+            &invocation_id,
+            open_abort_handle.clone(),
+            Some(stream_cancel_tx.clone()),
+        ) {
+            Ok(generation) => generation,
+            Err(err) => {
+                open_task.abort();
+                return Err(err);
+            }
+        };
         let mut active_guard = ActiveInvocationGuard {
             active_invocations: self.active_invocations.clone(),
             invocation_id: invocation_id.clone(),
@@ -1091,6 +1096,13 @@ impl PluginWorker for WorkerService {
             }
             Err(err) if err.is_cancelled() => {
                 abort_on_drop.disarm();
+                let explicitly_cancelled = *stream_cancel_rx.borrow();
+                if explicitly_cancelled {
+                    return Ok(Response::new(cancellation_aware_worker_stream(
+                        rx,
+                        stream_cancel_rx,
+                    )));
+                }
                 return Err(Status::cancelled("worker invocation was cancelled"));
             }
             Err(err) => {
@@ -1101,10 +1113,9 @@ impl PluginWorker for WorkerService {
             }
         };
         abort_on_drop.disarm();
-        let (tx, rx) = mpsc::channel(16);
         let active_invocations = self.active_invocations.clone();
         let task_invocation_id = invocation_id.clone();
-        let task_tx = tx.clone();
+        let task_tx = tx;
         let task = tokio::spawn(async move {
             let _active_guard = ActiveInvocationGuard {
                 active_invocations,
@@ -1151,22 +1162,26 @@ impl PluginWorker for WorkerService {
             ActiveInvocation {
                 generation,
                 abort_handle: task.abort_handle(),
-                stream_tx: Some(tx),
+                stream_cancel: Some(stream_cancel_tx),
             },
         );
         match replaced {
             Ok(true) => active_guard.disarm(),
             Ok(false) => {
                 task.abort();
-                return Err(Status::cancelled("worker invocation was cancelled"));
+                return Ok(Response::new(cancellation_aware_worker_stream(
+                    rx,
+                    stream_cancel_rx,
+                )));
             }
             Err(err) => {
                 task.abort();
                 return Err(err);
             }
         }
-        Ok(Response::new(Box::pin(
-            tokio_stream::wrappers::ReceiverStream::new(rx),
+        Ok(Response::new(cancellation_aware_worker_stream(
+            rx,
+            stream_cancel_rx,
         )))
     }
 
@@ -1189,8 +1204,8 @@ impl PluginWorker for WorkerService {
                 message: "invocation is not active".into(),
             }));
         };
-        if let Some(tx) = active.stream_tx {
-            let _ = tx.try_send(Ok(cancelled_stream_chunk()));
+        if let Some(cancel) = active.stream_cancel {
+            let _ = cancel.send(true);
         }
         active.abort_handle.abort();
         Ok(Response::new(WorkerAck {
@@ -1231,7 +1246,7 @@ impl WorkerService {
         &self,
         invocation_id: &str,
         abort_handle: tokio::task::AbortHandle,
-        stream_tx: Option<mpsc::Sender<std::result::Result<StreamChunk, Status>>>,
+        stream_cancel: Option<watch::Sender<bool>>,
     ) -> std::result::Result<u64, Status> {
         let generation = self
             .next_invocation_generation
@@ -1241,7 +1256,7 @@ impl WorkerService {
             ActiveInvocation {
                 generation,
                 abort_handle,
-                stream_tx,
+                stream_cancel,
             },
         )?;
         Ok(generation)
@@ -1729,6 +1744,53 @@ fn cancelled_stream_chunk() -> StreamChunk {
             cancelled_worker_error(),
         )),
     }
+}
+
+fn cancellation_aware_worker_stream(
+    rx: mpsc::Receiver<std::result::Result<StreamChunk, Status>>,
+    cancel_rx: watch::Receiver<bool>,
+) -> Pin<Box<dyn Stream<Item = std::result::Result<StreamChunk, Status>> + Send>> {
+    #[derive(Clone, Copy)]
+    enum CancellationState {
+        Watching,
+        Closed,
+        Done,
+    }
+
+    Box::pin(futures_util::stream::unfold(
+        (rx, cancel_rx, CancellationState::Watching),
+        |(mut rx, mut cancel_rx, mut state)| async move {
+            if matches!(state, CancellationState::Done) {
+                return None;
+            }
+            loop {
+                if matches!(state, CancellationState::Closed) {
+                    return rx
+                        .recv()
+                        .await
+                        .map(|item| (item, (rx, cancel_rx, CancellationState::Closed)));
+                }
+                tokio::select! {
+                    biased;
+                    changed = cancel_rx.changed() => match changed {
+                        Ok(()) if *cancel_rx.borrow() => {
+                            return Some((
+                                Ok(cancelled_stream_chunk()),
+                                (rx, cancel_rx, CancellationState::Done),
+                            ));
+                        }
+                        Ok(()) => {}
+                        Err(_) => state = CancellationState::Closed,
+                    },
+                    item = rx.recv() => {
+                        return item.map(|item| {
+                            (item, (rx, cancel_rx, CancellationState::Watching))
+                        });
+                    }
+                }
+            }
+        },
+    ))
 }
 
 fn worker_error_to_sdk(error: WorkerError) -> WorkerSdkError {

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 #[cfg(unix)]
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -230,7 +231,7 @@ async fn worker_service_enforces_auth_and_reports_registrations() {
         .expect("cancel returns ack")
         .into_inner();
     assert!(!cancel.accepted);
-    assert!(cancel.message.contains("not implemented"));
+    assert!(cancel.message.contains("not active"));
 
     let shutdown = client
         .shutdown(Request::new(ShutdownRequest {
@@ -243,6 +244,101 @@ async fn worker_service_enforces_auth_and_reports_registrations() {
         .into_inner();
     assert!(!shutdown.accepted);
     assert!(shutdown.message.contains("not implemented"));
+
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
+    let plugin = Arc::new(CancellationPlugin::default());
+    let (handle, mut client) = spawn_worker(plugin.clone(), "http://127.0.0.1:9".into()).await;
+    register_plugin(&mut client).await;
+
+    let mut unary_client = client.clone();
+    let unary_task = tokio::spawn(async move {
+        unary_client
+            .invoke(Request::new(InvokeRequest {
+                invocation_id: "cancel-unary".into(),
+                ..tool_invoke(
+                    "cancel-unary",
+                    RegistrationSurface::ToolExecutionIntercept,
+                    json!({}),
+                )
+            }))
+            .await
+            .expect("cancelled unary invocation should return a response")
+            .into_inner()
+    });
+    plugin.unary_started.notified().await;
+    let unary_ack = client
+        .cancel_invocation(Request::new(CancelInvocationRequest {
+            activation_id: ACTIVATION_ID.into(),
+            invocation_id: "cancel-unary".into(),
+            auth_token: AUTH_TOKEN.into(),
+            reason: "test timeout".into(),
+        }))
+        .await
+        .expect("active unary cancellation should return an ack")
+        .into_inner();
+    let unary_response = unary_task.await.expect("unary client task should join");
+    let unary_error = match unary_response.result {
+        Some(nemo_relay_worker_proto::v1::invoke_response::Result::Error(error)) => error,
+        other => panic!("expected cancellation error, got {other:?}"),
+    };
+    assert!(unary_ack.accepted);
+    assert_eq!(unary_error.code, "worker.cancelled");
+    assert!(plugin.unary_cancelled.load(Ordering::SeqCst));
+
+    let repeated = client
+        .cancel_invocation(Request::new(CancelInvocationRequest {
+            activation_id: ACTIVATION_ID.into(),
+            invocation_id: "cancel-unary".into(),
+            auth_token: AUTH_TOKEN.into(),
+            reason: "repeat".into(),
+        }))
+        .await
+        .expect("repeated cancellation should return an ack")
+        .into_inner();
+    assert!(!repeated.accepted);
+    assert!(repeated.message.contains("not active"));
+
+    let mut stream = client
+        .invoke_stream(Request::new(InvokeRequest {
+            invocation_id: "cancel-stream".into(),
+            ..llm_invoke(
+                "cancel-stream",
+                RegistrationSurface::LlmStreamExecutionIntercept,
+                llm_request(),
+                None,
+                None,
+            )
+        }))
+        .await
+        .expect("stream invocation should start")
+        .into_inner();
+    plugin.stream_started.notified().await;
+    let stream_ack = client
+        .cancel_invocation(Request::new(CancelInvocationRequest {
+            activation_id: ACTIVATION_ID.into(),
+            invocation_id: "cancel-stream".into(),
+            auth_token: AUTH_TOKEN.into(),
+            reason: "stream abandoned".into(),
+        }))
+        .await
+        .expect("active stream cancellation should return an ack")
+        .into_inner();
+    let chunk = stream
+        .next()
+        .await
+        .expect("cancelled stream should yield a terminal error")
+        .expect("cancelled stream chunk should be protocol data");
+    let stream_error = match chunk.item {
+        Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Error(error)) => error,
+        other => panic!("expected stream cancellation error, got {other:?}"),
+    };
+    assert!(stream_ack.accepted);
+    assert_eq!(stream_error.code, "worker.cancelled");
+    assert!(plugin.stream_cancelled.load(Ordering::SeqCst));
 
     handle.abort();
 }
@@ -1178,6 +1274,72 @@ impl WorkerPlugin for MinimalPlugin {
 
     fn register(&self, _ctx: &mut PluginContext, _config: &Json) -> Result<()> {
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CancellationPlugin {
+    unary_started: Arc<tokio::sync::Notify>,
+    unary_cancelled: Arc<AtomicBool>,
+    stream_started: Arc<tokio::sync::Notify>,
+    stream_cancelled: Arc<AtomicBool>,
+}
+
+impl WorkerPlugin for CancellationPlugin {
+    fn plugin_id(&self) -> &str {
+        "cancellation"
+    }
+
+    fn register(&self, ctx: &mut PluginContext, _config: &Json) -> Result<()> {
+        let unary_started = self.unary_started.clone();
+        let unary_cancelled = self.unary_cancelled.clone();
+        ctx.register_tool_execution_intercept("cancel-unary", 0, move |_, _, _| {
+            let unary_started = unary_started.clone();
+            let unary_cancelled = unary_cancelled.clone();
+            async move {
+                struct CancelledOnDrop(Arc<AtomicBool>);
+                impl Drop for CancelledOnDrop {
+                    fn drop(&mut self) {
+                        self.0.store(true, Ordering::SeqCst);
+                    }
+                }
+
+                let _cancelled = CancelledOnDrop(unary_cancelled);
+                unary_started.notify_one();
+                std::future::pending::<Result<Json>>().await
+            }
+        });
+
+        let stream_started = self.stream_started.clone();
+        let stream_cancelled = self.stream_cancelled.clone();
+        ctx.register_llm_stream_execution_intercept("cancel-stream", 0, move |_, _, _| {
+            let stream_started = stream_started.clone();
+            let stream_cancelled = stream_cancelled.clone();
+            async move {
+                stream_started.notify_one();
+                Ok(Box::pin(CancelPendingStream(stream_cancelled)) as JsonStream)
+            }
+        });
+        Ok(())
+    }
+}
+
+struct CancelPendingStream(Arc<AtomicBool>);
+
+impl Stream for CancelPendingStream {
+    type Item = Result<Json>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        std::task::Poll::Pending
+    }
+}
+
+impl Drop for CancelPendingStream {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
     }
 }
 

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -250,9 +250,12 @@ async fn worker_service_enforces_auth_and_reports_registrations() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
+    let timeout = Duration::from_secs(2);
     let plugin = Arc::new(CancellationPlugin::default());
     let (handle, mut client) = spawn_worker(plugin.clone(), "http://127.0.0.1:9".into()).await;
-    register_plugin(&mut client).await;
+    tokio::time::timeout(timeout, register_plugin(&mut client))
+        .await
+        .expect("worker registration should complete");
 
     let mut unary_client = client.clone();
     let unary_task = tokio::spawn(async move {
@@ -269,18 +272,26 @@ async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
             .expect("cancelled unary invocation should return a response")
             .into_inner()
     });
-    plugin.unary_started.notified().await;
-    let unary_ack = client
-        .cancel_invocation(Request::new(CancelInvocationRequest {
+    tokio::time::timeout(timeout, plugin.unary_started.notified())
+        .await
+        .expect("unary invocation should start");
+    let unary_ack = tokio::time::timeout(
+        timeout,
+        client.cancel_invocation(Request::new(CancelInvocationRequest {
             activation_id: ACTIVATION_ID.into(),
             invocation_id: "cancel-unary".into(),
             auth_token: AUTH_TOKEN.into(),
             reason: "test timeout".into(),
-        }))
+        })),
+    )
+    .await
+    .expect("unary cancellation should complete")
+    .expect("active unary cancellation should return an ack")
+    .into_inner();
+    let unary_response = tokio::time::timeout(timeout, unary_task)
         .await
-        .expect("active unary cancellation should return an ack")
-        .into_inner();
-    let unary_response = unary_task.await.expect("unary client task should join");
+        .expect("unary invocation should finish after cancellation")
+        .expect("unary client task should join");
     let unary_error = match unary_response.result {
         Some(nemo_relay_worker_proto::v1::invoke_response::Result::Error(error)) => error,
         other => panic!("expected cancellation error, got {other:?}"),
@@ -289,21 +300,25 @@ async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
     assert_eq!(unary_error.code, "worker.cancelled");
     assert!(plugin.unary_cancelled.load(Ordering::SeqCst));
 
-    let repeated = client
-        .cancel_invocation(Request::new(CancelInvocationRequest {
+    let repeated = tokio::time::timeout(
+        timeout,
+        client.cancel_invocation(Request::new(CancelInvocationRequest {
             activation_id: ACTIVATION_ID.into(),
             invocation_id: "cancel-unary".into(),
             auth_token: AUTH_TOKEN.into(),
             reason: "repeat".into(),
-        }))
-        .await
-        .expect("repeated cancellation should return an ack")
-        .into_inner();
+        })),
+    )
+    .await
+    .expect("repeated cancellation should complete")
+    .expect("repeated cancellation should return an ack")
+    .into_inner();
     assert!(!repeated.accepted);
     assert!(repeated.message.contains("not active"));
 
-    let mut stream = client
-        .invoke_stream(Request::new(InvokeRequest {
+    let mut stream = tokio::time::timeout(
+        timeout,
+        client.invoke_stream(Request::new(InvokeRequest {
             invocation_id: "cancel-stream".into(),
             ..llm_invoke(
                 "cancel-stream",
@@ -312,33 +327,109 @@ async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
                 None,
                 None,
             )
-        }))
+        })),
+    )
+    .await
+    .expect("stream invocation setup should complete")
+    .expect("stream invocation should start")
+    .into_inner();
+    tokio::time::timeout(timeout, plugin.stream_started.notified())
         .await
-        .expect("stream invocation should start")
-        .into_inner();
-    plugin.stream_started.notified().await;
-    let stream_ack = client
-        .cancel_invocation(Request::new(CancelInvocationRequest {
+        .expect("stream invocation should become active");
+    let stream_ack = tokio::time::timeout(
+        timeout,
+        client.cancel_invocation(Request::new(CancelInvocationRequest {
             activation_id: ACTIVATION_ID.into(),
             invocation_id: "cancel-stream".into(),
             auth_token: AUTH_TOKEN.into(),
             reason: "stream abandoned".into(),
-        }))
-        .await
-        .expect("active stream cancellation should return an ack")
-        .into_inner();
-    let chunk = stream
-        .next()
-        .await
-        .expect("cancelled stream should yield a terminal error")
-        .expect("cancelled stream chunk should be protocol data");
-    let stream_error = match chunk.item {
-        Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Error(error)) => error,
-        other => panic!("expected stream cancellation error, got {other:?}"),
-    };
+        })),
+    )
+    .await
+    .expect("stream cancellation should complete")
+    .expect("active stream cancellation should return an ack")
+    .into_inner();
+    let stream_error = tokio::time::timeout(timeout, async {
+        loop {
+            let chunk = stream
+                .next()
+                .await
+                .expect("cancelled stream should yield a terminal error")
+                .expect("cancelled stream chunk should be protocol data");
+            if let Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Error(error)) = chunk.item
+            {
+                break error;
+            }
+        }
+    })
+    .await
+    .expect("cancelled stream should terminate");
     assert!(stream_ack.accepted);
     assert_eq!(stream_error.code, "worker.cancelled");
     assert!(plugin.stream_cancelled.load(Ordering::SeqCst));
+
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn worker_service_cancels_stream_during_async_setup() {
+    let timeout = Duration::from_secs(2);
+    let plugin = Arc::new(CancellationPlugin::default());
+    let (handle, mut client) = spawn_worker(plugin.clone(), "http://127.0.0.1:9".into()).await;
+    tokio::time::timeout(timeout, register_plugin(&mut client))
+        .await
+        .expect("worker registration should complete");
+
+    let mut stream_client = client.clone();
+    let stream_task = tokio::spawn(async move {
+        stream_client
+            .invoke_stream(Request::new(InvokeRequest {
+                invocation_id: "cancel-stream-setup".into(),
+                ..llm_invoke(
+                    "cancel-stream-setup",
+                    RegistrationSurface::LlmStreamExecutionIntercept,
+                    llm_request(),
+                    None,
+                    None,
+                )
+            }))
+            .await
+    });
+    tokio::time::timeout(timeout, plugin.stream_setup_started.notified())
+        .await
+        .expect("stream setup should start");
+    let ack = tokio::time::timeout(
+        timeout,
+        client.cancel_invocation(Request::new(CancelInvocationRequest {
+            activation_id: ACTIVATION_ID.into(),
+            invocation_id: "cancel-stream-setup".into(),
+            auth_token: AUTH_TOKEN.into(),
+            reason: "cancel setup".into(),
+        })),
+    )
+    .await
+    .expect("stream setup cancellation should complete")
+    .expect("stream setup cancellation should return an ack")
+    .into_inner();
+    let mut stream = tokio::time::timeout(timeout, stream_task)
+        .await
+        .expect("cancelled stream setup should finish")
+        .expect("stream setup client task should join")
+        .expect("cancelled stream setup should return protocol data")
+        .into_inner();
+    let chunk = tokio::time::timeout(timeout, stream.next())
+        .await
+        .expect("cancelled setup stream should terminate")
+        .expect("cancelled setup stream should yield a terminal error")
+        .expect("cancelled setup stream chunk should be protocol data");
+    let error = match chunk.item {
+        Some(nemo_relay_worker_proto::v1::stream_chunk::Item::Error(error)) => error,
+        other => panic!("expected stream setup cancellation error, got {other:?}"),
+    };
+
+    assert!(ack.accepted);
+    assert_eq!(error.code, "worker.cancelled");
+    assert!(plugin.stream_setup_cancelled.load(Ordering::SeqCst));
 
     handle.abort();
 }
@@ -1283,6 +1374,16 @@ struct CancellationPlugin {
     unary_cancelled: Arc<AtomicBool>,
     stream_started: Arc<tokio::sync::Notify>,
     stream_cancelled: Arc<AtomicBool>,
+    stream_setup_started: Arc<tokio::sync::Notify>,
+    stream_setup_cancelled: Arc<AtomicBool>,
+}
+
+struct CancelledOnDrop(Arc<AtomicBool>);
+
+impl Drop for CancelledOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
 }
 
 impl WorkerPlugin for CancellationPlugin {
@@ -1297,13 +1398,6 @@ impl WorkerPlugin for CancellationPlugin {
             let unary_started = unary_started.clone();
             let unary_cancelled = unary_cancelled.clone();
             async move {
-                struct CancelledOnDrop(Arc<AtomicBool>);
-                impl Drop for CancelledOnDrop {
-                    fn drop(&mut self) {
-                        self.0.store(true, Ordering::SeqCst);
-                    }
-                }
-
                 let _cancelled = CancelledOnDrop(unary_cancelled);
                 unary_started.notify_one();
                 std::future::pending::<Result<Json>>().await
@@ -1316,30 +1410,56 @@ impl WorkerPlugin for CancellationPlugin {
             let stream_started = stream_started.clone();
             let stream_cancelled = stream_cancelled.clone();
             async move {
-                stream_started.notify_one();
-                Ok(Box::pin(CancelPendingStream(stream_cancelled)) as JsonStream)
+                Ok(Box::pin(FillThenPendingStream {
+                    started: stream_started,
+                    cancelled: stream_cancelled,
+                    yielded: 0,
+                }) as JsonStream)
+            }
+        });
+
+        let stream_setup_started = self.stream_setup_started.clone();
+        let stream_setup_cancelled = self.stream_setup_cancelled.clone();
+        ctx.register_llm_stream_execution_intercept("cancel-stream-setup", 0, move |_, _, _| {
+            let stream_setup_started = stream_setup_started.clone();
+            let stream_setup_cancelled = stream_setup_cancelled.clone();
+            async move {
+                let _cancelled = CancelledOnDrop(stream_setup_cancelled);
+                stream_setup_started.notify_one();
+                std::future::pending::<Result<JsonStream>>().await
             }
         });
         Ok(())
     }
 }
 
-struct CancelPendingStream(Arc<AtomicBool>);
+struct FillThenPendingStream {
+    started: Arc<tokio::sync::Notify>,
+    cancelled: Arc<AtomicBool>,
+    yielded: usize,
+}
 
-impl Stream for CancelPendingStream {
+impl Stream for FillThenPendingStream {
     type Item = Result<Json>;
 
     fn poll_next(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
+        if self.yielded < 17 {
+            self.yielded += 1;
+            if self.yielded == 17 {
+                self.started.notify_one();
+            }
+            return Poll::Ready(Some(Ok(json!({ "chunk": self.yielded }))));
+        }
         std::task::Poll::Pending
     }
 }
 
-impl Drop for CancelPendingStream {
+impl Drop for FillThenPendingStream {
     fn drop(&mut self) {
-        self.0.store(true, Ordering::SeqCst);
+        self.cancelled.store(true, Ordering::SeqCst);
     }
 }
 

--- a/examples/python-grpc-worker-plugin/README.md
+++ b/examples/python-grpc-worker-plugin/README.md
@@ -49,3 +49,9 @@ The worker process is started by Relay through the manifest entrypoint. Enable
 the dynamic plugin in `plugins.toml` instead of launching the process directly;
 Relay supplies the worker socket, host socket, activation ID, plugin ID, and
 activation token environment variables.
+
+Async callbacks are cancelled cooperatively when the host caller times out or
+stops consuming a worker stream. Let `asyncio.CancelledError` propagate and put
+resource cleanup in `finally` blocks. Synchronous or blocking callback code
+cannot be preempted by the SDK; move that work off the event-loop thread and
+define its cancellation behavior explicitly.

--- a/python/plugin/README.md
+++ b/python/plugin/README.md
@@ -56,6 +56,31 @@ appropriate executor.
 The SDK does not configure `maximum_concurrent_rpcs`, so gRPC does not enforce
 an application-level RPC admission limit.
 
+## Invocation Cancellation
+
+Relay assigns every unary and streaming callback an invocation ID. The host
+sends `CancelInvocation` when its managed caller is cancelled, its worker RPC
+times out, or it stops consuming a worker-backed stream. The SDK cancels the
+matching `asyncio.Task` and reports a structured `worker.cancelled` result.
+
+Cancellation is idempotent. The first request that matches an active callback
+returns `accepted = true`; requests for unknown, completed, or already
+cancelled IDs return `accepted = false`. Treat acceptance as confirmation that
+the SDK found and cancelled the task, not as proof that arbitrary user code has
+stopped.
+
+Python task cancellation is cooperative. Async callbacks should allow
+`asyncio.CancelledError` to propagate and use `try`/`finally` for cleanup.
+Synchronous callbacks run on the event-loop thread and cannot be preempted by
+task cancellation. A blocking synchronous callback can delay both the
+cancellation RPC and all other worker RPCs, so offload blocking work and make
+its own cancellation behavior explicit.
+
+`grpc-v1` workers are expected to implement this best-effort cancellation
+contract. Relay remains compatible with older workers that return
+`accepted = false`; in that case it still drops the transport request, but it
+cannot guarantee worker-side interruption.
+
 Windows ARM64 is not currently supported because `grpcio` does not publish a
 usable wheel for that platform. The NeMo Relay workspace skips installation and
 tests for this SDK on Windows ARM64 rather than creating a package without its

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -1159,6 +1159,12 @@ async def serve_plugin(plugin: _SupportsWorkerPlugin) -> None:
         await host_channel.close()
 
 
+@dataclass(slots=True)
+class _ActiveInvocation:
+    task: asyncio.Task[Any]
+    cancel_reason: str | None = None
+
+
 class _WorkerService(pb_grpc.PluginWorkerServicer):
     def __init__(
         self,
@@ -1172,6 +1178,7 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
         self._handlers = _Handlers.empty()
         self._registered_config: Json | object = _UNREGISTERED
         self._registration_lock = asyncio.Lock()
+        self._active_invocations: dict[str, _ActiveInvocation] = {}
 
     async def Handshake(self, request: Any, context: Any) -> Any:
         await self._authorize(request, context)
@@ -1238,29 +1245,81 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
     async def Invoke(self, request: Any, context: Any) -> Any:
         await self._authorize(request, context)
         try:
-            return await self._invoke_result(request)
+            active = self._start_invocation(request.invocation_id, self._invoke_result(request))
         except Exception as exc:  # noqa: BLE001 - callback failure is protocol data.
             return pb.InvokeResponse(error=_sdk_error_to_worker(exc))
+        try:
+            return await active.task
+        except asyncio.CancelledError:
+            if active.cancel_reason is None:
+                raise
+            return pb.InvokeResponse(error=_cancelled_worker_error(active.cancel_reason))
+        except Exception as exc:  # noqa: BLE001 - callback failure is protocol data.
+            return pb.InvokeResponse(error=_sdk_error_to_worker(exc))
+        finally:
+            self._forget_invocation(request.invocation_id, active)
 
     async def InvokeStream(self, request: Any, context: Any) -> AsyncIterator[Any]:
         await self._authorize(request, context)
+        queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=16)
+        active_ref: list[_ActiveInvocation] = []
+
+        async def produce() -> None:
+            active = active_ref[0]
+            try:
+                if request.surface != pb.LLM_STREAM_EXECUTION_INTERCEPT:
+                    raise WorkerSdkError("InvokeStream only supports LLM stream execution intercepts")
+                handler = self._handler(self._handlers.llm_stream_executions, request.registration_name)
+                payload = _require_payload(request, "llm")
+                llm_request = _decode_required_envelope(payload.request, "llm request", LLM_REQUEST_SCHEMA)
+                next_call = LlmStreamNext(self._runtime, request.continuation_id)
+                with _bind_invocation_scope(request):
+                    stream = await _maybe_await(handler(payload.model_name, llm_request, next_call))
+                    async for value in _as_async_iter(stream):
+                        await queue.put(pb.StreamChunk(value=_json_envelope(JSON_SCHEMA, value)))
+            except asyncio.CancelledError:
+                if active.cancel_reason is not None:
+                    while not queue.empty():
+                        queue.get_nowait()
+                    queue.put_nowait(pb.StreamChunk(error=_cancelled_worker_error(active.cancel_reason)))
+                raise
+            except Exception as exc:  # noqa: BLE001 - callback failure is protocol data.
+                await queue.put(pb.StreamChunk(error=_sdk_error_to_worker(exc)))
+
         try:
-            if request.surface != pb.LLM_STREAM_EXECUTION_INTERCEPT:
-                raise WorkerSdkError("InvokeStream only supports LLM stream execution intercepts")
-            handler = self._handler(self._handlers.llm_stream_executions, request.registration_name)
-            payload = _require_payload(request, "llm")
-            llm_request = _decode_required_envelope(payload.request, "llm request", LLM_REQUEST_SCHEMA)
-            next_call = LlmStreamNext(self._runtime, request.continuation_id)
-            with _bind_invocation_scope(request):
-                stream = await _maybe_await(handler(payload.model_name, llm_request, next_call))
-                async for value in _as_async_iter(stream):
-                    yield pb.StreamChunk(value=_json_envelope(JSON_SCHEMA, value))
+            active = self._start_invocation(request.invocation_id, produce())
+            active_ref.append(active)
         except Exception as exc:  # noqa: BLE001 - callback failure is protocol data.
             yield pb.StreamChunk(error=_sdk_error_to_worker(exc))
+            return
+        try:
+            while True:
+                if active.task.done() and queue.empty():
+                    return
+                next_item = asyncio.create_task(queue.get())
+                done, _ = await asyncio.wait((next_item, active.task), return_when=asyncio.FIRST_COMPLETED)
+                if next_item in done:
+                    yield next_item.result()
+                    continue
+                next_item.cancel()
+                await asyncio.gather(next_item, return_exceptions=True)
+                while not queue.empty():
+                    yield queue.get_nowait()
+                return
+        finally:
+            if not active.task.done():
+                active.task.cancel()
+            await asyncio.gather(active.task, return_exceptions=True)
+            self._forget_invocation(request.invocation_id, active)
 
     async def CancelInvocation(self, request: Any, context: Any) -> Any:
         await self._authorize(request, context)
-        return pb.WorkerAck(accepted=False, message="cancel is not implemented by the Python worker SDK")
+        active = self._active_invocations.pop(request.invocation_id, None)
+        if active is None or active.task.done():
+            return pb.WorkerAck(accepted=False, message="invocation is not active")
+        active.cancel_reason = request.reason or "host requested cancellation"
+        active.task.cancel()
+        return pb.WorkerAck(accepted=True, message=f"cancellation accepted: {active.cancel_reason}")
 
     async def Shutdown(self, request: Any, context: Any) -> Any:
         await self._authorize(request, context)
@@ -1380,6 +1439,28 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
                 )
                 return _json_response(result)
             raise WorkerSdkError(f"unsupported registration surface {request.surface}")
+
+    def _start_invocation(
+        self,
+        invocation_id: str,
+        coroutine: Any,
+    ) -> _ActiveInvocation:
+        if not invocation_id:
+            coroutine.close()
+            raise WorkerSdkError("invocation_id must not be empty")
+        current = self._active_invocations.get(invocation_id)
+        if current is not None and not current.task.done():
+            coroutine.close()
+            raise WorkerSdkError(f"invocation '{invocation_id}' is already active")
+        task = asyncio.create_task(coroutine)
+        active = _ActiveInvocation(task=task)
+        self._active_invocations[invocation_id] = active
+        task.add_done_callback(lambda _: self._forget_invocation(invocation_id, active))
+        return active
+
+    def _forget_invocation(self, invocation_id: str, active: _ActiveInvocation) -> None:
+        if self._active_invocations.get(invocation_id) is active:
+            self._active_invocations.pop(invocation_id, None)
 
     async def _authorize(self, request: Any, context: Any) -> None:
         if not hmac.compare_digest(request.activation_id, self._runtime._activation_id):
@@ -1527,6 +1608,14 @@ def _sdk_error_to_worker(error: BaseException) -> Any:
     if isinstance(error, WorkerSdkError):
         code = "worker.sdk_error"
     return pb.WorkerError(code=code, message=str(error), retryable=False)
+
+
+def _cancelled_worker_error(reason: str) -> Any:
+    return pb.WorkerError(
+        code="worker.cancelled",
+        message=f"worker invocation was cancelled: {reason}",
+        retryable=False,
+    )
 
 
 def _ack_to_result(response: Any) -> None:

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -1296,7 +1296,7 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
         try:
             while True:
                 if active.task.done() and queue.empty():
-                    return
+                    break
                 next_item = asyncio.create_task(queue.get())
                 done, _ = await asyncio.wait((next_item, active.task), return_when=asyncio.FIRST_COMPLETED)
                 if next_item in done:
@@ -1306,7 +1306,9 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
                 await asyncio.gather(next_item, return_exceptions=True)
                 while not queue.empty():
                     yield queue.get_nowait()
-                return
+                break
+            if active.task.cancelled() and active.cancel_reason is None:
+                yield pb.StreamChunk(error=_cancelled_worker_error("stream callback cancelled without a host request"))
         finally:
             if not active.task.done():
                 active.task.cancel()

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -1164,6 +1164,7 @@ class _ActiveInvocation:
     task: asyncio.Task[Any]
     cancel_reason: str | None = None
     cancel_requested: bool = False
+    cancel_callback: Callable[[str], None] | None = None
 
 
 class _WorkerService(pb_grpc.PluginWorkerServicer):
@@ -1263,10 +1264,13 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
     async def InvokeStream(self, request: Any, context: Any) -> AsyncIterator[Any]:
         await self._authorize(request, context)
         queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=16)
-        active_ref: list[_ActiveInvocation] = []
+
+        def cancel_stream(reason: str) -> None:
+            while not queue.empty():
+                queue.get_nowait()
+            queue.put_nowait(pb.StreamChunk(error=_cancelled_worker_error(reason)))
 
         async def produce() -> None:
-            active = active_ref[0]
             try:
                 if request.surface != pb.LLM_STREAM_EXECUTION_INTERCEPT:
                     raise WorkerSdkError("InvokeStream only supports LLM stream execution intercepts")
@@ -1279,17 +1283,13 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
                     async for value in _as_async_iter(stream):
                         await queue.put(pb.StreamChunk(value=_json_envelope(JSON_SCHEMA, value)))
             except asyncio.CancelledError:
-                if active.cancel_reason is not None:
-                    while not queue.empty():
-                        queue.get_nowait()
-                    queue.put_nowait(pb.StreamChunk(error=_cancelled_worker_error(active.cancel_reason)))
                 raise
             except Exception as exc:  # noqa: BLE001 - callback failure is protocol data.
                 await queue.put(pb.StreamChunk(error=_sdk_error_to_worker(exc)))
 
         try:
             active = self._start_invocation(request.invocation_id, produce())
-            active_ref.append(active)
+            active.cancel_callback = cancel_stream
         except Exception as exc:  # noqa: BLE001 - callback failure is protocol data.
             yield pb.StreamChunk(error=_sdk_error_to_worker(exc))
             return
@@ -1300,7 +1300,10 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
                 next_item = asyncio.create_task(queue.get())
                 done, _ = await asyncio.wait((next_item, active.task), return_when=asyncio.FIRST_COMPLETED)
                 if next_item in done:
-                    yield next_item.result()
+                    item = next_item.result()
+                    if active.cancel_requested and item.error.code != "worker.cancelled":
+                        continue
+                    yield item
                     continue
                 next_item.cancel()
                 await asyncio.gather(next_item, return_exceptions=True)
@@ -1318,11 +1321,16 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
     async def CancelInvocation(self, request: Any, context: Any) -> Any:
         await self._authorize(request, context)
         active = self._active_invocations.get(request.invocation_id)
-        if active is None or active.task.done() or active.cancel_requested:
+        if active is None or active.cancel_requested:
+            return pb.WorkerAck(accepted=False, message="invocation is not active")
+        if active.task.done() and active.cancel_callback is None:
             return pb.WorkerAck(accepted=False, message="invocation is not active")
         active.cancel_requested = True
         active.cancel_reason = request.reason or "host requested cancellation"
-        active.task.cancel()
+        if active.cancel_callback is not None:
+            active.cancel_callback(active.cancel_reason)
+        if not active.task.done():
+            active.task.cancel()
         return pb.WorkerAck(accepted=True, message=f"cancellation accepted: {active.cancel_reason}")
 
     async def Shutdown(self, request: Any, context: Any) -> Any:
@@ -1453,13 +1461,12 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
             coroutine.close()
             raise WorkerSdkError("invocation_id must not be empty")
         current = self._active_invocations.get(invocation_id)
-        if current is not None and not current.task.done():
+        if current is not None:
             coroutine.close()
             raise WorkerSdkError(f"invocation '{invocation_id}' is already active")
         task = asyncio.create_task(coroutine)
         active = _ActiveInvocation(task=task)
         self._active_invocations[invocation_id] = active
-        task.add_done_callback(lambda _: self._forget_invocation(invocation_id, active))
         return active
 
     def _forget_invocation(self, invocation_id: str, active: _ActiveInvocation) -> None:

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -1163,6 +1163,7 @@ async def serve_plugin(plugin: _SupportsWorkerPlugin) -> None:
 class _ActiveInvocation:
     task: asyncio.Task[Any]
     cancel_reason: str | None = None
+    cancel_requested: bool = False
 
 
 class _WorkerService(pb_grpc.PluginWorkerServicer):
@@ -1314,9 +1315,10 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
 
     async def CancelInvocation(self, request: Any, context: Any) -> Any:
         await self._authorize(request, context)
-        active = self._active_invocations.pop(request.invocation_id, None)
-        if active is None or active.task.done():
+        active = self._active_invocations.get(request.invocation_id)
+        if active is None or active.task.done() or active.cancel_requested:
             return pb.WorkerAck(accepted=False, message="invocation is not active")
+        active.cancel_requested = True
         active.cancel_reason = request.reason or "host requested cancellation"
         active.task.cancel()
         return pb.WorkerAck(accepted=True, message=f"cancellation accepted: {active.cancel_reason}")

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -1496,7 +1496,7 @@ async def test_lifecycle_acks(service: _WorkerService):
         AbortContext(),
     )
     assert not cancel.accepted
-    assert "not implemented" in cancel.message
+    assert "not active" in cancel.message
 
     shutdown = await service.Shutdown(
         pb.ShutdownRequest(activation_id=ACTIVATION_ID, auth_token=AUTH_TOKEN, reason="test"),
@@ -1504,6 +1504,120 @@ async def test_lifecycle_acks(service: _WorkerService):
     )
     assert shutdown.accepted
     assert "shutdown accepted" in shutdown.message
+
+
+async def test_cancel_invocation_stops_active_async_callback_and_is_idempotent():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class CancelPlugin(WorkerPlugin):
+        plugin_id = "tests.cancel"
+
+        def register(self, ctx: PluginContext, config: Json) -> None:
+            del config
+
+            async def tool_execution(tool_name: str, value: Json, next_call: ToolNext) -> Json:
+                del tool_name, value, next_call
+                started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+
+            ctx.register_tool_execution_intercept("cancel", tool_execution)
+
+    service = _service(CancelPlugin(), RecordingHostStub())
+    await _register(service)
+    request = _invoke_request(
+        "cancel",
+        pb.TOOL_EXECUTION_INTERCEPT,
+        invocation_id="cancel-unary",
+        tool=pb.ToolInvocation(tool_name="lookup", value=_json_envelope(JSON_SCHEMA, {})),
+    )
+    invoke_task = asyncio.create_task(service.Invoke(request, AbortContext()))
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    first = await service.CancelInvocation(
+        pb.CancelInvocationRequest(
+            activation_id=ACTIVATION_ID,
+            invocation_id="cancel-unary",
+            auth_token=AUTH_TOKEN,
+            reason="test timeout",
+        ),
+        AbortContext(),
+    )
+    second = await service.CancelInvocation(
+        pb.CancelInvocationRequest(
+            activation_id=ACTIVATION_ID,
+            invocation_id="cancel-unary",
+            auth_token=AUTH_TOKEN,
+            reason="repeat",
+        ),
+        AbortContext(),
+    )
+    response = await asyncio.wait_for(invoke_task, timeout=1)
+
+    assert first.accepted
+    assert not second.accepted
+    assert response.error.code == "worker.cancelled"
+    assert "test timeout" in response.error.message
+    assert cancelled.is_set()
+
+
+async def test_cancel_invocation_stops_active_async_stream():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class CancelStreamPlugin(WorkerPlugin):
+        plugin_id = "tests.cancel_stream"
+
+        def register(self, ctx: PluginContext, config: Json) -> None:
+            del config
+
+            async def llm_stream(model_name: str, request: Json, next_call: Any) -> AsyncIterator[Json]:
+                del model_name, request, next_call
+                started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+                if False:
+                    yield {}
+
+            ctx.register_llm_stream_execution_intercept("cancel_stream", llm_stream)
+
+    service = _service(CancelStreamPlugin(), RecordingHostStub())
+    await _register(service)
+    request = _invoke_request(
+        "cancel_stream",
+        pb.LLM_STREAM_EXECUTION_INTERCEPT,
+        invocation_id="cancel-stream",
+        llm=_llm_payload(),
+    )
+
+    async def consume() -> list[Any]:
+        return [chunk async for chunk in service.InvokeStream(request, AbortContext())]
+
+    consume_task = asyncio.create_task(consume())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    ack = await service.CancelInvocation(
+        pb.CancelInvocationRequest(
+            activation_id=ACTIVATION_ID,
+            invocation_id="cancel-stream",
+            auth_token=AUTH_TOKEN,
+            reason="stream abandoned",
+        ),
+        AbortContext(),
+    )
+    chunks = await asyncio.wait_for(consume_task, timeout=1)
+
+    assert ack.accepted
+    assert len(chunks) == 1
+    assert chunks[0].error.code == "worker.cancelled"
+    assert "stream abandoned" in chunks[0].error.message
+    assert cancelled.is_set()
 
 
 def test_required_environment_reports_missing_value(monkeypatch: pytest.MonkeyPatch):

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -1627,6 +1627,60 @@ async def test_cancel_invocation_stops_active_async_stream():
     assert cancelled.is_set()
 
 
+async def test_cancel_invocation_discards_buffered_chunks_after_stream_callback_finishes():
+    finished = asyncio.Event()
+
+    class BufferedStreamPlugin(WorkerPlugin):
+        plugin_id = "tests.buffered_stream"
+
+        def register(self, ctx: PluginContext, config: Json) -> None:
+            del config
+
+            async def llm_stream(model_name: str, request: Json, next_call: Any) -> AsyncIterator[Json]:
+                del model_name, request, next_call
+                for index in range(4):
+                    yield {"index": index}
+                finished.set()
+
+            ctx.register_llm_stream_execution_intercept("buffered_stream", llm_stream)
+
+    service = _service(BufferedStreamPlugin(), RecordingHostStub())
+    await _register(service)
+    request = _invoke_request(
+        "buffered_stream",
+        pb.LLM_STREAM_EXECUTION_INTERCEPT,
+        invocation_id="buffered-stream",
+        llm=_llm_payload(),
+    )
+    stream = service.InvokeStream(request, AbortContext())
+
+    first = await asyncio.wait_for(anext(stream), timeout=1)
+    await asyncio.wait_for(finished.wait(), timeout=1)
+    assert not first.error.code
+    assert "buffered-stream" in service._active_invocations
+
+    ack = await service.CancelInvocation(
+        pb.CancelInvocationRequest(
+            activation_id=ACTIVATION_ID,
+            invocation_id="buffered-stream",
+            auth_token=AUTH_TOKEN,
+            reason="stop buffered stream",
+        ),
+        AbortContext(),
+    )
+
+    async def consume_remaining() -> list[Any]:
+        return [chunk async for chunk in stream]
+
+    remaining = await asyncio.wait_for(consume_remaining(), timeout=1)
+
+    assert ack.accepted
+    assert len(remaining) == 1
+    assert remaining[0].error.code == "worker.cancelled"
+    assert "stop buffered stream" in remaining[0].error.message
+    assert "buffered-stream" not in service._active_invocations
+
+
 async def test_stream_callback_cancellation_without_host_reason_is_terminal_error():
     class CancelledStreamPlugin(WorkerPlugin):
         plugin_id = "tests.cancelled_stream"

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -1627,6 +1627,40 @@ async def test_cancel_invocation_stops_active_async_stream():
     assert cancelled.is_set()
 
 
+async def test_stream_callback_cancellation_without_host_reason_is_terminal_error():
+    class CancelledStreamPlugin(WorkerPlugin):
+        plugin_id = "tests.cancelled_stream"
+
+        def register(self, ctx: PluginContext, config: Json) -> None:
+            del config
+
+            async def llm_stream(model_name: str, request: Json, next_call: Any) -> AsyncIterator[Json]:
+                del model_name, request, next_call
+                if False:
+                    yield {}
+                raise asyncio.CancelledError
+
+            ctx.register_llm_stream_execution_intercept("cancelled_stream", llm_stream)
+
+    service = _service(CancelledStreamPlugin(), RecordingHostStub())
+    await _register(service)
+    request = _invoke_request(
+        "cancelled_stream",
+        pb.LLM_STREAM_EXECUTION_INTERCEPT,
+        invocation_id="self-cancelled-stream",
+        llm=_llm_payload(),
+    )
+
+    async def consume() -> list[Any]:
+        return [chunk async for chunk in service.InvokeStream(request, AbortContext())]
+
+    chunks = await asyncio.wait_for(consume(), timeout=1)
+
+    assert len(chunks) == 1
+    assert chunks[0].error.code == "worker.cancelled"
+    assert "stream callback cancelled without a host request" in chunks[0].error.message
+
+
 def test_required_environment_reports_missing_value(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("NEMO_RELAY_WORKER_SOCKET", raising=False)
     with pytest.raises(WorkerSdkError, match="NEMO_RELAY_WORKER_SOCKET"):

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -1509,6 +1509,7 @@ async def test_lifecycle_acks(service: _WorkerService):
 async def test_cancel_invocation_stops_active_async_callback_and_is_idempotent():
     started = asyncio.Event()
     cancelled = asyncio.Event()
+    release = asyncio.Event()
 
     class CancelPlugin(WorkerPlugin):
         plugin_id = "tests.cancel"
@@ -1523,6 +1524,7 @@ async def test_cancel_invocation_stops_active_async_callback_and_is_idempotent()
                     await asyncio.Event().wait()
                 except asyncio.CancelledError:
                     cancelled.set()
+                    await release.wait()
                     raise
 
             ctx.register_tool_execution_intercept("cancel", tool_execution)
@@ -1547,6 +1549,7 @@ async def test_cancel_invocation_stops_active_async_callback_and_is_idempotent()
         ),
         AbortContext(),
     )
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
     second = await service.CancelInvocation(
         pb.CancelInvocationRequest(
             activation_id=ACTIVATION_ID,
@@ -1556,10 +1559,14 @@ async def test_cancel_invocation_stops_active_async_callback_and_is_idempotent()
         ),
         AbortContext(),
     )
+    reused = await asyncio.wait_for(service.Invoke(request, AbortContext()), timeout=1)
+    release.set()
     response = await asyncio.wait_for(invoke_task, timeout=1)
 
     assert first.accepted
     assert not second.accepted
+    assert reused.error.code == "worker.sdk_error"
+    assert "already active" in reused.error.message
     assert response.error.code == "worker.cancelled"
     assert "test timeout" in response.error.message
     assert cancelled.is_set()


### PR DESCRIPTION
#### Overview

Implement end-to-end cooperative cancellation for `grpc-v1` worker invocations across the Relay host and the Rust and Python worker SDKs.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Track active unary and streaming callbacks by `invocation_id` in both worker SDKs.
- Send `CancelInvocation` when a host caller is dropped, a worker RPC times out, or a worker-backed stream is abandoned.
- Make cancellation idempotent and race-safe, release continuation and scope state exactly once, and surface cancellation as `worker.cancelled`.
- Document cooperative cancellation guarantees, including the limitation for blocking Python callbacks.
- Add Rust host/unit/integration coverage plus Rust and Python SDK tests for timeout, caller/stream cancellation, repeated requests, and completion races.
- Preserve compatibility with older `grpc-v1` workers that return `accepted = false`.

Validation:
- Full Rust, Python, Go, Node.js, WebAssembly, and documentation validation matrix.
- `uv run pre-commit run --all-files`.
- Commit-time Ruff, type, docs-link, Cargo formatting, Clippy, and Cargo check hooks.
- The Python matrix excluded the known pre-existing macOS hang in `test_unlink_unix_socket_refuses_an_active_socket` after reproducing it.

#### Where should the reviewer start?

Start with `WorkerInvocationGuard` in `crates/core/src/plugin/dynamic/worker.rs`, then compare the active-invocation tracking in `crates/worker/src/lib.rs` and `python/plugin/src/nemo_relay_plugin/_api.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #334
- Closes RELAY-395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added host-driven cooperative cancellation for unary and streaming worker invocations in both Rust and Python, including timeouts and “stopped consuming” scenarios.
  * Implemented `CancelInvocation` with idempotent, reason-aware acknowledgments.

* **Bug Fixes**
  * Improved cancellation propagation and guaranteed consistent cleanup of in-flight and streamed execution state.
  * Refined cancellation/timeout/inactive error reporting and adjusted timeout messaging granularity.

* **Tests**
  * Added integration and end-to-end coverage for cancellation propagation, dropped futures/streams, and streaming setup edge cases.

* **Documentation**
  * Updated Rust and Python plugin guidance to reflect cooperative async cancellation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->