### PR TITLE
test: backfill extraction and telemetry parity coverage

### DIFF
--- a/crates/cli/tests/coverage/adapters_tests.rs
+++ b/crates/cli/tests/coverage/adapters_tests.rs
@@ -1072,3 +1072,479 @@ fn stop_responses_preserve_vendor_shapes() {
     assert!(matches!(codex.events[0], NormalizedEvent::LlmHint(_)));
     assert_eq!(codex.response, json!({}));
 }
+
+#[test]
+fn claude_partial_tool_payload_mixes_native_and_fallback_identifiers() {
+    let outcome = claude_code::adapt(
+        json!({
+            "session_id": "claude-session",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash"
+        }),
+        &HeaderMap::new(),
+    );
+
+    match &outcome.events[0] {
+        NormalizedEvent::ToolStarted(event) => {
+            assert_eq!(event.session_id, "claude-session");
+            assert!(event.tool_call_id.starts_with("tool-"));
+            assert_eq!(event.tool_name, "Bash");
+            assert_eq!(event.arguments, json!(null));
+            assert_eq!(event.result, json!(null));
+            assert_eq!(event.status, None);
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+}
+
+#[test]
+fn codex_partial_tool_end_keeps_missing_fields_null() {
+    let outcome = codex::adapt(
+        json!({
+            "conversationId": "conversation-1",
+            "event": "toolEnded",
+            "tool_call_id": "call-1"
+        }),
+        &HeaderMap::new(),
+    );
+
+    match &outcome.events[0] {
+        NormalizedEvent::ToolEnded(event) => {
+            assert_eq!(event.session_id, "conversation-1");
+            assert_eq!(event.tool_call_id, "call-1");
+            assert_eq!(event.tool_name, "unknown_tool");
+            assert_eq!(event.arguments, json!(null));
+            assert_eq!(event.result, json!(null));
+            assert_eq!(event.status, None);
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+}
+
+#[test]
+fn hermes_partial_post_tool_payload_synthesizes_call_id_only() {
+    let outcome = hermes::adapt(
+        json!({
+            "hook_event_name": "post_tool_call",
+            "session_id": "hermes-session",
+            "tool_name": "terminal"
+        }),
+        &HeaderMap::new(),
+    );
+
+    match &outcome.events[0] {
+        NormalizedEvent::ToolEnded(event) => {
+            assert_eq!(event.session_id, "hermes-session");
+            assert!(event.tool_call_id.starts_with("tool-"));
+            assert_eq!(event.tool_name, "terminal");
+            assert_eq!(event.arguments, json!(null));
+            assert_eq!(event.result, json!(null));
+            assert_eq!(event.status, None);
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+}
+
+#[test]
+fn maps_hermes_post_tool_call_result_and_status_shapes() {
+    let outcome = hermes::adapt(
+        json!({
+            "hook_event_name": "post_tool_call",
+            "session_id": "hermes-session",
+            "tool_call_id": "tool-1",
+            "tool_name": "terminal",
+            "tool_response": { "stdout": "/repo" },
+            "decision": "allow"
+        }),
+        &HeaderMap::new(),
+    );
+
+    match &outcome.events[0] {
+        NormalizedEvent::ToolEnded(event) => {
+            assert_eq!(event.tool_call_id, "tool-1");
+            assert_eq!(event.result, json!({ "stdout": "/repo" }));
+            assert_eq!(event.status.as_deref(), Some("allow"));
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+}
+
+/// Walks a payload-path precedence chain: each step asserts the expected
+/// winner, then removes the winning key (from the payload root, or from its
+/// `extra` object when the first tuple field is true) so the next candidate
+/// takes over. Once every listed key is removed, the extraction must yield
+/// nothing.
+fn assert_string_fallback_chain(
+    payload: &mut serde_json::Value,
+    chain: &[(bool, &str, &str)],
+    extract: impl Fn(&serde_json::Value) -> Option<String>,
+) {
+    for (remove_from_extra, key, expected) in chain {
+        assert_eq!(
+            extract(payload).as_deref(),
+            Some(*expected),
+            "winner before removing `{key}`"
+        );
+        let object = if *remove_from_extra {
+            payload["extra"].as_object_mut().unwrap()
+        } else {
+            payload.as_object_mut().unwrap()
+        };
+        object.remove(*key);
+    }
+    assert_eq!(extract(payload), None, "chain should be exhausted");
+}
+
+#[test]
+fn hermes_tool_result_path_precedence_walks_fallback_chain() {
+    let headers = HeaderMap::new();
+    let mut payload = json!({
+        "tool_output": "from-tool-output",
+        "tool_response": "from-tool-response",
+        "output": "from-output",
+        "result": "from-result",
+        "extra": {
+            "tool_output": "from-extra-tool-output",
+            "result": "from-extra-result"
+        }
+    });
+
+    assert_string_fallback_chain(
+        &mut payload,
+        &[
+            (false, "tool_output", "from-tool-output"),
+            (false, "tool_response", "from-tool-response"),
+            (false, "output", "from-output"),
+            (false, "result", "from-result"),
+            (true, "tool_output", "from-extra-tool-output"),
+            (true, "result", "from-extra-result"),
+        ],
+        |payload| {
+            HERMES_PAYLOAD_EXTRACTOR
+                .tool_call(payload, &headers, "post_tool_call")
+                .result
+                .map(|result| result.as_str().expect("string tool result").to_string())
+        },
+    );
+}
+
+#[test]
+fn hermes_tool_status_prefers_explicit_fields_over_derived_status() {
+    let headers = HeaderMap::new();
+    let mut payload = json!({
+        "status": "success",
+        "decision": "block",
+        "permission": "deny"
+    });
+
+    assert_string_fallback_chain(
+        &mut payload,
+        &[
+            (false, "status", "success"),
+            (false, "decision", "block"),
+            (false, "permission", "deny"),
+        ],
+        |payload| {
+            HERMES_PAYLOAD_EXTRACTOR
+                .tool_call(payload, &headers, "post_tool_call")
+                .status
+        },
+    );
+
+    // Explicit status fields win over event-name-derived status; without them the conservative
+    // failure spellings still map to `error`.
+    assert_eq!(
+        HERMES_PAYLOAD_EXTRACTOR
+            .tool_call(
+                &json!({ "status": "success" }),
+                &headers,
+                "post_tool_call_failed"
+            )
+            .status
+            .as_deref(),
+        Some("success")
+    );
+    assert_eq!(
+        HERMES_PAYLOAD_EXTRACTOR
+            .tool_call(&json!({}), &headers, "post_tool_call_failed")
+            .status
+            .as_deref(),
+        Some("error")
+    );
+}
+
+#[test]
+fn claude_extractor_reads_llm_hint_fields() {
+    let headers = HeaderMap::new();
+    let payload = json!({
+        "hook_event_name": "Stop",
+        "session_id": "claude-session",
+        "subagent_id": "worker-1",
+        "agent_id": "agent-1",
+        "agent_type": "general-purpose",
+        "conversation_id": "conversation-1",
+        "generation_id": "generation-1",
+        "extra": { "request_id": "request-1" },
+        "model": "claude-sonnet-4"
+    });
+
+    assert_eq!(
+        CLAUDE_CODE_PAYLOAD_EXTRACTOR.llm_hint(&payload, &headers),
+        ExtractedLlmHint {
+            subagent_id: Some("worker-1".into()),
+            agent_id: Some("agent-1".into()),
+            agent_type: Some("general-purpose".into()),
+            conversation_id: Some("conversation-1".into()),
+            generation_id: Some("generation-1".into()),
+            request_id: Some("request-1".into()),
+            model: Some("claude-sonnet-4".into()),
+        }
+    );
+}
+
+#[test]
+fn claude_stop_with_partial_hint_fields_keeps_missing_fields_none() {
+    let outcome = claude_code::adapt(
+        json!({
+            "session_id": "claude-session",
+            "hook_event_name": "Stop",
+            "model": "claude-sonnet-4"
+        }),
+        &HeaderMap::new(),
+    );
+
+    match &outcome.events[0] {
+        NormalizedEvent::LlmHint(event) => {
+            assert_eq!(event.session_id, "claude-session");
+            assert_eq!(event.model.as_deref(), Some("claude-sonnet-4"));
+            assert_eq!(event.subagent_id, None);
+            assert_eq!(event.agent_id, None);
+            assert_eq!(event.agent_type, None);
+            assert_eq!(event.conversation_id, None);
+            assert_eq!(event.generation_id, None);
+            assert_eq!(event.request_id, None);
+            assert_eq!(event.metadata["model"], json!("claude-sonnet-4"));
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+    assert!(matches!(outcome.events[1], NormalizedEvent::TurnEnded(_)));
+}
+
+#[test]
+fn llm_hint_model_and_request_id_precedence_chains() {
+    let headers = HeaderMap::new();
+
+    // Hint extraction is shared across harnesses; Claude Code stands in for all of them.
+    let mut payload = json!({
+        "model": "flat-model",
+        "model_name": "snake-model",
+        "modelName": "camel-model"
+    });
+    assert_string_fallback_chain(
+        &mut payload,
+        &[
+            (false, "model", "flat-model"),
+            (false, "model_name", "snake-model"),
+            (false, "modelName", "camel-model"),
+        ],
+        |payload| {
+            CLAUDE_CODE_PAYLOAD_EXTRACTOR
+                .llm_hint(payload, &headers)
+                .model
+        },
+    );
+
+    let mut payload = json!({
+        "request_id": "flat-snake",
+        "requestId": "flat-camel",
+        "request": { "id": "nested" },
+        "extra": { "request_id": "extra" }
+    });
+    assert_string_fallback_chain(
+        &mut payload,
+        &[
+            (false, "request_id", "flat-snake"),
+            (false, "requestId", "flat-camel"),
+            (false, "request", "nested"),
+            (false, "extra", "extra"),
+        ],
+        |payload| {
+            CLAUDE_CODE_PAYLOAD_EXTRACTOR
+                .llm_hint(payload, &headers)
+                .request_id
+        },
+    );
+}
+
+#[test]
+fn session_id_path_precedence_walks_fallback_chain() {
+    let headers = HeaderMap::new();
+    // The canonical session-id chain is shared by every harness; Claude Code stands in for all.
+    let mut payload = json!({
+        "session_id": "flat-snake",
+        "sessionId": "flat-camel",
+        "session": { "id": "nested" },
+        "conversation_id": "conversation-snake",
+        "conversationId": "conversation-camel",
+        "parent_session_id": "parent",
+        "task_id": "task",
+        "extra": { "session_id": "extra-session", "task_id": "extra-task" }
+    });
+
+    assert_string_fallback_chain(
+        &mut payload,
+        &[
+            (false, "session_id", "flat-snake"),
+            (false, "sessionId", "flat-camel"),
+            (false, "session", "nested"),
+            (false, "conversation_id", "conversation-snake"),
+            (false, "conversationId", "conversation-camel"),
+            (false, "parent_session_id", "parent"),
+            (false, "task_id", "task"),
+            (true, "session_id", "extra-session"),
+            (true, "task_id", "extra-task"),
+        ],
+        |payload| CLAUDE_CODE_PAYLOAD_EXTRACTOR.session_id(payload, &headers),
+    );
+}
+
+#[test]
+fn event_name_path_precedence_walks_fallback_chain() {
+    let mut payload = json!({
+        "hook_event_name": "hook-name",
+        "eventName": "camel-name",
+        "type": "type-name",
+        "name": "name-name",
+        "extra": {
+            "hook_event_name": "extra-hook-name",
+            "name": "extra-name"
+        }
+    });
+
+    assert_string_fallback_chain(
+        &mut payload,
+        &[
+            (false, "hook_event_name", "hook-name"),
+            (false, "eventName", "camel-name"),
+            (false, "type", "type-name"),
+            (false, "name", "name-name"),
+            (true, "hook_event_name", "extra-hook-name"),
+            (true, "name", "extra-name"),
+        ],
+        |payload| CLAUDE_CODE_PAYLOAD_EXTRACTOR.event_name(payload),
+    );
+}
+
+#[test]
+fn subagent_id_path_precedence_falls_back_to_nested_shapes_then_header() {
+    let headers = HeaderMap::new();
+    let mut payload = json!({
+        "subagent_id": "flat-subagent",
+        "child_subagent_id": "flat-child",
+        "agent_id": "flat-agent",
+        "subagent": { "id": "nested-subagent" },
+        "agent": { "id": "nested-agent" },
+        "extra": { "agent_id": "extra-agent" }
+    });
+
+    assert_string_fallback_chain(
+        &mut payload,
+        &[
+            (false, "subagent_id", "flat-subagent"),
+            (false, "child_subagent_id", "flat-child"),
+            (false, "agent_id", "flat-agent"),
+            (false, "subagent", "nested-subagent"),
+            (false, "agent", "nested-agent"),
+            (true, "agent_id", "extra-agent"),
+        ],
+        |payload| CLAUDE_CODE_PAYLOAD_EXTRACTOR.subagent_id(payload, &headers),
+    );
+
+    // With every payload path exhausted, the explicit subagent header is the last fallback.
+    let mut header_map = HeaderMap::new();
+    header_map.insert("x-nemo-relay-subagent-id", "header-worker".parse().unwrap());
+    assert_eq!(
+        CLAUDE_CODE_PAYLOAD_EXTRACTOR
+            .subagent_id(&payload, &header_map)
+            .as_deref(),
+        Some("header-worker")
+    );
+}
+
+#[test]
+fn codex_subagent_id_prefers_flat_ids_over_thread_spawn_nickname() {
+    let headers = HeaderMap::new();
+    let mut payload = json!({
+        "subagent_id": "flat-subagent",
+        "source": {
+            "subagent": { "thread_spawn": { "agent_nickname": "codex-nickname" } }
+        },
+        "subagent": { "id": "nested-subagent" }
+    });
+
+    assert_string_fallback_chain(
+        &mut payload,
+        &[
+            (false, "subagent_id", "flat-subagent"),
+            (false, "source", "codex-nickname"),
+            (false, "subagent", "nested-subagent"),
+        ],
+        |payload| CODEX_PAYLOAD_EXTRACTOR.subagent_id(payload, &headers),
+    );
+}
+
+#[test]
+fn null_intermediate_objects_do_not_mask_string_fallback_paths() {
+    let headers = HeaderMap::new();
+    let payload = json!({
+        "subagent": null,
+        "agent": { "id": "nested-agent" }
+    });
+
+    // A null intermediate stops the `subagent.id` lookup without error, so the later
+    // `agent.id` candidate still supplies the identifier.
+    assert_eq!(
+        CLAUDE_CODE_PAYLOAD_EXTRACTOR
+            .subagent_id(&payload, &headers)
+            .as_deref(),
+        Some("nested-agent")
+    );
+}
+
+#[test]
+fn json_path_lookups_handle_empty_strings_arrays_and_deep_nesting() {
+    let payload = json!({
+        "empty": "",
+        "list": [{ "id": "inside-array" }],
+        "deep": { "level_two": { "level_three": { "value": "deep-value" } } }
+    });
+
+    // Empty strings exist as values but are filtered from string lookups.
+    assert_eq!(value_at(&payload, &["empty"]), Some(json!("")));
+    assert_eq!(string_at(&payload, &["empty"]), None);
+
+    // Arrays are not traversed by object-key paths.
+    assert_eq!(value_at(&payload, &["list", "id"]), None);
+
+    assert_eq!(
+        string_at(&payload, &["deep", "level_two", "level_three", "value"]).as_deref(),
+        Some("deep-value")
+    );
+    assert_eq!(
+        first_string_at(
+            &payload,
+            &[
+                &["missing"][..],
+                &["empty"][..],
+                &["list", "id"][..],
+                &["deep", "level_two", "level_three", "value"][..],
+            ],
+        )
+        .as_deref(),
+        Some("deep-value")
+    );
+    assert_eq!(
+        first_value_at(&payload, &[&["missing"][..], &["also", "missing"][..]]),
+        None
+    );
+}

--- a/crates/cli/tests/coverage/alignment_tests.rs
+++ b/crates/cli/tests/coverage/alignment_tests.rs
@@ -659,6 +659,195 @@ fn json_helpers_and_metadata_merge_cover_edge_shapes() {
     );
 }
 
+#[test]
+fn request_affinity_key_is_route_gated_not_content_gated() {
+    let request = LlmRequest {
+        headers: Map::new(),
+        content: json!({
+            "messages": [
+                { "role": "user", "content": "Review the Rust CLI gateway alignment code." }
+            ]
+        }),
+    };
+
+    // The same task text that produces a key on the chat/messages routes is ignored on routes
+    // whose extractors opt out of affinity keys entirely, and on unknown provider names.
+    assert!(request_affinity_key("openai.chat_completions", &request).is_some());
+    assert!(request_affinity_key("anthropic.messages", &request).is_some());
+    assert_eq!(request_affinity_key("openai.models", &request), None);
+    assert_eq!(
+        request_affinity_key("anthropic.count_tokens", &request),
+        None
+    );
+    assert_eq!(request_affinity_key("unknown.provider", &request), None);
+}
+
+#[test]
+fn request_affinity_key_returns_none_when_route_task_fields_are_missing() {
+    let responses_shape = LlmRequest {
+        headers: Map::new(),
+        content: json!({ "input": "Review the Rust CLI gateway alignment code." }),
+    };
+    let messages_shape = LlmRequest {
+        headers: Map::new(),
+        content: json!({
+            "messages": [
+                { "role": "user", "content": "Review the Rust CLI gateway alignment code." }
+            ]
+        }),
+    };
+    let assistant_only = LlmRequest {
+        headers: Map::new(),
+        content: json!({
+            "messages": [
+                { "role": "assistant", "content": "I will review the gateway alignment code." }
+            ]
+        }),
+    };
+
+    // Chat/messages extractors read `messages`; the responses extractor reads `input`/`prompt`.
+    // A body shaped for the other route yields no key instead of borrowing its fields.
+    assert!(request_affinity_key("openai.responses", &responses_shape).is_some());
+    assert_eq!(
+        request_affinity_key("openai.chat_completions", &responses_shape),
+        None
+    );
+    assert_eq!(
+        request_affinity_key("anthropic.messages", &responses_shape),
+        None
+    );
+    assert_eq!(
+        request_affinity_key("openai.responses", &messages_shape),
+        None
+    );
+    assert_eq!(
+        request_affinity_key("anthropic.messages", &assistant_only),
+        None
+    );
+}
+
+#[test]
+fn request_affinity_key_enforces_min_and_max_task_text_length() {
+    let request_with_text = |text: String| LlmRequest {
+        headers: Map::new(),
+        content: json!({ "messages": [{ "role": "user", "content": text }] }),
+    };
+
+    let below_min = request_with_text("a".repeat(REQUEST_AFFINITY_KEY_MIN_CHARS - 1));
+    let at_min = request_with_text("a".repeat(REQUEST_AFFINITY_KEY_MIN_CHARS));
+    let above_max = request_with_text("a".repeat(REQUEST_AFFINITY_KEY_MAX_CHARS + 100));
+
+    assert_eq!(request_affinity_key("anthropic.messages", &below_min), None);
+    assert_eq!(
+        request_affinity_key("anthropic.messages", &at_min).map(|key| key.chars().count()),
+        Some(REQUEST_AFFINITY_KEY_MIN_CHARS)
+    );
+    assert_eq!(
+        request_affinity_key("anthropic.messages", &above_max).map(|key| key.chars().count()),
+        Some(REQUEST_AFFINITY_KEY_MAX_CHARS)
+    );
+}
+
+#[test]
+fn gateway_turn_input_builds_claude_prompt_for_anthropic_messages_only() {
+    // Shorter than the affinity-key minimum on purpose: turn input has no length gate.
+    let request = LlmRequest {
+        headers: Map::new(),
+        content: json!({
+            "messages": [
+                { "role": "user", "content": "Fix the CLI tests." }
+            ]
+        }),
+    };
+
+    assert_eq!(
+        gateway_turn_input(AgentKind::ClaudeCode, "anthropic.messages", &request),
+        Some(json!({ "prompt": "Fix the CLI tests." }))
+    );
+
+    // Only Claude installed mode can race the UserPromptSubmit hook, so every other agent kind
+    // and route stays None.
+    for agent_kind in [AgentKind::Codex, AgentKind::Hermes, AgentKind::Gateway] {
+        assert_eq!(
+            gateway_turn_input(agent_kind, "anthropic.messages", &request),
+            None
+        );
+    }
+    for provider in [
+        "openai.responses",
+        "openai.chat_completions",
+        "openai.models",
+        "anthropic.count_tokens",
+    ] {
+        assert_eq!(
+            gateway_turn_input(AgentKind::ClaudeCode, provider, &request),
+            None
+        );
+    }
+
+    let no_messages = LlmRequest {
+        headers: Map::new(),
+        content: json!({ "input": "Fix the CLI tests." }),
+    };
+    assert_eq!(
+        gateway_turn_input(AgentKind::ClaudeCode, "anthropic.messages", &no_messages),
+        None
+    );
+}
+
+#[test]
+fn gateway_session_id_ignores_body_ids_on_header_only_routes() {
+    // Body fallbacks that succeed on the OpenAI Responses/Chat Completions routes must be
+    // ignored on the header-only routes.
+    let body = json!({
+        "session_id": "body-session",
+        "prompt_cache_key": "codex-thread",
+        "client_metadata": { "x-codex-installation-id": "install-1" }
+    });
+
+    for route in [
+        GatewayRouteKind::AnthropicMessages,
+        GatewayRouteKind::AnthropicCountTokens,
+        GatewayRouteKind::OpenAiModels,
+    ] {
+        assert_eq!(
+            gateway_session_id(&HeaderMap::new(), &body, route),
+            None,
+            "route {route:?} must not read body session ids"
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-claude-code-session-id",
+            HeaderValue::from_static("claude-thread"),
+        );
+        assert_eq!(
+            gateway_session_id(&headers, &body, route).as_deref(),
+            Some("claude-thread")
+        );
+
+        headers.insert(
+            "x-nemo-relay-session-id",
+            HeaderValue::from_static("explicit-thread"),
+        );
+        assert_eq!(
+            gateway_session_id(&headers, &body, route).as_deref(),
+            Some("explicit-thread")
+        );
+    }
+}
+
+#[test]
+fn gateway_route_names_round_trip_through_provider_lookup() {
+    for route in GatewayRouteKind::ALL {
+        assert_eq!(
+            GatewayRouteKind::from_provider_name(route.name()),
+            Some(route)
+        );
+    }
+    assert_eq!(GatewayRouteKind::from_provider_name("openai.unknown"), None);
+}
+
 fn event_metadata(event: &NormalizedEvent) -> &Value {
     match event {
         NormalizedEvent::AgentStarted(event)

--- a/crates/core/src/codec/mod.rs
+++ b/crates/core/src/codec/mod.rs
@@ -23,3 +23,7 @@ pub mod resolve;
 pub mod response;
 pub mod streaming;
 pub mod traits;
+
+#[cfg(test)]
+#[path = "../../tests/unit/codec/parity_tests.rs"]
+mod parity_tests;

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -22,6 +22,10 @@ pub mod openinference;
 pub mod otel;
 pub mod plugin_component;
 
+#[cfg(all(test, feature = "otel", feature = "openinference"))]
+#[path = "../../tests/unit/observability/exporter_parity_tests.rs"]
+mod exporter_parity_tests;
+
 #[cfg(any(feature = "otel", feature = "openinference"))]
 pub(crate) fn estimate_cost_for_response_or_requested_model(
     event: &crate::api::event::Event,

--- a/crates/core/tests/unit/codec/parity_tests.rs
+++ b/crates/core/tests/unit/codec/parity_tests.rs
@@ -1,0 +1,717 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-provider codec parity tests for the NeMo Relay core crate.
+//!
+//! Each test builds the same logical scenario in all three built-in provider
+//! schemas (OpenAI Chat Completions, Anthropic Messages, OpenAI Responses) and
+//! asserts that detection plus normalization produce agreeing output. Where
+//! the schemas legitimately diverge, the divergence is asserted explicitly:
+//! the asymmetry is part of the parity contract, and a change here means one
+//! codec drifted from the others.
+
+use serde_json::json;
+
+use super::model_pricing::pricing_test_mutex;
+use super::request::{GenerationParams, Message, MessageContent};
+use super::resolve::{normalize_request, normalize_request_with_hint, normalize_response};
+use super::response::{
+    AnnotatedLlmResponse, ApiSpecificResponse, CostEstimate, CostSource, FinishReason,
+    PricingCatalog, PricingResolver, Usage, reset_active_pricing_resolver,
+    set_active_pricing_resolver,
+};
+use crate::api::llm::LlmRequest;
+use crate::json::Json;
+
+// -------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------
+
+struct ResetPricingResolverGuard;
+
+impl Drop for ResetPricingResolverGuard {
+    fn drop(&mut self) {
+        let _ = reset_active_pricing_resolver();
+    }
+}
+
+fn install_parity_pricing(model_id: &str) {
+    let catalog = PricingCatalog::from_json_str(
+        &json!({
+            "version": 1,
+            "entries": [
+                {
+                    "provider": "test",
+                    "model_id": model_id,
+                    "pricing_as_of": "2026-06-05",
+                    "pricing_source": "test",
+                    "rates": {
+                        "input_per_million": 0.15,
+                        "output_per_million": 0.60,
+                        "cache_read_per_million": 0.075
+                    },
+                    "prompt_cache": {
+                        "read_accounting": "included_in_prompt_tokens"
+                    }
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    set_active_pricing_resolver(PricingResolver::from_catalogs(vec![catalog])).unwrap();
+}
+
+fn req(content: Json) -> LlmRequest {
+    LlmRequest {
+        headers: serde_json::Map::new(),
+        content,
+    }
+}
+
+fn decode(raw: &Json) -> AnnotatedLlmResponse {
+    normalize_response(raw).unwrap_or_else(|| panic!("response should detect and decode: {raw}"))
+}
+
+/// The same logical response (one assistant text message) in each schema.
+fn chat_text_response(model: &str) -> Json {
+    json!({
+        "id": "chatcmpl-parity",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "hello"},
+            "finish_reason": "stop"
+        }]
+    })
+}
+
+fn anthropic_text_response(model: &str) -> Json {
+    json!({
+        "id": "msg_parity",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": "hello"}],
+        "stop_reason": "end_turn"
+    })
+}
+
+fn responses_text_response(model: &str) -> Json {
+    json!({
+        "id": "resp_parity",
+        "model": model,
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hello"}]
+        }]
+    })
+}
+
+/// The same logical usage (1000 prompt / 500 completion / 200 cache-read)
+/// expressed in each schema's native usage shape. `extra_usage` merges extra
+/// schema-specific usage keys into the payload.
+fn chat_response_with_usage(model: &str, extra_usage: Json) -> Json {
+    let mut raw = chat_text_response(model);
+    let mut usage = json!({
+        "prompt_tokens": 1000,
+        "completion_tokens": 500,
+        "total_tokens": 1500,
+        "prompt_tokens_details": {"cached_tokens": 200}
+    });
+    merge_object(&mut usage, extra_usage);
+    raw.as_object_mut().unwrap().insert("usage".into(), usage);
+    raw
+}
+
+fn anthropic_response_with_usage(model: &str, extra_usage: Json) -> Json {
+    let mut raw = anthropic_text_response(model);
+    // Anthropic reports no total_tokens; the codec computes prompt + completion.
+    let mut usage = json!({
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "cache_read_input_tokens": 200
+    });
+    merge_object(&mut usage, extra_usage);
+    raw.as_object_mut().unwrap().insert("usage".into(), usage);
+    raw
+}
+
+fn responses_response_with_usage(model: &str, extra_usage: Json) -> Json {
+    let mut raw = responses_text_response(model);
+    let mut usage = json!({
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "total_tokens": 1500,
+        "input_tokens_details": {"cached_tokens": 200}
+    });
+    merge_object(&mut usage, extra_usage);
+    raw.as_object_mut().unwrap().insert("usage".into(), usage);
+    raw
+}
+
+fn merge_object(target: &mut Json, extra: Json) {
+    if let (Some(target), Json::Object(extra)) = (target.as_object_mut(), extra) {
+        target.extend(extra);
+    }
+}
+
+// ===================================================================
+// Response parity: model name and message text
+// ===================================================================
+
+#[test]
+fn test_response_model_name_and_text_parity() {
+    let chat = decode(&chat_text_response("parity-shared-model"));
+    let anthropic = decode(&anthropic_text_response("parity-shared-model"));
+    let responses = decode(&responses_text_response("parity-shared-model"));
+
+    for decoded in [&chat, &anthropic, &responses] {
+        assert_eq!(decoded.model.as_deref(), Some("parity-shared-model"));
+        assert_eq!(decoded.response_text(), Some("hello"));
+        assert_eq!(decoded.finish_reason, Some(FinishReason::Complete));
+    }
+
+    // Response IDs keep the provider-native value because IDs are
+    // provider-scoped identifiers; only the field mapping is normalized.
+    assert_eq!(chat.id.as_deref(), Some("chatcmpl-parity"));
+    assert_eq!(anthropic.id.as_deref(), Some("msg_parity"));
+    assert_eq!(responses.id.as_deref(), Some("resp_parity"));
+}
+
+// ===================================================================
+// Response parity: finish reasons
+// ===================================================================
+
+#[test]
+fn test_finish_reason_complete_parity() {
+    let raws = [
+        json!({"choices": [{"message": {"role": "assistant", "content": "x"}, "finish_reason": "stop"}]}),
+        json!({"type": "message", "content": [{"type": "text", "text": "x"}], "stop_reason": "end_turn"}),
+        json!({"status": "completed", "output": [{"type": "message", "content": [{"type": "output_text", "text": "x"}]}]}),
+    ];
+    for raw in &raws {
+        assert_eq!(
+            decode(raw).finish_reason,
+            Some(FinishReason::Complete),
+            "expected Complete for {raw}",
+        );
+    }
+}
+
+#[test]
+fn test_finish_reason_length_parity() {
+    let raws = [
+        json!({"choices": [{"message": {"role": "assistant", "content": "x"}, "finish_reason": "length"}]}),
+        json!({"type": "message", "content": [{"type": "text", "text": "x"}], "stop_reason": "max_tokens"}),
+        json!({
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": []
+        }),
+    ];
+    for raw in &raws {
+        assert_eq!(
+            decode(raw).finish_reason,
+            Some(FinishReason::Length),
+            "expected Length for {raw}",
+        );
+    }
+}
+
+#[test]
+fn test_finish_reason_tool_use_parity_and_responses_divergence() {
+    let chat = decode(&json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_parity_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"city\":\"NYC\"}"}
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    }));
+    let anthropic = decode(&json!({
+        "type": "message",
+        "content": [{
+            "type": "tool_use",
+            "id": "call_parity_1",
+            "name": "get_weather",
+            "input": {"city": "NYC"}
+        }],
+        "stop_reason": "tool_use"
+    }));
+    let responses = decode(&json!({
+        "status": "completed",
+        "output": [{
+            "type": "function_call",
+            "call_id": "call_parity_1",
+            "name": "get_weather",
+            "arguments": "{\"city\":\"NYC\"}"
+        }]
+    }));
+
+    assert_eq!(chat.finish_reason, Some(FinishReason::ToolUse));
+    assert_eq!(anthropic.finish_reason, Some(FinishReason::ToolUse));
+    // The Responses API has no distinct tool-use terminal status: a
+    // function_call turn still ends with status "completed", so the
+    // normalized finish reason is Complete and tool-call presence must be
+    // read from `tool_calls` instead.
+    assert_eq!(responses.finish_reason, Some(FinishReason::Complete));
+    assert!(responses.has_tool_calls());
+}
+
+// ===================================================================
+// Response parity: tool calls
+// ===================================================================
+
+#[test]
+fn test_response_tool_call_parity() {
+    // One logical tool invocation. The id lives in a schema-specific field
+    // (chat `tool_calls[].id`, Anthropic `tool_use.id`, Responses `call_id`),
+    // and arguments arrive as a JSON string in the OpenAI schemas but as
+    // parsed JSON in Anthropic's `input`. Normalization erases all of that.
+    let chat = decode(&json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_parity_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "{\"city\":\"NYC\",\"units\":\"c\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    }));
+    let anthropic = decode(&json!({
+        "type": "message",
+        "content": [{
+            "type": "tool_use",
+            "id": "call_parity_1",
+            "name": "get_weather",
+            "input": {"city": "NYC", "units": "c"}
+        }],
+        "stop_reason": "tool_use"
+    }));
+    // The Responses item-level `id` is ignored; the cross-provider
+    // correlation id is `call_id`.
+    let responses = decode(&json!({
+        "status": "completed",
+        "output": [{
+            "type": "function_call",
+            "id": "fc_item_1",
+            "call_id": "call_parity_1",
+            "name": "get_weather",
+            "arguments": "{\"city\":\"NYC\",\"units\":\"c\"}"
+        }]
+    }));
+
+    let chat_calls = chat.tool_calls.expect("chat tool calls");
+    let anthropic_calls = anthropic.tool_calls.expect("anthropic tool calls");
+    let responses_calls = responses.tool_calls.expect("responses tool calls");
+
+    assert_eq!(chat_calls, anthropic_calls);
+    assert_eq!(chat_calls, responses_calls);
+    assert_eq!(chat_calls.len(), 1);
+    assert_eq!(chat_calls[0].id, "call_parity_1");
+    assert_eq!(chat_calls[0].name, "get_weather");
+    assert_eq!(
+        chat_calls[0].arguments,
+        json!({"city": "NYC", "units": "c"})
+    );
+    assert!(chat_calls[0].arguments.is_object());
+}
+
+// ===================================================================
+// Response parity: usage
+// ===================================================================
+
+#[test]
+fn test_response_usage_parity() {
+    // The model name is unique to this test and never appears in any pricing
+    // catalog, so estimation deterministically yields no cost.
+    let chat = decode(&chat_response_with_usage("parity-usage-model", json!({})));
+    let anthropic = decode(&anthropic_response_with_usage(
+        "parity-usage-model",
+        json!({}),
+    ));
+    let responses = decode(&responses_response_with_usage(
+        "parity-usage-model",
+        json!({}),
+    ));
+
+    let expected = Usage {
+        prompt_tokens: Some(1000),
+        completion_tokens: Some(500),
+        total_tokens: Some(1500),
+        cache_read_tokens: Some(200),
+        cache_write_tokens: None,
+        cost: None,
+    };
+    assert_eq!(chat.usage, Some(expected.clone()));
+    // Anthropic supplies no total_tokens on the wire; the codec computes
+    // prompt + completion so the normalized usage still matches the others.
+    assert_eq!(anthropic.usage, Some(expected.clone()));
+    assert_eq!(responses.usage, Some(expected));
+}
+
+#[test]
+fn test_response_usage_schema_specific_extras() {
+    let chat = decode(&chat_response_with_usage("parity-usage-model", json!({})));
+    let anthropic = decode(&anthropic_response_with_usage(
+        "parity-usage-model",
+        json!({"cache_creation_input_tokens": 64}),
+    ));
+    let responses = decode(&responses_response_with_usage(
+        "parity-usage-model",
+        json!({"output_tokens_details": {"reasoning_tokens": 128}}),
+    ));
+
+    // Only Anthropic reports prompt-cache writes, so cache_write_tokens is
+    // populated for Anthropic alone.
+    assert_eq!(
+        anthropic.usage.as_ref().unwrap().cache_write_tokens,
+        Some(64)
+    );
+    assert_eq!(chat.usage.as_ref().unwrap().cache_write_tokens, None);
+    assert_eq!(responses.usage.as_ref().unwrap().cache_write_tokens, None);
+
+    // Only the Responses schema reports reasoning tokens; the normalized
+    // Usage has no reasoning slot, so the value is preserved in the
+    // schema-specific api_specific payload.
+    match responses.api_specific.as_ref().unwrap() {
+        ApiSpecificResponse::OpenAIResponses {
+            output_tokens_details,
+            ..
+        } => {
+            assert_eq!(
+                output_tokens_details,
+                &Some(json!({"reasoning_tokens": 128}))
+            );
+        }
+        other => panic!("expected OpenAIResponses api_specific, got {other:?}"),
+    }
+    assert!(matches!(
+        chat.api_specific,
+        Some(ApiSpecificResponse::OpenAIChat { .. })
+    ));
+    assert!(matches!(
+        anthropic.api_specific,
+        Some(ApiSpecificResponse::AnthropicMessages { .. })
+    ));
+
+    // The shared usage facts still agree despite the schema-specific extras.
+    for decoded in [&chat, &anthropic, &responses] {
+        let usage = decoded.usage.as_ref().unwrap();
+        assert_eq!(usage.prompt_tokens, Some(1000));
+        assert_eq!(usage.completion_tokens, Some(500));
+        assert_eq!(usage.total_tokens, Some(1500));
+        assert_eq!(usage.cache_read_tokens, Some(200));
+    }
+}
+
+// ===================================================================
+// Response parity: cost
+// ===================================================================
+
+#[test]
+fn test_provider_reported_cost_object_parity() {
+    // Provider-reported cost always wins over estimation, so this test does
+    // not depend on the active pricing resolver.
+    let cost = json!({"cost": {
+        "total": 0.0123,
+        "input": 0.004,
+        "output": 0.0083,
+        "currency": "USD"
+    }});
+    let chat = decode(&chat_response_with_usage(
+        "parity-reported-model",
+        cost.clone(),
+    ));
+    let anthropic = decode(&anthropic_response_with_usage(
+        "parity-reported-model",
+        cost.clone(),
+    ));
+    let responses = decode(&responses_response_with_usage(
+        "parity-reported-model",
+        cost,
+    ));
+
+    let expected = CostEstimate {
+        total: Some(0.0123),
+        currency: "USD".to_string(),
+        input: Some(0.004),
+        output: Some(0.0083),
+        cache_read: None,
+        cache_write: None,
+        source: CostSource::ProviderReported,
+        pricing_provider: None,
+        pricing_model: None,
+        pricing_as_of: None,
+        pricing_source: None,
+    };
+    assert_eq!(chat.usage.unwrap().cost, Some(expected.clone()));
+    assert_eq!(anthropic.usage.unwrap().cost, Some(expected.clone()));
+    assert_eq!(responses.usage.unwrap().cost, Some(expected));
+}
+
+#[test]
+fn test_provider_reported_scalar_cost_parity() {
+    // The legacy scalar `cost_usd` is accepted by all three schemas and is
+    // always interpreted as a USD total.
+    let cost = json!({"cost_usd": 0.5});
+    let decoded = [
+        decode(&chat_response_with_usage(
+            "parity-reported-model",
+            cost.clone(),
+        )),
+        decode(&anthropic_response_with_usage(
+            "parity-reported-model",
+            cost.clone(),
+        )),
+        decode(&responses_response_with_usage(
+            "parity-reported-model",
+            cost,
+        )),
+    ];
+    for response in decoded {
+        let cost = response.usage.unwrap().cost.expect("scalar reported cost");
+        assert_eq!(cost.total, Some(0.5));
+        assert_eq!(cost.currency, "USD");
+        assert_eq!(cost.source, CostSource::ProviderReported);
+        assert_eq!(cost.input, None);
+        assert_eq!(cost.output, None);
+    }
+}
+
+#[test]
+fn test_estimated_cost_parity_for_identical_model_and_usage() {
+    let _pricing_guard = pricing_test_mutex()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    install_parity_pricing("parity-priced-model");
+    let _reset_guard = ResetPricingResolverGuard;
+
+    // Each codec infers its own default provider ("openai" vs "anthropic"),
+    // but pricing lookup falls back to the model-only key, so an identical
+    // model + normalized usage must estimate identically everywhere.
+    let chat = decode(&chat_response_with_usage("parity-priced-model", json!({})));
+    let anthropic = decode(&anthropic_response_with_usage(
+        "parity-priced-model",
+        json!({}),
+    ));
+    let responses = decode(&responses_response_with_usage(
+        "parity-priced-model",
+        json!({}),
+    ));
+
+    let chat_cost = chat.usage.unwrap().cost.expect("chat estimated cost");
+    let anthropic_cost = anthropic
+        .usage
+        .unwrap()
+        .cost
+        .expect("anthropic estimated cost");
+    let responses_cost = responses
+        .usage
+        .unwrap()
+        .cost
+        .expect("responses estimated cost");
+
+    assert_eq!(chat_cost, anthropic_cost);
+    assert_eq!(chat_cost, responses_cost);
+    // 800 billable prompt (1000 - 200 cached) * 0.15/M
+    //   + 500 completion * 0.60/M + 200 cache-read * 0.075/M
+    let total = chat_cost.total.expect("estimated total");
+    assert!(
+        (total - 0.000_435).abs() < 1e-9,
+        "unexpected estimated total: {total}"
+    );
+    assert_eq!(chat_cost.currency, "USD");
+    assert_eq!(chat_cost.source, CostSource::ModelPricing);
+    assert_eq!(chat_cost.pricing_provider.as_deref(), Some("test"));
+    assert_eq!(
+        chat_cost.pricing_model.as_deref(),
+        Some("parity-priced-model")
+    );
+}
+
+// ===================================================================
+// Request parity: detection and hint hardening
+// ===================================================================
+
+#[test]
+fn test_request_hint_never_overrides_strong_signals() {
+    // A wrong hint must not reroute a body whose shape is unambiguous.
+    let responses_request = req(json!({
+        "model": "gpt-parity",
+        "instructions": "You are terse.",
+        "input": "Summarize the docs.",
+        "max_output_tokens": 64
+    }));
+    let hinted = normalize_request_with_hint(&responses_request, Some("anthropic"))
+        .expect("responses request decodes despite wrong hint");
+    assert_eq!(
+        hinted,
+        normalize_request(&responses_request).expect("responses request decodes"),
+    );
+    // Responses-only field proves the Responses codec handled the body.
+    assert_eq!(hinted.max_output_tokens, Some(64));
+
+    let anthropic_request = req(json!({
+        "model": "claude-parity",
+        "system": "You are terse.",
+        "messages": [{"role": "user", "content": "Summarize the docs."}],
+        "stop_sequences": ["END"]
+    }));
+    let hinted = normalize_request_with_hint(&anthropic_request, Some("openai.chat"))
+        .expect("anthropic request decodes despite wrong hint");
+    assert_eq!(
+        hinted,
+        normalize_request(&anthropic_request).expect("anthropic request decodes"),
+    );
+    // stop_sequences normalized into params (not left in extra) proves the
+    // Anthropic codec handled the body.
+    let stop = hinted
+        .params
+        .as_ref()
+        .and_then(|params| params.stop.as_ref())
+        .expect("anthropic stop_sequences normalized");
+    assert_eq!(stop, &vec!["END".to_string()]);
+    assert!(!hinted.extra.contains_key("stop_sequences"));
+}
+
+#[test]
+fn test_request_unknown_hint_matches_hintless_normalization() {
+    // Unrecognized hint strings are ignored: full decoded output (not just
+    // surface detection) must match the hintless path for every schema.
+    let bodies = [
+        json!({"model": "m", "instructions": "sys", "input": "hi"}),
+        json!({"model": "m", "system": "sys", "messages": [{"role": "user", "content": "hi"}]}),
+        json!({"model": "m", "messages": [{"role": "user", "content": "hi"}]}),
+    ];
+    for body in &bodies {
+        let request = req(body.clone());
+        let baseline = normalize_request(&request).expect("canonical body decodes");
+        for hint in ["gemini", "not-a-provider", "anthropic.count_tokens"] {
+            assert_eq!(
+                normalize_request_with_hint(&request, Some(hint)).as_ref(),
+                Some(&baseline),
+                "hint {hint:?} must not change normalization for {body}",
+            );
+        }
+    }
+}
+
+#[test]
+fn test_request_hint_none_equals_normalize_request() {
+    // normalize_request_with_hint(None) is the same full decode as
+    // normalize_request, for every canonical body shape.
+    let bodies = [
+        json!({"model": "m", "instructions": "sys", "input": "hi"}),
+        json!({"model": "m", "system": "sys", "messages": [{"role": "user", "content": "hi"}]}),
+        json!({"model": "m", "messages": [{"role": "user", "content": "hi"}]}),
+    ];
+    for body in &bodies {
+        let request = req(body.clone());
+        assert_eq!(
+            normalize_request_with_hint(&request, None),
+            normalize_request(&request),
+            "hint=None must equal normalize_request for {body}",
+        );
+    }
+}
+
+// ===================================================================
+// Request parity: normalization of an equivalent request
+// ===================================================================
+
+#[test]
+fn test_request_normalization_parity() {
+    let chat = normalize_request(&req(json!({
+        "model": "parity-request-model",
+        "messages": [
+            {"role": "system", "content": "You are terse."},
+            {"role": "user", "content": "Summarize the docs."}
+        ],
+        "temperature": 0.5,
+        "max_tokens": 256,
+        "stop": ["END"]
+    })))
+    .expect("chat request decodes");
+
+    let anthropic = normalize_request(&req(json!({
+        "model": "parity-request-model",
+        "system": "You are terse.",
+        "messages": [{"role": "user", "content": "Summarize the docs."}],
+        "temperature": 0.5,
+        "max_tokens": 256,
+        "stop_sequences": ["END"]
+    })))
+    .expect("anthropic request decodes");
+
+    let responses = normalize_request(&req(json!({
+        "model": "parity-request-model",
+        "instructions": "You are terse.",
+        "input": "Summarize the docs.",
+        "temperature": 0.5,
+        "max_output_tokens": 256
+    })))
+    .expect("responses request decodes");
+
+    let expected_messages = vec![
+        Message::System {
+            content: MessageContent::Text("You are terse.".to_string()),
+            name: None,
+        },
+        Message::User {
+            content: MessageContent::Text("Summarize the docs.".to_string()),
+            name: None,
+        },
+    ];
+    for decoded in [&chat, &anthropic, &responses] {
+        assert_eq!(decoded.messages, expected_messages);
+        assert_eq!(decoded.model.as_deref(), Some("parity-request-model"));
+        assert_eq!(decoded.system_prompt(), Some("You are terse."));
+        assert_eq!(decoded.last_user_message(), Some("Summarize the docs."));
+    }
+
+    // Chat `max_tokens`/`stop` and Anthropic `max_tokens`/`stop_sequences`
+    // normalize into identical GenerationParams.
+    let expected_params = GenerationParams {
+        temperature: Some(0.5),
+        max_tokens: Some(256),
+        top_p: None,
+        stop: Some(vec!["END".to_string()]),
+    };
+    assert_eq!(chat.params, Some(expected_params.clone()));
+    assert_eq!(anthropic.params, Some(expected_params));
+
+    // Responses schema deviations: `max_output_tokens` maps into
+    // params.max_tokens like the other schemas but is also preserved on the
+    // Responses-only field, and the schema has no stop sequences, so
+    // params.stop stays None.
+    assert_eq!(
+        responses.params,
+        Some(GenerationParams {
+            temperature: Some(0.5),
+            max_tokens: Some(256),
+            top_p: None,
+            stop: None,
+        })
+    );
+    assert_eq!(responses.max_output_tokens, Some(256));
+    assert_eq!(chat.max_output_tokens, None);
+    assert_eq!(anthropic.max_output_tokens, None);
+}

--- a/crates/core/tests/unit/observability/exporter_parity_tests.rs
+++ b/crates/core/tests/unit/observability/exporter_parity_tests.rs
@@ -1,0 +1,793 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-exporter parity tests for the NeMo Relay core crate.
+//!
+//! Each test feeds the same event stream to the ATIF, OpenTelemetry, and
+//! OpenInference exporters and asserts that the facts they project (cost,
+//! usage, model name, tool calls) agree. Where an exporter projects more or
+//! less than the others, the divergence is asserted explicitly so drift from
+//! the documented behavior fails loudly instead of silently.
+
+use std::collections::HashMap;
+
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SdkTracerProvider, SpanData};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::api::event::{
+    BaseEvent, CategoryProfile, Event, EventCategory, EventNormalizationExt, ScopeCategory,
+    ScopeEvent,
+};
+use crate::codec::model_pricing::pricing_test_mutex;
+use crate::codec::response::{
+    PricingCatalog, PricingResolver, reset_active_pricing_resolver, set_active_pricing_resolver,
+};
+use crate::json::Json;
+use crate::observability::atif::{
+    AtifAgentInfo, AtifExporter, AtifStep, AtifStepExtra, AtifTrajectory,
+};
+use crate::observability::openinference::OpenInferenceSubscriber;
+use crate::observability::otel::OpenTelemetrySubscriber;
+
+// -------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------
+
+struct ResetPricingResolverGuard;
+
+impl Drop for ResetPricingResolverGuard {
+    fn drop(&mut self) {
+        let _ = reset_active_pricing_resolver();
+    }
+}
+
+fn install_parity_pricing(model_id: &str) {
+    let catalog = PricingCatalog::from_json_str(
+        &json!({
+            "version": 1,
+            "entries": [
+                {
+                    "provider": "test",
+                    "model_id": model_id,
+                    "pricing_as_of": "2026-06-05",
+                    "pricing_source": "test",
+                    "rates": {
+                        "input_per_million": 0.15,
+                        "output_per_million": 0.60,
+                        "cache_read_per_million": 0.075
+                    },
+                    "prompt_cache": {
+                        "read_accounting": "included_in_prompt_tokens"
+                    }
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    set_active_pricing_resolver(PricingResolver::from_catalogs(vec![catalog])).unwrap();
+}
+
+fn make_agent_info() -> AtifAgentInfo {
+    AtifAgentInfo {
+        name: "parity-agent".to_string(),
+        version: "1.0.0".to_string(),
+        model_name: None,
+        tool_definitions: None,
+        extra: None,
+    }
+}
+
+fn make_provider() -> (
+    SdkTracerProvider,
+    opentelemetry_sdk::trace::InMemorySpanExporter,
+) {
+    let exporter = InMemorySpanExporterBuilder::new().build();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    (provider, exporter)
+}
+
+fn attr_map(attributes: &[KeyValue]) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for attribute in attributes {
+        let key = attribute.key.as_str().to_string();
+        let previous = map.insert(key.clone(), attribute.value.to_string());
+        assert!(previous.is_none(), "duplicate span attribute key: {key}");
+    }
+    map
+}
+
+fn assert_no_attribute_key_contains(attributes: &HashMap<String, String>, fragment: &str) {
+    let offending: Vec<&String> = attributes
+        .keys()
+        .filter(|key| key.contains(fragment))
+        .collect();
+    assert!(
+        offending.is_empty(),
+        "expected no attribute key containing {fragment:?}, found {offending:?}",
+    );
+}
+
+fn make_scope_event(
+    scope_category: ScopeCategory,
+    uuid: Uuid,
+    name: &str,
+    category: EventCategory,
+    data: Option<Json>,
+    profile: Option<CategoryProfile>,
+) -> Event {
+    Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .uuid(uuid)
+            .name(name)
+            .data_opt(data)
+            .build(),
+        scope_category,
+        Vec::new(),
+        category,
+        profile,
+    ))
+}
+
+/// LLM start event carrying the managed-pipeline `LlmRequest` envelope.
+fn llm_start(uuid: Uuid, name: &str, request_content: Json) -> Event {
+    make_scope_event(
+        ScopeCategory::Start,
+        uuid,
+        name,
+        EventCategory::llm(),
+        Some(json!({"headers": {}, "content": request_content})),
+        None,
+    )
+}
+
+fn llm_end(uuid: Uuid, name: &str, output: Json) -> Event {
+    make_scope_event(
+        ScopeCategory::End,
+        uuid,
+        name,
+        EventCategory::llm(),
+        Some(output),
+        None,
+    )
+}
+
+fn llm_event_with_model(
+    scope_category: ScopeCategory,
+    uuid: Uuid,
+    name: &str,
+    data: Json,
+    model_name: &str,
+) -> Event {
+    make_scope_event(
+        scope_category,
+        uuid,
+        name,
+        EventCategory::llm(),
+        Some(data),
+        Some(CategoryProfile::builder().model_name(model_name).build()),
+    )
+}
+
+fn tool_event(
+    scope_category: ScopeCategory,
+    uuid: Uuid,
+    name: &str,
+    data: Json,
+    tool_call_id: &str,
+) -> Event {
+    make_scope_event(
+        scope_category,
+        uuid,
+        name,
+        EventCategory::tool(),
+        Some(data),
+        Some(
+            CategoryProfile::builder()
+                .tool_call_id(tool_call_id)
+                .build(),
+        ),
+    )
+}
+
+struct ParityExports {
+    trajectory: AtifTrajectory,
+    otel_spans: Vec<SpanData>,
+    openinference_spans: Vec<SpanData>,
+}
+
+impl ParityExports {
+    fn otel_attrs(&self, span_name: &str) -> HashMap<String, String> {
+        span_attrs(&self.otel_spans, span_name)
+    }
+
+    fn openinference_attrs(&self, span_name: &str) -> HashMap<String, String> {
+        span_attrs(&self.openinference_spans, span_name)
+    }
+
+    /// The ATIF `agent` step projected from the LLM end event.
+    fn agent_step(&self) -> &AtifStep {
+        self.trajectory
+            .steps
+            .iter()
+            .find(|step| step.source == "agent")
+            .expect("trajectory should contain an agent step")
+    }
+}
+
+fn span_attrs(spans: &[SpanData], span_name: &str) -> HashMap<String, String> {
+    let span = spans
+        .iter()
+        .find(|span| span.name.as_ref() == span_name)
+        .unwrap_or_else(|| panic!("missing span {span_name}"));
+    attr_map(&span.attributes)
+}
+
+/// Feed the same events to all three exporters and collect their outputs.
+fn export_through_all_exporters(events: &[Event]) -> ParityExports {
+    let atif = AtifExporter::new("parity-session".to_string(), make_agent_info());
+    let atif_record = atif.subscriber();
+
+    let (otel_provider, otel_exporter) = make_provider();
+    let otel = OpenTelemetrySubscriber::from_tracer_provider(otel_provider, "parity-otel");
+    let otel_record = otel.subscriber();
+
+    let (openinference_provider, openinference_exporter) = make_provider();
+    let openinference = OpenInferenceSubscriber::from_tracer_provider(
+        openinference_provider,
+        "parity-openinference",
+    );
+    let openinference_record = openinference.subscriber();
+
+    for event in events {
+        atif_record(event);
+        otel_record(event);
+        openinference_record(event);
+    }
+
+    let trajectory = atif.export().unwrap();
+    otel.force_flush().unwrap();
+    openinference.force_flush().unwrap();
+
+    ParityExports {
+        trajectory,
+        otel_spans: otel_exporter.get_finished_spans().unwrap(),
+        openinference_spans: openinference_exporter.get_finished_spans().unwrap(),
+    }
+}
+
+fn run_llm_scenario(request_content: Json, output: Json) -> ParityExports {
+    let uuid = Uuid::now_v7();
+    export_through_all_exporters(&[
+        llm_start(uuid, "model-call", request_content),
+        llm_end(uuid, "model-call", output),
+    ])
+}
+
+// Shared provider-shaped payloads: the same logical call (one user message,
+// one assistant reply, 1000/500/200-cached usage) in two provider schemas so
+// codec x exporter drift is caught.
+
+fn chat_request_content(model: &str) -> Json {
+    json!({
+        "model": model,
+        "messages": [{"role": "user", "content": "price this"}]
+    })
+}
+
+fn chat_response_output(model: &str) -> Json {
+    json!({
+        "id": "chatcmpl-parity",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "hello"},
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 1000,
+            "completion_tokens": 500,
+            "total_tokens": 1500,
+            "prompt_tokens_details": {"cached_tokens": 200}
+        }
+    })
+}
+
+fn anthropic_request_content(model: &str) -> Json {
+    json!({
+        "model": model,
+        "system": "be terse",
+        "messages": [{"role": "user", "content": "price this"}]
+    })
+}
+
+fn anthropic_response_output(model: &str, usage: Json) -> Json {
+    json!({
+        "id": "msg_parity",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": "hello"}],
+        "stop_reason": "end_turn",
+        "usage": usage
+    })
+}
+
+// ===================================================================
+// Cost parity
+// ===================================================================
+
+#[test]
+fn test_exporters_agree_on_cost_total_for_openai_chat_payload() {
+    let _pricing_guard = pricing_test_mutex()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    install_parity_pricing("parity-priced-model");
+    let _reset_guard = ResetPricingResolverGuard;
+
+    let exports = run_llm_scenario(
+        chat_request_content("parity-priced-model"),
+        chat_response_output("parity-priced-model"),
+    );
+
+    // 800 billable prompt (1000 - 200 cached) * 0.15/M
+    //   + 500 completion * 0.60/M + 200 cache-read * 0.075/M = 0.000435 USD.
+    assert_eq!(
+        exports.agent_step().metrics.as_ref().unwrap().cost_usd,
+        Some(0.000_435)
+    );
+
+    let otel = exports.otel_attrs("model-call");
+    assert_eq!(
+        otel.get("nemo_relay.llm.cost.total"),
+        Some(&"0.000435".to_string())
+    );
+    assert_eq!(
+        otel.get("nemo_relay.llm.cost.currency"),
+        Some(&"USD".to_string())
+    );
+
+    let openinference = exports.openinference_attrs("model-call");
+    assert_eq!(
+        openinference.get("llm.cost.total"),
+        Some(&"0.000435".to_string())
+    );
+}
+
+#[test]
+fn test_exporters_agree_on_cost_total_for_anthropic_payload() {
+    let _pricing_guard = pricing_test_mutex()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    install_parity_pricing("parity-priced-model");
+    let _reset_guard = ResetPricingResolverGuard;
+
+    let exports = run_llm_scenario(
+        anthropic_request_content("parity-priced-model"),
+        anthropic_response_output(
+            "parity-priced-model",
+            json!({
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 200
+            }),
+        ),
+    );
+
+    // Identical normalized usage as the OpenAI Chat scenario, so the cost
+    // must match the chat-shaped run exactly: codec differences must not
+    // leak into exporter cost facts.
+    assert_eq!(
+        exports.agent_step().metrics.as_ref().unwrap().cost_usd,
+        Some(0.000_435)
+    );
+
+    let otel = exports.otel_attrs("model-call");
+    assert_eq!(
+        otel.get("nemo_relay.llm.cost.total"),
+        Some(&"0.000435".to_string())
+    );
+    assert_eq!(
+        otel.get("nemo_relay.llm.cost.currency"),
+        Some(&"USD".to_string())
+    );
+
+    let openinference = exports.openinference_attrs("model-call");
+    assert_eq!(
+        openinference.get("llm.cost.total"),
+        Some(&"0.000435".to_string())
+    );
+}
+
+// ===================================================================
+// Usage parity
+// ===================================================================
+
+#[test]
+fn test_usage_facts_parity_for_openai_chat_payload() {
+    // "parity-usage-model" never appears in a pricing catalog, so usage facts
+    // are deterministic regardless of the process-wide pricing resolver.
+    let exports = run_llm_scenario(
+        chat_request_content("parity-usage-model"),
+        chat_response_output("parity-usage-model"),
+    );
+
+    let metrics = exports.agent_step().metrics.as_ref().unwrap();
+    assert_eq!(metrics.prompt_tokens, Some(1000));
+    assert_eq!(metrics.completion_tokens, Some(500));
+    assert_eq!(metrics.cached_tokens, Some(200));
+
+    let openinference = exports.openinference_attrs("model-call");
+    assert_eq!(
+        openinference.get("llm.token_count.prompt"),
+        Some(&"1000".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.completion"),
+        Some(&"500".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.total"),
+        Some(&"1500".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.prompt_details.cache_read"),
+        Some(&"200".to_string())
+    );
+
+    let otel = exports.otel_attrs("model-call");
+    assert_no_attribute_key_contains(&otel, "token_count");
+    assert!(otel.contains_key("nemo_relay.end.output_json"));
+}
+
+#[test]
+fn test_usage_facts_parity_for_anthropic_payload_with_cache_write() {
+    let exports = run_llm_scenario(
+        anthropic_request_content("parity-usage-model"),
+        anthropic_response_output(
+            "parity-usage-model",
+            json!({
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 200,
+                "cache_creation_input_tokens": 64
+            }),
+        ),
+    );
+
+    let metrics = exports.agent_step().metrics.as_ref().unwrap();
+    assert_eq!(metrics.prompt_tokens, Some(1000));
+    assert_eq!(metrics.completion_tokens, Some(500));
+    // ATIF folds cache reads and writes into a single cached_tokens sum
+    // (200 + 64).
+    assert_eq!(metrics.cached_tokens, Some(264));
+
+    let openinference = exports.openinference_attrs("model-call");
+    assert_eq!(
+        openinference.get("llm.token_count.prompt"),
+        Some(&"1000".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.completion"),
+        Some(&"500".to_string())
+    );
+    // Anthropic reports no total; the shared codec computes 1000 + 500.
+    assert_eq!(
+        openinference.get("llm.token_count.total"),
+        Some(&"1500".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.prompt_details.cache_read"),
+        Some(&"200".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.prompt_details.cache_write"),
+        Some(&"64".to_string())
+    );
+
+    let otel = exports.otel_attrs("model-call");
+    assert_no_attribute_key_contains(&otel, "token_count");
+}
+
+// ===================================================================
+// Model-name parity
+// ===================================================================
+
+#[test]
+fn test_exporters_agree_on_model_name() {
+    let exports = run_llm_scenario(
+        chat_request_content("parity-name-model"),
+        chat_response_output("parity-name-model"),
+    );
+
+    assert_eq!(
+        exports.agent_step().model_name.as_deref(),
+        Some("parity-name-model")
+    );
+    assert_eq!(
+        exports
+            .otel_attrs("model-call")
+            .get("nemo_relay.model_name"),
+        Some(&"parity-name-model".to_string())
+    );
+    assert_eq!(
+        exports
+            .openinference_attrs("model-call")
+            .get("llm.model_name"),
+        Some(&"parity-name-model".to_string())
+    );
+}
+
+// ===================================================================
+// Tool-call parity
+// ===================================================================
+
+#[test]
+fn test_tool_call_projection_parity() {
+    let llm_uuid = Uuid::now_v7();
+    let tool_uuid = Uuid::now_v7();
+    let output = json!({
+        "id": "chatcmpl-parity-tools",
+        "model": "parity-tool-model",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_parity_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"city\":\"NYC\"}"}
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    });
+
+    let exports = export_through_all_exporters(&[
+        llm_start(
+            llm_uuid,
+            "model-call",
+            chat_request_content("parity-tool-model"),
+        ),
+        llm_end(llm_uuid, "model-call", output),
+        tool_event(
+            ScopeCategory::Start,
+            tool_uuid,
+            "get_weather",
+            json!({"city": "NYC"}),
+            "call_parity_1",
+        ),
+        tool_event(
+            ScopeCategory::End,
+            tool_uuid,
+            "get_weather",
+            json!({"temp_f": 72}),
+            "call_parity_1",
+        ),
+    ]);
+
+    // ATIF promotes the tool call onto the agent step and correlates the tool
+    // result observation by the same id.
+    let agent_step = exports.agent_step();
+    let tool_calls = agent_step.tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].tool_call_id, "call_parity_1");
+    assert_eq!(tool_calls[0].function_name, "get_weather");
+    assert_eq!(tool_calls[0].arguments, json!({"city": "NYC"}));
+    let observation = agent_step.observation.as_ref().unwrap();
+    assert_eq!(
+        observation.results[0].source_call_id.as_deref(),
+        Some("call_parity_1")
+    );
+
+    // OpenInference flattens the same facts onto the LLM span.
+    let openinference_llm = exports.openinference_attrs("model-call");
+    assert_eq!(
+        openinference_llm.get("llm.output_messages.0.message.tool_calls.0.tool_call.id"),
+        Some(&"call_parity_1".to_string())
+    );
+    assert_eq!(
+        openinference_llm.get("llm.output_messages.0.message.tool_calls.0.tool_call.function.name"),
+        Some(&"get_weather".to_string())
+    );
+    let openinference_arguments = openinference_llm
+        .get("llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments")
+        .expect("openinference tool-call arguments");
+    assert_eq!(
+        serde_json::from_str::<Json>(openinference_arguments).unwrap(),
+        tool_calls[0].arguments,
+    );
+    // The tool span carries the same correlation id.
+    assert_eq!(
+        exports
+            .openinference_attrs("get_weather")
+            .get("tool_call.id"),
+        Some(&"call_parity_1".to_string())
+    );
+
+    assert_eq!(
+        exports
+            .otel_attrs("get_weather")
+            .get("nemo_relay.tool_call_id"),
+        Some(&"call_parity_1".to_string())
+    );
+    assert_no_attribute_key_contains(&exports.otel_attrs("model-call"), "tool_call");
+}
+
+// ===================================================================
+// Reasoning projection
+// ===================================================================
+
+#[test]
+fn test_reasoning_projected_by_atif_only() {
+    let request_content = json!({
+        "model": "parity-reasoning-model",
+        "reasoning_effort": "high",
+        "messages": [{"role": "user", "content": "think hard"}]
+    });
+    let mut output = chat_response_output("parity-reasoning-model");
+    output.as_object_mut().unwrap().insert(
+        "reasoning".into(),
+        Json::String("I compared both options step by step.".to_string()),
+    );
+
+    let exports = run_llm_scenario(request_content, output);
+
+    // ATIF projects reasoning effort (from the request) and reasoning content
+    // (from the response) onto the agent step.
+    let agent_step = exports.agent_step();
+    assert_eq!(agent_step.reasoning_effort, Some(json!("high")));
+    assert_eq!(
+        agent_step.reasoning_content.as_deref(),
+        Some("I compared both options step by step.")
+    );
+
+    assert_no_attribute_key_contains(&exports.otel_attrs("model-call"), "reasoning");
+    assert_no_attribute_key_contains(&exports.openinference_attrs("model-call"), "reasoning");
+}
+
+// ===================================================================
+// Replay-payload preservation
+// ===================================================================
+
+#[test]
+fn test_replay_payload_preservation_across_exporters() {
+    let request_content = chat_request_content("parity-replay-model");
+    let output = chat_response_output("parity-replay-model");
+    let exports = run_llm_scenario(request_content.clone(), output.clone());
+
+    // ATIF preserves the full request on the user step and the full response
+    // on the agent step; both round-trip the original payloads exactly.
+    let user_step = exports
+        .trajectory
+        .steps
+        .iter()
+        .find(|step| step.source == "user")
+        .expect("user step");
+    let user_extra: AtifStepExtra =
+        serde_json::from_value(user_step.extra.clone().unwrap()).unwrap();
+    assert_eq!(user_extra.llm_request, Some(request_content.clone()));
+
+    let agent_extra: AtifStepExtra =
+        serde_json::from_value(exports.agent_step().extra.clone().unwrap()).unwrap();
+    assert_eq!(agent_extra.llm_response, Some(output.clone()));
+
+    // OTel preserves the same payloads as serialized JSON attributes (the
+    // start input keeps the LlmRequest envelope).
+    let otel = exports.otel_attrs("model-call");
+    let otel_input: Json =
+        serde_json::from_str(otel.get("nemo_relay.start.input_json").unwrap()).unwrap();
+    assert_eq!(
+        otel_input,
+        json!({"headers": {}, "content": request_content})
+    );
+    let otel_output: Json =
+        serde_json::from_str(otel.get("nemo_relay.end.output_json").unwrap()).unwrap();
+    assert_eq!(otel_output, output);
+
+    // OpenInference preserves the raw response payload but omits the raw
+    // LLM request JSON in favor of flattened message attributes plus a
+    // display input.value.
+    let openinference = exports.openinference_attrs("model-call");
+    let openinference_output: Json =
+        serde_json::from_str(openinference.get("nemo_relay.end.output_json").unwrap()).unwrap();
+    assert_eq!(openinference_output, output);
+    assert!(!openinference.contains_key("nemo_relay.start.input_json"));
+    assert!(openinference.contains_key("llm.input_messages.0.message.content"));
+}
+
+// ===================================================================
+// Manual-extraction fallback parity
+// ===================================================================
+
+#[test]
+fn test_manual_fallback_payload_parity() {
+    let _pricing_guard = pricing_test_mutex()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    install_parity_pricing("parity-manual-model");
+    let _reset_guard = ResetPricingResolverGuard;
+
+    // A non-provider-shaped payload: no codec detects it, so every exporter
+    // must agree via the shared manual-extraction fallback.
+    let uuid = Uuid::now_v7();
+    let output = json!({
+        "content": "manual answer",
+        "model": "parity-manual-model",
+        "usage": {
+            "prompt_tokens": 1000,
+            "completion_tokens": 500,
+            "total_tokens": 1500
+        }
+    });
+    let end = llm_event_with_model(
+        ScopeCategory::End,
+        uuid,
+        "model-call",
+        output,
+        "parity-manual-model",
+    );
+    assert!(
+        end.normalized_llm_response().is_none(),
+        "payload must exercise the manual fallback, not a codec",
+    );
+    let start = llm_event_with_model(
+        ScopeCategory::Start,
+        uuid,
+        "model-call",
+        json!({"prompt": "manual prompt"}),
+        "parity-manual-model",
+    );
+    let exports = export_through_all_exporters(&[start, end]);
+
+    // Cost: 1000 * 0.15/M + 500 * 0.60/M = 0.00045 USD from all exporters.
+    let metrics = exports.agent_step().metrics.as_ref().unwrap();
+    assert_eq!(metrics.prompt_tokens, Some(1000));
+    assert_eq!(metrics.completion_tokens, Some(500));
+    assert_eq!(metrics.cost_usd, Some(0.000_45));
+    assert_eq!(
+        exports.agent_step().model_name.as_deref(),
+        Some("parity-manual-model")
+    );
+
+    let otel = exports.otel_attrs("model-call");
+    assert_eq!(
+        otel.get("nemo_relay.llm.cost.total"),
+        Some(&"0.00045".to_string())
+    );
+    assert_eq!(
+        otel.get("nemo_relay.llm.cost.currency"),
+        Some(&"USD".to_string())
+    );
+    assert_eq!(
+        otel.get("nemo_relay.model_name"),
+        Some(&"parity-manual-model".to_string())
+    );
+
+    let openinference = exports.openinference_attrs("model-call");
+    assert_eq!(
+        openinference.get("llm.cost.total"),
+        Some(&"0.00045".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.model_name"),
+        Some(&"parity-manual-model".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.prompt"),
+        Some(&"1000".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.completion"),
+        Some(&"500".to_string())
+    );
+    assert_eq!(
+        openinference.get("llm.token_count.total"),
+        Some(&"1500".to_string())
+    );
+}


### PR DESCRIPTION
#### Overview

Backfill regression and parity coverage for the shared extraction seams established by #291, #300, #301, #304, and #318, so agent-payload extraction, provider-schema normalization, and exporter projection cannot drift silently. Test-only: the only `src` edits are `#[cfg(test)]` module wiring for two new suites; no production behavior changes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

**Agent payload extraction** (`crates/cli/tests/coverage/adapters_tests.rs`, 15 tests):

- Per-host partial-sparse payloads for Claude Code, Codex, and Hermes (real identifiers kept, absent fields synthesized or null at the adapter boundary).
- Path-precedence fallback-chain walks for session IDs, event names, subagent IDs, tool-call IDs, and tool results/status.
- Hermes tool result and status extraction (previously uncovered), including explicit-status vs event-name-derived status interaction.
- Claude Code LLM-hint extraction and hint field precedence chains.
- JSON-path primitive edge cases: empty-string filtering, array intermediates, deep nesting, all-paths-miss.

**Provider request extraction** (`crates/cli/tests/coverage/alignment_tests.rs`, 6 tests):

- First coverage for `request_affinity_key` (route-gated, length-bounded) and `gateway_turn_input` (Claude Code + Anthropic Messages only).
- Header-only session-id routing on the Models and Count-Tokens routes, contrasted with the body fallbacks on the Responses/Chat routes.
- Gateway route name round-trips.

**Codec parity** (`crates/core/tests/unit/codec/parity_tests.rs`, new, 14 tests):

Each test builds the same logical scenario in all three provider schemas (OpenAI Chat Completions, Anthropic Messages, OpenAI Responses) and asserts the normalized output agrees: model name, finish reasons, tool calls (full-struct equality), usage incl. cache-read tokens, provider-reported and catalog-estimated cost, hint hardening (`normalize_request_with_hint`), and request normalization. Schema-inherent divergences are asserted explicitly as part of the parity contract, e.g. Responses normalizes a tool-call turn to `Complete` (no tool-use terminal status), cache-write tokens are Anthropic-only, reasoning tokens are Responses-only.

**Exporter parity** (`crates/core/tests/unit/observability/exporter_parity_tests.rs`, new, 9 tests):

A shared harness feeds one event stream to the ATIF exporter, `OpenTelemetrySubscriber`, and `OpenInferenceSubscriber` (in-memory span exporters) and asserts the projected facts agree: cost totals, usage, model names, tool-call projection, replay-payload preservation, and the consolidated manual-fallback path — run against both OpenAI-Chat-shaped and Anthropic-shaped payloads. Intentional projection divergences are pinned with explicit assertions so drift fails loudly, notably: OTel emits no token-count attributes, reasoning facts are ATIF-only, ATIF sums cache read+write while OpenInference splits them, and OpenInference omits raw LLM request JSON. Cost-currency policy boundaries stay covered by the existing per-exporter tests from #304 and are not duplicated here.

**Validation**

- `just test-rust` — full workspace green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `uv run pre-commit run --files <changed files>` — all hooks green (SPDX, fmt, clippy, check, linkcheck)
- Rebased onto current `main` and re-ran `cargo test -p nemo-relay` and `cargo test -p nemo-relay-cli` — green, including the parity suites against the latest observability changes
- Binding matrix not run: the change is test-only; the `#[cfg(test)]` modules are not compiled into the library targets, so binding-facing behavior is unchanged

**Breaking changes**

None.

#### Where should the reviewer start?

`crates/core/tests/unit/observability/exporter_parity_tests.rs` — the `export_through_all_exporters` harness and the explicitly pinned divergences. These assertions encode current behavior. The OTel cost-only projection and the ATIF cache-sum vs OpenInference cache-split asymmetry match the token/cost field-semantics contract documented in #330; the remaining pinned divergences (reasoning projection being ATIF-only, OTel not flattening LLM tool calls, OpenInference omitting raw LLM request JSON) encode current behavior without a recorded decision — if any is ruled a defect, the fix should land together with flipping the pinning assertion.

Then `crates/core/tests/unit/codec/parity_tests.rs` for the cross-schema normalization contract, and the adapter/alignment additions in `crates/cli/tests/coverage/`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none (test backfill for the extraction-strategy refactors #291, #300, #301, #304, #318)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for Hermes and Claude tool adapter/extractor precedence, partial payload handling, and hint/session/model/request-id resolution (including null/empty-string and fallback-chain behaviors).
  * Expanded gateway alignment tests for affinity-key/session-id gating and route/provider-specific prompt building.
  * Introduced core codec and observability cross-provider/exporter parity tests validating normalized fields, tool-call mapping, and consistent usage/cost/model/replay projections (with expected divergence checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->