### PR TITLE
ci: publish Python plugin wheel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -392,6 +392,12 @@ jobs:
           merge-multiple: true
           path: dist/
 
+      - name: Download Python plugin SDK wheel artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: plugin-wheel
+          path: dist/
+
       - name: Publish to PyPI with trusted publishing
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -290,7 +290,7 @@ jobs:
         if: ${{ matrix.platform == 'linux-amd64' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: python-plugin-wheel
+          name: plugin-wheel
           path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/plugin-wheels/*.whl
           if-no-files-found: error
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,6 +130,7 @@ collect:github-artifacts:
       fi
 
       gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'wheel-*' --dir downloaded/wheels
+      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --name 'plugin-wheel' --dir downloaded/wheels
       gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --name npm-consolidated --dir downloaded/node
 
       find downloaded/wheels -type f -name '*.whl' -exec cp {} collected/wheels/ \;

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,7 +31,7 @@ The release pipeline publishes these package surfaces from a tag push:
 | Ecosystem | Published Surface |
 |---|---|
 | crates.io | `nemo-relay-types`, `nemo-relay-plugin`, `nemo-relay-worker-proto`, `nemo-relay-worker`, `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-pii-redaction`, `nemo-relay-ffi`, `nemo-relay-cli` |
-| PyPI | `nemo-relay` |
+| PyPI | `nemo-relay`, `nemo-relay-plugin` |
 | npm | `nemo-relay-node`, `nemo-relay-openclaw` |
 | GitHub Releases | CLI binaries and `SHA256SUMS` |
 | Fern | The documentation site |
@@ -238,7 +238,8 @@ The release pipeline then:
    - `package-rust` packs the published Rust crates for local validation.
    - `package-node` packs the npm Node.js package.
    - `package-openclaw` packs the npm OpenClaw plugin package.
-   - `package-python` builds platform wheels.
+   - `package-python` builds platform `nemo-relay` wheels.
+   - `package-python-plugin` builds the `nemo-relay-plugin` wheel.
    - The CLI release-asset job uploads each platform `nemo-relay` binary and
      includes those binaries in `SHA256SUMS`.
 4. Publishes packages from the top-level workflow after the reusable packaging
@@ -249,8 +250,9 @@ The release pipeline then:
      `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-pii-redaction`,
      `nemo-relay-ffi`, and `nemo-relay-cli` through trusted publishing from
      the top-level workflow
-   - `publish-python` uploads the wheel artifacts to PyPI with trusted
-     publishing from the top-level workflow
+   - `publish-python` downloads both the `nemo-relay` and `nemo-relay-plugin`
+     wheel artifacts and uploads them to PyPI with trusted publishing from the
+     top-level workflow
    - `publish-npm` publishes the Node.js and OpenClaw plugin npm packages
      through npm trusted publishing from the top-level workflow
      - Stable tags publish to the npm `latest` dist-tag


### PR DESCRIPTION
#### Overview

Make the `nemo-relay-plugin` Python wheel an explicit release artifact so tag releases publish it to PyPI alongside `nemo-relay`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Rename the plugin wheel artifact to `plugin-wheel` so it is not hidden by the general platform-wheel glob.
- Download the plugin wheel explicitly in the top-level PyPI publish job.
- Include the plugin wheel in the mirrored GitLab Artifactory collection.
- Document `nemo-relay-plugin` as a published PyPI surface.

#### Where should the reviewer start?

Start with `.github/workflows/ci.yaml`, where the release job explicitly downloads the plugin wheel before invoking trusted PyPI publishing.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PyPI releases now include the plugin package alongside the main package.
  * CI release steps now collect and publish both wheel artifacts together.

* **Documentation**
  * Updated release docs to reflect the expanded Python packaging and publishing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->