### PR TITLE
refactor: use reqwest rustls provider defaults

### DIFF
--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -9710,6 +9710,250 @@ limitations under the License.
 
 ```
 
+## encoding_rs - 0.8.35
+**Repository URL**: https://github.com/hsivonen/encoding_rs
+**License Type(s)**: Apache-2.0
+### License: https://spdx.org/licenses/Apache-2.0.html
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+
+## encoding_rs - 0.8.35
+**Repository URL**: https://github.com/hsivonen/encoding_rs
+**License Type(s)**: BSD-3-Clause
+### License: https://spdx.org/licenses/BSD-3-Clause.html
+```
+Copyright © WHATWG (Apple, Google, Mozilla, Microsoft).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+
 ## equivalent - 1.0.2
 **Repository URL**: https://github.com/indexmap-rs/equivalent
 **License Type(s)**: Apache-2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,7 +1344,6 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "reqwest",
- "rustls",
  "schemars",
  "semver",
  "serde",
@@ -1395,7 +1403,6 @@ dependencies = [
  "opentelemetry_sdk",
  "reqwest",
  "ring",
- "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2247,6 +2254,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2259,6 +2267,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,9 +39,8 @@ futures-util = "0.3"
 http = "1"
 http-body-util = "0.1"
 dialoguer = { version = "0.11", default-features = false }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots-no-provider", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls-native-roots", "stream"] }
 ring = "0.17"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -906,7 +906,6 @@ async fn probe_atof_http_upload(
     index: usize,
     transport: &str,
 ) -> Check {
-    crate::tls::install_rustls_crypto_provider();
     let client = match reqwest::Client::builder().timeout(timeout_duration).build() {
         Ok(client) => client,
         Err(err) => {
@@ -1094,7 +1093,6 @@ fn check_dir_writable(dir: &Path) -> Result<(), std::io::Error> {
 }
 
 async fn probe_http_named(name: &'static str, url: &str) -> Check {
-    crate::tls::install_rustls_crypto_provider();
     let client = match reqwest::Client::builder().timeout(NETWORK_TIMEOUT).build() {
         Ok(c) => c,
         Err(err) => {

--- a/crates/cli/src/installer.rs
+++ b/crates/cli/src/installer.rs
@@ -112,7 +112,6 @@ async fn send_hook_forward_request(
     url: String,
     input: String,
 ) -> Result<Result<reqwest::Response, reqwest::Error>, CliError> {
-    crate::tls::install_rustls_crypto_provider();
     Ok(reqwest::Client::builder()
         .timeout(HOOK_FORWARD_TIMEOUT)
         .build()?

--- a/crates/cli/src/launcher.rs
+++ b/crates/cli/src/launcher.rs
@@ -746,7 +746,6 @@ fn exit_code(status: std::process::ExitStatus) -> ExitCode {
 // Polls the ephemeral gateway health endpoint for roughly one second before launching the agent.
 // Startup failures return a launcher error so the child command is never run against a dead proxy.
 async fn wait_for_health(gateway_url: &str) -> Result<(), CliError> {
-    crate::tls::install_rustls_crypto_provider();
     let client = Client::new();
     let url = format!("{}/healthz", gateway_url.trim_end_matches('/'));
     for _ in 0..50 {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,7 +22,6 @@ mod plugins;
 mod server;
 mod session;
 mod setup;
-mod tls;
 
 use std::process::ExitCode;
 

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -244,7 +244,6 @@ pub(crate) fn router(config: GatewayConfig) -> Router {
 
 impl AppState {
     fn new(config: GatewayConfig) -> Self {
-        crate::tls::install_rustls_crypto_provider();
         let sessions = SessionManager::new(config.clone());
         sessions.start_idle_sweeper();
         let http = Client::builder()

--- a/crates/cli/src/tls.rs
+++ b/crates/cli/src/tls.rs
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-pub(crate) fn install_rustls_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}

--- a/crates/cli/tests/coverage/gateway_tests.rs
+++ b/crates/cli/tests/coverage/gateway_tests.rs
@@ -13,7 +13,6 @@ use http_body_util::BodyExt;
 use reqwest::Client;
 
 fn test_http_client() -> Client {
-    crate::tls::install_rustls_crypto_provider();
     Client::new()
 }
 

--- a/crates/cli/tests/coverage/server_tests.rs
+++ b/crates/cli/tests/coverage/server_tests.rs
@@ -105,7 +105,6 @@ impl Drop for SubscriberCleanup {
 }
 
 fn test_http_client() -> reqwest::Client {
-    crate::tls::install_rustls_crypto_provider();
     reqwest::Client::new()
 }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,7 +23,6 @@ default = [
 atof-streaming = [
     "dep:futures-util",
     "dep:reqwest",
-    "dep:rustls",
     "dep:tokio-tungstenite",
     "tokio/io-util",
     "tokio/net",
@@ -33,12 +32,10 @@ atof-streaming = [
 schema = ["dep:schemars", "nemo-relay-types/schema"]
 guardrails-remote = [
     "dep:reqwest",
-    "dep:rustls",
 ]
 object-store = [
     "dep:object_store",
     "dep:reqwest",
-    "dep:rustls",
     "tokio/net",
     "tokio/time",
 ]
@@ -47,7 +44,6 @@ otel = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry_sdk",
     "dep:reqwest",
-    "dep:rustls",
     "dep:tonic",
 ]
 openinference = [
@@ -56,7 +52,6 @@ openinference = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry_sdk",
     "dep:reqwest",
-    "dep:rustls",
     "dep:tonic",
 ]
 worker-grpc = [
@@ -98,8 +93,7 @@ libloading = "0.8"
 semver = "1"
 sha2 = "0.11"
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client", "grpc-tonic"], optional = true }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots-no-provider", "stream"], optional = true }
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "rustls-tls-native-roots", "stream"], optional = true }
 tonic = { version = "0.14.1", default-features = false, optional = true }
 object_store = { version = "0.13", default-features = false, features = ["aws"], optional = true }
 tokio-tungstenite = { version = "0.27", default-features = false, features = ["connect", "rustls-tls-native-roots"], optional = true }

--- a/crates/core/src/observability/atof.rs
+++ b/crates/core/src/observability/atof.rs
@@ -608,7 +608,6 @@ fn run_endpoint_worker(
     config: AtofEndpointConfig,
     rx: tokio::sync::mpsc::UnboundedReceiver<EndpointMessage>,
 ) {
-    install_rustls_crypto_provider();
     let runtime = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -626,11 +625,6 @@ fn run_endpoint_worker(
             AtofEndpointTransport::Ndjson => run_ndjson_endpoint(index, config, rx).await,
         }
     });
-}
-
-#[cfg(feature = "atof-streaming")]
-fn install_rustls_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 #[cfg(feature = "atof-streaming")]

--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -285,7 +285,6 @@ impl OpenInferenceSubscriber {
 fn build_tracer_provider(config: &OpenInferenceConfig) -> Result<SdkTracerProvider> {
     let exporter = match config.transport {
         OtlpTransport::HttpBinary => {
-            install_rustls_crypto_provider();
             let mut builder = SpanExporter::builder()
                 .with_http()
                 .with_protocol(Protocol::HttpBinary)
@@ -349,10 +348,6 @@ fn build_tracer_provider(config: &OpenInferenceConfig) -> Result<SdkTracerProvid
     } else {
         Ok(builder.with_simple_exporter(exporter).build())
     }
-}
-
-fn install_rustls_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 fn build_grpc_metadata(headers: &HashMap<String, String>) -> Result<MetadataMap> {

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -280,7 +280,6 @@ impl OpenTelemetrySubscriber {
 fn build_tracer_provider(config: &OpenTelemetryConfig) -> Result<SdkTracerProvider> {
     let exporter = match config.transport {
         OtlpTransport::HttpBinary => {
-            install_rustls_crypto_provider();
             let mut builder = SpanExporter::builder()
                 .with_http()
                 .with_protocol(Protocol::HttpBinary)
@@ -343,10 +342,6 @@ fn build_tracer_provider(config: &OpenTelemetryConfig) -> Result<SdkTracerProvid
     } else {
         Ok(builder.with_simple_exporter(exporter).build())
     }
-}
-
-fn install_rustls_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 fn build_grpc_metadata(headers: &HashMap<String, String>) -> Result<MetadataMap> {

--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -2309,7 +2309,6 @@ impl AtifRemoteStorage {
         std::thread::Builder::new()
             .name("nemo-relay-atif-storage".to_string())
             .spawn(move || {
-                install_rustls_crypto_provider();
                 let runtime = match tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
@@ -2378,7 +2377,6 @@ impl AtifRemoteStorage {
         std::thread::Builder::new()
             .name("nemo-relay-atif-storage".to_string())
             .spawn(move || {
-                install_rustls_crypto_provider();
                 let runtime = match tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
@@ -2559,11 +2557,6 @@ async fn post_atif_http(
             response.status()
         )))
     }
-}
-
-#[cfg(feature = "object-store")]
-fn install_rustls_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 #[cfg(feature = "object-store")]

--- a/crates/core/src/plugins/nemo_guardrails/remote.rs
+++ b/crates/core/src/plugins/nemo_guardrails/remote.rs
@@ -17,7 +17,6 @@ use crate::codec::traits::LlmCodec;
 use crate::error::FlowError;
 use crate::plugin::{PluginError, PluginRegistrationContext, Result as PluginResult};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use rustls::crypto::ring;
 
 use super::{NeMoGuardrailsConfig, RequestDefaultsConfig, RequestRailsConfig};
 
@@ -62,8 +61,6 @@ impl RemoteBackendRuntime {
             })?;
             default_headers.insert(header_name, header_value);
         }
-
-        let _ = ring::default_provider().install_default();
 
         let client = reqwest::Client::builder()
             .default_headers(default_headers)

--- a/crates/core/tests/unit/observability/atof_tests.rs
+++ b/crates/core/tests/unit/observability/atof_tests.rs
@@ -437,7 +437,6 @@ fn endpoint_field_name_policy_preserves_raw_json_and_falls_back_for_invalid_json
 #[test]
 #[cfg(feature = "atof-streaming")]
 fn endpoint_http_helper_edges_are_safe() {
-    install_rustls_crypto_provider();
     assert_eq!(
         AtofEndpointFieldNamePolicy::parse("unknown"),
         None,


### PR DESCRIPTION
#### Overview

Use Reqwest's provider-enabled Rustls feature and remove the manual crypto-provider initialization that was only required by the previous no-provider feature selection.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace `rustls-tls-native-roots-no-provider` with `rustls-tls-native-roots` in the core and CLI.
- Explicitly enable `http2` and `charset`; retain CLI-only `json`; leave compression features disabled.
- Remove the direct Rustls dependencies and all redundant crypto-provider installation helpers.
- Regenerate the Rust attribution file for the new `encoding_rs` dependency.

#### Where should the reviewer start?

Start with `crates/core/Cargo.toml` and `crates/cli/Cargo.toml`, then review the deleted `install_rustls_crypto_provider` call sites.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP client configuration for the CLI and core components, including broader protocol and text handling support.
  * Removed redundant internal setup steps across several startup and network paths.
  * Cleaned up TLS-related wiring and dependency declarations.

* **Documentation**
  * Added attribution and license details for a bundled Rust dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->