### PR TITLE
fix: report ATIF remote storage destinations in CLI status banner

### DIFF
--- a/crates/cli/src/launcher.rs
+++ b/crates/cli/src/launcher.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use nemo_relay::observability::plugin_component::{OBSERVABILITY_PLUGIN_KIND, ObservabilityConfig};
+use nemo_relay::observability::plugin_component::{
+    AtifStorageConfig, OBSERVABILITY_PLUGIN_KIND, ObservabilityConfig,
+};
 use nemo_relay::plugin::PluginConfig;
 use reqwest::Client;
 use serde_json::{Value, json};
@@ -678,14 +680,23 @@ fn observability_exporter_destinations(config: &ObservabilityConfig) -> Vec<Stri
         destinations.push(format!("ATOF {}", path.display()));
     }
     if let Some(section) = config.atif.as_ref().filter(|section| section.enabled) {
-        let directory = section
-            .output_directory
-            .clone()
-            .unwrap_or_else(current_output_directory);
-        destinations.push(format!(
-            "ATIF {}",
-            directory.join(&section.filename_template).display()
-        ));
+        if section.storage.is_empty() {
+            let directory = section
+                .output_directory
+                .clone()
+                .unwrap_or_else(current_output_directory);
+            destinations.push(format!(
+                "ATIF {}",
+                directory.join(&section.filename_template).display()
+            ));
+        } else {
+            // Non-empty `storage` skips the local file write and uploads to each remote backend
+            // instead, so report the actual upload destinations rather than a local path that is
+            // never written.
+            for backend in &section.storage {
+                destinations.push(format!("ATIF {}", atif_storage_destination(backend)));
+            }
+        }
     }
     if let Some(section) = config
         .opentelemetry
@@ -714,6 +725,23 @@ fn observability_exporter_destinations(config: &ObservabilityConfig) -> Vec<Stri
         ));
     }
     destinations
+}
+
+// Renders a single ATIF remote storage backend as a human-readable destination for the status
+// banner. S3 keys are summarized as `s3://<bucket>/<key_prefix>`; the per-trajectory object suffix
+// is omitted because it is only known once a session starts.
+fn atif_storage_destination(storage: &AtifStorageConfig) -> String {
+    match storage {
+        AtifStorageConfig::Http(http) => http.endpoint.clone(),
+        AtifStorageConfig::S3(s3) => {
+            let prefix = s3.key_prefix.as_deref().unwrap_or("").trim_matches('/');
+            if prefix.is_empty() {
+                format!("s3://{}", s3.bucket)
+            } else {
+                format!("s3://{}/{}", s3.bucket, prefix)
+            }
+        }
+    }
 }
 
 fn current_output_directory() -> PathBuf {

--- a/crates/cli/tests/coverage/launcher_tests.rs
+++ b/crates/cli/tests/coverage/launcher_tests.rs
@@ -397,6 +397,51 @@ fn exporter_destinations_describe_observability_outputs() {
 }
 
 #[test]
+fn exporter_destinations_describe_atif_remote_storage_instead_of_local_path() {
+    let gateway = GatewayConfig {
+        plugin_config: Some(json!({
+            "version": 1,
+            "components": [{
+                "kind": OBSERVABILITY_PLUGIN_KIND,
+                "enabled": true,
+                "config": {
+                    "version": 1,
+                    "atif": {
+                        "enabled": true,
+                        "output_directory": "trajectories",
+                        "filename_template": "agent-{session_id}.json",
+                        "storage": [
+                            {"type": "s3", "bucket": "traj-bucket", "key_prefix": "runs/"},
+                            {"type": "http", "endpoint": "https://collector.example/ingest"}
+                        ]
+                    }
+                }
+            }]
+        })),
+        ..GatewayConfig::default()
+    };
+
+    let destinations = exporter_destinations(&gateway);
+
+    assert!(
+        destinations
+            .iter()
+            .any(|line| line == "ATIF s3://traj-bucket/runs")
+    );
+    assert!(
+        destinations
+            .iter()
+            .any(|line| line == "ATIF https://collector.example/ingest")
+    );
+    // The local path is skipped at runtime when storage is configured, so it must not be reported.
+    assert!(
+        !destinations
+            .iter()
+            .any(|line| line.contains("agent-{session_id}.json"))
+    );
+}
+
+#[test]
 fn exporter_destinations_cover_invalid_disabled_and_missing_plugin_configs() {
     let invalid_plugin = GatewayConfig {
         plugin_config: Some(json!({"components": "not-a-list"})),


### PR DESCRIPTION
#### Overview

When an ATIF observability section configures remote `storage`, the launcher status banner (and `nemo-relay run --print` / `--dry-run` output) reported a local trajectory path that is never written and omitted the actual upload destinations. This corrects the CLI output to describe the real remote destinations.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- `crates/cli/src/launcher.rs`: `observability_exporter_destinations` now branches on the ATIF section's `storage`. When `storage` is empty it keeps the existing local `output_directory`/`filename_template` line; when `storage` is non-empty it emits one destination per backend via a new `atif_storage_destination` helper (`s3://<bucket>/<key_prefix>` for S3, the endpoint URL for HTTP).
- This matches the runtime: `AtifDispatcher::prepare_destination` returns `local_path = None` and `sink_targets` yields only `Remote(_)` sinks when `storage` is non-empty, so no local file is written. The previous banner line pointed at a path that never exists.
- Behavior is unchanged when no remote storage is configured.
- Added regression test `exporter_destinations_describe_atif_remote_storage_instead_of_local_path`, which asserts the S3/HTTP destinations are reported and the phantom local path is not.

#### Where should the reviewer start?

`crates/cli/src/launcher.rs` — the ATIF branch in `observability_exporter_destinations` plus the new `atif_storage_destination` helper. Compare against `AtifDispatcher::prepare_destination` in `crates/core/src/observability/plugin_component.rs`, which is the runtime behavior the banner now mirrors.

Validation: `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p nemo-relay-cli exporter_destinations` all pass. Two unrelated `plugin_shim` sidecar-health tests fail identically with and without this change on this machine (a local sidecar is running), so they are pre-existing and environment-dependent.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved destination reporting for ATIF storage so remote backends are shown correctly.
  * Local file paths are now omitted when remote storage is configured, reducing confusion in status output.

* **Tests**
  * Added coverage for ATIF destination reporting with multiple remote storage backends, including S3 and HTTP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->