### PR TITLE
docs: clarify Codex `--config` flag placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ crates/wasm/coverage/
 
 # VSCode
 /.vscode
+
+# Relay
+/.nemo-relay

--- a/docs/nemo-relay-cli/codex.mdx
+++ b/docs/nemo-relay-cli/codex.mdx
@@ -66,7 +66,7 @@ nemo-relay codex -- --config 'model_reasoning_effort="high"' exec "Summarize thi
 
 Codex accepts overrides before or after `exec`, but treats overrides after
 `exec` as command-specific and gives them higher precedence than root-level
-overrides which can conflict with `--config` settings provided by Relay.
+overrides, which can conflict with `--config` settings that Relay provides.
 </Warning>
 
 ## Persistent Plugin Install

--- a/docs/nemo-relay-cli/codex.mdx
+++ b/docs/nemo-relay-cli/codex.mdx
@@ -57,6 +57,18 @@ nemo-relay run \
   -- codex
 ```
 
+<Warning>
+Place Codex `--config` overrides before the `exec` subcommand:
+
+```bash
+nemo-relay codex -- --config 'model_reasoning_effort="high"' exec "Summarize this repository."
+```
+
+Codex accepts overrides before or after `exec`, but treats overrides after
+`exec` as command-specific and gives them higher precedence than root-level
+overrides which can conflict with `--config` settings provided by Relay.
+</Warning>
+
 ## Persistent Plugin Install
 
 Install the persistent plugin for Codex. It should start normally and load


### PR DESCRIPTION
#### Overview

Add a warning to `docs/nemo-relay-cli/codex.mdx` about the placement of the `--config` flag

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add a warning to `docs/nemo-relay-cli/codex.mdx` about the placement of the `--config` flag
- Add `.nemo-relay` to `.gitignore`

#### Where should the reviewer start?

Start with `docs/nemo-relay-cli/codex.mdx`, especially the warning following the dry-run example.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for running Codex via Relay, including that `--config` overrides must be provided before the `exec` subcommand, and how precedence differs when overrides appear after `exec`.
* **Chores**
  * Updated version control ignore rules to exclude Relay’s local state directory (`/.nemo-relay`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->