### PR TITLE
feat(plugin)!: support pending marks from tool execution intercepts

### DIFF
--- a/crates/adaptive/src/intercepts.rs
+++ b/crates/adaptive/src/intercepts.rs
@@ -128,7 +128,7 @@ pub(crate) fn create_tool_execution_intercept_with_mode(
         let name = name.to_string();
         Box::pin(async move {
             let Some(cohort_key) = resolve_warm_first_cohort_key(&name, &mode, &cache) else {
-                return next(args).await;
+                return next(args).await.map(Into::into);
             };
 
             match resolve_warm_first_role(&registry, cohort_key.clone()).await {
@@ -136,7 +136,7 @@ pub(crate) fn create_tool_execution_intercept_with_mode(
                     let result = next(args).await;
                     gate.release();
                     cleanup_cohort_gate(&registry, &cohort_key, &gate).await;
-                    result
+                    result.map(Into::into)
                 }
                 WarmFirstRole::Follower(gate) => {
                     let _ = tokio::time::timeout(
@@ -144,10 +144,19 @@ pub(crate) fn create_tool_execution_intercept_with_mode(
                         gate.wait_for_release(),
                     )
                     .await;
-                    next(args).await
+                    next(args).await.map(Into::into)
                 }
             }
-        }) as Pin<Box<dyn Future<Output = FlowResult<Json>> + Send>>
+        })
+            as Pin<
+                Box<
+                    dyn Future<
+                            Output = FlowResult<
+                                nemo_relay::api::tool::ToolExecutionInterceptOutcome,
+                            >,
+                        > + Send,
+                >,
+            >
     })
 }
 

--- a/crates/adaptive/tests/unit/intercepts_tests.rs
+++ b/crates/adaptive/tests/unit/intercepts_tests.rs
@@ -102,7 +102,7 @@ async fn test_tool_intercept_calls_next() {
 
     let result = intercept("test", json!({"input": 1}), next).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), json!({"result": "ok"}));
+    assert_eq!(result.unwrap(), json!({"result": "ok"}).into());
 }
 
 #[tokio::test]
@@ -125,7 +125,7 @@ async fn test_tool_intercept_with_populated_cache() {
     // Should not panic and should return next's result
     let result = intercept("test", json!({"tool_input": "data"}), next).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), json!({"from_next": true}));
+    assert_eq!(result.unwrap(), json!({"from_next": true}).into());
 }
 
 #[tokio::test]
@@ -147,7 +147,7 @@ async fn test_tool_intercept_passes_args_to_next() {
     let input = json!({"tool_arg": "value", "count": 42});
     let result = intercept("test", input.clone(), next).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), input);
+    assert_eq!(result.unwrap(), input.into());
 }
 
 #[test]
@@ -325,8 +325,8 @@ async fn test_schedule_mode_intercept_waits_for_primer_before_running_follower()
     tokio::task::yield_now().await;
     let follower = tokio::spawn(intercept("search", json!({"call": 2}), next.clone()));
 
-    assert_eq!(primer.await.unwrap().unwrap(), json!({"call": 1}));
-    assert_eq!(follower.await.unwrap().unwrap(), json!({"call": 2}));
+    assert_eq!(primer.await.unwrap().unwrap(), json!({"call": 1}).into());
+    assert_eq!(follower.await.unwrap().unwrap(), json!({"call": 2}).into());
     assert_eq!(next_order.load(Ordering::SeqCst), 2);
 
     reset_scope_stack();

--- a/crates/adaptive/tests/unit/runtime_features_tests.rs
+++ b/crates/adaptive/tests/unit/runtime_features_tests.rs
@@ -206,14 +206,22 @@ fn assert_llm_stream_execution_intercept_absent(name: &str) {
 
 fn assert_tool_execution_intercept_registered(name: &str) {
     assert_already_registered(
-        register_tool_execution_intercept(name, i32::MAX, Arc::new(|_name, args, next| next(args))),
+        register_tool_execution_intercept(
+            name,
+            i32::MAX,
+            Arc::new(|_name, args, next| Box::pin(async move { next(args).await.map(Into::into) })),
+        ),
         name,
     );
 }
 
 fn assert_tool_execution_intercept_absent(name: &str) {
-    register_tool_execution_intercept(name, i32::MAX, Arc::new(|_name, args, next| next(args)))
-        .unwrap();
+    register_tool_execution_intercept(
+        name,
+        i32::MAX,
+        Arc::new(|_name, args, next| Box::pin(async move { next(args).await.map(Into::into) })),
+    )
+    .unwrap();
     deregister_tool_execution_intercept(name).unwrap();
 }
 
@@ -753,7 +761,7 @@ async fn registration_context_registers_all_supported_callback_types() {
     ctx.register_tool_execution_intercept(
         "adaptive_test_tool",
         8,
-        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args) })),
+        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args.into()) })),
     )
     .unwrap();
 

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -508,7 +508,9 @@ global_intercept_registry_api!(
 );
 global_execution_registry_api!(
     /// Register a global tool execution intercept.
-    /// Execution intercepts can wrap or replace the tool callback.
+    /// Execution intercepts can wrap or replace the tool callback. Each
+    /// callback returns a canonical tool execution outcome, while its
+    /// continuation resolves to the raw downstream result JSON.
     register_tool_execution_intercept,
     /// Deregister a global tool execution intercept.
     deregister_tool_execution_intercept,
@@ -616,7 +618,8 @@ scope_intercept_registry_api!(
 scope_execution_registry_api!(
     /// Register a scope-local tool execution intercept.
     /// Execution intercepts can wrap or replace the tool callback inside the
-    /// owning scope.
+    /// owning scope. Each callback returns a canonical tool execution outcome,
+    /// while its continuation resolves to the raw downstream result JSON.
     scope_register_tool_execution_intercept,
     /// Deregister a scope-local tool execution intercept.
     scope_deregister_tool_execution_intercept,

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -4,10 +4,11 @@
 //! Middleware registry helpers for global and scope-local guardrails,
 //! intercepts, and subscribers.
 
+use crate::api::runtime::callbacks::ToolExecutionCallback;
 use crate::api::runtime::{
     LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn, ToolExecutionFn,
-    ToolInterceptFn, ToolSanitizeFn,
+    ToolExecutionOutcomeFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::runtime::{current_scope_stack, global_context};
 use crate::api::shared::ensure_runtime_owner;
@@ -506,15 +507,49 @@ global_intercept_registry_api!(
     tool_request_intercepts,
     ToolInterceptFn
 );
-global_execution_registry_api!(
-    /// Register a global tool execution intercept.
-    /// Execution intercepts can wrap or replace the tool callback.
-    register_tool_execution_intercept,
-    /// Deregister a global tool execution intercept.
-    deregister_tool_execution_intercept,
-    tool_execution_intercepts,
-    ToolExecutionFn
-);
+/// Register a global tool execution intercept.
+/// Execution intercepts can wrap or replace the tool callback.
+pub fn register_tool_execution_intercept(
+    name: &str,
+    priority: i32,
+    callable: ToolExecutionFn,
+) -> Result<()> {
+    register_tool_execution_callback(name, priority, ToolExecutionCallback::Raw(callable))
+}
+
+pub(crate) fn register_tool_execution_outcome_intercept(
+    name: &str,
+    priority: i32,
+    callable: ToolExecutionOutcomeFn,
+) -> Result<()> {
+    register_tool_execution_callback(name, priority, ToolExecutionCallback::Outcome(callable))
+}
+
+fn register_tool_execution_callback(
+    name: &str,
+    priority: i32,
+    callable: ToolExecutionCallback,
+) -> Result<()> {
+    ensure_runtime_owner()?;
+    let context = global_context();
+    let mut state = context
+        .write()
+        .map_err(|error| FlowError::Internal(error.to_string()))?;
+    state
+        .tool_execution_intercepts
+        .register(ExecutionIntercept::new(name, priority, callable))
+        .map_err(FlowError::AlreadyExists)
+}
+
+/// Deregister a global tool execution intercept.
+pub fn deregister_tool_execution_intercept(name: &str) -> Result<bool> {
+    ensure_runtime_owner()?;
+    let context = global_context();
+    let mut state = context
+        .write()
+        .map_err(|error| FlowError::Internal(error.to_string()))?;
+    Ok(state.tool_execution_intercepts.deregister(name))
+}
 
 global_guardrail_registry_api!(
     /// Register a global LLM sanitize-request guardrail.
@@ -613,16 +648,44 @@ scope_intercept_registry_api!(
     tool_request_intercepts,
     ToolInterceptFn
 );
-scope_execution_registry_api!(
-    /// Register a scope-local tool execution intercept.
-    /// Execution intercepts can wrap or replace the tool callback inside the
-    /// owning scope.
-    scope_register_tool_execution_intercept,
-    /// Deregister a scope-local tool execution intercept.
-    scope_deregister_tool_execution_intercept,
-    tool_execution_intercepts,
-    ToolExecutionFn
-);
+/// Register a scope-local tool execution intercept.
+/// Execution intercepts can wrap or replace the tool callback inside the
+/// owning scope.
+pub fn scope_register_tool_execution_intercept(
+    scope_uuid: &uuid::Uuid,
+    name: &str,
+    priority: i32,
+    callable: ToolExecutionFn,
+) -> Result<()> {
+    ensure_runtime_owner()?;
+    let scope_stack = current_scope_stack();
+    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
+    let registries = guard
+        .local_registries_mut(scope_uuid)
+        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
+    registries
+        .tool_execution_intercepts
+        .register(ExecutionIntercept::new(
+            name,
+            priority,
+            ToolExecutionCallback::Raw(callable),
+        ))
+        .map_err(FlowError::AlreadyExists)
+}
+
+/// Deregister a scope-local tool execution intercept.
+pub fn scope_deregister_tool_execution_intercept(
+    scope_uuid: &uuid::Uuid,
+    name: &str,
+) -> Result<bool> {
+    ensure_runtime_owner()?;
+    let scope_stack = current_scope_stack();
+    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
+    let registries = guard
+        .local_registries_mut(scope_uuid)
+        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
+    Ok(registries.tool_execution_intercepts.deregister(name))
+}
 
 scope_guardrail_registry_api!(
     /// Register a scope-local LLM sanitize-request guardrail.

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -4,11 +4,10 @@
 //! Middleware registry helpers for global and scope-local guardrails,
 //! intercepts, and subscribers.
 
-use crate::api::runtime::callbacks::ToolExecutionCallback;
 use crate::api::runtime::{
     LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn, ToolExecutionFn,
-    ToolExecutionOutcomeFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::runtime::{current_scope_stack, global_context};
 use crate::api::shared::ensure_runtime_owner;
@@ -507,49 +506,15 @@ global_intercept_registry_api!(
     tool_request_intercepts,
     ToolInterceptFn
 );
-/// Register a global tool execution intercept.
-/// Execution intercepts can wrap or replace the tool callback.
-pub fn register_tool_execution_intercept(
-    name: &str,
-    priority: i32,
-    callable: ToolExecutionFn,
-) -> Result<()> {
-    register_tool_execution_callback(name, priority, ToolExecutionCallback::Raw(callable))
-}
-
-pub(crate) fn register_tool_execution_outcome_intercept(
-    name: &str,
-    priority: i32,
-    callable: ToolExecutionOutcomeFn,
-) -> Result<()> {
-    register_tool_execution_callback(name, priority, ToolExecutionCallback::Outcome(callable))
-}
-
-fn register_tool_execution_callback(
-    name: &str,
-    priority: i32,
-    callable: ToolExecutionCallback,
-) -> Result<()> {
-    ensure_runtime_owner()?;
-    let context = global_context();
-    let mut state = context
-        .write()
-        .map_err(|error| FlowError::Internal(error.to_string()))?;
-    state
-        .tool_execution_intercepts
-        .register(ExecutionIntercept::new(name, priority, callable))
-        .map_err(FlowError::AlreadyExists)
-}
-
-/// Deregister a global tool execution intercept.
-pub fn deregister_tool_execution_intercept(name: &str) -> Result<bool> {
-    ensure_runtime_owner()?;
-    let context = global_context();
-    let mut state = context
-        .write()
-        .map_err(|error| FlowError::Internal(error.to_string()))?;
-    Ok(state.tool_execution_intercepts.deregister(name))
-}
+global_execution_registry_api!(
+    /// Register a global tool execution intercept.
+    /// Execution intercepts can wrap or replace the tool callback.
+    register_tool_execution_intercept,
+    /// Deregister a global tool execution intercept.
+    deregister_tool_execution_intercept,
+    tool_execution_intercepts,
+    ToolExecutionFn
+);
 
 global_guardrail_registry_api!(
     /// Register a global LLM sanitize-request guardrail.
@@ -648,44 +613,16 @@ scope_intercept_registry_api!(
     tool_request_intercepts,
     ToolInterceptFn
 );
-/// Register a scope-local tool execution intercept.
-/// Execution intercepts can wrap or replace the tool callback inside the
-/// owning scope.
-pub fn scope_register_tool_execution_intercept(
-    scope_uuid: &uuid::Uuid,
-    name: &str,
-    priority: i32,
-    callable: ToolExecutionFn,
-) -> Result<()> {
-    ensure_runtime_owner()?;
-    let scope_stack = current_scope_stack();
-    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
-    let registries = guard
-        .local_registries_mut(scope_uuid)
-        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
-    registries
-        .tool_execution_intercepts
-        .register(ExecutionIntercept::new(
-            name,
-            priority,
-            ToolExecutionCallback::Raw(callable),
-        ))
-        .map_err(FlowError::AlreadyExists)
-}
-
-/// Deregister a scope-local tool execution intercept.
-pub fn scope_deregister_tool_execution_intercept(
-    scope_uuid: &uuid::Uuid,
-    name: &str,
-) -> Result<bool> {
-    ensure_runtime_owner()?;
-    let scope_stack = current_scope_stack();
-    let mut guard = scope_stack.write().expect("scope stack lock poisoned");
-    let registries = guard
-        .local_registries_mut(scope_uuid)
-        .ok_or_else(|| FlowError::NotFound(format!("scope {scope_uuid} not found")))?;
-    Ok(registries.tool_execution_intercepts.deregister(name))
-}
+scope_execution_registry_api!(
+    /// Register a scope-local tool execution intercept.
+    /// Execution intercepts can wrap or replace the tool callback inside the
+    /// owning scope.
+    scope_register_tool_execution_intercept,
+    /// Deregister a scope-local tool execution intercept.
+    scope_deregister_tool_execution_intercept,
+    tool_execution_intercepts,
+    ToolExecutionFn
+);
 
 scope_guardrail_registry_api!(
     /// Register a scope-local LLM sanitize-request guardrail.

--- a/crates/core/src/api/runtime.rs
+++ b/crates/core/src/api/runtime.rs
@@ -13,7 +13,7 @@ pub use callbacks::{
     EventSubscriberFn, LlmCollectorFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn,
     LlmFinalizerFn, LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn, ToolConditionalFn,
-    ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolExecutionFn, ToolExecutionNextFn, ToolExecutionOutcomeFn, ToolInterceptFn, ToolSanitizeFn,
 };
 pub use global::global_context;
 pub use scope_stack::{

--- a/crates/core/src/api/runtime.rs
+++ b/crates/core/src/api/runtime.rs
@@ -13,7 +13,7 @@ pub use callbacks::{
     EventSubscriberFn, LlmCollectorFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn,
     LlmFinalizerFn, LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestFn,
     LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn, ToolConditionalFn,
-    ToolExecutionFn, ToolExecutionNextFn, ToolExecutionOutcomeFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
 };
 pub use global::global_context;
 pub use scope_stack::{

--- a/crates/core/src/api/runtime/callbacks.rs
+++ b/crates/core/src/api/runtime/callbacks.rs
@@ -16,6 +16,7 @@ use tokio_stream::Stream;
 
 use crate::api::event::Event;
 use crate::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
+use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::codec::request::AnnotatedLlmRequest;
 use crate::error::Result;
 use crate::json::Json;
@@ -105,6 +106,37 @@ pub type ToolExecutionNextFn =
 /// chain fails.
 pub type ToolExecutionFn = Arc<
     dyn Fn(&str, Json, ToolExecutionNextFn) -> Pin<Box<dyn Future<Output = Result<Json>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Wrap or replace tool execution while scheduling lifecycle marks.
+///
+/// This callback receives the same raw-result continuation as
+/// [`ToolExecutionFn`]. The runtime retains marks returned by downstream
+/// outcome callbacks and prepends them to the marks returned here.
+pub type ToolExecutionOutcomeFn = Arc<
+    dyn Fn(
+            &str,
+            Json,
+            ToolExecutionNextFn,
+        ) -> Pin<Box<dyn Future<Output = Result<ToolExecutionInterceptOutcome>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Mixed representation stored by tool execution registries.
+#[derive(Clone)]
+pub(crate) enum ToolExecutionCallback {
+    /// Existing raw JSON execution callback.
+    Raw(ToolExecutionFn),
+    /// Outcome callback capable of scheduling tool lifecycle marks.
+    Outcome(ToolExecutionOutcomeFn),
+}
+
+/// Internal continuation carrying both a tool result and accumulated marks.
+pub(crate) type ToolExecutionOutcomeNextFn = Arc<
+    dyn Fn(Json) -> Pin<Box<dyn Future<Output = Result<ToolExecutionInterceptOutcome>> + Send>>
         + Send
         + Sync,
 >;

--- a/crates/core/src/api/runtime/callbacks.rs
+++ b/crates/core/src/api/runtime/callbacks.rs
@@ -82,7 +82,9 @@ pub type ToolInterceptFn = Arc<dyn Fn(&str, Json) -> Result<Json> + Send + Sync>
 ///   chain.
 ///
 /// # Returns
-/// A future resolving to the tool result JSON.
+/// A future resolving to the downstream tool result JSON. Pending marks from
+/// downstream intercepts are retained by the runtime and are not exposed
+/// through this continuation.
 ///
 /// # Errors
 /// The future resolves to an error when the remaining execution chain fails.
@@ -99,23 +101,13 @@ pub type ToolExecutionNextFn =
 /// - Third argument: Continuation for the remaining execution chain.
 ///
 /// # Returns
-/// A future resolving to the tool result JSON.
+/// A future resolving to the canonical tool execution outcome, containing the
+/// tool result and any pending lifecycle marks produced by this intercept.
 ///
 /// # Errors
 /// The future resolves to an error when the intercept or remaining execution
 /// chain fails.
 pub type ToolExecutionFn = Arc<
-    dyn Fn(&str, Json, ToolExecutionNextFn) -> Pin<Box<dyn Future<Output = Result<Json>> + Send>>
-        + Send
-        + Sync,
->;
-
-/// Wrap or replace tool execution while scheduling lifecycle marks.
-///
-/// This callback receives the same raw-result continuation as
-/// [`ToolExecutionFn`]. The runtime retains marks returned by downstream
-/// outcome callbacks and prepends them to the marks returned here.
-pub type ToolExecutionOutcomeFn = Arc<
     dyn Fn(
             &str,
             Json,
@@ -124,15 +116,6 @@ pub type ToolExecutionOutcomeFn = Arc<
         + Send
         + Sync,
 >;
-
-/// Mixed representation stored by tool execution registries.
-#[derive(Clone)]
-pub(crate) enum ToolExecutionCallback {
-    /// Existing raw JSON execution callback.
-    Raw(ToolExecutionFn),
-    /// Outcome callback capable of scheduling tool lifecycle marks.
-    Outcome(ToolExecutionOutcomeFn),
-}
 
 /// Internal continuation carrying both a tool result and accumulated marks.
 pub(crate) type ToolExecutionOutcomeNextFn = Arc<

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -23,7 +23,7 @@ use crate::api::registry::{ExecutionIntercept, Guardrail, Intercept};
 use crate::api::runtime::callbacks::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmRequestInterceptFn,
     LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn,
-    LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionCallback, ToolExecutionNextFn,
+    LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionFn, ToolExecutionNextFn,
     ToolExecutionOutcomeNextFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::runtime::subscriber_dispatcher;
@@ -58,7 +58,7 @@ pub struct NemoRelayContextState {
     /// Global tool request intercepts that can rewrite arguments before execution.
     pub(crate) tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
     /// Global tool execution intercepts that wrap or replace callback execution.
-    pub(crate) tool_execution_intercepts: SortedRegistry<ExecutionIntercept<ToolExecutionCallback>>,
+    pub(crate) tool_execution_intercepts: SortedRegistry<ExecutionIntercept<ToolExecutionFn>>,
     /// Global LLM request sanitizers applied to emitted LLM-start payloads.
     pub(crate) llm_sanitize_request_guardrails: SortedRegistry<Guardrail<LlmSanitizeRequestFn>>,
     /// Global LLM response sanitizers applied to emitted LLM-end payloads.
@@ -824,13 +824,13 @@ impl NemoRelayContextState {
     ///   from the active scope stack.
     ///
     /// # Returns
-    /// A composed [`ToolExecutionNextFn`] that wraps `default_fn` in every
-    /// matching execution intercept.
+    /// A composed [`ToolExecutionOutcomeNextFn`] that wraps `default_fn` in
+    /// every matching execution intercept.
     pub(crate) fn tool_build_execution_chain(
         &self,
         name: &str,
         default_fn: ToolExecutionNextFn,
-        scope_locals: &[&SortedRegistry<ExecutionIntercept<ToolExecutionCallback>>],
+        scope_locals: &[&SortedRegistry<ExecutionIntercept<ToolExecutionFn>>],
     ) -> ToolExecutionOutcomeNextFn {
         let matching =
             merge_execution_intercept_callables(&self.tool_execution_intercepts, scope_locals);
@@ -870,14 +870,7 @@ impl NemoRelayContextState {
                     })
                 };
                 Box::pin(async move {
-                    let mut outcome = match callable {
-                        ToolExecutionCallback::Raw(callable) => ToolExecutionInterceptOutcome::new(
-                            callable(&current_name, args, raw_next).await?,
-                        ),
-                        ToolExecutionCallback::Outcome(callable) => {
-                            callable(&current_name, args, raw_next).await?
-                        }
-                    };
+                    let mut outcome = callable(&current_name, args, raw_next).await?;
                     let mut downstream_batches = std::mem::take(
                         &mut *downstream_marks
                             .lock()

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -10,7 +10,8 @@
 
 use std::any::Any;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crate::api::event::{
     BaseEvent, CategoryProfile, Event, EventCategory, MarkEvent, ScopeCategory, ScopeEvent,
@@ -22,13 +23,15 @@ use crate::api::registry::{ExecutionIntercept, Guardrail, Intercept};
 use crate::api::runtime::callbacks::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmRequestInterceptFn,
     LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, LlmStreamExecutionNextFn,
-    LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionFn, ToolExecutionNextFn,
-    ToolInterceptFn, ToolSanitizeFn,
+    LlmStreamExecutionRegistryRefs, ToolConditionalFn, ToolExecutionCallback, ToolExecutionNextFn,
+    ToolExecutionOutcomeNextFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::runtime::subscriber_dispatcher;
 use crate::api::scope::{CreateScopeHandleParams, EndScopeHandleParams, ScopeHandle, ScopeType};
 use crate::api::tool::ToolHandle;
-use crate::api::tool::{CreateToolHandleParams, EndToolHandleParams};
+use crate::api::tool::{
+    CreateToolHandleParams, EndToolHandleParams, ToolExecutionInterceptOutcome,
+};
 use crate::codec::request::AnnotatedLlmRequest;
 use crate::codec::response::AnnotatedLlmResponse;
 use crate::context::registries::{
@@ -55,7 +58,7 @@ pub struct NemoRelayContextState {
     /// Global tool request intercepts that can rewrite arguments before execution.
     pub(crate) tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
     /// Global tool execution intercepts that wrap or replace callback execution.
-    pub(crate) tool_execution_intercepts: SortedRegistry<ExecutionIntercept<ToolExecutionFn>>,
+    pub(crate) tool_execution_intercepts: SortedRegistry<ExecutionIntercept<ToolExecutionCallback>>,
     /// Global LLM request sanitizers applied to emitted LLM-start payloads.
     pub(crate) llm_sanitize_request_guardrails: SortedRegistry<Guardrail<LlmSanitizeRequestFn>>,
     /// Global LLM response sanitizers applied to emitted LLM-end payloads.
@@ -827,16 +830,69 @@ impl NemoRelayContextState {
         &self,
         name: &str,
         default_fn: ToolExecutionNextFn,
-        scope_locals: &[&SortedRegistry<ExecutionIntercept<ToolExecutionFn>>],
-    ) -> ToolExecutionNextFn {
+        scope_locals: &[&SortedRegistry<ExecutionIntercept<ToolExecutionCallback>>],
+    ) -> ToolExecutionOutcomeNextFn {
         let matching =
             merge_execution_intercept_callables(&self.tool_execution_intercepts, scope_locals);
-        let mut next = default_fn;
+        let mut next: ToolExecutionOutcomeNextFn = Arc::new(move |args| {
+            let default_fn = default_fn.clone();
+            Box::pin(async move {
+                default_fn(args)
+                    .await
+                    .map(ToolExecutionInterceptOutcome::new)
+            })
+        });
         let name = name.to_string();
         for (callable, _) in matching.into_iter().rev() {
             let current_next = next.clone();
             let current_name = name.clone();
-            next = Arc::new(move |args| callable(&current_name, args, current_next.clone()));
+            next = Arc::new(move |args| {
+                let callable = callable.clone();
+                let current_name = current_name.clone();
+                let next_sequence = Arc::new(AtomicUsize::new(0));
+                let downstream_marks = Arc::new(Mutex::new(Vec::new()));
+                let raw_next: ToolExecutionNextFn = {
+                    let current_next = current_next.clone();
+                    let next_sequence = next_sequence.clone();
+                    let downstream_marks = downstream_marks.clone();
+                    Arc::new(move |args| {
+                        let sequence = next_sequence.fetch_add(1, Ordering::Relaxed);
+                        let current_next = current_next.clone();
+                        let downstream_marks = downstream_marks.clone();
+                        Box::pin(async move {
+                            let outcome = current_next(args).await?;
+                            downstream_marks
+                                .lock()
+                                .expect("tool pending mark accumulator lock poisoned")
+                                .push((sequence, outcome.pending_marks));
+                            Ok(outcome.result)
+                        })
+                    })
+                };
+                Box::pin(async move {
+                    let mut outcome = match callable {
+                        ToolExecutionCallback::Raw(callable) => ToolExecutionInterceptOutcome::new(
+                            callable(&current_name, args, raw_next).await?,
+                        ),
+                        ToolExecutionCallback::Outcome(callable) => {
+                            callable(&current_name, args, raw_next).await?
+                        }
+                    };
+                    let mut downstream_batches = std::mem::take(
+                        &mut *downstream_marks
+                            .lock()
+                            .expect("tool pending mark accumulator lock poisoned"),
+                    );
+                    downstream_batches.sort_by_key(|(sequence, _)| *sequence);
+                    let mut marks = downstream_batches
+                        .into_iter()
+                        .flat_map(|(_, marks)| marks)
+                        .collect::<Vec<_>>();
+                    marks.append(&mut outcome.pending_marks);
+                    outcome.pending_marks = marks;
+                    Ok(outcome)
+                })
+            });
         }
         next
     }

--- a/crates/core/src/api/tool.rs
+++ b/crates/core/src/api/tool.rs
@@ -3,10 +3,11 @@
 
 use serde_json::json;
 
+use crate::api::event::{BaseEvent, Event, MarkEvent, PendingMarkSpec};
 use crate::api::runtime::NemoRelayContextState;
-use crate::api::runtime::ToolExecutionNextFn;
 use crate::api::runtime::current_scope_stack;
 use crate::api::runtime::global_context;
+use crate::api::runtime::{EventSubscriberFn, ToolExecutionNextFn};
 use crate::api::scope::event;
 use crate::api::scope::{EmitMarkEventParams, ScopeHandle};
 use crate::api::shared::{
@@ -15,12 +16,12 @@ use crate::api::shared::{
 };
 use crate::error::{FlowError, Result};
 use crate::json::Json;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
-pub use nemo_relay_types::api::tool::ToolAttributes;
+pub use nemo_relay_types::api::tool::{ToolAttributes, ToolExecutionInterceptOutcome};
 
 /// Runtime-owned handle identifying an active or completed tool call.
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
@@ -204,6 +205,13 @@ pub struct ToolCallEndParams<'a> {
 /// Sanitize-request guardrails affect only the emitted start-event payload, not
 /// the caller-owned `args` value.
 pub fn tool_call(params: ToolCallParams<'_>) -> Result<ToolHandle> {
+    let (handle, _) = tool_call_with_subscriber_snapshot(params)?;
+    Ok(handle)
+}
+
+fn tool_call_with_subscriber_snapshot(
+    params: ToolCallParams<'_>,
+) -> Result<(ToolHandle, Vec<EventSubscriberFn>)> {
     ensure_runtime_owner()?;
     let parent_uuid = resolve_parent_uuid(params.parent);
     let (entries, subscribers) = {
@@ -245,7 +253,7 @@ pub fn tool_call(params: ToolCallParams<'_>) -> Result<ToolHandle> {
         (handle, event)
     };
     NemoRelayContextState::emit_event(&event, &subscribers);
-    Ok(handle)
+    Ok((handle, subscribers))
 }
 
 /// Finish a manual tool lifecycle span.
@@ -275,6 +283,14 @@ pub fn tool_call(params: ToolCallParams<'_>) -> Result<ToolHandle> {
 /// Sanitize-response guardrails affect only the emitted end-event payload, not
 /// the caller-owned `result` value.
 pub fn tool_call_end(params: ToolCallEndParams<'_>) -> Result<()> {
+    tool_call_end_with_pending_marks(params, Vec::new(), None)
+}
+
+fn tool_call_end_with_pending_marks(
+    params: ToolCallEndParams<'_>,
+    pending_marks: Vec<PendingMarkSpec>,
+    lifecycle_subscribers: Option<&[EventSubscriberFn]>,
+) -> Result<()> {
     ensure_runtime_owner()?;
     let (entries, subscribers) = {
         let scope_stack = current_scope_stack();
@@ -282,8 +298,11 @@ pub fn tool_call_end(params: ToolCallEndParams<'_>) -> Result<()> {
         let scope_locals = scope_guard.collect_scope_local_registries(|registries| {
             &registries.tool_sanitize_response_guardrails
         });
-        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
-        let subscribers = snapshot_event_subscribers(scope_subscribers)?;
+        let subscribers = if lifecycle_subscribers.is_some() {
+            Vec::new()
+        } else {
+            snapshot_event_subscribers(scope_guard.collect_scope_local_subscribers())?
+        };
         let context = global_context();
         let state = context
             .read()
@@ -291,6 +310,7 @@ pub fn tool_call_end(params: ToolCallEndParams<'_>) -> Result<()> {
         let entries = state.tool_sanitize_response_entries(&scope_locals);
         (entries, subscribers)
     };
+    let subscribers = lifecycle_subscribers.unwrap_or(&subscribers);
     let sanitized_result = NemoRelayContextState::tool_sanitize_response_snapshot_chain(
         &params.handle.name,
         params.result,
@@ -315,25 +335,46 @@ pub fn tool_call_end(params: ToolCallEndParams<'_>) -> Result<()> {
                 .build(),
         )
     };
-    NemoRelayContextState::emit_event(&event, &subscribers);
+    let marks = pending_marks
+        .into_iter()
+        .enumerate()
+        .map(|(index, mark)| {
+            let timestamp = *event.timestamp()
+                + TimeDelta::microseconds(i64::try_from(index).unwrap_or_default() + 1);
+            Event::Mark(MarkEvent::new(
+                BaseEvent::builder()
+                    .name(mark.name)
+                    .parent_uuid(params.handle.uuid)
+                    .timestamp(timestamp)
+                    .data_opt(mark.data)
+                    .metadata_opt(mark.metadata)
+                    .build(),
+                mark.category,
+                mark.category_profile,
+            ))
+        })
+        .collect::<Vec<_>>();
+    NemoRelayContextState::emit_event(&event, subscribers);
+    for mark in marks {
+        NemoRelayContextState::emit_event(&mark, subscribers);
+    }
     Ok(())
 }
 
-fn emit_tool_end_without_output(handle: &ToolHandle, metadata: Option<Json>) -> Result<()> {
+fn emit_tool_end_without_output(
+    handle: &ToolHandle,
+    metadata: Option<Json>,
+    lifecycle_subscribers: &[EventSubscriberFn],
+) -> Result<()> {
     ensure_runtime_owner()?;
-    let (event, subscribers) = {
-        let scope_stack = current_scope_stack();
-        let scope_guard = scope_stack.read().expect("scope stack lock poisoned");
-        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
-        let subscribers = snapshot_event_subscribers(scope_subscribers)?;
+    let event = {
         let context = global_context();
         let state = context
             .read()
             .map_err(|error| FlowError::Internal(error.to_string()))?;
-        let event = state.end_tool_handle(handle, handle.data.clone(), metadata);
-        (event, subscribers)
+        state.end_tool_handle(handle, handle.data.clone(), metadata)
     };
-    NemoRelayContextState::emit_event(&event, &subscribers);
+    NemoRelayContextState::emit_event(&event, lifecycle_subscribers);
     Ok(())
 }
 
@@ -439,7 +480,7 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<Json> {
         &intercept_entries,
     )?;
 
-    let handle = tool_call(
+    let (handle, lifecycle_subscribers) = tool_call_with_subscriber_snapshot(
         ToolCallParams::builder()
             .name(name.as_str())
             .args(intercepted_args.clone())
@@ -463,22 +504,28 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<Json> {
     };
 
     match execution(intercepted_args).await {
-        Ok(result) => {
+        Ok(outcome) => {
+            let ToolExecutionInterceptOutcome {
+                result,
+                pending_marks,
+            } = outcome;
             let end_metadata = metadata_with_otel_status(metadata, "OK", None);
-            tool_call_end(
+            tool_call_end_with_pending_marks(
                 ToolCallEndParams::builder()
                     .handle(&handle)
                     .result(result.clone())
                     .data_opt(data)
                     .metadata_opt(end_metadata)
                     .build(),
+                pending_marks,
+                Some(&lifecycle_subscribers),
             )?;
             Ok(result)
         }
         Err(error) => {
             let end_metadata =
                 metadata_with_otel_status(metadata, "ERROR", Some(error.to_string()));
-            let _ = emit_tool_end_without_output(&handle, end_metadata);
+            let _ = emit_tool_end_without_output(&handle, end_metadata, &lifecycle_subscribers);
             Err(error)
         }
     }

--- a/crates/core/src/context/registries.rs
+++ b/crates/core/src/context/registries.rs
@@ -10,10 +10,11 @@
 use std::collections::HashMap;
 
 use crate::api::registry::{ExecutionIntercept, Guardrail, Intercept};
+use crate::api::runtime::callbacks::ToolExecutionCallback;
 use crate::api::runtime::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn,
     LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
-    ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::registry::SortedRegistry;
 
@@ -33,7 +34,7 @@ pub(crate) struct ScopeLocalRegistries {
     /// Tool request intercepts that can rewrite arguments before execution.
     pub(crate) tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
     /// Tool execution intercepts that wrap or replace callback execution.
-    pub(crate) tool_execution_intercepts: SortedRegistry<ExecutionIntercept<ToolExecutionFn>>,
+    pub(crate) tool_execution_intercepts: SortedRegistry<ExecutionIntercept<ToolExecutionCallback>>,
     /// LLM request sanitizers applied to emitted LLM-start payloads.
     pub(crate) llm_sanitize_request_guardrails: SortedRegistry<Guardrail<LlmSanitizeRequestFn>>,
     /// LLM response sanitizers applied to emitted LLM-end payloads.

--- a/crates/core/src/context/registries.rs
+++ b/crates/core/src/context/registries.rs
@@ -10,11 +10,10 @@
 use std::collections::HashMap;
 
 use crate::api::registry::{ExecutionIntercept, Guardrail, Intercept};
-use crate::api::runtime::callbacks::ToolExecutionCallback;
 use crate::api::runtime::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn,
     LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
-    ToolInterceptFn, ToolSanitizeFn,
+    ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::registry::SortedRegistry;
 
@@ -34,7 +33,7 @@ pub(crate) struct ScopeLocalRegistries {
     /// Tool request intercepts that can rewrite arguments before execution.
     pub(crate) tool_request_intercepts: SortedRegistry<Intercept<ToolInterceptFn>>,
     /// Tool execution intercepts that wrap or replace callback execution.
-    pub(crate) tool_execution_intercepts: SortedRegistry<ExecutionIntercept<ToolExecutionCallback>>,
+    pub(crate) tool_execution_intercepts: SortedRegistry<ExecutionIntercept<ToolExecutionFn>>,
     /// LLM request sanitizers applied to emitted LLM-start payloads.
     pub(crate) llm_sanitize_request_guardrails: SortedRegistry<Guardrail<LlmSanitizeRequestFn>>,
     /// LLM response sanitizers applied to emitted LLM-end payloads.

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -29,14 +29,13 @@ use crate::api::registry::{
     register_llm_execution_intercept, register_llm_request_intercept,
     register_llm_sanitize_request_guardrail, register_llm_sanitize_response_guardrail,
     register_llm_stream_execution_intercept, register_tool_conditional_execution_guardrail,
-    register_tool_execution_intercept, register_tool_execution_outcome_intercept,
-    register_tool_request_intercept, register_tool_sanitize_request_guardrail,
-    register_tool_sanitize_response_guardrail,
+    register_tool_execution_intercept, register_tool_request_intercept,
+    register_tool_sanitize_request_guardrail, register_tool_sanitize_response_guardrail,
 };
 use crate::api::runtime::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn,
     LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
-    ToolExecutionFn, ToolExecutionOutcomeFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::subscriber::{deregister_subscriber, register_subscriber};
 pub use nemo_relay_types::plugin::{ConfigDiagnostic, DiagnosticLevel};
@@ -648,37 +647,6 @@ impl PluginRegistrationContext {
                     .map_err(|err| {
                         PluginError::RegistrationFailed(format!(
                             "tool execution intercept deregistration failed: {err}"
-                        ))
-                    })
-            }),
-        ));
-        Ok(())
-    }
-
-    /// Registers a tool execution outcome intercept and records its rollback closure.
-    pub fn register_tool_execution_outcome_intercept(
-        &mut self,
-        name: &str,
-        priority: i32,
-        callback: ToolExecutionOutcomeFn,
-    ) -> Result<()> {
-        let qualified_name = self.qualify_name(name);
-        register_tool_execution_outcome_intercept(&qualified_name, priority, callback).map_err(
-            |err| {
-                PluginError::RegistrationFailed(format!("tool execution outcome intercept: {err}"))
-            },
-        )?;
-
-        let name_owned = qualified_name;
-        self.registrations.push(PluginRegistration::new(
-            "plugin",
-            name_owned.clone(),
-            Box::new(move || {
-                deregister_tool_execution_intercept(&name_owned)
-                    .map(|_| ())
-                    .map_err(|err| {
-                        PluginError::RegistrationFailed(format!(
-                            "tool execution outcome intercept deregistration failed: {err}"
                         ))
                     })
             }),

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -29,13 +29,14 @@ use crate::api::registry::{
     register_llm_execution_intercept, register_llm_request_intercept,
     register_llm_sanitize_request_guardrail, register_llm_sanitize_response_guardrail,
     register_llm_stream_execution_intercept, register_tool_conditional_execution_guardrail,
-    register_tool_execution_intercept, register_tool_request_intercept,
-    register_tool_sanitize_request_guardrail, register_tool_sanitize_response_guardrail,
+    register_tool_execution_intercept, register_tool_execution_outcome_intercept,
+    register_tool_request_intercept, register_tool_sanitize_request_guardrail,
+    register_tool_sanitize_response_guardrail,
 };
 use crate::api::runtime::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn,
     LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
-    ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolExecutionFn, ToolExecutionOutcomeFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::subscriber::{deregister_subscriber, register_subscriber};
 pub use nemo_relay_types::plugin::{ConfigDiagnostic, DiagnosticLevel};
@@ -647,6 +648,37 @@ impl PluginRegistrationContext {
                     .map_err(|err| {
                         PluginError::RegistrationFailed(format!(
                             "tool execution intercept deregistration failed: {err}"
+                        ))
+                    })
+            }),
+        ));
+        Ok(())
+    }
+
+    /// Registers a tool execution outcome intercept and records its rollback closure.
+    pub fn register_tool_execution_outcome_intercept(
+        &mut self,
+        name: &str,
+        priority: i32,
+        callback: ToolExecutionOutcomeFn,
+    ) -> Result<()> {
+        let qualified_name = self.qualify_name(name);
+        register_tool_execution_outcome_intercept(&qualified_name, priority, callback).map_err(
+            |err| {
+                PluginError::RegistrationFailed(format!("tool execution outcome intercept: {err}"))
+            },
+        )?;
+
+        let name_owned = qualified_name;
+        self.registrations.push(PluginRegistration::new(
+            "plugin",
+            name_owned.clone(),
+            Box::new(move || {
+                deregister_tool_execution_intercept(&name_owned)
+                    .map(|_| ())
+                    .map_err(|err| {
+                        PluginError::RegistrationFailed(format!(
+                            "tool execution outcome intercept deregistration failed: {err}"
                         ))
                     })
             }),

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -36,7 +36,7 @@ use crate::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 use crate::api::runtime::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmJsonStream,
     LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn,
-    LlmStreamExecutionNextFn, ToolConditionalFn, ToolExecutionFn, ToolExecutionNextFn,
+    LlmStreamExecutionNextFn, ToolConditionalFn, ToolExecutionNextFn, ToolExecutionOutcomeFn,
     ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::runtime::{
@@ -48,6 +48,7 @@ use crate::api::scope::{
     EmitMarkEventParams, PopScopeParams, PushScopeParams, ScopeAttributes, ScopeHandle, ScopeType,
 };
 use crate::api::scope::{event as emit_scope_mark, get_handle, pop_scope, push_scope};
+use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
     ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
@@ -1214,7 +1215,7 @@ unsafe extern "C" fn native_plugin_context_register_tool_execution_intercept(
         Ok(name) => name,
         Err(status) => return status,
     };
-    match ctx.register_tool_execution_intercept(
+    match ctx.register_tool_execution_outcome_intercept(
         &name,
         priority,
         wrap_tool_execution_fn(instance, cb, user_data, free_fn),
@@ -1512,7 +1513,7 @@ fn wrap_tool_execution_fn(
     cb: NemoRelayNativeToolExecutionCb,
     user_data: *mut c_void,
     free_fn: NemoRelayNativeFreeFn,
-) -> ToolExecutionFn {
+) -> ToolExecutionOutcomeFn {
     let user_data = make_user_data(instance, user_data, free_fn);
     Arc::new(move |name, args, next| {
         let name = name.to_owned();
@@ -1524,7 +1525,7 @@ fn wrap_tool_execution_fn(
             let args_string = native_string_from_json(&args)
                 .ok_or_else(|| FlowError::Internal("failed to allocate native args".into()))?;
             let next_ctx = Box::into_raw(Box::new(next)) as *mut c_void;
-            let mut out = ptr::null_mut();
+            let mut out_outcome = ptr::null_mut();
             let status = unsafe {
                 cb(
                     user_data.ptr,
@@ -1532,7 +1533,7 @@ fn wrap_tool_execution_fn(
                     args_string,
                     native_tool_next,
                     next_ctx,
-                    &mut out,
+                    &mut out_outcome,
                 )
             };
             unsafe {
@@ -1541,15 +1542,21 @@ fn wrap_tool_execution_fn(
                 native_string_free(args_string);
             }
             if status != NemoRelayStatus::Ok {
-                if !out.is_null() {
-                    unsafe { native_string_free(out) };
+                if !out_outcome.is_null() {
+                    unsafe { native_string_free(out_outcome) };
                 }
                 return Err(flow_error_from_status(
                     status,
                     "native tool execution failed",
                 ));
             }
-            take_json_from_native_string(out, "native tool execution returned null")
+            let outcome_json = take_json_from_native_string(
+                out_outcome,
+                "native tool execution returned null outcome",
+            )?;
+            serde_json::from_value::<ToolExecutionInterceptOutcome>(outcome_json).map_err(|err| {
+                FlowError::Internal(format!("invalid native tool execution outcome JSON: {err}"))
+            })
         })
     })
 }

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -36,7 +36,7 @@ use crate::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 use crate::api::runtime::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmJsonStream,
     LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn,
-    LlmStreamExecutionNextFn, ToolConditionalFn, ToolExecutionNextFn, ToolExecutionOutcomeFn,
+    LlmStreamExecutionNextFn, ToolConditionalFn, ToolExecutionFn, ToolExecutionNextFn,
     ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::runtime::{
@@ -1215,7 +1215,7 @@ unsafe extern "C" fn native_plugin_context_register_tool_execution_intercept(
         Ok(name) => name,
         Err(status) => return status,
     };
-    match ctx.register_tool_execution_outcome_intercept(
+    match ctx.register_tool_execution_intercept(
         &name,
         priority,
         wrap_tool_execution_fn(instance, cb, user_data, free_fn),
@@ -1513,7 +1513,7 @@ fn wrap_tool_execution_fn(
     cb: NemoRelayNativeToolExecutionCb,
     user_data: *mut c_void,
     free_fn: NemoRelayNativeFreeFn,
-) -> ToolExecutionOutcomeFn {
+) -> ToolExecutionFn {
     let user_data = make_user_data(instance, user_data, free_fn);
     Arc::new(move |name, args, next| {
         let name = name.to_owned();

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -61,6 +61,7 @@ use crate::api::scope::{
     EmitMarkEventParams, PopScopeParams, PushScopeParams, ScopeAttributes, ScopeHandle, ScopeType,
     event as emit_scope_mark, pop_scope, push_scope,
 };
+use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::codec::request::AnnotatedLlmRequest;
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
@@ -1180,7 +1181,7 @@ impl WorkerPluginCallback {
         tool_name: &str,
         value: Json,
         next: ToolExecutionNextFn,
-    ) -> FlowResult<Json> {
+    ) -> FlowResult<ToolExecutionInterceptOutcome> {
         let continuation_id = self
             .host_state
             .insert_continuation(Continuation::Tool(next))?;
@@ -1190,7 +1191,28 @@ impl WorkerPluginCallback {
             Some(continuation_id),
             Some(invoke_request_payload_tool(tool_name, value)),
         );
-        json_from_invoke_response(self.invoke_async(request).await?)
+        let response = self.invoke_async(request).await?;
+        match response.result {
+            Some(invoke_response_result::Result::ToolExecution(result)) => {
+                let outcome =
+                    required_envelope(result.outcome, "tool execution intercept outcome")?;
+                if outcome.schema != "nemo.relay.ToolExecutionInterceptOutcome@1" {
+                    return Err(FlowError::Internal(format!(
+                        "worker returned unsupported tool execution intercept outcome schema: {}",
+                        outcome.schema
+                    )));
+                }
+                decode_json_envelope(&outcome).map_err(|err| {
+                    FlowError::Internal(format!(
+                        "worker returned invalid tool execution intercept outcome: {err}"
+                    ))
+                })
+            }
+            Some(invoke_response_result::Result::Error(error)) => Err(worker_error_to_flow(error)),
+            _ => Err(FlowError::Internal(
+                "worker tool execution intercept returned unexpected result".into(),
+            )),
+        }
     }
 
     fn invoke_llm_request_json(

--- a/crates/core/src/plugins/nemo_guardrails/python.rs
+++ b/crates/core/src/plugins/nemo_guardrails/python.rs
@@ -99,13 +99,14 @@ pub(super) fn register_local_backend(
                 };
 
                 let tool_result = next(current_args.clone()).await?;
-                if !enable_tool_output {
-                    return Ok(tool_result);
-                }
-
-                runtime
-                    .check_tool_output(&tool_name, &current_args, &tool_result)
-                    .await
+                let tool_result = if enable_tool_output {
+                    runtime
+                        .check_tool_output(&tool_name, &current_args, &tool_result)
+                        .await?
+                } else {
+                    tool_result
+                };
+                Ok(tool_result.into())
             })
         });
         ctx.register_tool_execution_intercept(

--- a/crates/core/src/plugins/nemo_guardrails/remote.rs
+++ b/crates/core/src/plugins/nemo_guardrails/remote.rs
@@ -938,13 +938,14 @@ pub(super) fn register_remote_backend(
                 };
 
                 let tool_result = next(current_args.clone()).await?;
-                if !enable_tool_output {
-                    return Ok(tool_result);
-                }
-
-                runtime
-                    .check_tool_output(&tool_name, &current_args, &tool_result)
-                    .await
+                let tool_result = if enable_tool_output {
+                    runtime
+                        .check_tool_output(&tool_name, &current_args, &tool_result)
+                        .await?
+                } else {
+                    tool_result
+                };
+                Ok(tool_result.into())
             })
         });
         ctx.register_tool_execution_intercept(

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -8,7 +8,8 @@ use nemo_relay_plugin::{
     CategoryProfile, ConfigDiagnostic, DiagnosticLevel, Event, EventCategory, Json, LlmJsonStream,
     LlmRequest, LlmRequestInterceptOutcome, NemoRelayNativeHostApiV1,
     NemoRelayNativePluginContext, NemoRelayNativePluginV1, NemoRelayNativeString, NemoRelayStatus,
-    NativePlugin, PendingMarkSpec, PluginContext, PluginRuntime, ScopeCategory, ScopeType,
+    NemoRelayNativeToolNextFn, NativePlugin, PendingMarkSpec, PluginContext, PluginRuntime,
+    ScopeCategory, ScopeType, ToolExecutionInterceptOutcome,
 };
 use serde_json::{Map, json};
 
@@ -95,7 +96,21 @@ impl NativePlugin for FixtureNativePlugin {
                 } else {
                     next.call(args)?
                 };
-                Ok(mark_json(result, "native_plugin_tool_execution"))
+                let result = mark_json(result, "native_plugin_tool_execution");
+                Ok(
+                    ToolExecutionInterceptOutcome::new(result).with_pending_mark(
+                        PendingMarkSpec::builder()
+                            .name("fixture.native.tool_execution.mark")
+                            .category(EventCategory::custom())
+                            .category_profile(CategoryProfile {
+                                subtype: Some("fixture.native.tool_execution".into()),
+                                ..CategoryProfile::default()
+                            })
+                            .data(json!({ "source": "native_tool_execution" }))
+                            .metadata(json!({ "fixture": true }))
+                            .build(),
+                    ),
+                )
             }
         })?;
 
@@ -350,6 +365,23 @@ pub unsafe extern "C" fn nemo_relay_fixture_register_error(
     }
 }
 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_fixture_tool_outcome_errors(
+    host: *const NemoRelayNativeHostApiV1,
+    out: *mut NemoRelayNativePluginV1,
+) -> NemoRelayStatus {
+    unsafe {
+        write_raw_descriptor(
+            host,
+            out,
+            "fixture_native",
+            None,
+            None,
+            Some(raw_register_tool_outcome_errors),
+        )
+    }
+}
+
 type RawValidate = unsafe extern "C" fn(
     *mut c_void,
     *const NemoRelayNativeString,
@@ -432,6 +464,80 @@ unsafe extern "C" fn raw_register_error(
     NemoRelayStatus::Internal
 }
 
+unsafe extern "C" fn raw_register_tool_outcome_errors(
+    user_data: *mut c_void,
+    _plugin_config_json: *const NemoRelayNativeString,
+    ctx: *mut NemoRelayNativePluginContext,
+) -> NemoRelayStatus {
+    let Some(host) = (unsafe { raw_host_from_user_data(user_data) }) else {
+        return NemoRelayStatus::NullPointer;
+    };
+    let name = unsafe { raw_host_string(host, "fixture_raw_tool_outcome") };
+    if name.is_null() {
+        return NemoRelayStatus::Internal;
+    }
+    let status = unsafe {
+        (host.plugin_context_register_tool_execution_intercept)(
+            ctx,
+            name,
+            0,
+            raw_tool_outcome_callback,
+            user_data,
+            None,
+        )
+    };
+    unsafe { (host.string_free)(name) };
+    status
+}
+
+unsafe extern "C" fn raw_tool_outcome_callback(
+    user_data: *mut c_void,
+    name: *const NemoRelayNativeString,
+    _args_json: *const NemoRelayNativeString,
+    _next_fn: NemoRelayNativeToolNextFn,
+    _next_ctx: *mut c_void,
+    out_outcome_json: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    if out_outcome_json.is_null() {
+        return NemoRelayStatus::NullPointer;
+    }
+    unsafe { *out_outcome_json = ptr::null_mut() };
+    let Some(host) = (unsafe { raw_host_from_user_data(user_data) }) else {
+        return NemoRelayStatus::NullPointer;
+    };
+    let Some(name) = (unsafe { raw_host_string_value(host, name) }) else {
+        return NemoRelayStatus::InvalidUtf8;
+    };
+    match name.as_str() {
+        "fixture-null-outcome" => NemoRelayStatus::Ok,
+        "fixture-malformed-outcome" => {
+            unsafe {
+                *out_outcome_json = raw_host_string(host, r#"{"pending_marks":[]}"#);
+            }
+            NemoRelayStatus::Ok
+        }
+        "fixture-status-error-outcome" => {
+            unsafe {
+                *out_outcome_json = raw_host_string(
+                    host,
+                    r#"{"result":{"stale":true},"pending_marks":[]}"#,
+                );
+                set_raw_last_error_from_user_data(user_data, "fixture tool execution failed");
+            }
+            NemoRelayStatus::Internal
+        }
+        _ => {
+            unsafe {
+                *out_outcome_json = raw_host_string(
+                    host,
+                    r#"{"result":{"raw_tool_outcome":true},"pending_marks":[]}"#,
+                );
+            }
+            NemoRelayStatus::Ok
+        }
+    }
+}
+
 unsafe extern "C" fn raw_drop_host(user_data: *mut c_void) {
     if !user_data.is_null() {
         drop(unsafe { Box::from_raw(user_data as *mut NemoRelayNativeHostApiV1) });
@@ -479,4 +585,24 @@ unsafe fn raw_host_string(
     } else {
         ptr::null_mut()
     }
+}
+
+unsafe fn raw_host_string_value(
+    host: &NemoRelayNativeHostApiV1,
+    value: *const NemoRelayNativeString,
+) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+    let len = unsafe { (host.string_len)(value) };
+    let data = unsafe { (host.string_data)(value) };
+    if data.is_null() && len > 0 {
+        return None;
+    }
+    let bytes = if len == 0 {
+        &[][..]
+    } else {
+        unsafe { std::slice::from_raw_parts(data, len) }
+    };
+    std::str::from_utf8(bytes).ok().map(str::to_owned)
 }

--- a/crates/core/tests/fixtures/worker_plugin/src/main.rs
+++ b/crates/core/tests/fixtures/worker_plugin/src/main.rs
@@ -3,7 +3,7 @@
 
 use nemo_relay_worker::{
     JsonStream, LlmNext, LlmStreamNext, PluginContext, ScopeType, ToolNext, WorkerPlugin,
-    WorkerSdkError, serve_plugin,
+    ToolExecutionInterceptOutcome, WorkerSdkError, serve_plugin,
 };
 use nemo_relay_worker::{
     ConfigDiagnostic, DiagnosticLevel, Json, LlmRequest, PendingMarkSpec,
@@ -155,7 +155,17 @@ impl WorkerPlugin for FixtureWorkerPlugin {
                 let result = next
                     .call(mark_json(args, "worker_plugin_tool_execution_request"))
                     .await?;
-                Ok(mark_json(result, "worker_plugin_tool_execution"))
+                Ok(
+                    ToolExecutionInterceptOutcome::new(mark_json(
+                        result,
+                        "worker_plugin_tool_execution",
+                    ))
+                    .with_pending_mark(
+                        PendingMarkSpec::builder()
+                            .name("fixture.worker.tool_execution.mark")
+                            .build(),
+                    ),
+                )
             },
         );
 

--- a/crates/core/tests/integration/api_surface_tests.rs
+++ b/crates/core/tests/integration/api_surface_tests.rs
@@ -394,7 +394,7 @@ fn test_global_registry_and_subscriber_wrappers_cover_success_and_duplicates() {
     register_tool_execution_intercept(
         "tool-execution",
         1,
-        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args) })),
+        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args.into()) })),
     )
     .unwrap();
     assert!(deregister_tool_execution_intercept("tool-execution").unwrap());
@@ -570,7 +570,7 @@ fn test_scope_registry_and_subscriber_wrappers_cover_success_duplicates_and_miss
         &scope.uuid,
         "tool-execution",
         1,
-        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args) })),
+        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args.into()) })),
     )
     .unwrap();
     assert!(scope_deregister_tool_execution_intercept(&scope.uuid, "tool-execution").unwrap());
@@ -690,7 +690,7 @@ fn test_scope_registry_and_subscriber_wrappers_cover_success_duplicates_and_miss
             &scope.uuid,
             "missing-tool-exec",
             1,
-            Arc::new(|_name, args, _next| Box::pin(async move { Ok(args) })),
+            Arc::new(|_name, args, _next| Box::pin(async move { Ok(args.into()) })),
         )
         .unwrap_err(),
         "scope",

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -457,7 +457,7 @@ async fn test_execution_intercept_calls_next() {
         Arc::new(|_name, args, next| {
             Box::pin(async move {
                 // Call next — this should reach the original callable
-                next(args).await
+                next(args).await.map(Into::into)
             })
         }),
     )
@@ -506,7 +506,7 @@ async fn test_execution_intercept_skips_next() {
         Arc::new(|_name, _args, _next| {
             Box::pin(async move {
                 // Return a custom result without calling next
-                Ok(json!({"intercepted": true}))
+                Ok(json!({"intercepted": true}).into())
             })
         }),
     )
@@ -559,7 +559,7 @@ async fn test_execution_intercept_chain_ordering() {
                 o.lock().unwrap().push("intercept_1_before".into());
                 let result = next(args).await;
                 o.lock().unwrap().push("intercept_1_after".into());
-                result
+                result.map(Into::into)
             })
         }),
     )
@@ -576,7 +576,7 @@ async fn test_execution_intercept_chain_ordering() {
                 o.lock().unwrap().push("intercept_2_before".into());
                 let result = next(args).await;
                 o.lock().unwrap().push("intercept_2_after".into());
-                result
+                result.map(Into::into)
             })
         }),
     )
@@ -632,7 +632,7 @@ async fn test_execution_intercept_modifies_args() {
                 args.as_object_mut()
                     .unwrap()
                     .insert("injected".into(), json!(true));
-                next(args).await
+                next(args).await.map(Into::into)
             })
         }),
     )
@@ -673,7 +673,7 @@ async fn test_tool_execution_outcome_marks_follow_end_with_tool_parentage() {
 
     let mut plugin_ctx = PluginRegistrationContext::new();
     plugin_ctx
-        .register_tool_execution_outcome_intercept(
+        .register_tool_execution_intercept(
             "outcome_outer",
             1,
             Arc::new(|_name, args, next| {
@@ -692,13 +692,13 @@ async fn test_tool_execution_outcome_marks_follow_end_with_tool_parentage() {
         )
         .unwrap();
     register_tool_execution_intercept(
-        "raw_between_outcomes",
+        "passthrough_between_outcomes",
         2,
-        Arc::new(|_name, args, next| Box::pin(async move { next(args).await })),
+        Arc::new(|_name, args, next| Box::pin(async move { next(args).await.map(Into::into) })),
     )
     .unwrap();
     plugin_ctx
-        .register_tool_execution_outcome_intercept(
+        .register_tool_execution_intercept(
             "outcome_inner",
             3,
             Arc::new(|_name, args, next| {
@@ -712,7 +712,7 @@ async fn test_tool_execution_outcome_marks_follow_end_with_tool_parentage() {
                                 .category(EventCategory::custom())
                                 .category_profile(
                                     CategoryProfile::builder()
-                                        .subtype("nvidia.visor.compression")
+                                        .subtype("example.tool.compression")
                                         .build(),
                                 )
                                 .data(json!({"saved_tokens": 12}))
@@ -777,13 +777,13 @@ async fn test_tool_execution_outcome_marks_follow_end_with_tool_parentage() {
         inner
             .category_profile()
             .and_then(|profile| profile.subtype.as_deref()),
-        Some("nvidia.visor.compression")
+        Some("example.tool.compression")
     );
     assert_eq!(inner.data().unwrap()["saved_tokens"], 12);
     assert_eq!(inner.metadata().unwrap()["source"], "test");
     drop(captured);
 
-    deregister_tool_execution_intercept("raw_between_outcomes").unwrap();
+    deregister_tool_execution_intercept("passthrough_between_outcomes").unwrap();
     let mut registrations = plugin_ctx.into_registrations();
     rollback_registrations(&mut registrations);
     deregister_subscriber("tool_outcome_mark_observer").unwrap();
@@ -816,7 +816,7 @@ async fn test_tool_execution_error_discards_downstream_pending_marks() {
     .unwrap();
     let mut plugin_ctx = PluginRegistrationContext::new();
     plugin_ctx
-        .register_tool_execution_outcome_intercept(
+        .register_tool_execution_intercept(
             "outcome_before_error",
             2,
             Arc::new(|_name, args, next| {
@@ -881,7 +881,7 @@ async fn test_managed_tool_reuses_start_subscriber_snapshot_for_end_and_marks() 
     let captured_replacement = replacement_events.clone();
     let mut plugin_ctx = PluginRegistrationContext::new();
     plugin_ctx
-        .register_tool_execution_outcome_intercept(
+        .register_tool_execution_intercept(
             "mutate_tool_subscribers",
             1,
             Arc::new(move |_name, args, next| {
@@ -1030,7 +1030,8 @@ async fn test_repeated_next_marks_follow_invocation_order_not_completion_order()
                 Ok(json!({
                     "first": first?,
                     "second": second?,
-                }))
+                })
+                .into())
             })
         }),
     )
@@ -1040,7 +1041,7 @@ async fn test_repeated_next_marks_follow_invocation_order_not_completion_order()
     let captured_completion_order = completion_order.clone();
     let mut plugin_ctx = PluginRegistrationContext::new();
     plugin_ctx
-        .register_tool_execution_outcome_intercept(
+        .register_tool_execution_intercept(
             "delayed_outcomes",
             2,
             Arc::new(move |_name, args, next| {
@@ -1434,7 +1435,7 @@ async fn test_scope_local_execution_intercept_cleanup() {
         1,
         Arc::new(move |_name, args, next| {
             ic.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async move { next(args).await })
+            Box::pin(async move { next(args).await.map(Into::into) })
         }),
     )
     .unwrap();
@@ -1592,7 +1593,7 @@ async fn test_scope_local_and_global_execution_intercept_merge() {
                 o.lock().unwrap().push("global_before".into());
                 let r = next(args).await;
                 o.lock().unwrap().push("global_after".into());
-                r
+                r.map(Into::into)
             })
         }),
     )
@@ -1610,7 +1611,7 @@ async fn test_scope_local_and_global_execution_intercept_merge() {
                 o.lock().unwrap().push("local_before".into());
                 let r = next(args).await;
                 o.lock().unwrap().push("local_after".into());
-                r
+                r.map(Into::into)
             })
         }),
     )
@@ -1733,7 +1734,7 @@ async fn test_conditional_rejection_prevents_execution() {
         1,
         Arc::new(move |_name, args, next| {
             ec.store(true, Ordering::SeqCst);
-            Box::pin(async move { next(args).await })
+            Box::pin(async move { next(args).await.map(Into::into) })
         }),
     )
     .unwrap();
@@ -2272,7 +2273,7 @@ async fn test_tool_middleware_callbacks_run_without_registry_or_scope_locks() {
         Arc::new(move |_, args, next| {
             record_middleware_callback(&tracked, "tool_execution_global");
             assert_middleware_callback_locks_are_free();
-            Box::pin(async move { next(args).await })
+            Box::pin(async move { next(args).await.map(Into::into) })
         }),
     )
     .unwrap();
@@ -2284,7 +2285,7 @@ async fn test_tool_middleware_callbacks_run_without_registry_or_scope_locks() {
         Arc::new(move |_, args, next| {
             record_middleware_callback(&tracked, "tool_execution_scope");
             assert_middleware_callback_locks_are_free();
-            Box::pin(async move { next(args).await })
+            Box::pin(async move { next(args).await.map(Into::into) })
         }),
     )
     .unwrap();
@@ -2676,7 +2677,7 @@ async fn test_full_pipeline_integration() {
             let o = o4.clone();
             Box::pin(async move {
                 o.lock().unwrap().push("execution_intercept".into());
-                next(args).await
+                next(args).await.map(Into::into)
             })
         }),
     )

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -51,10 +51,11 @@ use nemo_relay::api::scope::{ScopeHandle, ScopeType};
 use nemo_relay::api::scope::{pop_scope, push_scope};
 use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
 use nemo_relay::api::tool::{
-    tool_call, tool_call_end, tool_call_execute, tool_conditional_execution,
-    tool_request_intercepts,
+    ToolExecutionInterceptOutcome, tool_call, tool_call_end, tool_call_execute,
+    tool_conditional_execution, tool_request_intercepts,
 };
 use nemo_relay::error::FlowError;
+use nemo_relay::plugin::{PluginRegistrationContext, rollback_registrations};
 use serde_json::json;
 
 // All tests share the global context, so we serialize them.
@@ -654,6 +655,448 @@ async fn test_execution_intercept_modifies_args() {
 
     // Cleanup
     deregister_tool_execution_intercept("arg_modifier").unwrap();
+}
+
+#[tokio::test]
+async fn test_tool_execution_outcome_marks_follow_end_with_tool_parentage() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = events.clone();
+    register_subscriber(
+        "tool_outcome_mark_observer",
+        Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    let mut plugin_ctx = PluginRegistrationContext::new();
+    plugin_ctx
+        .register_tool_execution_outcome_intercept(
+            "outcome_outer",
+            1,
+            Arc::new(|_name, args, next| {
+                Box::pin(async move {
+                    let result = next(args).await?;
+                    Ok(
+                        ToolExecutionInterceptOutcome::new(result).with_pending_mark(
+                            PendingMarkSpec::builder()
+                                .name("tool.mark.outer")
+                                .data(json!({"layer": "outer"}))
+                                .build(),
+                        ),
+                    )
+                })
+            }),
+        )
+        .unwrap();
+    register_tool_execution_intercept(
+        "raw_between_outcomes",
+        2,
+        Arc::new(|_name, args, next| Box::pin(async move { next(args).await })),
+    )
+    .unwrap();
+    plugin_ctx
+        .register_tool_execution_outcome_intercept(
+            "outcome_inner",
+            3,
+            Arc::new(|_name, args, next| {
+                Box::pin(async move {
+                    let mut result = next(args).await?;
+                    result["compressed"] = json!(true);
+                    Ok(
+                        ToolExecutionInterceptOutcome::new(result).with_pending_mark(
+                            PendingMarkSpec::builder()
+                                .name("tool.mark.inner")
+                                .category(EventCategory::custom())
+                                .category_profile(
+                                    CategoryProfile::builder()
+                                        .subtype("nvidia.visor.compression")
+                                        .build(),
+                                )
+                                .data(json!({"saved_tokens": 12}))
+                                .metadata(json!({"source": "test"}))
+                                .build(),
+                        ),
+                    )
+                })
+            }),
+        )
+        .unwrap();
+
+    let result = tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("tool-outcome")
+            .args(json!({"value": 42}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(args) })))
+            .build(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result, json!({"value": 42, "compressed": true}));
+    assert!(result.get("pending_marks").is_none());
+
+    flush_subscribers().unwrap();
+    let captured = events.lock().unwrap();
+    let start_index = captured
+        .iter()
+        .position(|event| {
+            event.name() == "tool-outcome" && event.scope_category() == Some(ScopeCategory::Start)
+        })
+        .unwrap();
+    let end_index = captured
+        .iter()
+        .position(|event| {
+            event.name() == "tool-outcome" && event.scope_category() == Some(ScopeCategory::End)
+        })
+        .unwrap();
+    let inner_index = captured
+        .iter()
+        .position(|event| event.name() == "tool.mark.inner")
+        .unwrap();
+    let outer_index = captured
+        .iter()
+        .position(|event| event.name() == "tool.mark.outer")
+        .unwrap();
+    assert!(start_index < end_index);
+    assert!(end_index < inner_index);
+    assert!(inner_index < outer_index);
+
+    let start = &captured[start_index];
+    let end = &captured[end_index];
+    let inner = &captured[inner_index];
+    let outer = &captured[outer_index];
+    assert_eq!(inner.parent_uuid(), Some(start.uuid()));
+    assert_eq!(outer.parent_uuid(), Some(start.uuid()));
+    assert!(inner.timestamp() > end.timestamp());
+    assert!(outer.timestamp() > inner.timestamp());
+    assert_eq!(end.data().unwrap(), &result);
+    assert_eq!(inner.category().map(EventCategory::as_str), Some("custom"));
+    assert_eq!(
+        inner
+            .category_profile()
+            .and_then(|profile| profile.subtype.as_deref()),
+        Some("nvidia.visor.compression")
+    );
+    assert_eq!(inner.data().unwrap()["saved_tokens"], 12);
+    assert_eq!(inner.metadata().unwrap()["source"], "test");
+    drop(captured);
+
+    deregister_tool_execution_intercept("raw_between_outcomes").unwrap();
+    let mut registrations = plugin_ctx.into_registrations();
+    rollback_registrations(&mut registrations);
+    deregister_subscriber("tool_outcome_mark_observer").unwrap();
+}
+
+#[tokio::test]
+async fn test_tool_execution_error_discards_downstream_pending_marks() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = events.clone();
+    register_subscriber(
+        "tool_outcome_error_observer",
+        Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    register_tool_execution_intercept(
+        "error_after_outcome",
+        1,
+        Arc::new(|_name, args, next| {
+            Box::pin(async move {
+                let _ = next(args).await?;
+                Err(FlowError::Internal("outer failure".into()))
+            })
+        }),
+    )
+    .unwrap();
+    let mut plugin_ctx = PluginRegistrationContext::new();
+    plugin_ctx
+        .register_tool_execution_outcome_intercept(
+            "outcome_before_error",
+            2,
+            Arc::new(|_name, args, next| {
+                Box::pin(async move {
+                    let result = next(args).await?;
+                    Ok(
+                        ToolExecutionInterceptOutcome::new(result).with_pending_mark(
+                            PendingMarkSpec::builder()
+                                .name("tool.mark.must_not_emit")
+                                .build(),
+                        ),
+                    )
+                })
+            }),
+        )
+        .unwrap();
+
+    let error = tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("tool-outcome-error")
+            .args(json!({}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(args) })))
+            .build(),
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("outer failure"));
+
+    flush_subscribers().unwrap();
+    let captured = events.lock().unwrap();
+    assert!(
+        captured
+            .iter()
+            .all(|event| event.name() != "tool.mark.must_not_emit")
+    );
+    assert!(captured.iter().any(|event| {
+        event.name() == "tool-outcome-error" && event.scope_category() == Some(ScopeCategory::End)
+    }));
+    drop(captured);
+
+    deregister_tool_execution_intercept("error_after_outcome").unwrap();
+    let mut registrations = plugin_ctx.into_registrations();
+    rollback_registrations(&mut registrations);
+    deregister_subscriber("tool_outcome_error_observer").unwrap();
+}
+
+#[tokio::test]
+async fn test_managed_tool_reuses_start_subscriber_snapshot_for_end_and_marks() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let original_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured_original = original_events.clone();
+    register_subscriber(
+        "tool_lifecycle_original",
+        Arc::new(move |event| captured_original.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    let replacement_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured_replacement = replacement_events.clone();
+    let mut plugin_ctx = PluginRegistrationContext::new();
+    plugin_ctx
+        .register_tool_execution_outcome_intercept(
+            "mutate_tool_subscribers",
+            1,
+            Arc::new(move |_name, args, next| {
+                let captured_replacement = captured_replacement.clone();
+                Box::pin(async move {
+                    assert!(deregister_subscriber("tool_lifecycle_original").unwrap());
+                    register_subscriber(
+                        "tool_lifecycle_replacement",
+                        Arc::new(move |event| {
+                            captured_replacement.lock().unwrap().push(event.clone());
+                        }),
+                    )
+                    .unwrap();
+                    let result = next(args).await?;
+                    Ok(
+                        ToolExecutionInterceptOutcome::new(result).with_pending_mark(
+                            PendingMarkSpec::builder()
+                                .name("tool.snapshot.mark")
+                                .build(),
+                        ),
+                    )
+                })
+            }),
+        )
+        .unwrap();
+
+    tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("tool-subscriber-snapshot")
+            .args(json!({"value": 1}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(args) })))
+            .build(),
+    )
+    .await
+    .unwrap();
+    flush_subscribers().unwrap();
+
+    let original_events = original_events.lock().unwrap();
+    assert!(original_events.iter().any(|event| {
+        event.name() == "tool-subscriber-snapshot"
+            && event.scope_category() == Some(ScopeCategory::Start)
+    }));
+    assert!(original_events.iter().any(|event| {
+        event.name() == "tool-subscriber-snapshot"
+            && event.scope_category() == Some(ScopeCategory::End)
+    }));
+    assert!(
+        original_events
+            .iter()
+            .any(|event| event.name() == "tool.snapshot.mark")
+    );
+    drop(original_events);
+    assert!(replacement_events.lock().unwrap().is_empty());
+
+    assert!(deregister_subscriber("tool_lifecycle_replacement").unwrap());
+    let mut registrations = plugin_ctx.into_registrations();
+    rollback_registrations(&mut registrations);
+}
+
+#[tokio::test]
+async fn test_managed_tool_reuses_start_subscriber_snapshot_for_error_end() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let original_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured_original = original_events.clone();
+    register_subscriber(
+        "tool_error_original",
+        Arc::new(move |event| captured_original.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    let replacement_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured_replacement = replacement_events.clone();
+    register_tool_execution_intercept(
+        "mutate_tool_error_subscribers",
+        1,
+        Arc::new(move |_name, _args, _next| {
+            let captured_replacement = captured_replacement.clone();
+            Box::pin(async move {
+                assert!(deregister_subscriber("tool_error_original").unwrap());
+                register_subscriber(
+                    "tool_error_replacement",
+                    Arc::new(move |event| {
+                        captured_replacement.lock().unwrap().push(event.clone());
+                    }),
+                )
+                .unwrap();
+                Err(FlowError::Internal("managed tool failure".into()))
+            })
+        }),
+    )
+    .unwrap();
+
+    let error = tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("tool-error-subscriber-snapshot")
+            .args(json!({}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(args) })))
+            .build(),
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("managed tool failure"));
+    flush_subscribers().unwrap();
+
+    let original_events = original_events.lock().unwrap();
+    assert!(original_events.iter().any(|event| {
+        event.name() == "tool-error-subscriber-snapshot"
+            && event.scope_category() == Some(ScopeCategory::Start)
+    }));
+    assert!(original_events.iter().any(|event| {
+        event.name() == "tool-error-subscriber-snapshot"
+            && event.scope_category() == Some(ScopeCategory::End)
+    }));
+    drop(original_events);
+    assert!(replacement_events.lock().unwrap().is_empty());
+
+    deregister_tool_execution_intercept("mutate_tool_error_subscribers").unwrap();
+    assert!(deregister_subscriber("tool_error_replacement").unwrap());
+}
+
+#[tokio::test]
+async fn test_repeated_next_marks_follow_invocation_order_not_completion_order() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured_events = events.clone();
+    register_subscriber(
+        "tool_concurrent_next_observer",
+        Arc::new(move |event| captured_events.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    register_tool_execution_intercept(
+        "concurrent_next",
+        1,
+        Arc::new(|_name, _args, next| {
+            Box::pin(async move {
+                let first = next(json!({"branch": "first", "delay_ms": 40}));
+                let second = next(json!({"branch": "second", "delay_ms": 1}));
+                let (first, second) = tokio::join!(first, second);
+                Ok(json!({
+                    "first": first?,
+                    "second": second?,
+                }))
+            })
+        }),
+    )
+    .unwrap();
+
+    let completion_order = Arc::new(Mutex::new(Vec::<String>::new()));
+    let captured_completion_order = completion_order.clone();
+    let mut plugin_ctx = PluginRegistrationContext::new();
+    plugin_ctx
+        .register_tool_execution_outcome_intercept(
+            "delayed_outcomes",
+            2,
+            Arc::new(move |_name, args, next| {
+                let captured_completion_order = captured_completion_order.clone();
+                Box::pin(async move {
+                    let branch = args["branch"].as_str().unwrap().to_string();
+                    let delay_ms = args["delay_ms"].as_u64().unwrap();
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    let result = next(args).await?;
+                    captured_completion_order
+                        .lock()
+                        .unwrap()
+                        .push(branch.clone());
+                    Ok(
+                        ToolExecutionInterceptOutcome::new(result).with_pending_mark(
+                            PendingMarkSpec::builder()
+                                .name(format!("tool.concurrent.{branch}"))
+                                .build(),
+                        ),
+                    )
+                })
+            }),
+        )
+        .unwrap();
+
+    tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("tool-concurrent-next")
+            .args(json!({}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(args) })))
+            .build(),
+    )
+    .await
+    .unwrap();
+    flush_subscribers().unwrap();
+
+    assert_eq!(
+        *completion_order.lock().unwrap(),
+        vec!["second".to_string(), "first".to_string()]
+    );
+    let events = events.lock().unwrap();
+    let marks = events
+        .iter()
+        .filter(|event| event.name().starts_with("tool.concurrent."))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        marks.iter().map(|event| event.name()).collect::<Vec<_>>(),
+        ["tool.concurrent.first", "tool.concurrent.second"]
+    );
+    assert!(marks[0].timestamp() < marks[1].timestamp());
+    drop(events);
+
+    deregister_tool_execution_intercept("concurrent_next").unwrap();
+    let mut registrations = plugin_ctx.into_registrations();
+    rollback_registrations(&mut registrations);
+    deregister_subscriber("tool_concurrent_next_observer").unwrap();
 }
 
 // =========================================================================

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -156,6 +156,7 @@ async fn sdk_cdylib_registers_tool_request_intercept() {
         tool_result["args"]["native_plugin_tool_execution_request"],
         true
     );
+    assert!(tool_result.get("pending_marks").is_none());
 
     flush_subscribers().expect("native fixture events should flush");
     let first_events = events.lock().unwrap().clone();
@@ -197,6 +198,34 @@ async fn sdk_cdylib_registers_tool_request_intercept() {
         tool_end.output().unwrap()["native_plugin_tool_sanitize_response"],
         true
     );
+    assert!(tool_end.output().unwrap().get("pending_marks").is_none());
+    let tool_mark = find_event(&first_events, "fixture.native.tool_execution.mark", None);
+    assert_eq!(tool_mark.parent_uuid(), Some(tool_start.uuid()));
+    assert_eq!(
+        tool_mark.category().map(|category| category.as_str()),
+        Some("custom")
+    );
+    assert_eq!(
+        tool_mark
+            .category_profile()
+            .and_then(|profile| profile.subtype.as_deref()),
+        Some("fixture.native.tool_execution")
+    );
+    assert_eq!(tool_mark.data().unwrap()["source"], "native_tool_execution");
+    assert_eq!(tool_mark.metadata().unwrap()["fixture"], true);
+    assert!(tool_mark.timestamp() > tool_end.timestamp());
+    let tool_end_index = first_events
+        .iter()
+        .position(|event| {
+            event.name() == "native-fixture-tool"
+                && event.scope_category() == Some(ScopeCategory::End)
+        })
+        .unwrap();
+    let tool_mark_index = first_events
+        .iter()
+        .position(|event| event.name() == "fixture.native.tool_execution.mark")
+        .unwrap();
+    assert!(tool_end_index < tool_mark_index);
 
     events.lock().unwrap().clear();
     let isolated_next_stack = create_scope_stack();
@@ -503,6 +532,73 @@ async fn native_validation_diagnostics_prevent_initialization() {
     assert!(error.contains("fixture rejection requested"), "{error}");
 
     clear_plugin_configuration().expect("native plugin config should clear");
+    activation.clear();
+}
+
+#[tokio::test]
+async fn native_tool_execution_rejects_null_malformed_and_error_outcomes() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref =
+        write_manifest_with_symbol(&fixture, "nemo_relay_fixture_tool_outcome_errors");
+    let activation = load_native_plugins([load_spec("fixture_native", &manifest_ref)])
+        .expect("raw native outcome fixture should load");
+    let mut cleanup = NativePluginTestCleanup::new();
+
+    let mut plugin_config = PluginConfig::default();
+    plugin_config.components.push(PluginComponentSpec {
+        kind: "fixture_native".into(),
+        enabled: true,
+        config: Map::new(),
+    });
+    initialize_plugins_exact(plugin_config)
+        .await
+        .expect("raw native outcome fixture should initialize");
+    cleanup.mark_plugin_configuration_active();
+
+    for (name, expected) in [
+        (
+            "fixture-null-outcome",
+            "native tool execution returned null outcome",
+        ),
+        (
+            "fixture-malformed-outcome",
+            "invalid native tool execution outcome JSON",
+        ),
+        (
+            "fixture-status-error-outcome",
+            "fixture tool execution failed",
+        ),
+    ] {
+        let error = tool_call_execute(
+            ToolCallExecuteParams::builder()
+                .name(name)
+                .args(json!({ "input": true }))
+                .func(Arc::new(|args| Box::pin(async move { Ok(args) })))
+                .build(),
+        )
+        .await
+        .expect_err("invalid native tool outcome should fail")
+        .to_string();
+        assert!(
+            error.contains(expected),
+            "expected {expected:?} in {error:?}"
+        );
+    }
+
+    let result = tool_call_execute(
+        ToolCallExecuteParams::builder()
+            .name("fixture-valid-outcome")
+            .args(json!({ "input": true }))
+            .func(Arc::new(|args| Box::pin(async move { Ok(args) })))
+            .build(),
+    )
+    .await
+    .expect("native loader should remain usable after rejected outcomes");
+    assert_eq!(result["raw_tool_outcome"], true);
+    assert!(result.get("pending_marks").is_none());
+
+    drop(cleanup);
     activation.clear();
 }
 

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -144,6 +144,9 @@ async fn rust_worker_registers_and_invokes_all_current_surfaces() {
         tool_end.output().unwrap()["worker_plugin_tool_sanitize_response"],
         true
     );
+    let tool_mark = find_event(&captured_events, "fixture.worker.tool_execution.mark", None);
+    assert_eq!(tool_mark.parent_uuid(), Some(tool_start.uuid()));
+    assert!(tool_mark.timestamp() > tool_end.timestamp());
 
     let llm_execute_response = llm_call_execute(
         LlmCallExecuteParams::builder()

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -752,7 +752,7 @@ fn test_plugin_registration_context_covers_all_registration_helpers() {
     ctx.register_tool_execution_intercept(
         "tool-exec",
         1,
-        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args) })),
+        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args.into()) })),
     )
     .unwrap();
     ctx.register_llm_request_intercept(
@@ -1223,14 +1223,14 @@ fn test_plugin_registration_context_maps_duplicate_registration_errors() {
     ctx.register_tool_execution_intercept(
         "tool-exec",
         1,
-        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args) })),
+        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args.into()) })),
     )
     .unwrap();
     expect_registration_failed(
         ctx.register_tool_execution_intercept(
             "tool-exec",
             1,
-            Arc::new(|_name, args, _next| Box::pin(async move { Ok(args) })),
+            Arc::new(|_name, args, _next| Box::pin(async move { Ok(args.into()) })),
         ),
         "tool execution intercept:",
     );
@@ -1313,7 +1313,7 @@ fn test_plugin_registration_context_maps_deregistration_errors() {
     ctx.register_tool_execution_intercept(
         "tool-exec",
         1,
-        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args) })),
+        Arc::new(|_name, args, _next| Box::pin(async move { Ok(args.into()) })),
     )
     .unwrap();
 

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -326,7 +326,10 @@ typedef char *(*NemoRelayToolExecNextFn)(const char *args_json, void *next_ctx);
  * a `next` callback and its context. Call `next_fn(args, next_ctx)` to invoke
  * the next layer in the middleware chain, or return directly to short-circuit.
  * The returned JSON must contain a `result` field and may contain a
- * `pending_marks` array.
+ * `pending_marks` array. The returned string must be allocated with `malloc`
+ * or an equivalent allocation compatible with `nemo_relay_string_free`.
+ * Ownership transfers to Relay when the callback returns; the callback must
+ * not free or reuse the string afterward, and Relay frees it exactly once.
  */
 typedef char *(*NemoRelayToolExecInterceptCb)(void *user_data,
                                               const char *args_json,

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -325,6 +325,9 @@ typedef char *(*NemoRelayToolExecNextFn)(const char *args_json, void *next_ctx);
  * Callback for tool execution intercepts. Receives arguments as JSON plus
  * a `next` callback and its context. Call `next_fn(args, next_ctx)` to invoke
  * the next layer in the middleware chain, or return directly to short-circuit.
+ * The `result` field is passed to the remaining middleware and application;
+ * `pending_marks` are Relay-owned lifecycle metadata emitted after the
+ * tool-end event and are not included in the application-visible result.
  * The returned JSON must contain a `result` field and may contain a
  * `pending_marks` array. The returned string must be allocated with `malloc`
  * or an equivalent allocation compatible with `nemo_relay_string_free`.

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -325,6 +325,8 @@ typedef char *(*NemoRelayToolExecNextFn)(const char *args_json, void *next_ctx);
  * Callback for tool execution intercepts. Receives arguments as JSON plus
  * a `next` callback and its context. Call `next_fn(args, next_ctx)` to invoke
  * the next layer in the middleware chain, or return directly to short-circuit.
+ * The returned JSON must contain a `result` field and may contain a
+ * `pending_marks` array.
  */
 typedef char *(*NemoRelayToolExecInterceptCb)(void *user_data,
                                               const char *args_json,

--- a/crates/ffi/src/callable.rs
+++ b/crates/ffi/src/callable.rs
@@ -25,13 +25,14 @@ use libc::c_char;
 use nemo_relay::api::runtime::{
     EventSubscriberFn, LlmConditionalFn, LlmExecutionNextFn, LlmRequestInterceptFn,
     LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionNextFn, ToolConditionalFn,
-    ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
+    ToolExecutionFn, ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use serde_json::Value as Json;
 use tokio_stream::{Stream, StreamExt};
 
 use nemo_relay::api::event::Event;
 use nemo_relay::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
+use nemo_relay::api::tool::ToolExecutionInterceptOutcome;
 use nemo_relay::codec::request::AnnotatedLlmRequest as AnnotatedLLMRequest;
 use nemo_relay::codec::traits::LlmCodec;
 use nemo_relay::error::{FlowError, Result};
@@ -81,6 +82,8 @@ pub type NemoRelayToolExecNextFn =
 /// Callback for tool execution intercepts. Receives arguments as JSON plus
 /// a `next` callback and its context. Call `next_fn(args, next_ctx)` to invoke
 /// the next layer in the middleware chain, or return directly to short-circuit.
+/// The returned JSON must contain a `result` field and may contain a
+/// `pending_marks` array.
 pub type NemoRelayToolExecInterceptCb = unsafe extern "C" fn(
     user_data: *mut libc::c_void,
     args_json: *const c_char,
@@ -335,19 +338,16 @@ pub fn wrap_tool_exec_fn(
     })
 }
 
-/// Wrap a C tool execution intercept callback into an `Arc<dyn Fn(Json, ToolExecutionNextFn) -> ...>`.
+/// Wrap a C tool execution intercept callback into a [`ToolExecutionFn`].
 ///
 /// The wrapper packages the Rust `ToolExecutionNextFn` into a C-callable
-/// `(next_fn, next_ctx)` pair and passes both to the C intercept callback.
+/// `(next_fn, next_ctx)` pair and passes both to the C intercept callback. The
+/// callback must return a serialized [`ToolExecutionInterceptOutcome`].
 pub fn wrap_tool_exec_intercept_fn(
     cb: NemoRelayToolExecInterceptCb,
     user_data: *mut libc::c_void,
     free_fn: NemoRelayFreeFn,
-) -> Arc<
-    dyn Fn(&str, Json, ToolExecutionNextFn) -> Pin<Box<dyn Future<Output = Result<Json>> + Send>>
-        + Send
-        + Sync,
-> {
+) -> ToolExecutionFn {
     let ud = make_user_data(user_data, free_fn);
     Arc::new(move |_name: &str, args: Json, next: ToolExecutionNextFn| {
         let ud = ud.clone();
@@ -387,10 +387,14 @@ pub fn wrap_tool_exec_intercept_fn(
             let result_ptr = unsafe { cb(ud.ptr, c_args, tool_next_trampoline, next_ctx) };
             unsafe { drop(Box::from_raw(next_ctx as *mut ToolExecutionNextFn)) };
             unsafe { nemo_relay_string_free_internal(c_args) };
-            let result =
+            let outcome_json =
                 json_result_from_ptr(result_ptr, "tool execution intercept callback failed")?;
             unsafe { nemo_relay_string_free_internal(result_ptr) };
-            Ok(result)
+            serde_json::from_value::<ToolExecutionInterceptOutcome>(outcome_json).map_err(|error| {
+                FlowError::Internal(format!(
+                    "invalid tool execution intercept outcome JSON: {error}"
+                ))
+            })
         })
     })
 }

--- a/crates/ffi/src/callable.rs
+++ b/crates/ffi/src/callable.rs
@@ -83,7 +83,10 @@ pub type NemoRelayToolExecNextFn =
 /// a `next` callback and its context. Call `next_fn(args, next_ctx)` to invoke
 /// the next layer in the middleware chain, or return directly to short-circuit.
 /// The returned JSON must contain a `result` field and may contain a
-/// `pending_marks` array.
+/// `pending_marks` array. The returned string must be allocated with `malloc`
+/// or an equivalent allocation compatible with `nemo_relay_string_free`.
+/// Ownership transfers to Relay when the callback returns; the callback must
+/// not free or reuse the string afterward, and Relay frees it exactly once.
 pub type NemoRelayToolExecInterceptCb = unsafe extern "C" fn(
     user_data: *mut libc::c_void,
     args_json: *const c_char,

--- a/crates/ffi/src/callable.rs
+++ b/crates/ffi/src/callable.rs
@@ -82,6 +82,9 @@ pub type NemoRelayToolExecNextFn =
 /// Callback for tool execution intercepts. Receives arguments as JSON plus
 /// a `next` callback and its context. Call `next_fn(args, next_ctx)` to invoke
 /// the next layer in the middleware chain, or return directly to short-circuit.
+/// The `result` field is passed to the remaining middleware and application;
+/// `pending_marks` are Relay-owned lifecycle metadata emitted after the
+/// tool-end event and are not included in the application-visible result.
 /// The returned JSON must contain a `result` field and may contain a
 /// `pending_marks` array. The returned string must be allocated with `malloc`
 /// or an equivalent allocation compatible with `nemo_relay_string_free`.

--- a/crates/ffi/tests/integration/api_tests.rs
+++ b/crates/ffi/tests/integration/api_tests.rs
@@ -328,7 +328,16 @@ unsafe extern "C" fn tool_exec_intercept_cb(
     next_fn: NemoRelayToolExecNextFn,
     next_ctx: *mut libc::c_void,
 ) -> *mut c_char {
-    unsafe { next_fn(args_json, next_ctx) }
+    let result_ptr = unsafe { next_fn(args_json, next_ctx) };
+    if result_ptr.is_null() {
+        return ptr::null_mut();
+    }
+    let result: Json =
+        serde_json::from_str(unsafe { CStr::from_ptr(result_ptr) }.to_str().unwrap()).unwrap();
+    unsafe { nemo_relay_string_free(result_ptr) };
+    CString::new(json!({ "result": result, "pending_marks": [] }).to_string())
+        .unwrap()
+        .into_raw()
 }
 
 unsafe extern "C" fn llm_request_cb(

--- a/crates/ffi/tests/unit/api/registry_tests.rs
+++ b/crates/ffi/tests/unit/api/registry_tests.rs
@@ -1154,7 +1154,7 @@ fn test_ffi_duplicate_registration_sweep_and_helper_callbacks() {
         .unwrap();
         assert_eq!(
             serde_json::from_str::<Json>(&tool_intercept_json).unwrap(),
-            json!({"next": true})
+            json!({"result": {"next": true}, "pending_marks": []})
         );
 
         let request = cstring(r#"{"headers":{},"content":{"model":"ffi-model","messages":[]}}"#);

--- a/crates/ffi/tests/unit/api_tests.rs
+++ b/crates/ffi/tests/unit/api_tests.rs
@@ -325,7 +325,16 @@ unsafe extern "C" fn tool_exec_intercept_cb(
     next_fn: NemoRelayToolExecNextFn,
     next_ctx: *mut libc::c_void,
 ) -> *mut c_char {
-    unsafe { next_fn(args_json, next_ctx) }
+    let result_ptr = unsafe { next_fn(args_json, next_ctx) };
+    if result_ptr.is_null() {
+        return ptr::null_mut();
+    }
+    let result: Json =
+        serde_json::from_str(unsafe { CStr::from_ptr(result_ptr) }.to_str().unwrap()).unwrap();
+    unsafe { nemo_relay_string_free(result_ptr) };
+    CString::new(json!({ "result": result, "pending_marks": [] }).to_string())
+        .unwrap()
+        .into_raw()
 }
 
 unsafe extern "C" fn llm_request_cb(

--- a/crates/ffi/tests/unit/callable_tests.rs
+++ b/crates/ffi/tests/unit/callable_tests.rs
@@ -96,7 +96,13 @@ unsafe extern "C" fn tool_exec_intercept_cb(
     CString::new(
         json!({
             "result": result,
-            "pending_marks": [],
+            "pending_marks": [{
+                "name": "ffi.tool.execution",
+                "category": "custom",
+                "category_profile": { "subtype": "ffi.tool.execution" },
+                "data": { "source": "c" },
+                "metadata": { "fixture": true },
+            }],
         })
         .to_string(),
     )
@@ -291,7 +297,21 @@ fn test_wrap_tool_exec_and_intercept_callbacks() {
         .unwrap();
     assert_eq!(intercepted.result["intercepted"], json!(true));
     assert_eq!(intercepted.result["from_next"]["v"], json!(1));
-    assert!(intercepted.pending_marks.is_empty());
+    assert_eq!(intercepted.pending_marks.len(), 1);
+    let mark = &intercepted.pending_marks[0];
+    assert_eq!(mark.name, "ffi.tool.execution");
+    assert_eq!(
+        mark.category.as_ref().map(|category| category.as_str()),
+        Some("custom")
+    );
+    assert_eq!(
+        mark.category_profile
+            .as_ref()
+            .and_then(|profile| profile.subtype.as_deref()),
+        Some("ffi.tool.execution")
+    );
+    assert_eq!(mark.data.as_ref().unwrap()["source"], "c");
+    assert_eq!(mark.metadata.as_ref().unwrap()["fixture"], true);
 
     let legacy_intercept =
         wrap_tool_exec_intercept_fn(tool_exec_legacy_intercept_cb, std::ptr::null_mut(), None);

--- a/crates/ffi/tests/unit/callable_tests.rs
+++ b/crates/ffi/tests/unit/callable_tests.rs
@@ -93,7 +93,26 @@ unsafe extern "C" fn tool_exec_intercept_cb(
         serde_json::from_str(unsafe { CStr::from_ptr(result_ptr) }.to_str().unwrap()).unwrap();
     unsafe { nemo_relay_string_free_internal(result_ptr) };
     result["intercepted"] = json!(true);
-    CString::new(result.to_string()).unwrap().into_raw()
+    CString::new(
+        json!({
+            "result": result,
+            "pending_marks": [],
+        })
+        .to_string(),
+    )
+    .unwrap()
+    .into_raw()
+}
+
+unsafe extern "C" fn tool_exec_legacy_intercept_cb(
+    _user_data: *mut libc::c_void,
+    _args_json: *const c_char,
+    _next_fn: NemoRelayToolExecNextFn,
+    _next_ctx: *mut libc::c_void,
+) -> *mut c_char {
+    CString::new(r#"{"legacy_result":true}"#)
+        .unwrap()
+        .into_raw()
 }
 
 /// Intercept-specific callback with the unified annotated-aware signature
@@ -270,8 +289,20 @@ fn test_wrap_tool_exec_and_intercept_callbacks() {
     let intercepted = runtime
         .block_on(intercept("tool", json!({"v": 1}), next))
         .unwrap();
-    assert_eq!(intercepted["intercepted"], json!(true));
-    assert_eq!(intercepted["from_next"]["v"], json!(1));
+    assert_eq!(intercepted.result["intercepted"], json!(true));
+    assert_eq!(intercepted.result["from_next"]["v"], json!(1));
+    assert!(intercepted.pending_marks.is_empty());
+
+    let legacy_intercept =
+        wrap_tool_exec_intercept_fn(tool_exec_legacy_intercept_cb, std::ptr::null_mut(), None);
+    let next: ToolExecutionNextFn = Arc::new(|args| Box::pin(async move { Ok(args) }));
+    let err = runtime
+        .block_on(legacy_intercept("tool", json!({}), next))
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("invalid tool execution intercept outcome JSON")
+    );
 
     let failing_intercept =
         wrap_tool_exec_intercept_fn(tool_exec_intercept_cb, std::ptr::null_mut(), None);

--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -45,6 +45,21 @@ export interface PluginConfig {
   policy?: ConfigPolicy;
 }
 
+/** A mark Relay materializes under a managed lifecycle. */
+export interface PendingMarkSpec {
+  name: string;
+  category?: string | null;
+  categoryProfile?: Json;
+  data?: Json;
+  metadata?: Json;
+}
+
+/** Canonical result returned by a tool execution intercept. */
+export interface ToolExecutionInterceptOutcome {
+  result: Json;
+  pendingMarks?: PendingMarkSpec[];
+}
+
 /** Component-scoped registration context passed to plugin handlers. */
 export interface PluginContext {
   /** Register an infallible event subscriber for this component. */
@@ -120,7 +135,10 @@ export interface PluginContext {
   registerToolExecutionIntercept(
     name: string,
     priority: number,
-    callback: (args: Json, next: (args: Json) => Json | Promise<Json>) => Json | Promise<Json>,
+    callback: (
+      args: Json,
+      next: (args: Json) => Json | Promise<Json>,
+    ) => ToolExecutionInterceptOutcome | Promise<ToolExecutionInterceptOutcome>,
   ): void;
 }
 

--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -131,7 +131,10 @@ export interface PluginContext {
     breakChain: boolean,
     callback: (name: string, args: Json) => Json,
   ): void;
-  /** Register a tool execution intercept for this component. */
+  /**
+   * Register tool execution middleware that returns a canonical outcome.
+   * The `next` callback resolves to the raw downstream result.
+   */
   registerToolExecutionIntercept(
     name: string,
     priority: number,

--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -100,13 +100,7 @@ export interface PluginContext {
     callback: (args: { name: string; request: Json; annotated: Json | null }) => {
       request: Json;
       annotated?: Json | null;
-      pendingMarks?: Array<{
-        name: string;
-        category?: string | null;
-        categoryProfile?: Json;
-        data?: Json;
-        metadata?: Json;
-      }>;
+      pendingMarks?: PendingMarkSpec[];
     },
   ): void;
   /** Register an LLM execution intercept for this component. */

--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -54,7 +54,13 @@ export interface PendingMarkSpec {
   metadata?: Json;
 }
 
-/** Canonical result returned by a tool execution intercept. */
+/**
+ * Canonical result returned by a tool execution intercept.
+ *
+ * `result` is passed to the remaining middleware and application. `pendingMarks`
+ * are Relay-owned lifecycle metadata emitted after the tool-end event and are
+ * not included in the application-visible result.
+ */
 export interface ToolExecutionInterceptOutcome {
   result: Json;
   pendingMarks?: PendingMarkSpec[];

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -2130,6 +2130,9 @@ pub fn register_tool_execution_intercept(
     env: Env,
     name: String,
     priority: i32,
+    #[napi(
+        ts_arg_type = "(args: Json, next: (args: Json) => Json | Promise<Json>) => { result: Json; pendingMarks?: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }> } | Promise<{ result: Json; pendingMarks?: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }> }>"
+    )]
     callable: JsFunction,
 ) -> Result<()> {
     let key = PromiseAwareKey::GlobalToolExecution(name.clone());
@@ -2560,6 +2563,9 @@ pub fn scope_register_tool_execution_intercept(
     scope_uuid: String,
     name: String,
     priority: i32,
+    #[napi(
+        ts_arg_type = "(args: Json, next: (args: Json) => Json | Promise<Json>) => { result: Json; pendingMarks?: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }> } | Promise<{ result: Json; pendingMarks?: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }> }>"
+    )]
     callable: JsFunction,
 ) -> Result<()> {
     let key = PromiseAwareKey::ScopeToolExecution {

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -25,6 +25,7 @@ use tokio_stream::StreamExt;
 
 use nemo_relay::api::event::{CategoryProfile, Event, EventCategory, PendingMarkSpec};
 use nemo_relay::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
+use nemo_relay::api::tool::ToolExecutionInterceptOutcome;
 use nemo_relay::codec::request::AnnotatedLlmRequest;
 use nemo_relay::codec::response::AnnotatedLlmResponse;
 use nemo_relay::codec::traits::{LlmCodec, LlmResponseCodec};
@@ -625,21 +626,35 @@ pub fn wrap_js_response_codec(
     })
 }
 
-/// Wrap a JS function `(args, next) => result` for tool execution intercept.
+/// Wrap a JS function `(args, next) => { result, pendingMarks? }` for tool execution intercept.
 ///
 /// The JS callback receives the tool arguments and a real `next(args)` function
 /// that returns a Promise for the downstream result.
 pub fn wrap_js_tool_exec_intercept_fn(
     func: Arc<PromiseAwareFn>,
-) -> Arc<
-    dyn Fn(&str, Json, ToolExecutionNextFn) -> Pin<Box<dyn Future<Output = Result<Json>> + Send>>
-        + Send
-        + Sync,
-> {
+) -> nemo_relay::api::runtime::ToolExecutionFn {
     Arc::new(move |_name: &str, args: Json, next: ToolExecutionNextFn| {
         let func = func.clone();
         let next_json: JsonNextFn = Arc::new(move |next_args| next(next_args));
-        Box::pin(async move { func.call_with_json_next(args, next_json).await })
+        Box::pin(async move {
+            let result = func.call_with_json_next(args, next_json).await?;
+            #[derive(Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            struct JsOutcome {
+                result: Json,
+                #[serde(default)]
+                pending_marks: Vec<JsPendingMarkSpec>,
+            }
+            let outcome: JsOutcome = serde_json::from_value(result).map_err(|error| {
+                FlowError::Internal(format!(
+                    "invalid JS tool execution intercept outcome: {error}"
+                ))
+            })?;
+            Ok(ToolExecutionInterceptOutcome {
+                result: outcome.result,
+                pending_marks: outcome.pending_marks.into_iter().map(Into::into).collect(),
+            })
+        })
     })
 }
 

--- a/crates/node/tests/scope_local_tests.mjs
+++ b/crates/node/tests/scope_local_tests.mjs
@@ -494,8 +494,10 @@ describe('Scope-local auto-cleanup on scope pop', () => {
         fromPoppedScope: true,
       });
       return {
-        ...result,
-        wrapped: true,
+        result: {
+          ...result,
+          wrapped: true,
+        },
       };
     });
     popScope(scope);
@@ -699,8 +701,10 @@ describe('Priority merge of global and scope-local middleware', () => {
         from_global: true,
       });
       return {
-        ...result,
-        global_exec: true,
+        result: {
+          ...result,
+          global_exec: true,
+        },
       };
     });
 
@@ -711,8 +715,10 @@ describe('Priority merge of global and scope-local middleware', () => {
         from_scope: true,
       });
       return {
-        ...result,
-        scope_exec: true,
+        result: {
+          ...result,
+          scope_exec: true,
+        },
       };
     });
 
@@ -1253,7 +1259,10 @@ describe('Scope-local subscriber receives events', () => {
       () => scopeDeregisterToolConditionalExecutionGuardrail('not-a-uuid', 'bad_tool_cond'),
       () => scopeRegisterToolRequestIntercept('not-a-uuid', 'bad_tool_int', 10, false, (_name, args) => args),
       () => scopeDeregisterToolRequestIntercept('not-a-uuid', 'bad_tool_int'),
-      () => scopeRegisterToolExecutionIntercept('not-a-uuid', 'bad_tool_exec', 10, async (args, next) => next(args)),
+      () =>
+        scopeRegisterToolExecutionIntercept('not-a-uuid', 'bad_tool_exec', 10, async (args, next) => ({
+          result: await next(args),
+        })),
       () => scopeDeregisterToolExecutionIntercept('not-a-uuid', 'bad_tool_exec'),
       () => scopeRegisterLlmSanitizeRequestGuardrail('not-a-uuid', 'bad_llm_req', 10, (request) => request),
       () => scopeDeregisterLlmSanitizeRequestGuardrail('not-a-uuid', 'bad_llm_req'),

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -571,7 +571,7 @@ describe('Tool intercepts', () => {
   });
 
   it('execution intercept register/deregister', () => {
-    registerToolExecutionIntercept('node_tool_exec_int', 10, async (args, next) => next(args));
+    registerToolExecutionIntercept('node_tool_exec_int', 10, async (args, next) => ({ result: await next(args) }));
     deregisterToolExecutionIntercept('node_tool_exec_int');
   });
 
@@ -627,30 +627,47 @@ describe('Tool intercepts', () => {
   });
 
   it('execution intercept composes with next', async () => {
+    const events = [];
+    registerSubscriber('node_tool_exec_mark_sub', (event) => events.push(event));
     registerToolExecutionIntercept('node_tool_exec_repl', 10, async (args, next) => {
       const result = await next({
         ...args,
         intercepted: true,
       });
       return {
-        ...result,
-        wrapped: true,
+        result: {
+          ...result,
+          wrapped: true,
+        },
+        pendingMarks: [{ name: 'node.tool.execution' }],
       };
     });
-    const result = await toolCallExecute(
-      'replaced_tool',
-      {},
-      (args) => ({
-        original: !args.intercepted,
-      }),
-      null,
-      null,
-      null,
-      null,
-    );
-    assert.equal(result.original, false);
-    assert.equal(result.wrapped, true);
-    deregisterToolExecutionIntercept('node_tool_exec_repl');
+    try {
+      const result = await toolCallExecute(
+        'replaced_tool',
+        {},
+        (args) => ({
+          original: !args.intercepted,
+        }),
+        null,
+        null,
+        null,
+        null,
+      );
+      assert.equal(result.original, false);
+      assert.equal(result.wrapped, true);
+      await waitForSubscriberCallbacks(() => events.some((event) => event.name === 'node.tool.execution'));
+      const start = events.find(
+        (event) => event.name === 'replaced_tool' && event.kind === 'scope' && event.scope_category === 'start',
+      );
+      const mark = events.find((event) => event.name === 'node.tool.execution');
+      assert.ok(start, 'expected tool start event');
+      assert.ok(mark, 'expected tool execution pending mark');
+      assert.equal(mark.parent_uuid, start.uuid);
+    } finally {
+      deregisterToolExecutionIntercept('node_tool_exec_repl');
+      deregisterSubscriber('node_tool_exec_mark_sub');
+    }
   });
 
   it('execution intercept propagates Error messages', async () => {
@@ -675,6 +692,18 @@ describe('Tool intercepts', () => {
       );
     } finally {
       deregisterToolExecutionIntercept('node_tool_exec_throw');
+    }
+  });
+
+  it('execution intercept rejects legacy raw results', async () => {
+    registerToolExecutionIntercept('node_tool_exec_legacy', 10, async () => ({ legacyResult: true }));
+    try {
+      await assert.rejects(
+        () => toolCallExecute('legacy_tool', {}, (args) => args, null, null, null, null),
+        /invalid JS tool execution intercept outcome/i,
+      );
+    } finally {
+      deregisterToolExecutionIntercept('node_tool_exec_legacy');
     }
   });
 

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -656,14 +656,26 @@ describe('Tool intercepts', () => {
       );
       assert.equal(result.original, false);
       assert.equal(result.wrapped, true);
-      await waitForSubscriberCallbacks(() => events.some((event) => event.name === 'node.tool.execution'));
+      await waitForSubscriberCallbacks(
+        () =>
+          events.some(
+            (event) =>
+              event.name === 'replaced_tool' && event.kind === 'scope' && event.scope_category === 'end',
+          ) && events.some((event) => event.name === 'node.tool.execution'),
+      );
       const start = events.find(
         (event) => event.name === 'replaced_tool' && event.kind === 'scope' && event.scope_category === 'start',
       );
+      const end = events.find(
+        (event) => event.name === 'replaced_tool' && event.kind === 'scope' && event.scope_category === 'end',
+      );
       const mark = events.find((event) => event.name === 'node.tool.execution');
       assert.ok(start, 'expected tool start event');
+      assert.ok(end, 'expected tool end event');
       assert.ok(mark, 'expected tool execution pending mark');
       assert.equal(mark.parent_uuid, start.uuid);
+      assert.ok(events.indexOf(end) < events.indexOf(mark), 'expected tool end before pending mark');
+      assert.ok(mark.timestamp > end.timestamp, 'expected pending mark timestamp after tool end');
     } finally {
       deregisterToolExecutionIntercept('node_tool_exec_repl');
       deregisterSubscriber('node_tool_exec_mark_sub');

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -707,6 +707,21 @@ describe('Tool intercepts', () => {
     }
   });
 
+  it('execution intercept rejects unknown pending-mark fields', async () => {
+    registerToolExecutionIntercept('node_tool_exec_bad_mark', 10, async () => ({
+      result: { ok: true },
+      pendingMarks: [{ name: 'node.bad.mark', category_profile: { subtype: 'invalid.snake.case' } }],
+    }));
+    try {
+      await assert.rejects(
+        () => toolCallExecute('bad_mark_tool', {}, (args) => args, null, null, null, null),
+        /unknown field.*category_profile/i,
+      );
+    } finally {
+      deregisterToolExecutionIntercept('node_tool_exec_bad_mark');
+    }
+  });
+
   it('async execute falls back to unknown error for primitive rejections', async () => {
     await assert.rejects(
       () =>

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -21,7 +21,7 @@ pub use nemo_relay_types::api::event::{
 };
 pub use nemo_relay_types::api::llm::{LlmAttributes, LlmRequest, LlmRequestInterceptOutcome};
 pub use nemo_relay_types::api::scope::{HandleAttributes, ScopeAttributes, ScopeType};
-pub use nemo_relay_types::api::tool::ToolAttributes;
+pub use nemo_relay_types::api::tool::{ToolAttributes, ToolExecutionInterceptOutcome};
 pub use nemo_relay_types::codec::request::AnnotatedLlmRequest;
 pub use nemo_relay_types::codec::response::AnnotatedLlmResponse;
 pub use nemo_relay_types::plugin::{ConfigDiagnostic, DiagnosticLevel};
@@ -223,7 +223,7 @@ pub type NemoRelayNativeToolExecutionCb = unsafe extern "C" fn(
     args_json: *const NemoRelayNativeString,
     next_fn: NemoRelayNativeToolNextFn,
     next_ctx: *mut c_void,
-    out_json: *mut *mut NemoRelayNativeString,
+    out_outcome_json: *mut *mut NemoRelayNativeString,
 ) -> NemoRelayStatus;
 
 /// Native LLM request transform callback for request sanitizers.
@@ -1360,7 +1360,10 @@ impl<'a> PluginContext<'a> {
         callback: F,
     ) -> Result<()>
     where
-        F: for<'next> Fn(&str, Json, ToolNext<'next>) -> Result<Json> + Send + Sync + 'static,
+        F: for<'next> Fn(&str, Json, ToolNext<'next>) -> Result<ToolExecutionInterceptOutcome>
+            + Send
+            + Sync
+            + 'static,
     {
         let user_data = typed_callback_user_data(self.host, callback);
         let status = unsafe {
@@ -1996,15 +1999,18 @@ unsafe extern "C" fn typed_tool_execution_trampoline<F>(
     args_json: *const NemoRelayNativeString,
     next_fn: NemoRelayNativeToolNextFn,
     next_ctx: *mut c_void,
-    out_json: *mut *mut NemoRelayNativeString,
+    out_outcome_json: *mut *mut NemoRelayNativeString,
 ) -> NemoRelayStatus
 where
-    F: for<'next> Fn(&str, Json, ToolNext<'next>) -> Result<Json> + Send + Sync + 'static,
+    F: for<'next> Fn(&str, Json, ToolNext<'next>) -> Result<ToolExecutionInterceptOutcome>
+        + Send
+        + Sync
+        + 'static,
 {
-    if user_data.is_null() || out_json.is_null() {
+    if user_data.is_null() || out_outcome_json.is_null() {
         return NemoRelayStatus::NullPointer;
     }
-    unsafe { *out_json = ptr::null_mut() };
+    unsafe { *out_outcome_json = ptr::null_mut() };
     let state = unsafe { &*(user_data as *const TypedCallback<F>) };
     let result = catch_unwind(AssertUnwindSafe(|| {
         let name = read_required_host_string(&state.host, name, "tool name")?;
@@ -2015,7 +2021,15 @@ where
             next_ctx,
         };
         match (state.callback)(&name, args, next) {
-            Ok(output) => Ok::<_, NemoRelayStatus>(write_json(&state.host, &output, out_json)),
+            Ok(outcome) => {
+                let Some(outcome) = HostString::from_json(&state.host, &outcome) else {
+                    set_last_error(&state.host, "failed to allocate tool execution outcome");
+                    return Ok(NemoRelayStatus::Internal);
+                };
+                unsafe { *out_outcome_json = outcome.ptr };
+                std::mem::forget(outcome);
+                Ok(NemoRelayStatus::Ok)
+            }
             Err(message) => Ok(callback_error(&state.host, message)),
         }
     }));

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -1353,6 +1353,10 @@ impl<'a> PluginContext<'a> {
     }
 
     /// Registers a typed tool execution intercept.
+    ///
+    /// The callback returns a [`ToolExecutionInterceptOutcome`]. Calling
+    /// [`ToolNext::call`] continues the chain and returns only the raw
+    /// downstream result JSON; Relay retains downstream pending marks.
     pub fn register_tool_execution_intercept<F>(
         &mut self,
         name: &str,

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -13,8 +13,8 @@ use std::sync::{
 };
 
 use nemo_relay_plugin::{
-    AnnotatedLlmRequest, ConfigDiagnostic, DiagnosticLevel, Event, Json, LlmJsonStream, LlmNext,
-    LlmRequest, LlmRequestInterceptOutcome, LlmStream, LlmStreamNext,
+    AnnotatedLlmRequest, CategoryProfile, ConfigDiagnostic, DiagnosticLevel, Event, EventCategory,
+    Json, LlmJsonStream, LlmNext, LlmRequest, LlmRequestInterceptOutcome, LlmStream, LlmStreamNext,
     NEMO_RELAY_NATIVE_ABI_VERSION, NativePlugin, NemoRelayNativeEventSubscriberCb,
     NemoRelayNativeFreeFn, NemoRelayNativeHostApiV1, NemoRelayNativeJsonCb,
     NemoRelayNativeLlmConditionalCb, NemoRelayNativeLlmExecutionCb, NemoRelayNativeLlmRequestCb,
@@ -23,7 +23,8 @@ use nemo_relay_plugin::{
     NemoRelayNativeScopeHandle, NemoRelayNativeScopeStack, NemoRelayNativeScopeStackBinding,
     NemoRelayNativeScopeType, NemoRelayNativeString, NemoRelayNativeToolConditionalCb,
     NemoRelayNativeToolExecutionCb, NemoRelayNativeToolJsonCb, NemoRelayNativeWithScopeStackCb,
-    NemoRelayStatus, PendingMarkSpec, PluginContext, PluginRuntime, ScopeType, ToolNext,
+    NemoRelayStatus, PendingMarkSpec, PluginContext, PluginRuntime, ScopeType,
+    ToolExecutionInterceptOutcome, ToolNext,
 };
 use serde_json::{Map, json};
 
@@ -2464,7 +2465,7 @@ fn typed_callbacks_reject_null_abi_pointers_before_decoding_inputs() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_tool_execution_intercept("tool-exec", 0, |_name, value, _next| Ok(value))
+    ctx.register_tool_execution_intercept("tool-exec", 0, |_name, value, _next| Ok(value.into()))
         .unwrap();
     let registration = take_tool_execution_registration();
     let name = host_string(&host, "tool");
@@ -2789,7 +2790,7 @@ fn typed_callbacks_report_invalid_json_for_each_decoder_family() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_tool_execution_intercept("tool-exec", 0, |_name, value, _next| Ok(value))
+    ctx.register_tool_execution_intercept("tool-exec", 0, |_name, value, _next| Ok(value.into()))
         .unwrap();
     let registration = take_tool_execution_registration();
     let name = host_string(&host, "tool");
@@ -3486,7 +3487,21 @@ fn typed_tool_execution_registration_calls_next() {
     let called = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
     ctx.register_tool_execution_intercept("tool", 23, |_name, args, next: ToolNext<'_>| {
-        next.call(args)
+        let result = next.call(args)?;
+        Ok(
+            ToolExecutionInterceptOutcome::new(result).with_pending_mark(
+                PendingMarkSpec::builder()
+                    .name("plugin.tool.completed")
+                    .category(EventCategory::custom())
+                    .category_profile(CategoryProfile {
+                        subtype: Some("plugin.tool.pending".into()),
+                        ..CategoryProfile::default()
+                    })
+                    .data(json!({ "saved_tokens": 7 }))
+                    .metadata(json!({ "source": "typed-test" }))
+                    .build(),
+            ),
+        )
     })
     .unwrap();
 
@@ -3512,11 +3527,62 @@ fn typed_tool_execution_registration_calls_next() {
     };
     assert_eq!(status, NemoRelayStatus::Ok);
     assert_eq!(called.load(Ordering::SeqCst), 1);
-    assert_eq!(read_json_and_free(&host, out)["next_called"], json!(true));
+    let outcome = read_json_and_free(&host, out);
+    assert_eq!(outcome["result"]["next_called"], json!(true));
+    assert_eq!(outcome["pending_marks"][0]["name"], "plugin.tool.completed");
+    assert_eq!(outcome["pending_marks"][0]["category"], "custom");
+    assert_eq!(
+        outcome["pending_marks"][0]["category_profile"]["subtype"],
+        "plugin.tool.pending"
+    );
+    assert_eq!(outcome["pending_marks"][0]["data"]["saved_tokens"], 7);
+    assert_eq!(
+        outcome["pending_marks"][0]["metadata"]["source"],
+        "typed-test"
+    );
     unsafe {
         (host.string_free)(name);
         (host.string_free)(args);
         drop(Box::from_raw(next_state));
+        registration.free();
+    }
+}
+
+#[test]
+fn typed_tool_execution_does_not_publish_partial_outcome() {
+    let _guard = begin_test();
+    let host = test_host();
+    let mut ctx = test_context(&host);
+    ctx.register_tool_execution_intercept("tool", 0, |_name, args, _next| {
+        Ok(ToolExecutionInterceptOutcome::new(args))
+    })
+    .unwrap();
+
+    let registration = take_tool_execution_registration();
+    let name = host_string(&host, "tool");
+    let args = json_host_string(&host, json!({ "input": true }));
+    let stale_outcome = host_string(&host, r#"{"stale":true}"#);
+    let mut out_outcome = stale_outcome;
+    *STRING_NEW_REMAINING_SUCCESSES.lock().unwrap() = Some(0);
+    let live_before = live_host_strings();
+    let status = unsafe {
+        (registration.cb)(
+            registration.user_data as *mut c_void,
+            name,
+            args,
+            fake_tool_next,
+            ptr::null_mut(),
+            &mut out_outcome,
+        )
+    };
+    *STRING_NEW_REMAINING_SUCCESSES.lock().unwrap() = None;
+    assert_eq!(status, NemoRelayStatus::Internal);
+    assert!(out_outcome.is_null());
+    assert_eq!(live_host_strings(), live_before);
+    unsafe {
+        (host.string_free)(stale_outcome);
+        (host.string_free)(name);
+        (host.string_free)(args);
         registration.free();
     }
 }
@@ -3528,7 +3594,7 @@ fn typed_tool_execution_surfaces_next_status_failures() {
     let called = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
     ctx.register_tool_execution_intercept("tool", 0, |_name, args, next: ToolNext<'_>| {
-        next.call(args)
+        next.call(args).map(Into::into)
     })
     .unwrap();
 
@@ -3572,7 +3638,7 @@ fn typed_tool_execution_surfaces_invalid_next_json() {
     let called = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
     ctx.register_tool_execution_intercept("tool", 0, |_name, args, next: ToolNext<'_>| {
-        next.call(args)
+        next.call(args).map(Into::into)
     })
     .unwrap();
 
@@ -3618,7 +3684,7 @@ fn typed_tool_execution_surfaces_null_next_output() {
     let called = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
     ctx.register_tool_execution_intercept("tool", 0, |_name, args, next: ToolNext<'_>| {
-        next.call(args)
+        next.call(args).map(Into::into)
     })
     .unwrap();
 

--- a/crates/python/src/py_callable.rs
+++ b/crates/python/src/py_callable.rs
@@ -36,6 +36,7 @@ use tokio_stream::Stream;
 
 use nemo_relay::api::event::Event;
 use nemo_relay::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
+use nemo_relay::api::tool::ToolExecutionInterceptOutcome;
 use nemo_relay::codec::request::AnnotatedLlmRequest as AnnotatedLLMRequest;
 use nemo_relay::codec::response::AnnotatedLlmResponse as AnnotatedLLMResponse;
 use nemo_relay::codec::traits::{LlmCodec, LlmResponseCodec};
@@ -43,6 +44,7 @@ use nemo_relay::codec::traits::{LlmCodec, LlmResponseCodec};
 use crate::convert::{json_to_py, py_to_json};
 use crate::py_types::{
     PyAnnotatedLLMRequest, PyAnnotatedLLMResponse, PyLLMRequest, PyLLMRequestInterceptOutcome,
+    PyToolExecutionInterceptOutcome,
 };
 
 type PyValueFuture = Pin<Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send>>;
@@ -393,26 +395,21 @@ impl PyLlmStreamNextFn {
     }
 }
 
-/// Wrap a Python callable `(Json, next) -> Json` for tool execution intercepts.
+/// Wrap a Python callable `(Json, next) -> ToolExecutionInterceptOutcome` for tool execution intercepts.
 /// The `next` parameter is a `PyToolNextFn` that the Python code can `await`.
 pub fn wrap_py_tool_exec_intercept_fn(
     py_fn: Py<PyAny>,
-) -> Arc<
-    dyn Fn(
-            &str,
-            Json,
-            ToolExecutionNextFn,
-        ) -> Pin<Box<dyn Future<Output = FlowResult<Json>> + Send>>
-        + Send
-        + Sync,
-> {
+) -> nemo_relay::api::runtime::ToolExecutionFn {
     let py_fn = Arc::new(py_fn);
     Arc::new(move |name: &str, args: Json, next: ToolExecutionNextFn| {
         let py_fn = py_fn.clone();
         let name = name.to_string();
         Box::pin(async move {
             let outcome: FlowResult<
-                Result<Json, Pin<Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send>>>,
+                Result<
+                    ToolExecutionInterceptOutcome,
+                    Pin<Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send>>,
+                >,
             > = Python::attach(|py| {
                 let py_args =
                     json_to_py(py, &args).map_err(|e: PyErr| FlowError::Internal(e.to_string()))?;
@@ -440,9 +437,14 @@ pub fn wrap_py_tool_exec_intercept_fn(
                             Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send>,
                         >))
                 } else {
-                    let json =
-                        py_to_json(bound).map_err(|e: PyErr| FlowError::Internal(e.to_string()))?;
-                    Ok(Ok(json))
+                    let outcome = result
+                        .extract::<PyToolExecutionInterceptOutcome>(py)
+                        .map_err(|e| {
+                            FlowError::Internal(format!(
+                                "tool execution intercept must return ToolExecutionInterceptOutcome: {e}"
+                            ))
+                        })?;
+                    Ok(Ok(outcome.inner))
                 }
             });
 
@@ -453,8 +455,14 @@ pub fn wrap_py_tool_exec_intercept_fn(
                         .await
                         .map_err(|e| FlowError::Internal(e.to_string()))?;
                     Python::attach(|py| {
-                        py_to_json(py_result.bind(py))
-                            .map_err(|e: PyErr| FlowError::Internal(e.to_string()))
+                        py_result
+                            .extract::<PyToolExecutionInterceptOutcome>(py)
+                            .map(|value| value.inner)
+                            .map_err(|e| {
+                                FlowError::Internal(format!(
+                                    "tool execution intercept must return ToolExecutionInterceptOutcome: {e}"
+                                ))
+                            })
                     })
                 }
             }

--- a/crates/python/src/py_types/core.rs
+++ b/crates/python/src/py_types/core.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use nemo_relay::api::event::{CategoryProfile, EventCategory, PendingMarkSpec};
 use nemo_relay::api::llm::LlmRequestInterceptOutcome;
+use nemo_relay::api::tool::ToolExecutionInterceptOutcome;
 
 // ---------------------------------------------------------------------------
 // LlmStream (async iterator)
@@ -716,6 +717,42 @@ impl PyLLMRequestInterceptOutcome {
             .annotated_request
             .clone()
             .map(|inner: AnnotatedLLMRequest| PyAnnotatedLLMRequest { inner })
+    }
+
+    #[getter]
+    fn pending_marks(&self) -> Vec<PyPendingMarkSpec> {
+        self.inner
+            .pending_marks
+            .iter()
+            .cloned()
+            .map(|inner| PyPendingMarkSpec { inner })
+            .collect()
+    }
+}
+
+/// Canonical result returned by Python tool execution intercepts.
+#[pyclass(name = "ToolExecutionInterceptOutcome", from_py_object)]
+#[derive(Clone)]
+pub struct PyToolExecutionInterceptOutcome {
+    pub inner: ToolExecutionInterceptOutcome,
+}
+
+#[pymethods]
+impl PyToolExecutionInterceptOutcome {
+    #[new]
+    #[pyo3(signature = (result, pending_marks=Vec::new()))]
+    fn new(result: &Bound<'_, PyAny>, pending_marks: Vec<PyPendingMarkSpec>) -> PyResult<Self> {
+        Ok(Self {
+            inner: ToolExecutionInterceptOutcome {
+                result: py_to_json(result)?,
+                pending_marks: pending_marks.into_iter().map(|value| value.inner).collect(),
+            },
+        })
+    }
+
+    #[getter]
+    fn result(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        json_to_py(py, &self.inner.result)
     }
 
     #[getter]

--- a/crates/python/src/py_types/mod.rs
+++ b/crates/python/src/py_types/mod.rs
@@ -134,6 +134,7 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyLLMRequest>()?;
     m.add_class::<PyPendingMarkSpec>()?;
     m.add_class::<PyLLMRequestInterceptOutcome>()?;
+    m.add_class::<PyToolExecutionInterceptOutcome>()?;
     m.add_class::<PyAnnotatedLLMRequest>()?;
     m.add_class::<PyAnnotatedLLMResponse>()?;
     m.add_class::<PyScopeEvent>()?;

--- a/crates/python/tests/coverage/coverage_tests.rs
+++ b/crates/python/tests/coverage/coverage_tests.rs
@@ -38,6 +38,12 @@ fn load_module<'py>(py: Python<'py>, code: &str) -> Bound<'py, PyModule> {
         )
         .unwrap();
     module
+        .setattr(
+            "ToolOutcome",
+            py.get_type::<crate::py_types::PyToolExecutionInterceptOutcome>(),
+        )
+        .unwrap();
+    module
 }
 
 fn make_request() -> LlmRequest {
@@ -409,7 +415,7 @@ def tool_request_intercept(name, value):
     return value
 
 async def tool_execution_intercept(name, value, next):
-    return await next(value)
+    return ToolOutcome(await next(value))
 
 class CoveragePlugin:
     def validate(self, plugin_config):
@@ -714,7 +720,7 @@ async def tool_exec(args):
 async def tool_intercept(name, args, next):
     result = await next({"x": args["x"] + 1})
     result["wrapped"] = True
-    return result
+    return ToolOutcome(result)
 
 async def llm_exec(request):
     return {"model": request.content["model"]}
@@ -725,6 +731,13 @@ async def llm_intercept(name, request, next):
     return result
 "#,
         );
+
+        module
+            .setattr(
+                "ToolOutcome",
+                py.get_type::<crate::py_types::PyToolExecutionInterceptOutcome>(),
+            )
+            .unwrap();
 
         let tool_exec_py: Py<PyAny> = module.getattr("tool_exec").unwrap().unbind();
         let tool_intercept_py: Py<PyAny> = module.getattr("tool_intercept").unwrap().unbind();
@@ -746,7 +759,7 @@ async def llm_intercept(name, request, next):
                     tool_intercept("tool", json!({"x": 2}), tool_next)
                         .await
                         .unwrap(),
-                    json!({"next": 3, "wrapped": true})
+                    json!({"next": 3, "wrapped": true}).into()
                 );
 
                 let llm_exec = wrap_py_llm_exec_fn(llm_exec_py);

--- a/crates/python/tests/coverage/py_api_coverage_tests.rs
+++ b/crates/python/tests/coverage/py_api_coverage_tests.rs
@@ -177,7 +177,7 @@ async def tool_exec(args):
 async def tool_exec_intercept(name, args, next):
     result = await next({"value": args["value"] + 3})
     result["tool_intercepted"] = True
-    return result
+    return ToolExecutionInterceptOutcome(result)
 
 def llm_sanitize_request(request):
     return request
@@ -332,6 +332,14 @@ async def run_stream(api, request, func, collector, finalizer, handle, attribute
             .setattr(
                 "LLMRequestInterceptOutcome",
                 types_module.getattr("LLMRequestInterceptOutcome").unwrap(),
+            )
+            .unwrap();
+        helpers
+            .setattr(
+                "ToolExecutionInterceptOutcome",
+                types_module
+                    .getattr("ToolExecutionInterceptOutcome")
+                    .unwrap(),
             )
             .unwrap();
         helpers

--- a/crates/python/tests/coverage/py_callable_coverage_tests.rs
+++ b/crates/python/tests/coverage/py_callable_coverage_tests.rs
@@ -51,7 +51,7 @@ def sync_tool_exec(args):
     return {"sync_tool": args["x"] + 1}
 
 def sync_tool_intercept(name, args, next):
-    return {"name": name, "value": args["x"] + 2}
+    return ToolOutcome({"name": name, "value": args["x"] + 2})
 
 def sync_llm_exec(request):
     return {"model": request.content["model"], "mode": "sync"}
@@ -99,6 +99,12 @@ class RaisingResponseCodec:
                 py.get_type::<crate::py_types::PyLLMRequestInterceptOutcome>(),
             )
             .unwrap();
+        module
+            .setattr(
+                "ToolOutcome",
+                py.get_type::<crate::py_types::PyToolExecutionInterceptOutcome>(),
+            )
+            .unwrap();
 
         let tool_exec_py: Py<PyAny> = module.getattr("sync_tool_exec").unwrap().unbind();
         let tool_intercept_py: Py<PyAny> = module.getattr("sync_tool_intercept").unwrap().unbind();
@@ -120,7 +126,7 @@ class RaisingResponseCodec:
                 tool_intercept("tool", json!({"x": 3}), tool_next)
                     .await
                     .unwrap(),
-                json!({"name": "tool", "value": 5})
+                json!({"name": "tool", "value": 5}).into()
             );
 
             let llm_exec = wrap_py_llm_exec_fn(llm_exec_py);

--- a/crates/python/tests/coverage/py_plugin_coverage_tests.rs
+++ b/crates/python/tests/coverage/py_plugin_coverage_tests.rs
@@ -24,6 +24,12 @@ fn load_module<'py>(py: Python<'py>, code: &str) -> Bound<'py, PyModule> {
         )
         .unwrap();
     module
+        .setattr(
+            "ToolOutcome",
+            py.get_type::<crate::py_types::PyToolExecutionInterceptOutcome>(),
+        )
+        .unwrap();
+    module
 }
 
 fn with_event_loop<T>(py: Python<'_>, f: impl FnOnce(Bound<'_, PyAny>) -> T) -> T {
@@ -142,7 +148,7 @@ def tool_request_intercept(name, value):
     return value
 
 async def tool_execution_intercept(name, value, next):
-    return await next(value)
+    return ToolOutcome(await next(value))
 "#,
         );
 
@@ -598,7 +604,7 @@ def tool_request_intercept(name, value):
     return value
 
 async def tool_execution_intercept(name, value, next):
-    return await next(value)
+    return ToolOutcome(await next(value))
 "#,
         );
 
@@ -882,7 +888,7 @@ def tool_request_intercept(name, value):
     return value
 
 async def tool_execution_intercept(name, value, next):
-    return await next(value)
+    return ToolOutcome(await next(value))
 "#,
         );
 

--- a/crates/types/src/api/event.rs
+++ b/crates/types/src/api/event.rs
@@ -364,7 +364,7 @@ pub struct MarkEvent {
     pub category_profile: Option<CategoryProfile>,
 }
 
-/// Mark requested by middleware before its owning runtime scope exists.
+/// Mark requested by middleware for materialization by a lifecycle owner.
 ///
 /// The runtime assigns the parent UUID, event UUID, and timestamp when it
 /// materializes the mark at the appropriate lifecycle boundary.

--- a/crates/types/src/api/tool.rs
+++ b/crates/types/src/api/tool.rs
@@ -6,11 +6,47 @@
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
+use crate::Json;
+use crate::api::event::PendingMarkSpec;
+
 bitflags! {
     /// Bitflags that modify tool-call behavior and observability.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub struct ToolAttributes: u32 {
         /// Marks the tool as executing out-of-process.
         const REMOTE = 0b01;
+    }
+}
+
+/// Result of a tool execution intercept that can schedule lifecycle marks.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolExecutionInterceptOutcome {
+    /// Tool result returned to the remaining middleware and application.
+    pub result: Json,
+    /// Ordered marks for the managed tool lifecycle owner to emit.
+    #[serde(default)]
+    pub pending_marks: Vec<PendingMarkSpec>,
+}
+
+impl ToolExecutionInterceptOutcome {
+    /// Create an outcome without pending marks.
+    pub fn new(result: Json) -> Self {
+        Self {
+            result,
+            pending_marks: Vec::new(),
+        }
+    }
+
+    /// Append one pending mark while preserving callback order.
+    #[must_use]
+    pub fn with_pending_mark(mut self, mark: PendingMarkSpec) -> Self {
+        self.pending_marks.push(mark);
+        self
+    }
+}
+
+impl From<Json> for ToolExecutionInterceptOutcome {
+    fn from(result: Json) -> Self {
+        Self::new(result)
     }
 }

--- a/crates/types/src/api/tool.rs
+++ b/crates/types/src/api/tool.rs
@@ -18,7 +18,11 @@ bitflags! {
     }
 }
 
-/// Result of a tool execution intercept that can schedule lifecycle marks.
+/// Canonical result returned by a tool execution intercept.
+///
+/// `result` is passed to the remaining middleware and application. `pending_marks`
+/// are Relay-owned lifecycle metadata retained separately and emitted after the
+/// tool-end event; they are not included in the application-visible result.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolExecutionInterceptOutcome {
     /// Tool result returned to the remaining middleware and application.

--- a/crates/types/tests/serialization_tests.rs
+++ b/crates/types/tests/serialization_tests.rs
@@ -10,6 +10,7 @@ use nemo_relay_types::api::event::{
     llm_attributes_to_strings,
 };
 use nemo_relay_types::api::llm::{LlmAttributes, LlmRequest, LlmRequestInterceptOutcome};
+use nemo_relay_types::api::tool::ToolExecutionInterceptOutcome;
 use nemo_relay_types::codec::request::{AnnotatedLlmRequest, Message, MessageContent};
 use nemo_relay_types::codec::response::AnnotatedLlmResponse;
 use serde_json::{Map, json};
@@ -170,4 +171,54 @@ fn llm_request_intercept_outcome_converts_from_request_inputs() {
         optional_annotation,
         LlmRequestInterceptOutcome::new(request, Some(annotated_request))
     );
+}
+
+#[test]
+fn tool_execution_intercept_outcome_round_trips_pending_marks() {
+    let outcome = ToolExecutionInterceptOutcome::new(json!({"stdout": "compacted"}))
+        .with_pending_mark(
+            PendingMarkSpec::builder()
+                .name("tool.output.compacted")
+                .category(EventCategory::custom())
+                .category_profile(
+                    CategoryProfile::builder()
+                        .subtype("optimizer.saved_tokens")
+                        .build(),
+                )
+                .data(json!({"saved_tokens": 12}))
+                .metadata(json!({"source": "test"}))
+                .build(),
+        );
+
+    let encoded = serde_json::to_value(&outcome).expect("outcome should serialize");
+    assert_eq!(encoded["result"]["stdout"], "compacted");
+    assert_eq!(encoded["pending_marks"][0]["name"], "tool.output.compacted");
+    assert_eq!(encoded["pending_marks"][0]["category"], "custom");
+
+    let decoded: ToolExecutionInterceptOutcome =
+        serde_json::from_value(encoded).expect("outcome should deserialize");
+    assert_eq!(decoded, outcome);
+
+    let defaults: ToolExecutionInterceptOutcome = serde_json::from_value(json!({
+        "result": "plain",
+        "future_field": true
+    }))
+    .expect("omitted pending marks and unknown fields should be accepted");
+    assert!(defaults.pending_marks.is_empty());
+    assert_eq!(defaults.result, json!("plain"));
+
+    assert!(
+        serde_json::from_value::<ToolExecutionInterceptOutcome>(json!({
+            "pending_marks": []
+        }))
+        .is_err(),
+        "result is required"
+    );
+}
+
+#[test]
+fn tool_execution_intercept_outcome_converts_from_json() {
+    let result = json!({"value": 42});
+    let outcome: ToolExecutionInterceptOutcome = result.clone().into();
+    assert_eq!(outcome, ToolExecutionInterceptOutcome::new(result));
 }

--- a/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
+++ b/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
@@ -166,6 +166,7 @@ message InvokeResponse {
     GuardrailResult guardrail = 3;
     LlmRequestInterceptResult llm_request = 4;
     WorkerError error = 5;
+    ToolExecutionInterceptResult tool_execution = 6;
   }
 }
 
@@ -181,6 +182,10 @@ message GuardrailResult {
 }
 
 message LlmRequestInterceptResult {
+  JsonEnvelope outcome = 1;
+}
+
+message ToolExecutionInterceptResult {
   JsonEnvelope outcome = 1;
 }
 

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -37,6 +37,7 @@ pub use nemo_relay_types::Json;
 pub use nemo_relay_types::api::event::{Event, PendingMarkSpec};
 pub use nemo_relay_types::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 pub use nemo_relay_types::api::scope::ScopeType;
+pub use nemo_relay_types::api::tool::ToolExecutionInterceptOutcome;
 use nemo_relay_types::codec::request::AnnotatedLlmRequest;
 pub use nemo_relay_types::plugin::{ConfigDiagnostic, DiagnosticLevel};
 use nemo_relay_worker_proto::v1::plugin_worker_server::{PluginWorker, PluginWorkerServer};
@@ -47,8 +48,8 @@ use nemo_relay_worker_proto::v1::{
     HealthResponse, InvokeRequest, InvokeResponse, JsonEnvelope, JsonResult, LlmNextRequest,
     LlmRequestInterceptResult, LlmStreamNextRequest, PopScopeRequest, PushScopeRequest,
     RegisterRequest, RegisterResponse, Registration, RegistrationSurface, ScopeContext,
-    ShutdownRequest, StreamChunk, ToolNextRequest, ValidateRequest, ValidateResponse, WorkerAck,
-    WorkerError,
+    ShutdownRequest, StreamChunk, ToolExecutionInterceptResult, ToolNextRequest, ValidateRequest,
+    ValidateResponse, WorkerAck, WorkerError,
 };
 use nemo_relay_worker_proto::{WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, json_envelope};
 use tokio::net::TcpListener;
@@ -120,7 +121,9 @@ type SubscriberFn = Arc<dyn Fn(&Event) + Send + Sync>;
 type ToolSanitizeFn = Arc<dyn Fn(&str, Json) -> Json + Send + Sync>;
 type ToolConditionalFn = Arc<dyn Fn(&str, &Json) -> Result<Option<String>> + Send + Sync>;
 type ToolRequestFn = Arc<dyn Fn(&str, Json) -> Result<Json> + Send + Sync>;
-type ToolExecutionFn = Arc<dyn Fn(&str, Json, ToolNext) -> BoxFutureResult<Json> + Send + Sync>;
+type ToolExecutionFn = Arc<
+    dyn Fn(&str, Json, ToolNext) -> BoxFutureResult<ToolExecutionInterceptOutcome> + Send + Sync,
+>;
 type LlmSanitizeRequestFn = Arc<dyn Fn(LlmRequest) -> LlmRequest + Send + Sync>;
 type LlmSanitizeResponseFn = Arc<dyn Fn(Json) -> Json + Send + Sync>;
 type LlmConditionalFn = Arc<dyn Fn(&LlmRequest) -> Result<Option<String>> + Send + Sync>;
@@ -278,7 +281,7 @@ impl PluginContext {
         callback: F,
     ) where
         F: Fn(&str, Json, ToolNext) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<Json>> + Send + 'static,
+        Fut: Future<Output = Result<ToolExecutionInterceptOutcome>> + Send + 'static,
     {
         self.push_registration(
             name,
@@ -1364,7 +1367,7 @@ impl WorkerService {
                 };
                 let future =
                     with_thread_scope(&scope, || handler(&payload.tool_name, payload.value, next));
-                Ok(json_response(future.await?))
+                Ok(tool_execution_response(future.await?)?)
             }
             RegistrationSurface::LlmSanitizeRequestGuardrail => {
                 let payload = llm_payload(request.payload)?;
@@ -1663,6 +1666,21 @@ fn llm_request_response(outcome: LlmRequestInterceptOutcome) -> Result<InvokeRes
                 LlmRequestInterceptResult {
                     outcome: Some(json_envelope(
                         "nemo.relay.LlmRequestInterceptOutcome@1",
+                        &outcome,
+                    )?),
+                },
+            ),
+        ),
+    })
+}
+
+fn tool_execution_response(outcome: ToolExecutionInterceptOutcome) -> Result<InvokeResponse> {
+    Ok(InvokeResponse {
+        result: Some(
+            nemo_relay_worker_proto::v1::invoke_response::Result::ToolExecution(
+                ToolExecutionInterceptResult {
+                    outcome: Some(json_envelope(
+                        "nemo.relay.ToolExecutionInterceptOutcome@1",
                         &outcome,
                     )?),
                 },

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -274,6 +274,10 @@ impl PluginContext {
     }
 
     /// Registers a tool execution intercept.
+    ///
+    /// The callback returns a [`ToolExecutionInterceptOutcome`]. Calling
+    /// [`ToolNext::call`] continues the chain and returns only the raw
+    /// downstream result JSON; Relay retains downstream pending marks.
     pub fn register_tool_execution_intercept<F, Fut>(
         &mut self,
         name: &str,

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -17,11 +17,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use futures_util::{Stream, StreamExt};
 #[cfg(unix)]
 use hyper_util::rt::TokioIo;
-use nemo_relay_types::api::event::{BaseEvent, Event, MarkEvent};
+use nemo_relay_types::api::event::{BaseEvent, Event, MarkEvent, PendingMarkSpec};
 use nemo_relay_worker::{
     Json, JsonStream, LlmNext, LlmRequest, LlmStreamNext, PluginContext, PluginRuntime, Result,
-    ScopeType, ToolNext, WorkerPlugin, WorkerSdkError, WorkerServerConfig, serve_plugin,
-    serve_plugin_arc, serve_plugin_arc_with_config,
+    ScopeType, ToolExecutionInterceptOutcome, ToolNext, WorkerPlugin, WorkerSdkError,
+    WorkerServerConfig, serve_plugin, serve_plugin_arc, serve_plugin_arc_with_config,
 };
 use nemo_relay_worker_proto::v1::plugin_worker_client::PluginWorkerClient;
 use nemo_relay_worker_proto::v1::relay_host_runtime_server::{
@@ -505,7 +505,7 @@ async fn worker_service_invokes_every_registration_surface() {
         "phase",
         "tool_request",
     );
-    let tool_exec = invoke_json(
+    let tool_outcome = invoke_tool_execution(
         &mut client,
         tool_invoke(
             "tool-exec",
@@ -514,6 +514,9 @@ async fn worker_service_invokes_every_registration_surface() {
         ),
     )
     .await;
+    assert_eq!(tool_outcome.pending_marks.len(), 1);
+    assert_eq!(tool_outcome.pending_marks[0].name, "worker.tool.execution");
+    let tool_exec = tool_outcome.result;
     assert_json_field(tool_exec.clone(), "next", "tool");
     assert_json_field(tool_exec, "phase", "tool_exec");
     assert!(
@@ -1400,7 +1403,7 @@ impl WorkerPlugin for CancellationPlugin {
             async move {
                 let _cancelled = CancelledOnDrop(unary_cancelled);
                 unary_started.notify_one();
-                std::future::pending::<Result<Json>>().await
+                std::future::pending::<Result<ToolExecutionInterceptOutcome>>().await
             }
         });
 
@@ -1540,7 +1543,16 @@ impl WorkerPlugin for SurfacePlugin {
                 runtime.pop_scope(&handle, None, None).await?;
                 runtime.drop_scope_stack(&stack_id).await?;
                 let next_value = next.call(value).await?;
-                Ok(set_json_field(next_value, "phase", "tool_exec"))
+                Ok(ToolExecutionInterceptOutcome::new(set_json_field(
+                    next_value,
+                    "phase",
+                    "tool_exec",
+                ))
+                .with_pending_mark(
+                    PendingMarkSpec::builder()
+                        .name("worker.tool.execution")
+                        .build(),
+                ))
             }
         });
         let scope_runtime = runtime.clone();
@@ -1572,7 +1584,7 @@ impl WorkerPlugin for SurfacePlugin {
                         .await?;
                     runtime.pop_scope(&handle, None, None).await?;
                 }
-                Ok(Json::Null)
+                Ok(Json::Null.into())
             }
         });
 
@@ -2250,6 +2262,32 @@ async fn invoke_json(client: &mut PluginWorkerClient<Channel>, request: InvokeRe
     match response.result.expect("invoke result") {
         nemo_relay_worker_proto::v1::invoke_response::Result::Json(result) => {
             decode_json_envelope(&result.value.expect("json value")).expect("decode JSON result")
+        }
+        nemo_relay_worker_proto::v1::invoke_response::Result::ToolExecution(result) => {
+            decode_json_envelope::<ToolExecutionInterceptOutcome>(
+                &result.outcome.expect("tool execution outcome"),
+            )
+            .expect("decode tool execution outcome")
+            .result
+        }
+        other => panic!("unexpected invoke result: {other:?}"),
+    }
+}
+
+async fn invoke_tool_execution(
+    client: &mut PluginWorkerClient<Channel>,
+    request: InvokeRequest,
+) -> ToolExecutionInterceptOutcome {
+    let response = client
+        .invoke(Request::new(request))
+        .await
+        .expect("invoke succeeds")
+        .into_inner();
+    match response.result.expect("invoke result") {
+        nemo_relay_worker_proto::v1::invoke_response::Result::ToolExecution(result) => {
+            let outcome = result.outcome.expect("tool execution outcome");
+            assert_eq!(outcome.schema, "nemo.relay.ToolExecutionInterceptOutcome@1");
+            decode_json_envelope(&outcome).expect("decode tool execution outcome")
         }
         other => panic!("unexpected invoke result: {other:?}"),
     }

--- a/examples/rust-native-plugin/src/lib.rs
+++ b/examples/rust-native-plugin/src/lib.rs
@@ -4,7 +4,7 @@
 use nemo_relay_plugin::{
     CategoryProfile, ConfigDiagnostic, DiagnosticLevel, Event, EventCategory, Json, LlmJsonStream,
     LlmRequest, LlmRequestInterceptOutcome, NativePlugin, PendingMarkSpec, PluginContext,
-    PluginRuntime, ScopeCategory, ScopeType,
+    PluginRuntime, ScopeCategory, ScopeType, ToolExecutionInterceptOutcome,
 };
 use serde_json::{Map, json};
 
@@ -215,7 +215,20 @@ impl NativePlugin for ExampleNativePlugin {
             move |_name, args, next| {
                 let request = tag_json(args, "native_tool_execution_request", &tag);
                 let result = next.call(request)?;
-                Ok(tag_json(result, "native_tool_execution_response", &tag))
+                let result = tag_json(result, "native_tool_execution_response", &tag);
+                Ok(
+                    ToolExecutionInterceptOutcome::new(result).with_pending_mark(
+                        PendingMarkSpec::builder()
+                            .name("example.native.tool_execution")
+                            .category(EventCategory::custom())
+                            .category_profile(CategoryProfile {
+                                subtype: Some("example.native.tool_result_rewrite".into()),
+                                ..CategoryProfile::default()
+                            })
+                            .data(json!({ "tag": &tag }))
+                            .build(),
+                    ),
+                )
             }
         })?;
 

--- a/go/nemo_relay/adaptive_plugin_test.go
+++ b/go/nemo_relay/adaptive_plugin_test.go
@@ -129,12 +129,13 @@ func registerLifecycleInterceptors(ctx *PluginContext, pluginKind string) error 
 	if err := ctx.RegisterToolExecutionIntercept(
 		"tool_exec",
 		7,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
 			resultJSON, err := next(args)
 			if err != nil {
-				return nil, err
+				return ToolExecutionInterceptOutcome{}, err
 			}
-			return decorateJSONPayload(resultJSON, "goToolExecPlugin", pluginKind)
+			result, err := decorateJSONPayload(resultJSON, "goToolExecPlugin", pluginKind)
+			return ToolExecutionInterceptOutcome{Result: result}, err
 		},
 	); err != nil {
 		return err
@@ -460,8 +461,8 @@ func TestPluginFuncsAndClosedContextBranches(t *testing.T) {
 			})
 		}},
 		{"tool execution", func() error {
-			return closed.RegisterToolExecutionIntercept("tool_exec", 1, func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
-				return next(args)
+			return closed.RegisterToolExecutionIntercept("tool_exec", 1, func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
+				return toolExecutionOutcome(next(args))
 			})
 		}},
 	}

--- a/go/nemo_relay/callbacks.go
+++ b/go/nemo_relay/callbacks.go
@@ -157,8 +157,9 @@ type ToolExecutionFunc func(args json.RawMessage) (json.RawMessage, error)
 // following the middleware chain pattern. It receives the tool arguments and
 // a `next` function. Call `next` to invoke the next intercept in the chain
 // (or the original tool implementation if this is the innermost intercept).
-// Skip calling `next` to short-circuit the chain entirely.
-type ToolExecutionInterceptFunc func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error)
+// Skip calling `next` to short-circuit the chain entirely. The callback returns
+// the canonical outcome containing the tool result and any pending marks.
+type ToolExecutionInterceptFunc func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error)
 
 // LLMResponseFunc is a callback that transforms an LLM response. It receives
 // the response as plain JSON and must return the (possibly modified) response
@@ -218,7 +219,7 @@ type LLMRequestDTO struct {
 	Content json.RawMessage `json:"content"`
 }
 
-// PendingMarkSpec describes a mark Relay emits after starting a managed LLM call.
+// PendingMarkSpec describes a mark Relay materializes under a managed lifecycle.
 type PendingMarkSpec struct {
 	Name            string          `json:"name"`
 	Category        *string         `json:"category,omitempty"`
@@ -232,6 +233,12 @@ type LLMRequestInterceptOutcome struct {
 	Request          LLMRequestDTO     `json:"request"`
 	AnnotatedRequest json.RawMessage   `json:"annotated_request"`
 	PendingMarks     []PendingMarkSpec `json:"pending_marks"`
+}
+
+// ToolExecutionInterceptOutcome is the canonical result of a tool execution intercept.
+type ToolExecutionInterceptOutcome struct {
+	Result       json.RawMessage   `json:"result"`
+	PendingMarks []PendingMarkSpec `json:"pending_marks"`
 }
 
 // LLMRequestInterceptFunc is a callback for LLM request intercepts. When
@@ -484,12 +491,20 @@ func goToolExecInterceptTrampoline(userData unsafe.Pointer, argsJSON *C.char, ne
 		defer C.nemo_relay_string_free(result)
 		return json.RawMessage(C.GoString(result)), nil
 	}
-	result, err := fn(goArgs, goNext)
+	outcome, err := fn(goArgs, goNext)
 	if err != nil {
 		setLastErrorMessage(err.Error())
 		return nil
 	}
-	return C.CString(string(result))
+	if outcome.PendingMarks == nil {
+		outcome.PendingMarks = []PendingMarkSpec{}
+	}
+	outcomeJSON, err := jsonMarshal(outcome)
+	if err != nil {
+		setLastErrorMessage(err.Error())
+		return nil
+	}
+	return C.CString(string(outcomeJSON))
 }
 
 //export goLlmExecInterceptTrampoline

--- a/go/nemo_relay/callbacks.go
+++ b/go/nemo_relay/callbacks.go
@@ -235,7 +235,10 @@ type LLMRequestInterceptOutcome struct {
 	PendingMarks     []PendingMarkSpec `json:"pending_marks"`
 }
 
-// ToolExecutionInterceptOutcome is the canonical result of a tool execution intercept.
+// ToolExecutionInterceptOutcome is the canonical result of a tool execution
+// intercept. Result is passed to the remaining middleware and application;
+// PendingMarks are Relay-owned lifecycle metadata emitted after the tool-end
+// event and are not included in the application-visible result.
 type ToolExecutionInterceptOutcome struct {
 	Result       json.RawMessage   `json:"result"`
 	PendingMarks []PendingMarkSpec `json:"pending_marks"`

--- a/go/nemo_relay/callbacks_test.go
+++ b/go/nemo_relay/callbacks_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+func toolExecutionOutcome(result json.RawMessage, err error) (ToolExecutionInterceptOutcome, error) {
+	return ToolExecutionInterceptOutcome{Result: result}, err
+}
+
 func TestRegisterAndUnregisterClosure(t *testing.T) {
 	fn := ToolExecutionFunc(func(args json.RawMessage) (json.RawMessage, error) {
 		return args, nil

--- a/go/nemo_relay/deregister_test.go
+++ b/go/nemo_relay/deregister_test.go
@@ -135,8 +135,8 @@ func TestRegisterDeregisterReregisterToolRequestIntercept(t *testing.T) {
 
 func TestRegisterDeregisterReregisterToolExecutionIntercept(t *testing.T) {
 	name := "go_reregister_exec_int"
-	fn := func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
-		return next(args)
+	fn := func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
+		return toolExecutionOutcome(next(args))
 	}
 
 	err := RegisterToolExecutionIntercept(name, 1, fn)
@@ -235,8 +235,8 @@ func TestDeregisterAllInterceptTypes(t *testing.T) {
 		func(n string, args json.RawMessage) json.RawMessage { return args },
 	)
 	RegisterToolExecutionIntercept("go_dereg_all_exec_int", 1,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
-			return next(args)
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
+			return toolExecutionOutcome(next(args))
 		},
 	)
 

--- a/go/nemo_relay/error_test.go
+++ b/go/nemo_relay/error_test.go
@@ -89,8 +89,8 @@ func TestAlreadyExistsErrorOnDuplicateToolRequestIntercept(t *testing.T) {
 
 func TestAlreadyExistsErrorOnDuplicateToolExecutionIntercept(t *testing.T) {
 	name := "go_err_dup_exec_int"
-	fn := func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
-		return next(args)
+	fn := func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
+		return toolExecutionOutcome(next(args))
 	}
 
 	err := RegisterToolExecutionIntercept(name, 1, fn)

--- a/go/nemo_relay/intercepts/intercepts_test.go
+++ b/go/nemo_relay/intercepts/intercepts_test.go
@@ -47,16 +47,16 @@ func runGlobalToolInterceptShorthandChecks(t *testing.T) {
 	}
 
 	if err := intercepts.RegisterToolExecution("intercepts_tool_exec", 1,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (nemo_relay.ToolExecutionInterceptOutcome, error) {
 			result, err := next(args)
 			if err != nil {
-				return nil, err
+				return nemo_relay.ToolExecutionInterceptOutcome{}, err
 			}
 			var payload map[string]interface{}
 			_ = json.Unmarshal(result, &payload)
 			payload["wrapped"] = true
 			out, _ := json.Marshal(payload)
-			return out, nil
+			return nemo_relay.ToolExecutionInterceptOutcome{Result: out}, nil
 		},
 	); err != nil {
 		t.Fatalf("RegisterToolExecution failed: %v", err)
@@ -174,8 +174,9 @@ func runScopeLocalToolInterceptShorthandChecks(t *testing.T, scopeUUID string) {
 		t.Fatalf("ScopeRegisterToolRequest failed: %v", err)
 	}
 	if err := intercepts.ScopeRegisterToolExecution(scopeUUID, "intercepts_scope_tool_exec", 1,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
-			return next(args)
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (nemo_relay.ToolExecutionInterceptOutcome, error) {
+			result, err := next(args)
+			return nemo_relay.ToolExecutionInterceptOutcome{Result: result}, err
 		},
 	); err != nil {
 		t.Fatalf("ScopeRegisterToolExecution failed: %v", err)

--- a/go/nemo_relay/scope_local_test.go
+++ b/go/nemo_relay/scope_local_test.go
@@ -698,16 +698,16 @@ func TestScopeLocalToolExecutionIntercept(t *testing.T) {
 	stack.Run(func() {
 		handle, _ := PushScope("exec_intercept_scope", ScopeTypeAgent)
 		defer PopScope(handle)
-		err := ScopeRegisterToolExecutionIntercept(handle.UUID(), "scope_exec_int", 1, func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+		err := ScopeRegisterToolExecutionIntercept(handle.UUID(), "scope_exec_int", 1, func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
 			result, err := next(args)
 			if err != nil {
-				return nil, err
+				return ToolExecutionInterceptOutcome{}, err
 			}
 			var m map[string]interface{}
 			json.Unmarshal(result, &m)
 			m["exec_intercepted"] = true
 			out, _ := json.Marshal(m)
-			return out, nil
+			return ToolExecutionInterceptOutcome{Result: out}, nil
 		})
 		if err != nil {
 			t.Fatalf("ScopeRegisterToolExecutionIntercept failed: %v", err)
@@ -1034,9 +1034,9 @@ func assertScopeLocalToolWrappersDeregister(t *testing.T, scopeUUID string) {
 		&executionInterceptCalls,
 		func() error {
 			return ScopeRegisterToolExecutionIntercept(scopeUUID, "tool_scope_exec_int", 1,
-				func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+				func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
 					executionInterceptCalls++
-					return next(args)
+					return toolExecutionOutcome(next(args))
 				},
 			)
 		},

--- a/go/nemo_relay/tools_test.go
+++ b/go/nemo_relay/tools_test.go
@@ -314,8 +314,8 @@ func TestToolRequestInterceptRegisterDeregister(t *testing.T) {
 
 func TestToolExecutionInterceptRegisterDeregister(t *testing.T) {
 	err := RegisterToolExecutionIntercept("go_exec_int", 1,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
-			return next(args)
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
+			return toolExecutionOutcome(next(args))
 		},
 	)
 	if err != nil {
@@ -368,9 +368,9 @@ func TestToolRequestInterceptModifiesArgs(t *testing.T) {
 
 func TestToolExecutionInterceptReplacesFunc(t *testing.T) {
 	RegisterToolExecutionIntercept("go_exec_replace", 1,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
 			// Short-circuit: don't call next, return directly
-			return json.RawMessage(`{"from_intercept": true}`), nil
+			return ToolExecutionInterceptOutcome{Result: json.RawMessage(`{"from_intercept": true}`)}, nil
 		},
 	)
 
@@ -454,16 +454,16 @@ func TestToolFullPipelineInterceptsAndExecute(t *testing.T) {
 
 	// Register an execution intercept that wraps the callable
 	RegisterToolExecutionIntercept("go_pipe_exec_int", 1,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
 			result, err := next(args)
 			if err != nil {
-				return nil, err
+				return ToolExecutionInterceptOutcome{}, err
 			}
 			var m map[string]interface{}
 			json.Unmarshal(result, &m)
 			m["exec_intercepted"] = true
 			out, _ := json.Marshal(m)
-			return out, nil
+			return ToolExecutionInterceptOutcome{Result: out}, nil
 		},
 	)
 	defer DeregisterToolExecutionIntercept("go_pipe_exec_int")
@@ -668,7 +668,7 @@ func TestToolCallableErrorPropagation(t *testing.T) {
 func TestToolExecutionInterceptWrapsCallable(t *testing.T) {
 	// Register an execution intercept that modifies args and result
 	RegisterToolExecutionIntercept("go_wrap_exec_int", 1,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
 			// Before: modify args
 			var m map[string]interface{}
 			json.Unmarshal(args, &m)
@@ -678,7 +678,7 @@ func TestToolExecutionInterceptWrapsCallable(t *testing.T) {
 			// Call the next function in the chain
 			result, err := next(modifiedArgs)
 			if err != nil {
-				return nil, err
+				return ToolExecutionInterceptOutcome{}, err
 			}
 
 			// After: modify result
@@ -686,7 +686,7 @@ func TestToolExecutionInterceptWrapsCallable(t *testing.T) {
 			json.Unmarshal(result, &out)
 			out["after_exec"] = true
 			final, _ := json.Marshal(out)
-			return final, nil
+			return ToolExecutionInterceptOutcome{Result: final}, nil
 		},
 	)
 	defer DeregisterToolExecutionIntercept("go_wrap_exec_int")
@@ -720,8 +720,8 @@ func TestToolExecutionInterceptWrapsCallable(t *testing.T) {
 
 func TestToolExecutionInterceptSeesNextError(t *testing.T) {
 	RegisterToolExecutionIntercept("go_wrap_exec_err", 1,
-		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
-			return next(args)
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
+			return toolExecutionOutcome(next(args))
 		},
 	)
 	defer DeregisterToolExecutionIntercept("go_wrap_exec_err")

--- a/go/nemo_relay/tools_test.go
+++ b/go/nemo_relay/tools_test.go
@@ -718,6 +718,111 @@ func TestToolExecutionInterceptWrapsCallable(t *testing.T) {
 	}
 }
 
+func TestToolExecutionInterceptEmitsPendingMarks(t *testing.T) {
+	const (
+		interceptName  = "go_pending_mark_exec"
+		subscriberName = "go_pending_mark_sub"
+		toolName       = "go_pending_mark_tool"
+		markName       = "go.tool.execution"
+	)
+
+	var mu sync.Mutex
+	events := make([]Event, 0, 3)
+	if err := RegisterSubscriber(subscriberName, func(event Event) {
+		mu.Lock()
+		events = append(events, event)
+		mu.Unlock()
+	}); err != nil {
+		t.Fatalf("RegisterSubscriber failed: %v", err)
+	}
+	t.Cleanup(func() { _ = DeregisterSubscriber(subscriberName) })
+
+	category := "custom"
+	if err := RegisterToolExecutionIntercept(
+		interceptName,
+		1,
+		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {
+			result, err := next(args)
+			if err != nil {
+				return ToolExecutionInterceptOutcome{}, err
+			}
+			return ToolExecutionInterceptOutcome{
+				Result: result,
+				PendingMarks: []PendingMarkSpec{{
+					Name:            markName,
+					Category:        &category,
+					CategoryProfile: json.RawMessage(`{"subtype":"go.tool.execution"}`),
+					Data:            json.RawMessage(`{"source":"go"}`),
+					Metadata:        json.RawMessage(`{"fixture":true}`),
+				}},
+			}, nil
+		},
+	); err != nil {
+		t.Fatalf(registerFailed, err)
+	}
+	t.Cleanup(func() { _ = DeregisterToolExecutionIntercept(interceptName) })
+
+	result, err := ToolCallExecute(
+		toolName,
+		json.RawMessage(`{"value":42}`),
+		func(args json.RawMessage) (json.RawMessage, error) { return args, nil },
+	)
+	if err != nil {
+		t.Fatalf(toolCallExecuteFailed, err)
+	}
+	var applicationResult map[string]any
+	if err := json.Unmarshal(result, &applicationResult); err != nil {
+		t.Fatalf("decode tool result: %v", err)
+	}
+	if applicationResult["value"] != float64(42) {
+		t.Fatalf("unexpected tool result: %s", result)
+	}
+	if _, leaked := applicationResult["pending_marks"]; leaked {
+		t.Fatalf("pending marks leaked into tool result: %s", result)
+	}
+
+	if err := FlushSubscribers(); err != nil {
+		t.Fatalf(toolFlushSubscribersFailed, err)
+	}
+	mu.Lock()
+	captured := append([]Event(nil), events...)
+	mu.Unlock()
+
+	startIndex, endIndex, markIndex := -1, -1, -1
+	var start, mark Event
+	for index, event := range captured {
+		switch {
+		case event.Name() == toolName && event.Kind() == "scope" && event.ScopeCategory() == "start":
+			startIndex, start = index, event
+		case event.Name() == toolName && event.Kind() == "scope" && event.ScopeCategory() == "end":
+			endIndex = index
+		case event.Name() == markName && event.Kind() == "mark":
+			markIndex, mark = index, event
+		}
+	}
+	if startIndex < 0 || endIndex < 0 || markIndex < 0 {
+		t.Fatalf("missing lifecycle events: start=%d end=%d mark=%d", startIndex, endIndex, markIndex)
+	}
+	if !(startIndex < endIndex && endIndex < markIndex) {
+		t.Fatalf("unexpected lifecycle order: start=%d end=%d mark=%d", startIndex, endIndex, markIndex)
+	}
+	if mark.ParentUUID() != start.UUID() {
+		t.Fatalf("mark parent %q does not match tool UUID %q", mark.ParentUUID(), start.UUID())
+	}
+	if mark.Category() != category {
+		t.Fatalf("mark category = %q, expected %q", mark.Category(), category)
+	}
+	assertJSONFieldString(t, mark.CategoryProfile(), "subtype", "go.tool.execution")
+	assertJSONFieldString(t, mark.Data(), "source", "go")
+	var metadata map[string]any
+	if err := json.Unmarshal(mark.Metadata(), &metadata); err != nil {
+		t.Fatalf("decode mark metadata: %v", err)
+	}
+	if metadata["fixture"] != true {
+		t.Fatalf("unexpected mark metadata: %s", mark.Metadata())
+	}
+}
+
 func TestToolExecutionInterceptSeesNextError(t *testing.T) {
 	RegisterToolExecutionIntercept("go_wrap_exec_err", 1,
 		func(args json.RawMessage, next func(json.RawMessage) (json.RawMessage, error)) (ToolExecutionInterceptOutcome, error) {

--- a/python/nemo_relay/__init__.py
+++ b/python/nemo_relay/__init__.py
@@ -111,6 +111,7 @@ from nemo_relay._native import (
     ScopeStack,
     ScopeType,
     ToolAttributes,
+    ToolExecutionInterceptOutcome,
     ToolHandle,
 )
 from nemo_relay._native import create_scope_stack as _create_scope_stack
@@ -164,7 +165,7 @@ ToolRequestIntercept: TypeAlias = AbcCallable[[str, Json], Json]
 #: next callable. It may await and return ``next(args)`` or short-circuit.
 ToolExecutionIntercept: TypeAlias = Callable[
     [str, Json, Callable[[Json], Awaitable[Json]]],
-    Json | Awaitable[Json],
+    ToolExecutionInterceptOutcome | Awaitable[ToolExecutionInterceptOutcome],
 ]
 #: Request intercept callback that returns the canonical request, annotation,
 #: and pending-mark outcome passed to later intercepts and managed execution.
@@ -458,6 +459,7 @@ __all__ = [
     "MarkEvent",
     "ScopeHandle",
     "ToolHandle",
+    "ToolExecutionInterceptOutcome",
     "LLMHandle",
     "LLMRequest",
     "LLMRequestInterceptOutcome",

--- a/python/nemo_relay/__init__.pyi
+++ b/python/nemo_relay/__init__.pyi
@@ -109,6 +109,9 @@ from nemo_relay._native import (
     ToolAttributes as ToolAttributes,
 )
 from nemo_relay._native import (
+    ToolExecutionInterceptOutcome as ToolExecutionInterceptOutcome,
+)
+from nemo_relay._native import (
     ToolHandle as ToolHandle,
 )
 
@@ -199,7 +202,7 @@ Return:
 """
 ToolExecutionIntercept: TypeAlias = Callable[
     [str, Json, Callable[[Json], Awaitable[Json]]],
-    Json | Awaitable[Json],
+    ToolExecutionInterceptOutcome | Awaitable[ToolExecutionInterceptOutcome],
 ]
 """Execution intercept callback that wraps tool execution.
 
@@ -207,7 +210,7 @@ Arguments:
     The tool name, current JSON arguments, and next callable.
 
 Return:
-    A JSON-compatible result, either directly or as an awaitable.
+    A canonical tool execution outcome, either directly or as an awaitable.
 
 Exceptional flow:
     The callback may short-circuit by not invoking ``next``. Exceptions

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -383,7 +383,7 @@ class LLMRequest:
         ...
 
 class PendingMarkSpec:
-    """A runtime-owned mark specification returned by request middleware."""
+    """A runtime-owned mark specification returned by lifecycle middleware."""
     def __init__(
         self,
         name: str,
@@ -415,6 +415,18 @@ class LLMRequestInterceptOutcome:
     def request(self) -> LLMRequest: ...
     @property
     def annotated_request(self) -> Optional[AnnotatedLLMRequest]: ...
+    @property
+    def pending_marks(self) -> list[PendingMarkSpec]: ...
+
+class ToolExecutionInterceptOutcome:
+    """Canonical result returned by a tool execution intercept."""
+    def __init__(
+        self,
+        result: _Json,
+        pending_marks: list[PendingMarkSpec] = ...,
+    ) -> None: ...
+    @property
+    def result(self) -> _Json: ...
     @property
     def pending_marks(self) -> list[PendingMarkSpec]: ...
 

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -419,7 +419,12 @@ class LLMRequestInterceptOutcome:
     def pending_marks(self) -> list[PendingMarkSpec]: ...
 
 class ToolExecutionInterceptOutcome:
-    """Canonical result returned by a tool execution intercept."""
+    """Canonical result returned by a tool execution intercept.
+
+    ``result`` is passed to the remaining middleware and application.
+    ``pending_marks`` are Relay-owned lifecycle metadata emitted after the
+    tool-end event and are not included in the application-visible result.
+    """
     def __init__(
         self,
         result: _Json,

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -1757,7 +1757,10 @@ def register_tool_execution_intercept(name: str, priority: int, callable: _ToolE
     Args:
         name: Unique intercept name.
         priority: Execution order; lower values run first.
-        callable: Middleware callback that may call or short-circuit ``next``.
+        callable: Middleware callback returning
+            ``ToolExecutionInterceptOutcome``. It may call or short-circuit
+            ``next``; ``next`` resolves to the raw downstream result while
+            Relay retains downstream pending marks.
 
     Returns:
         ``None``.
@@ -1987,7 +1990,10 @@ def scope_register_tool_execution_intercept(
         scope_uuid: UUID of the owning scope.
         name: Unique intercept name within that scope.
         priority: Execution order; lower values run first.
-        callable: Middleware callback used while the owning scope is active.
+        callable: Middleware callback returning
+            ``ToolExecutionInterceptOutcome`` while the owning scope is active.
+            Its ``next`` continuation resolves to the raw downstream result
+            while Relay retains downstream pending marks.
 
     Returns:
         ``None``.

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -38,7 +38,7 @@ _LlmConditionalExecutionGuardrail: TypeAlias = Callable[["LLMRequest"], Optional
 _ToolRequestIntercept: TypeAlias = Callable[[str, _Json], _Json]
 _ToolExecutionIntercept: TypeAlias = Callable[
     [str, _Json, Callable[[_Json], Awaitable[_Json]]],
-    _Json | Awaitable[_Json],
+    "ToolExecutionInterceptOutcome | Awaitable[ToolExecutionInterceptOutcome]",
 ]
 _LlmRequestIntercept: TypeAlias = Callable[
     [str, "LLMRequest", "AnnotatedLLMRequest | None"],

--- a/python/nemo_relay/intercepts.py
+++ b/python/nemo_relay/intercepts.py
@@ -128,6 +128,7 @@ def register_tool_execution(name: str, priority: int, fn: ToolExecutionIntercept
         fn: Callable invoked as ``fn(tool_name, args, next_call)``. The
             callback may await or call ``next_call(args)`` to continue the
             chain, modify the result, or bypass downstream execution entirely.
+            It must return ``ToolExecutionInterceptOutcome``.
 
     Returns:
         None: This function returns after the intercept is registered.

--- a/python/nemo_relay/scope_local.py
+++ b/python/nemo_relay/scope_local.py
@@ -271,7 +271,8 @@ def register_tool_execution(scope_handle, name, priority, fn):
         priority: Execution order for the intercept. Lower values run first.
         fn: Callable invoked as ``fn(tool_name, args, next_call)``. It may call
             ``next_call(args)`` to continue execution, modify the result, or
-            short-circuit the tool call entirely.
+            short-circuit the tool call entirely. It must return
+            ``ToolExecutionInterceptOutcome``.
 
     Returns:
         None: This function returns after the scope-local intercept is

--- a/python/plugin/src/nemo_relay_plugin/__init__.py
+++ b/python/plugin/src/nemo_relay_plugin/__init__.py
@@ -21,8 +21,9 @@ Public data types:
     LlmRequest: A Relay LLM request represented as a JSON object.
     AnnotatedLlmRequest: An annotated Relay LLM request represented as a JSON
         object.
-    PendingMarkSpec: A mark Relay emits under the future managed LLM scope.
+    PendingMarkSpec: A mark Relay emits under its managed lifecycle scope.
     LlmRequestInterceptOutcome: Canonical LLM request-intercept result.
+    ToolExecutionInterceptOutcome: Canonical tool execution-intercept result.
     DiagnosticLevel: Severity of a configuration diagnostic.
     ConfigDiagnostic: Structured configuration warning or error.
     ScopeType: Semantic category for a Relay execution scope.
@@ -76,6 +77,7 @@ from ._api import (
     SubscriberCallback,
     ToolConditionalCallback,
     ToolExecutionCallback,
+    ToolExecutionInterceptOutcome,
     ToolNext,
     ToolRequestCallback,
     ToolSanitizeCallback,
@@ -107,6 +109,7 @@ __all__ = [
     "SubscriberCallback",
     "ToolConditionalCallback",
     "ToolExecutionCallback",
+    "ToolExecutionInterceptOutcome",
     "ToolNext",
     "ToolRequestCallback",
     "ToolSanitizeCallback",

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -16,7 +16,7 @@ Public data types:
     LlmRequest: A Relay LLM request represented as a JSON object.
     AnnotatedLlmRequest: An annotated Relay LLM request represented as a JSON
         object.
-    PendingMarkSpec: A mark Relay emits under the future managed LLM scope.
+    PendingMarkSpec: A mark Relay emits under its managed lifecycle scope.
     LlmRequestInterceptOutcome: Canonical LLM request-intercept result.
     DiagnosticLevel: Severity of a configuration diagnostic.
     ConfigDiagnostic: Structured configuration warning or error.
@@ -91,6 +91,7 @@ EVENT_SCHEMA = "nemo.relay.Event@1"
 LLM_REQUEST_SCHEMA = "nemo.relay.LlmRequest@1"
 ANNOTATED_LLM_REQUEST_SCHEMA = "nemo.relay.AnnotatedLlmRequest@1"
 LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA = "nemo.relay.LlmRequestInterceptOutcome@1"
+TOOL_EXECUTION_INTERCEPT_OUTCOME_SCHEMA = "nemo.relay.ToolExecutionInterceptOutcome@1"
 PLUGIN_DIAGNOSTICS_SCHEMA = "nemo.relay.PluginDiagnostics@1"
 _OBJECT_SCHEMAS = frozenset(
     {
@@ -98,6 +99,7 @@ _OBJECT_SCHEMAS = frozenset(
         LLM_REQUEST_SCHEMA,
         ANNOTATED_LLM_REQUEST_SCHEMA,
         LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA,
+        TOOL_EXECUTION_INTERCEPT_OUTCOME_SCHEMA,
     }
 )
 _UNREGISTERED = object()
@@ -183,7 +185,7 @@ class ConfigDiagnostic:
 
 @dataclass(slots=True)
 class PendingMarkSpec:
-    """Describe a mark Relay emits after starting a managed LLM call."""
+    """Describe a mark Relay emits under a managed lifecycle scope."""
 
     name: str
     category: str | None = None
@@ -220,6 +222,28 @@ class LlmRequestInterceptOutcome:
         return {
             "request": self.request,
             "annotated_request": self.annotated_request,
+            "pending_marks": marks,
+        }
+
+
+@dataclass(slots=True)
+class ToolExecutionInterceptOutcome:
+    """Canonical result returned by a Python worker tool execution intercept."""
+
+    result: Json
+    pending_marks: list[PendingMarkSpec] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Json]:
+        """Convert this outcome to the canonical worker-envelope payload."""
+        marks = []
+        for mark in self.pending_marks:
+            if not isinstance(mark, PendingMarkSpec):
+                raise WorkerSdkError(
+                    "tool execution intercept outcome pending_marks must contain PendingMarkSpec values"
+                )
+            marks.append(mark.to_json())
+        return {
+            "result": self.result,
             "pending_marks": marks,
         }
 
@@ -372,7 +396,10 @@ SubscriberCallback: TypeAlias = Callable[[Event], None | Awaitable[None]]
 ToolSanitizeCallback: TypeAlias = Callable[[str, Json], Json | Awaitable[Json]]
 ToolConditionalCallback: TypeAlias = Callable[[str, Json], str | None | Awaitable[str | None]]
 ToolRequestCallback: TypeAlias = Callable[[str, Json], Json | Awaitable[Json]]
-ToolExecutionCallback: TypeAlias = Callable[[str, Json, "ToolNext"], Json | Awaitable[Json]]
+ToolExecutionCallback: TypeAlias = Callable[
+    [str, Json, "ToolNext"],
+    ToolExecutionInterceptOutcome | Awaitable[ToolExecutionInterceptOutcome],
+]
 LlmSanitizeRequestCallback: TypeAlias = Callable[[LlmRequest], LlmRequest | Awaitable[LlmRequest]]
 LlmSanitizeResponseCallback: TypeAlias = Callable[[Json], Json | Awaitable[Json]]
 LlmConditionalCallback: TypeAlias = Callable[[LlmRequest], str | None | Awaitable[str | None]]
@@ -565,9 +592,9 @@ class PluginContext:
         Args:
             name: Component-local registration name.
             callback: Function receiving ``(tool_name, arguments, next_call)``
-                and returning the tool result as JSON, directly or through an
-                awaitable. It can call :meth:`ToolNext.call` zero, one, or
-                multiple times while the invocation is active.
+                and returning :class:`ToolExecutionInterceptOutcome`, directly
+                or through an awaitable. It can call :meth:`ToolNext.call`
+                zero, one, or multiple times while the invocation is active.
             priority: Execution order. Lower values run first.
         """
         self._push_registration(name, pb.TOOL_EXECUTION_INTERCEPT, priority, False)
@@ -1437,7 +1464,16 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
                         ToolNext(self._runtime, request.continuation_id),
                     )
                 )
-                return _json_response(result)
+                if not isinstance(result, ToolExecutionInterceptOutcome):
+                    raise WorkerSdkError("tool execution intercept must return ToolExecutionInterceptOutcome")
+                return pb.InvokeResponse(
+                    tool_execution=pb.ToolExecutionInterceptResult(
+                        outcome=_json_envelope(
+                            TOOL_EXECUTION_INTERCEPT_OUTCOME_SCHEMA,
+                            result.to_json(),
+                        ),
+                    )
+                )
             if request.surface == pb.LLM_SANITIZE_REQUEST_GUARDRAIL:
                 return _json_response(
                     await _maybe_await(

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -1590,6 +1590,7 @@ async def test_cancel_invocation_stops_active_async_callback_and_is_idempotent()
                     cancelled.set()
                     await release.wait()
                     raise
+                raise AssertionError("unreachable")
 
             ctx.register_tool_execution_intercept("cancel", tool_execution)
 

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -32,6 +32,7 @@ from nemo_relay_plugin import (  # noqa: E402
     PluginContext,
     PluginRuntime,
     ScopeType,
+    ToolExecutionInterceptOutcome,
     ToolNext,
     WorkerPlugin,
     WorkerSdkError,
@@ -44,6 +45,7 @@ from nemo_relay_plugin._api import (  # noqa: E402
     JSON_SCHEMA,
     LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA,
     LLM_REQUEST_SCHEMA,
+    TOOL_EXECUTION_INTERCEPT_OUTCOME_SCHEMA,
     WORKER_PROTOCOL,
     _announced_worker_endpoint,
     _decode_required_envelope,
@@ -192,9 +194,12 @@ class AllSurfacesPlugin(WorkerPlugin):
         async def tool_request(name: str, value: Json) -> Json:
             return _tag(value, f"request_{name}")
 
-        async def tool_execution(name: str, value: Json, next_call: ToolNext) -> Json:
+        async def tool_execution(name: str, value: Json, next_call: ToolNext) -> ToolExecutionInterceptOutcome:
             result = await next_call.call(_tag(value, f"execute_{name}"))
-            return _tag(result, "tool_execution")
+            return ToolExecutionInterceptOutcome(
+                result=_tag(result, "tool_execution"),
+                pending_marks=[PendingMarkSpec("worker.tool.execution")],
+            )
 
         def llm_sanitize_request(request: Json) -> Json:
             return _tag_llm_request(request, "llm_sanitize_request")
@@ -905,9 +910,10 @@ async def test_unary_invoke_success_paths(service: _WorkerService, host_stub: Re
 
     tool_request = await _invoke_json_async(service, "tool_request", pb.TOOL_REQUEST_INTERCEPT)
     assert tool_request["tag"] == "request_lookup"
-    tool_execution = await _invoke_json_async(service, "tool_execution", pb.TOOL_EXECUTION_INTERCEPT)
-    assert tool_execution["tag"] == "tool_execution"
-    assert tool_execution["next_tool"]["tag"] == "execute_lookup"
+    tool_execution = await _invoke_tool_execution_async(service, "tool_execution")
+    assert tool_execution["result"]["tag"] == "tool_execution"
+    assert tool_execution["result"]["next_tool"]["tag"] == "execute_lookup"
+    assert tool_execution["pending_marks"][0]["name"] == "worker.tool.execution"
 
     llm_sanitize_request = await _invoke_json_async(
         service,
@@ -1064,6 +1070,30 @@ async def test_llm_request_intercept_rejects_non_object_typed_results(invalid_pa
 
     assert response.WhichOneof("result") == "error"
     assert "must be a JSON object" in response.error.message
+
+
+async def test_tool_execution_intercept_rejects_legacy_raw_result():
+    class LegacyResultPlugin(WorkerPlugin):
+        plugin_id = "tests.legacy_tool_execution_result"
+
+        def register(self, ctx: PluginContext, config: Json) -> None:
+            del config
+
+            def legacy_result(name: str, value: Json, next_call: ToolNext) -> Any:
+                del name, value, next_call
+                return {"legacy_result": True}
+
+            ctx.register_tool_execution_intercept("legacy", legacy_result)
+
+    service = _service(LegacyResultPlugin(), RecordingHostStub())
+    await _register(service)
+    response = await service.Invoke(
+        _tool_request("legacy", pb.TOOL_EXECUTION_INTERCEPT, {}),
+        AbortContext(),
+    )
+
+    assert response.WhichOneof("result") == "error"
+    assert "must return ToolExecutionInterceptOutcome" in response.error.message
 
 
 @pytest.mark.parametrize(
@@ -1551,7 +1581,7 @@ async def test_cancel_invocation_stops_active_async_callback_and_is_idempotent()
         def register(self, ctx: PluginContext, config: Json) -> None:
             del config
 
-            async def tool_execution(tool_name: str, value: Json, next_call: ToolNext) -> Json:
+            async def tool_execution(tool_name: str, value: Json, next_call: ToolNext) -> ToolExecutionInterceptOutcome:
                 del tool_name, value, next_call
                 started.set()
                 try:
@@ -2249,6 +2279,19 @@ async def _invoke_json_async(
     response = await service.Invoke(request, AbortContext())
     assert response.WhichOneof("result") == "json", response
     return _envelope_value(response.json.value)
+
+
+async def _invoke_tool_execution_async(
+    service: _WorkerService,
+    registration_name: str,
+) -> Json:
+    response = await service.Invoke(
+        _tool_request(registration_name, pb.TOOL_EXECUTION_INTERCEPT, {"query": "relay"}),
+        AbortContext(),
+    )
+    assert response.WhichOneof("result") == "tool_execution", response
+    assert response.tool_execution.outcome.schema == TOOL_EXECUTION_INTERCEPT_OUTCOME_SCHEMA
+    return _envelope_value(response.tool_execution.outcome)
 
 
 def _envelope_value(envelope: Any) -> Json:

--- a/python/tests/test_scope_local.py
+++ b/python/tests/test_scope_local.py
@@ -20,6 +20,7 @@ from nemo_relay import (
     MarkEvent,
     ScopeEvent,
     ScopeType,
+    ToolExecutionInterceptOutcome,
     guardrails,
     llm,
     scope,
@@ -495,7 +496,7 @@ class TestScopeLocalExecutionIntercept:
                 handle,
                 "sl_exec_intercept",
                 1,
-                lambda name, args, next_fn: {"from": "intercept"},
+                lambda name, args, next_fn: ToolExecutionInterceptOutcome({"from": "intercept"}),
             )
             result = await tools.execute("exec_int_tool", {}, my_tool)
 
@@ -517,7 +518,7 @@ class TestScopeLocalExecutionIntercept:
         def intercept_fn(name, args, next_fn):
             # Cannot call next_fn here — it returns a Future.
             args["x"] = args["x"] + 1
-            return {"value": args["x"] * 2, "intercepted": True}
+            return ToolExecutionInterceptOutcome({"value": args["x"] * 2, "intercepted": True})
 
         with scope.scope("exec_next_scope", ScopeType.Agent) as handle:
             scope_local.register_tool_execution(handle, "sl_exec_next", 1, intercept_fn)
@@ -593,7 +594,12 @@ class TestScopeLocalLlmWrappers:
             scope_local.register_tool_request(handle, "sl_tool_req_cov", 1, False, lambda name, args: args)
             assert scope_local.deregister_tool_request(handle, "sl_tool_req_cov") is True
 
-            scope_local.register_tool_execution(handle, "sl_tool_exec_cov", 1, lambda name, args, next_fn: args)
+            scope_local.register_tool_execution(
+                handle,
+                "sl_tool_exec_cov",
+                1,
+                lambda name, args, next_fn: ToolExecutionInterceptOutcome(args),
+            )
             assert scope_local.deregister_tool_execution(handle, "sl_tool_exec_cov") is True
 
             scope_local.register_llm_sanitize_request(handle, "sl_llm_req_cov", 1, lambda req: req)

--- a/python/tests/test_tools.py
+++ b/python/tests/test_tools.py
@@ -375,7 +375,7 @@ class TestToolInterceptsAsync:
         intercepts.register_tool_execution(
             "py_exec_legacy",
             1,
-            lambda name, args, next: {"legacy_result": True},
+            lambda name, args, next: {"legacy_result": True},  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
         )
         try:
             with pytest.raises(RuntimeError, match="must return ToolExecutionInterceptOutcome"):

--- a/python/tests/test_tools.py
+++ b/python/tests/test_tools.py
@@ -8,9 +8,12 @@ from typing import cast
 import pytest
 
 from nemo_relay import (
+    MarkEvent,
+    PendingMarkSpec,
     ScopeEvent,
     ScopeType,
     ToolAttributes,
+    ToolExecutionInterceptOutcome,
     ToolHandle,
     guardrails,
     intercepts,
@@ -274,7 +277,7 @@ class TestToolIntercepts:
         intercepts.register_tool_execution(
             "py_exec_int",
             1,
-            lambda name, args, next: {"intercepted": True},
+            lambda name, args, next: ToolExecutionInterceptOutcome({"intercepted": True}),
         )
         assert intercepts.deregister_tool_execution("py_exec_int")
 
@@ -327,7 +330,7 @@ class TestToolInterceptsAsync:
         intercepts.register_tool_execution(
             "py_exec_replace",
             1,
-            lambda name, args, next: {"from_intercept": True},
+            lambda name, args, next: ToolExecutionInterceptOutcome({"from_intercept": True}),
         )
 
         def original_func(args):
@@ -340,12 +343,15 @@ class TestToolInterceptsAsync:
         intercepts.deregister_tool_execution("py_exec_replace")
 
     async def test_execution_intercept_can_await_next(self):
+        events = []
+
         async def middleware(name, args, next):
             result = await next({"value": args["value"] + 1})
             result["from_intercept"] = True
-            return result
+            return ToolExecutionInterceptOutcome(result, [PendingMarkSpec("python.tool.execution")])
 
         intercepts.register_tool_execution("py_exec_next", 1, middleware)
+        subscribers.register("py_exec_mark_sub", lambda event: events.append(event))
 
         def original(args):
             return {"value": args["value"] * 2}
@@ -353,8 +359,29 @@ class TestToolInterceptsAsync:
         try:
             result = await tools.execute("next_tool", {"value": 2}, original)
             assert result == {"value": 6, "from_intercept": True}
+            subscribers.flush()
+            start = _tool_event(events, "next_tool", "start")
+            end = _tool_event(events, "next_tool", "end")
+            mark = next(
+                event for event in events if isinstance(event, MarkEvent) and event.name == "python.tool.execution"
+            )
+            assert mark.parent_uuid == start.uuid
+            assert events.index(end) < events.index(mark)
         finally:
             intercepts.deregister_tool_execution("py_exec_next")
+            subscribers.deregister("py_exec_mark_sub")
+
+    async def test_execution_intercept_rejects_legacy_raw_result(self):
+        intercepts.register_tool_execution(
+            "py_exec_legacy",
+            1,
+            lambda name, args, next: {"legacy_result": True},
+        )
+        try:
+            with pytest.raises(RuntimeError, match="must return ToolExecutionInterceptOutcome"):
+                await tools.execute("legacy_tool", {}, lambda args: args)
+        finally:
+            intercepts.deregister_tool_execution("py_exec_legacy")
 
     async def test_request_intercept_break_chain(self):
         def first_fn(name, args):


### PR DESCRIPTION
## Summary

- make `ToolExecutionInterceptOutcome` the canonical return type for every registered tool execution intercept
- keep the default tool callable and `next(args)` continuation as raw JSON while Relay retains downstream pending marks
- use the existing global, scope-local, and plugin registration paths without a mark-specific registration API
- emit ordered pending marks after the managed tool end event, parented to the Relay-owned tool UUID
- carry the same contract through native plugins, `grpc-v1` workers, C, Go, Python, and Node

## Motivation

Tool execution intercepts only learn the final result after execution, while Relay owns the managed tool lifecycle and its UUID. Returning a canonical outcome keeps plugin control data separate from the application-visible tool result and lets Relay materialize marks with correct parentage.

This follows the outcome-return convention already used by LLM request intercepts instead of introducing a second registration family or an implementation-specific callback variant.

## Behavior

- applications and sanitize-response guardrails receive only `outcome.result`
- successful calls emit the tool end event first, followed by pending marks in effective middleware order
- marks retain category, category profile, data, and metadata
- repeated concurrent `next(...)` calls preserve invocation order rather than completion order
- execution errors discard accumulated marks
- the subscriber snapshot taken at tool start is reused for the end event and pending marks
- legacy raw intercept results are rejected at public and dynamic-plugin boundaries

## Boundary contracts

- Rust and native plugins return `ToolExecutionInterceptOutcome`
- `grpc-v1` workers return a `ToolExecutionInterceptResult` containing the exact `nemo.relay.ToolExecutionInterceptOutcome@1` envelope
- C callbacks return JSON with `result` and optional `pending_marks`
- Go callbacks return `ToolExecutionInterceptOutcome`
- Python callbacks return `ToolExecutionInterceptOutcome`
- Node callbacks return `{ result, pendingMarks? }`

## Breaking changes

- every registered tool execution intercept must return the canonical outcome type
- the raw default tool callable and raw `next(args)` result are unchanged
- existing registration names are unchanged; there is no parallel outcome-specific registration path
- native plugins, workers, and language bindings must rebuild against current `main`

## Validation

- `cargo test --workspace --all-targets -- --test-threads=1`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- native plugin SDK: 53 tests passed
- worker SDK: 11 tests passed
- Node: 246 tests passed
- Python: 496 tests passed, 39 optional-integration tests skipped
- Go: `go test ./...` and `go vet ./...`
- Ruff checks and formatting
- `git diff --check`

## Documentation

No documentation changes are included. Follow-up documentation remains in #341.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool execution intercepts now return a typed, structured outcome containing `result` plus optional `pendingMarks`, with consistent support across Rust, Node, Python, Go, and the worker SDK.
  * Pending marks are emitted and associated deterministically with the correct tool execution lifecycle events.
* **Bug Fixes**
  * Improved propagation/merging of downstream pending marks for pass-through, chaining, and global+scope-local flows.
  * Rejections for legacy, malformed, or nonconforming outcomes are clearer; event ordering/parent-child relationships are corrected.
* **Documentation**
  * Updated API docs and type definitions to reflect the new outcome contract and `pendingMarks` timing semantics.
* **Tests**
  * Expanded and adjusted coverage for the new typed outcome and mark-emission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
