### PR TITLE
fix: flush gateway events on shutdown

### DIFF
--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -65,7 +67,13 @@ pub(crate) async fn serve_with_dynamic(
             CliError::Io(err)
         }
     })?;
-    serve_listener_with_dynamic(listener, config, dynamic_plugins, None).await
+    serve_listener_with_dynamic_inner(
+        listener,
+        config,
+        dynamic_plugins,
+        Some(ShutdownMode::ProcessSignal),
+    )
+    .await
 }
 
 /// Serves the gateway router on a caller-owned listener with optional graceful shutdown.
@@ -88,36 +96,71 @@ pub(crate) async fn serve_listener_with_dynamic(
     dynamic_plugins: Vec<ActiveDynamicPluginComponent>,
     shutdown: Option<oneshot::Receiver<()>>,
 ) -> Result<(), CliError> {
+    serve_listener_with_dynamic_inner(
+        listener,
+        config,
+        dynamic_plugins,
+        shutdown.map(ShutdownMode::Receiver),
+    )
+    .await
+}
+
+type ShutdownFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+enum ShutdownMode {
+    Receiver(oneshot::Receiver<()>),
+    ProcessSignal,
+}
+
+async fn serve_listener_with_dynamic_inner(
+    listener: TcpListener,
+    config: GatewayConfig,
+    dynamic_plugins: Vec<ActiveDynamicPluginComponent>,
+    shutdown_mode: Option<ShutdownMode>,
+) -> Result<(), CliError> {
     let plugin_activation =
         PluginActivation::initialize(config.plugin_config.clone(), dynamic_plugins).await?;
     let state = AppState::new(config);
     let sessions = state.sessions.clone();
     let last_activity = state.last_activity.clone();
     let app = router_with_state(state);
-    let idle_shutdown = (shutdown.is_none())
+    let idle_shutdown = matches!(&shutdown_mode, None | Some(ShutdownMode::ProcessSignal))
         .then(plugin_idle_timeout)
         .flatten()
         .map(|timeout| idle_shutdown_future(last_activity, sessions.clone(), timeout));
-    let serve_result = match (shutdown, idle_shutdown) {
-        (Some(receiver), _) => {
+    let shutdown: Option<ShutdownFuture> = match shutdown_mode {
+        Some(ShutdownMode::Receiver(receiver)) => Some(Box::pin(async move {
+            let _ = receiver.await;
+        })),
+        Some(ShutdownMode::ProcessSignal) => Some(Box::pin(async move {
+            if let Some(idle) = idle_shutdown {
+                tokio::select! {
+                    _ = shutdown_signal() => {}
+                    _ = idle => {}
+                }
+            } else {
+                shutdown_signal().await;
+            }
+        })),
+        None => idle_shutdown.map(|idle| Box::pin(idle) as ShutdownFuture),
+    };
+    let serve_result = match shutdown {
+        Some(shutdown) => {
             axum::serve(listener, app)
-                .with_graceful_shutdown(async {
-                    let _ = receiver.await;
-                })
+                .with_graceful_shutdown(shutdown)
                 .await
         }
-        (None, Some(idle)) => {
-            axum::serve(listener, app)
-                .with_graceful_shutdown(idle)
-                .await
-        }
-        (None, None) => axum::serve(listener, app).await,
+        None => axum::serve(listener, app).await,
     };
     let close_result = sessions.close_all("gateway_shutdown").await;
+    let flush_result = nemo_relay::api::runtime::flush_subscribers().map_err(CliError::from);
     let clear_result = plugin_activation.clear();
     if let Err(serve_error) = serve_result {
         if let Err(close_error) = close_result {
             eprintln!("session teardown failed after server error: {close_error}");
+        }
+        if let Err(flush_error) = flush_result {
+            eprintln!("subscriber flush failed after server error: {flush_error}");
         }
         if let Err(clear_error) = clear_result {
             eprintln!("plugin teardown failed after server error: {clear_error}");
@@ -125,7 +168,36 @@ pub(crate) async fn serve_listener_with_dynamic(
         return Err(serve_error.into());
     }
     close_result?;
+    flush_result?;
     clear_result
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("installing SIGTERM handler should succeed");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = terminate.recv() => {}
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let mut ctrl_shutdown = tokio::signal::windows::ctrl_shutdown()
+            .expect("installing Windows shutdown handler should succeed");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = ctrl_shutdown.recv() => {}
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 /// Builds the gateway HTTP router and shared state.

--- a/crates/cli/tests/coverage/server_tests.rs
+++ b/crates/cli/tests/coverage/server_tests.rs
@@ -360,6 +360,70 @@ async fn serve_listener_honors_plugin_idle_timeout_env() {
 }
 
 #[tokio::test]
+async fn serve_listener_flushes_shutdown_scope_events_without_plugins() {
+    let _guard = PLUGIN_CONFIG_TEST_LOCK.lock().await;
+    let subscriber_name = "server-shutdown-flush-without-plugins-test";
+    let _ = deregister_subscriber(subscriber_name);
+    let captured = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let captured_events = captured.clone();
+    register_subscriber(
+        subscriber_name,
+        Arc::new(move |event| {
+            if event.scope_category() == Some(ScopeCategory::End)
+                && event
+                    .metadata()
+                    .and_then(|metadata| metadata.get("session_id"))
+                    .and_then(Value::as_str)
+                    == Some("shutdown-flush-session")
+            {
+                captured_events
+                    .lock()
+                    .unwrap()
+                    .push(event.name().to_string());
+            }
+        }),
+    )
+    .unwrap();
+    let _subscriber_cleanup = SubscriberCleanup(subscriber_name);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let url = format!("http://{address}");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let handle =
+        tokio::spawn(
+            async move { serve_listener(listener, test_config(), Some(shutdown_rx)).await },
+        );
+
+    wait_for_gateway(&url).await;
+    let client = test_http_client();
+    for hook_event_name in ["sessionStart", "UserPromptSubmit"] {
+        let response = client
+            .post(format!("{url}/hooks/codex"))
+            .json(&json!({
+                "session_id": "shutdown-flush-session",
+                "hook_event_name": hook_event_name
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    shutdown_tx.send(()).unwrap();
+    handle.await.unwrap().unwrap();
+
+    assert!(
+        captured
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|name| name == "codex-turn"),
+        "expected shutdown scope-end event to be flushed"
+    );
+}
+
+#[tokio::test]
 async fn plugin_idle_timeout_parses_absent_invalid_zero_and_positive_values() {
     let _guard = PLUGIN_CONFIG_TEST_LOCK.lock().await;
 


### PR DESCRIPTION
#### Overview

Add graceful gateway shutdown handling so process termination closes active scopes and flushes queued observability events before teardown.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Gateway mode now handles SIGINT/SIGTERM on Unix and Ctrl+C/Windows console shutdown signals, while preserving the existing idle-shutdown path. Shutdown closes all active session scopes first, then flushes subscribers before clearing plugin configuration. A regression test verifies shutdown-generated Codex turn-end events are delivered without an active plugin configuration.

Validation: `just test-rust`; `cargo clippy --workspace --all-targets -- -D warnings`; `uv run pre-commit run --all-files`; SIGTERM gateway smoke test.

#### Where should the reviewer start?

Start in `crates/cli/src/server.rs` at the shutdown-mode selection and teardown ordering, then review `crates/cli/tests/coverage/server_tests.rs` for the flush regression test.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-399


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown behavior so it now responds more reliably to process termination signals and idle timeouts.
  * Ensured shutdown-related events are flushed properly, even when no plugins are active, so session activity is more consistently recorded.
  * Preserved cleanup on exit by closing sessions and clearing runtime state after the server stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->