### PR TITLE
docs: require issues before contribution PRs

### DIFF
--- a/.agents/skills/contribute-docs/SKILL.md
+++ b/.agents/skills/contribute-docs/SKILL.md
@@ -20,6 +20,7 @@ Use this skill for docs-only or example-heavy changes.
 
 - Prefer the documented public API, not internal shortcuts
 - Keep package names, repo references, and build commands current
+- When documenting contribution workflow, require an issue before external contribution PRs and note that NVIDIA contributors may use a GitHub or Linear issue.
 - Update entry-point docs when examples or reading paths change
 - Keep release-process and release-notes guidance in repo-maintainer docs such as
   `RELEASING.md`, not as user-facing docs pages or `CHANGELOG.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,11 +214,12 @@ This section describes how to prepare and submit changes for review.
 
 Complete these checks before opening or updating a pull request.
 
-1. Ensure all pre-commit hooks pass.
-2. Run the relevant test suites and confirm they pass.
-3. Verify your changes compile cleanly with the relevant target-specific build recipe, such as `just build-rust` or `just build-python`.
-4. Update the relevant documentation entry points and references.
-5. Rebase your branch on the latest `main` to avoid merge conflicts.
+1. Open or identify an issue describing the proposed enhancement or bug fix before submitting a pull request. External contributors should use a GitHub issue; NVIDIA contributors may use a GitHub or Linear issue.
+2. Ensure all pre-commit hooks pass.
+3. Run the relevant test suites and confirm they pass.
+4. Verify your changes compile cleanly with the relevant target-specific build recipe, such as `just build-rust` or `just build-python`.
+5. Update the relevant documentation entry points and references.
+6. Rebase your branch on the latest `main` to avoid merge conflicts.
 
 ### PR Description
 

--- a/docs/contribute/workflow-and-reviews.mdx
+++ b/docs/contribute/workflow-and-reviews.mdx
@@ -29,10 +29,11 @@ The configured hooks include a lightweight Markdown link check for
 
 Before submitting a PR:
 
-1. Ensure relevant hooks and tests pass.
-2. Verify the workspace builds cleanly.
-3. Update docs for public changes.
-4. Rebase on the latest `main`.
+1. Open or identify an issue describing the proposed enhancement or bug fix before submitting a PR. External contributors should use a GitHub issue; NVIDIA contributors may use a GitHub or Linear issue.
+2. Ensure relevant hooks and tests pass.
+3. Verify the workspace builds cleanly.
+4. Update docs for public changes.
+5. Rebase on the latest `main`.
 
 ## Release Tags
 


### PR DESCRIPTION
#### Overview

Require contributors to open or identify an issue before submitting enhancement or bug-fix pull requests. External contributors should use GitHub issues; NVIDIA contributors may use GitHub or Linear issues.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Updated the root contribution guide and docs-site workflow guide with the issue requirement.
- Documented that NVIDIA contributors may use Linear issues.
- Updated the docs-contribution skill to preserve the same guidance.

#### Where should the reviewer start?

Start with the PR checklist changes in CONTRIBUTING.md and docs/contribute/workflow-and-reviews.mdx.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to require an issue to be opened or identified before submitting a pull request.
  * Clarified the checklist for external contributors and NVIDIA contributors, including acceptable issue-tracking options.
  * Renumbered and refreshed the review checklist to keep submission steps clear and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->