### PR TITLE
fix: restrict BestEffortAnyCodec pickle decoding

### DIFF
--- a/python/nemo_relay/typed.py
+++ b/python/nemo_relay/typed.py
@@ -39,6 +39,7 @@ import base64
 import dataclasses
 import importlib
 import inspect
+import io
 import json
 import pickle
 import typing
@@ -72,6 +73,23 @@ class _SupportsModelValidate(Protocol[T]):
 
 _RUNTIME_TYPE_REGISTRY: weakref.WeakValueDictionary[str, type[object]] = weakref.WeakValueDictionary()
 _NO_RECONSTRUCTION = object()
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickle only the builtin containers used by the fallback codec."""
+
+    _ALLOWED_GLOBALS = {
+        ("builtins", "dict"),
+        ("builtins", "frozenset"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "tuple"),
+    }
+
+    def find_class(self, module: str, name: str) -> object:
+        if (module, name) not in self._ALLOWED_GLOBALS:
+            raise pickle.UnpicklingError(f"global '{module}.{name}' is not allowed")
+        return super().find_class(module, name)
 
 
 def _serialize_dataclass_instance(value: DataclassInstance) -> Json:
@@ -284,6 +302,8 @@ class BestEffortAnyCodec(Codec[object]):
 
     It prefers JSON-native encodings, then dataclass or Pydantic-style model
     support, and finally falls back to pickle or string encoding when needed.
+    Pickle decoding is restricted to a small allowlist of builtin containers;
+    arbitrary classes and callable globals are never reconstructed.
 
     Notes:
         This codec favors resilience over strictness. If it cannot preserve the
@@ -394,8 +414,8 @@ class BestEffortAnyCodec(Codec[object]):
             if payload is None:
                 return _NO_RECONSTRUCTION
 
-            decoded = base64.b64decode(payload)
-            return pickle.loads(decoded)
+            decoded = base64.b64decode(payload, validate=True)
+            return _RestrictedUnpickler(io.BytesIO(decoded)).load()
         except Exception:
             return _NO_RECONSTRUCTION
 
@@ -420,6 +440,7 @@ class BestEffortAnyCodec(Codec[object]):
         Recognises the ``__nv_pydantic__``, ``__nv_dataclass__``,
         ``__nv_pickle__``, and ``__nv_fallback_str__`` tags produced by
         ``to_json`` and dispatches to the appropriate reconstruction strategy.
+        Pickle tags are decoded only for allowlisted builtin containers.
         Falls through to returning the raw data if no tag is recognised.
         """
         if isinstance(data, dict) and "data" in data:

--- a/python/tests/test_typed.py
+++ b/python/tests/test_typed.py
@@ -3,7 +3,10 @@
 
 """Tests for NeMo Relay typed wrappers with explicit Codec protocol."""
 
+import base64
 import dataclasses
+import os
+import pickle
 from typing import cast
 
 import pytest
@@ -100,6 +103,14 @@ class UnpickleableValue:
 
     def __str__(self):
         return "unpickleable"
+
+
+class PickleRceValue:
+    def __init__(self, command: str):
+        self.command = command
+
+    def __reduce__(self):
+        return (os.system, (self.command,))
 
 
 # ---------------------------------------------------------------------------
@@ -805,6 +816,14 @@ class TestBestEffortAnyCodec:
     def test_from_json_pickle_with_non_string_payload_returns_raw_dict(self):
         data = {"__nv_pickle__": "broken.Type", "data": {"not": "a-string"}}
         assert self.codec.from_json(data) == data
+
+    def test_from_json_pickle_rejects_callable_globals(self, tmp_path):
+        marker = tmp_path / "pickle-rce-marker"
+        payload = base64.b64encode(pickle.dumps(PickleRceValue(f"touch {marker}"))).decode("ascii")
+        data = {"__nv_pickle__": "posix.system", "data": payload}
+
+        assert self.codec.from_json(data) == data
+        assert not marker.exists()
 
     def test_from_json_fallback_string_returns_string(self):
         data = {"__nv_fallback_str__": "broken.Type", "data": "fallback-value"}


### PR DESCRIPTION
#### Overview

Restrict `BestEffortAnyCodec` pickle decoding so untrusted tagged payloads cannot invoke arbitrary globals.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace unrestricted `pickle.loads()` with an allowlisted `Unpickler` for builtin containers.
- Reject callable and arbitrary class globals by falling back to the raw tagged dictionary.
- Add a regression test using an `os.system` reduction gadget and preserve safe `frozenset` fallback round-tripping.
- This addresses the RCE path described in RELAY-403 without changing the trusted encode-side wire format.

#### Where should the reviewer start?

Start with `python/nemo_relay/typed.py` and the `test_from_json_pickle_rejects_callable_globals` regression test in `python/tests/test_typed.py`.

Validation: focused typed tests (76 passed), broader Python tests excluding packaging/integration suites (385 passed), and changed-file pre-commit checks passed.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened handling of serialized data so only simple built-in container values can be restored.
  * Improved validation of encoded payloads to reject malformed data more reliably.
  * Added protection against unsafe deserialization attempts, helping prevent unexpected code execution.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->