### PR TITLE
test: stabilize dynamic worker cleanup lock test

### DIFF
--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -863,18 +863,19 @@ fn invocation_cleanup_releases_host_state_locks_before_unwinding() {
             .expect("scope cleanup lock")
             .iter()
             .any(|handle| Arc::ptr_eq(handle, &stack));
-        if cleanup_registered {
+        if cleanup_registered
+            && state.scope_stacks.try_lock().is_ok()
+            && state.pending_scope_cleanups.try_lock().is_ok()
+        {
             break;
         }
         assert!(
             std::time::Instant::now() < deadline,
-            "scope cleanup should register before unwinding"
+            "scope cleanup should release host state locks before unwinding"
         );
         std::thread::yield_now();
     }
 
-    assert!(state.scope_stacks.try_lock().is_ok());
-    assert!(state.pending_scope_cleanups.try_lock().is_ok());
     drop(stack_guard);
     done_rx
         .recv_timeout(std::time::Duration::from_secs(1))


### PR DESCRIPTION
#### Overview

Stabilize the dynamic worker cleanup lock regression test.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Wait until cleanup registration and both host-state locks are observable as released before allowing scope-stack unwinding. This removes the test's race without changing runtime behavior.

#### Where should the reviewer start?

Review `invocation_cleanup_releases_host_state_locks_before_unwinding` in `crates/core/tests/unit/dynamic_worker_tests.rs`; the existing held stack write lock ensures cleanup cannot unwind before the lock-release assertion passes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup behavior during worker invocation to better ensure resources are released before shutdown, reducing the chance of intermittent failures and improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->