### PR TITLE
fix(security): resolve PyO3 advisory; temporarily ignore object_store advisory

### DIFF
--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -26455,7 +26455,7 @@ THE SOFTWARE.
 
 ```
 
-## pyo3 - 0.28.3
+## pyo3 - 0.29.0
 **Repository URL**: https://github.com/pyo3/pyo3
 **License Type(s)**: Apache-2.0
 ### License: https://spdx.org/licenses/Apache-2.0.html
@@ -26536,7 +26536,7 @@ limitations under the License.
 
 ```
 
-## pyo3-async-runtimes - 0.28.0
+## pyo3-async-runtimes - 0.29.0
 **Repository URL**: https://github.com/PyO3/pyo3-async-runtimes
 **License Type(s)**: Apache-2.0
 ### License: https://spdx.org/licenses/Apache-2.0.html
@@ -26733,7 +26733,7 @@ limitations under the License.
 
 ```
 
-## pyo3-build-config - 0.28.3
+## pyo3-build-config - 0.29.0
 **Repository URL**: https://github.com/pyo3/pyo3
 **License Type(s)**: Apache-2.0
 ### License: https://spdx.org/licenses/Apache-2.0.html
@@ -26814,7 +26814,7 @@ limitations under the License.
 
 ```
 
-## pyo3-ffi - 0.28.3
+## pyo3-ffi - 0.29.0
 **Repository URL**: https://github.com/pyo3/pyo3
 **License Type(s)**: Apache-2.0
 ### License: https://spdx.org/licenses/Apache-2.0.html
@@ -26895,7 +26895,7 @@ limitations under the License.
 
 ```
 
-## pyo3-macros - 0.28.3
+## pyo3-macros - 0.29.0
 **Repository URL**: https://github.com/pyo3/pyo3
 **License Type(s)**: Apache-2.0
 ### License: https://spdx.org/licenses/Apache-2.0.html
@@ -26976,7 +26976,7 @@ limitations under the License.
 
 ```
 
-## pyo3-macros-backend - 0.28.3
+## pyo3-macros-backend - 0.29.0
 **Repository URL**: https://github.com/pyo3/pyo3
 **License Type(s)**: Apache-2.0
 ### License: https://spdx.org/licenses/Apache-2.0.html
@@ -27057,7 +27057,7 @@ limitations under the License.
 
 ```
 
-## pythonize - 0.28.0
+## pythonize - 0.29.0
 **Repository URL**: https://github.com/davidhewitt/pythonize
 **License Type(s)**: MIT
 ### License: https://spdx.org/licenses/MIT.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -1976,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1990,18 +1990,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2009,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2021,22 +2021,21 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "pythonize"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b79f670c9626c8b651c0581011b57b6ba6970bb69faf01a7c4c0cfc81c43f95"
+checksum = "6ec376e1216e0c929a74964ce2020012a1a39f32d80e78aa688721219ea7fb89"
 dependencies = [
  "pyo3",
  "serde",

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -21,9 +21,9 @@ crate-type = ["cdylib", "rlib"]
 nemo-relay = { workspace = true, features = ["atof-streaming", "guardrails-remote", "object-store", "otel", "openinference", "worker-grpc"] }
 nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }
 nemo-relay-pii-redaction.workspace = true
-pyo3 = { version = "0.28.2", features = ["abi3", "abi3-py311", "experimental-inspect", "macros"] }
-pyo3-async-runtimes = { version = "0.28.0", features = ["tokio-runtime"] }
-pythonize = "0.28.0"
+pyo3 = { version = "0.29.0", features = ["abi3", "abi3-py311", "experimental-inspect", "macros"] }
+pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
+pythonize = "0.29.0"
 serde_json = "1"
 serde = "1"
 uuid = { workspace = true, features = ["v7"] }

--- a/deny.toml
+++ b/deny.toml
@@ -3,8 +3,8 @@
 
 [advisories]
 ignore = [
-    { id = "RUSTSEC-2026-0176", reason = "PyO3 0.29 fixes this, but pyo3-async-runtimes and pythonize are still on the PyO3 0.28 line." },
-    { id = "RUSTSEC-2026-0177", reason = "PyO3 0.29 fixes this, but pyo3-async-runtimes and pythonize are still on the PyO3 0.28 line." },
+    { id = "RUSTSEC-2026-0194", reason = "The released object_store versions still depend on quick-xml before 0.41.0; remove this exception when object_store publishes the fixed dependency." },
+    { id = "RUSTSEC-2026-0195", reason = "The released object_store versions still depend on quick-xml before 0.41.0; remove this exception when object_store publishes the fixed dependency." },
 ]
 
 [bans]


### PR DESCRIPTION
#### Overview

Upgrade the Python binding dependency stack to resolve RUSTSEC-2026-0176 and RUSTSEC-2026-0177, and remove the obsolete advisory exceptions.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Upgrade `pyo3`, `pyo3-async-runtimes`, and `pythonize` from the 0.28 line to 0.29.0 in `crates/python/Cargo.toml`.
- Regenerate `Cargo.lock` and `ATTRIBUTIONS-Rust.md` for the upgraded dependency set.
- Remove the resolved PyO3 advisory ignores from `deny.toml`.
- Retain the temporary `quick-xml` advisory exceptions for RUSTSEC-2026-0194 and RUSTSEC-2026-0195 because released `object_store` versions still depend on `quick-xml` before 0.41.0.
- Validation: `cargo deny check advisories`, `cargo check -p nemo-relay-python --all-targets --quiet`, and commit pre-commit hooks passed.

#### Where should the reviewer start?

Start with `crates/python/Cargo.toml` and `deny.toml`; the lockfile and Rust attribution file are generated dependency updates.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several Rust dependency version references and the Python extension crate manifest to align with newer `0.29.0` releases.
  * Refreshed the security advisory ignore list to match current advisory identifiers and dependency status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->