### PR TITLE
fix: report daemon bind and exporter status

### DIFF
--- a/crates/cli/src/launcher.rs
+++ b/crates/cli/src/launcher.rs
@@ -613,7 +613,7 @@ impl PreparedRun {
     }
 }
 
-fn exporter_destinations(config: &GatewayConfig) -> Vec<String> {
+pub(crate) fn exporter_destinations(config: &GatewayConfig) -> Vec<String> {
     let Some(plugin_config) = config.plugin_config.as_ref() else {
         return Vec::new();
     };

--- a/crates/cli/src/launcher.rs
+++ b/crates/cli/src/launcher.rs
@@ -558,23 +558,7 @@ impl PreparedRun {
         // Color decisions key off stderr (where we actually emit), not stdout.
         let use_color = std::io::IsTerminal::is_terminal(&std::io::stderr())
             && std::env::var_os("NO_COLOR").is_none();
-        let max_w = lines.iter().map(|l| l.chars().count()).max().unwrap_or(0);
-        // 1-char padding on each side of the longest line.
-        let inner = max_w + 2;
-
-        eprintln!();
-        eprint_border_line('╭', '╮', inner, use_color);
-        for line in &lines {
-            let pad = max_w - line.chars().count();
-            let body = format!(" {line}{spaces} ", spaces = " ".repeat(pad));
-            if use_color {
-                eprintln!("\x1b[38;5;112m│\x1b[0m{body}\x1b[38;5;112m│\x1b[0m");
-            } else {
-                eprintln!("│{body}│");
-            }
-        }
-        eprint_border_line('╰', '╯', inner, use_color);
-        eprintln!();
+        eprint!("{}", render_status_frame(&lines, use_color));
     }
 
     // Prints the resolved transparent-run plan, including dynamic gateway URL, upstream base URLs,
@@ -611,6 +595,31 @@ impl PreparedRun {
             println!("note = {note}");
         }
     }
+}
+
+/// Renders a bordered status frame for daemon and transparent-run startup output.
+pub(crate) fn render_status_frame(lines: &[String], color: bool) -> String {
+    let max_w = lines.iter().map(|l| l.chars().count()).max().unwrap_or(0);
+    // 1-char padding on each side of the longest line.
+    let inner = max_w + 2;
+    let mut output = String::new();
+
+    output.push('\n');
+    push_status_border(&mut output, '╭', '╮', inner, color);
+    for line in lines {
+        let pad = max_w - line.chars().count();
+        let body = format!(" {line}{spaces} ", spaces = " ".repeat(pad));
+        if color {
+            output.push_str(&format!(
+                "\x1b[38;5;112m│\x1b[0m{body}\x1b[38;5;112m│\x1b[0m\n"
+            ));
+        } else {
+            output.push_str(&format!("│{body}│\n"));
+        }
+    }
+    push_status_border(&mut output, '╰', '╯', inner, color);
+    output.push('\n');
+    output
 }
 
 pub(crate) fn exporter_destinations(config: &GatewayConfig) -> Vec<String> {
@@ -744,15 +753,20 @@ fn codex_gateway_provider_config(gateway_url: &str) -> String {
     )
 }
 
-// Prints one horizontal border line for the live-status frame in NVIDIA green when color is
-// enabled, otherwise plain ASCII-compatible box-drawing. Writes to stderr so the banner doesn't
-// contaminate piped/redirected agent stdout.
-fn eprint_border_line(left: char, right: char, inner_width: usize, color: bool) {
+// Appends one horizontal border line in NVIDIA green when color is enabled, otherwise plain
+// ASCII-compatible box-drawing.
+fn push_status_border(
+    output: &mut String,
+    left: char,
+    right: char,
+    inner_width: usize,
+    color: bool,
+) {
     let dashes = "─".repeat(inner_width);
     if color {
-        eprintln!("\x1b[38;5;112m{left}{dashes}{right}\x1b[0m");
+        output.push_str(&format!("\x1b[38;5;112m{left}{dashes}{right}\x1b[0m\n"));
     } else {
-        eprintln!("{left}{dashes}{right}");
+        output.push_str(&format!("{left}{dashes}{right}\n"));
     }
 }
 

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -3,6 +3,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -67,6 +68,7 @@ pub(crate) async fn serve_with_dynamic(
             CliError::Io(err)
         }
     })?;
+    print_startup_status(listener.local_addr()?, &config);
     serve_listener_with_dynamic_inner(
         listener,
         config,
@@ -74,6 +76,74 @@ pub(crate) async fn serve_with_dynamic(
         Some(ShutdownMode::ProcessSignal),
     )
     .await
+}
+
+fn print_startup_status(bind: SocketAddr, config: &GatewayConfig) {
+    let use_color = std::io::IsTerminal::is_terminal(&std::io::stderr())
+        && std::env::var_os("NO_COLOR").is_none();
+    eprint!("{}", render_startup_status(bind, config, use_color));
+}
+
+fn render_startup_status(bind: SocketAddr, config: &GatewayConfig, color: bool) -> String {
+    let mut lines = vec![
+        "NeMo Relay".to_string(),
+        format!("  Gateway        http://{bind}"),
+    ];
+    let destinations = crate::launcher::exporter_destinations(config);
+    if destinations.is_empty() {
+        lines.push("  Exporters      not configured".into());
+    } else {
+        for (index, destination) in destinations.iter().enumerate() {
+            lines.push(format!(
+                "  {}{}",
+                if index == 0 {
+                    "Exporters      "
+                } else {
+                    "               "
+                },
+                destination
+            ));
+        }
+    }
+
+    let max_width = lines
+        .iter()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0);
+    let inner_width = max_width + 2;
+    let mut output = String::new();
+    output.push('\n');
+    push_status_border(&mut output, '╭', '╮', inner_width, color);
+    for line in lines {
+        let padding = max_width - line.chars().count();
+        let body = format!(" {line}{} ", " ".repeat(padding));
+        if color {
+            output.push_str(&format!(
+                "\x1b[38;5;112m│\x1b[0m{body}\x1b[38;5;112m│\x1b[0m\n"
+            ));
+        } else {
+            output.push_str(&format!("│{body}│\n"));
+        }
+    }
+    push_status_border(&mut output, '╰', '╯', inner_width, color);
+    output.push('\n');
+    output
+}
+
+fn push_status_border(
+    output: &mut String,
+    left: char,
+    right: char,
+    inner_width: usize,
+    color: bool,
+) {
+    let dashes = "─".repeat(inner_width);
+    if color {
+        output.push_str(&format!("\x1b[38;5;112m{left}{dashes}{right}\x1b[0m\n"));
+    } else {
+        output.push_str(&format!("{left}{dashes}{right}\n"));
+    }
 }
 
 /// Serves the gateway router on a caller-owned listener with optional graceful shutdown.

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::future::Future;
-use std::pin::Pin;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -106,44 +106,7 @@ fn render_startup_status(bind: SocketAddr, config: &GatewayConfig, color: bool) 
         }
     }
 
-    let max_width = lines
-        .iter()
-        .map(|line| line.chars().count())
-        .max()
-        .unwrap_or(0);
-    let inner_width = max_width + 2;
-    let mut output = String::new();
-    output.push('\n');
-    push_status_border(&mut output, '╭', '╮', inner_width, color);
-    for line in lines {
-        let padding = max_width - line.chars().count();
-        let body = format!(" {line}{} ", " ".repeat(padding));
-        if color {
-            output.push_str(&format!(
-                "\x1b[38;5;112m│\x1b[0m{body}\x1b[38;5;112m│\x1b[0m\n"
-            ));
-        } else {
-            output.push_str(&format!("│{body}│\n"));
-        }
-    }
-    push_status_border(&mut output, '╰', '╯', inner_width, color);
-    output.push('\n');
-    output
-}
-
-fn push_status_border(
-    output: &mut String,
-    left: char,
-    right: char,
-    inner_width: usize,
-    color: bool,
-) {
-    let dashes = "─".repeat(inner_width);
-    if color {
-        output.push_str(&format!("\x1b[38;5;112m{left}{dashes}{right}\x1b[0m\n"));
-    } else {
-        output.push_str(&format!("{left}{dashes}{right}\n"));
-    }
+    crate::launcher::render_status_frame(&lines, color)
 }
 
 /// Serves the gateway router on a caller-owned listener with optional graceful shutdown.

--- a/crates/cli/tests/coverage/server_tests.rs
+++ b/crates/cli/tests/coverage/server_tests.rs
@@ -170,6 +170,33 @@ fn test_config() -> GatewayConfig {
     }
 }
 
+#[test]
+fn startup_status_reports_bound_gateway_and_exporters() {
+    let config = GatewayConfig {
+        plugin_config: Some(json!({
+            "version": 1,
+            "components": [{
+                "kind": "observability",
+                "enabled": true,
+                "config": {
+                    "version": 1,
+                    "opentelemetry": {
+                        "enabled": true,
+                        "endpoint": "http://127.0.0.1:4318/v1/traces"
+                    }
+                }
+            }]
+        })),
+        ..test_config()
+    };
+
+    let output = render_startup_status("127.0.0.1:4567".parse().unwrap(), &config, false);
+
+    assert!(output.contains("NeMo Relay"));
+    assert!(output.contains("Gateway        http://127.0.0.1:4567"));
+    assert!(output.contains("OpenTelemetry http://127.0.0.1:4318/v1/traces"));
+}
+
 fn write_missing_native_plugin_manifest(
     dir: &std::path::Path,
     plugin_id: &str,

--- a/crates/cli/tests/coverage/server_tests.rs
+++ b/crates/cli/tests/coverage/server_tests.rs
@@ -197,6 +197,13 @@ fn startup_status_reports_bound_gateway_and_exporters() {
     assert!(output.contains("OpenTelemetry http://127.0.0.1:4318/v1/traces"));
 }
 
+#[test]
+fn startup_status_reports_not_configured_when_no_exporters() {
+    let output = render_startup_status("127.0.0.1:4567".parse().unwrap(), &test_config(), false);
+
+    assert!(output.contains("Exporters      not configured"));
+}
+
 fn write_missing_native_plugin_manifest(
     dir: &std::path::Path,
     plugin_id: &str,


### PR DESCRIPTION
#### Overview

Add informative startup output to daemon mode so `nemo-relay --bind ...` reports the bound gateway address and configured exporter destinations. This addresses RELAY-400.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Daemon startup now renders the same compact status frame used by transparent agent launches. It reports the listener's actual address, including the assigned port for `--bind ...:0`, and lists configured observability destinations. Existing exporter discovery is reused, and the output is written to stderr with terminal-aware color handling.

#### Where should the reviewer start?

Start with `crates/cli/src/server.rs`, especially the startup status rendering and its call immediately after listener binding. The focused regression test is in `crates/cli/tests/coverage/server_tests.rs`.

Validation completed:

- Focused startup-status test passed.
- CLI tests passed: 575 unit tests and 49 integration tests.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- Targeted pre-commit checks, formatting, and cargo check passed.
- `just test-rust` passed for core, adaptive, CLI, and other exercised targets but reported five unrelated existing FFI test failures.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-400 (Linear)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a startup status banner that shows the bound gateway address and any configured exporter endpoints when the service launches.
  * Live status output is now rendered in a bordered frame, and startup/status formatting adapts to terminal color support while respecting `NO_COLOR`.
* **Bug Fixes**
  * Startup output now clearly indicates when no exporter destinations are configured.
* **Tests**
  * Added unit tests to verify startup banner formatting for both configured and unconfigured exporter scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->