### PR TITLE
chore: prepare 0.5 release freeze

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,3 +3,4 @@
 
 branches:
   - main
+  - release/0.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-adaptive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-node"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "napi",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-pii-redaction"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures",
  "nemo-relay",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nemo-relay-types",
  "serde",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-python"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-util",
  "hyper-util",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker-proto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,21 +20,21 @@ exclude = [".tmp", ".uv-cache"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/NeMo-Relay"
 
 [workspace.dependencies]
-nemo-relay = { version = "0.5.0", path = "crates/core", default-features = false }
-nemo-relay-types = { version = "0.5.0", path = "crates/types" }
-nemo-relay-plugin = { version = "0.5.0", path = "crates/plugin" }
-nemo-relay-worker-proto = { version = "0.5.0", path = "crates/worker-proto" }
-nemo-relay-worker = { version = "0.5.0", path = "crates/worker" }
-nemo-relay-adaptive = { version = "0.5.0", path = "crates/adaptive" }
-nemo-relay-pii-redaction = { version = "0.5.0", path = "crates/pii-redaction" }
-nemo-relay-ffi = { version = "0.5.0", path = "crates/ffi" }
-nemo-relay-cli = { version = "0.5.0", path = "crates/cli" }
+nemo-relay = { version = "0.6.0", path = "crates/core", default-features = false }
+nemo-relay-types = { version = "0.6.0", path = "crates/types" }
+nemo-relay-plugin = { version = "0.6.0", path = "crates/plugin" }
+nemo-relay-worker-proto = { version = "0.6.0", path = "crates/worker-proto" }
+nemo-relay-worker = { version = "0.6.0", path = "crates/worker" }
+nemo-relay-adaptive = { version = "0.6.0", path = "crates/adaptive" }
+nemo-relay-pii-redaction = { version = "0.6.0", path = "crates/pii-redaction" }
+nemo-relay-ffi = { version = "0.6.0", path = "crates/ffi" }
+nemo-relay-cli = { version = "0.6.0", path = "crates/cli" }
 opentelemetry = { version = "0.31", default-features = false }
 opentelemetry_sdk = { version = "0.31", default-features = false }
 uuid = "=1.18.1"

--- a/crates/core/tests/fixtures/worker_plugin/Cargo.lock
+++ b/crates/core/tests/fixtures/worker_plugin/Cargo.lock
@@ -536,7 +536,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-util",
  "hyper-util",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker-proto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prost",
  "prost-build",

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-node",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Node.js bindings for the NeMo Relay agent runtime.",
   "keywords": [
     "agents",

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -100,7 +100,7 @@ asset is published.
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | NEMO_RELAY_VERSION=0.5.0 sh
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | NEMO_RELAY_VERSION=0.6.0 sh
 ```
 
 Install into another directory:
@@ -124,7 +124,7 @@ Set the same environment variable before invoking the installer to install a
 specific version:
 
 ```powershell
-$env:NEMO_RELAY_VERSION = '0.5.0'
+$env:NEMO_RELAY_VERSION = '0.6.0'
 irm https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.ps1 | iex
 ```
 
@@ -178,7 +178,7 @@ Install the Python package when your application uses NeMo Relay through the
 Python wrapper and owns the tool or LLM call boundary.
 
 ```bash
-uv add nemo-relay@0.5.0
+uv add nemo-relay@0.6.0
 ```
 
 Use `uv add` from an application project that has a `pyproject.toml`; it records
@@ -201,8 +201,8 @@ npm install nemo-relay-node
 Add the Rust crates when your application uses NeMo Relay directly from Rust.
 
 ```bash
-cargo add nemo-relay@0.5.0
-cargo add nemo-relay-adaptive@0.5.0
+cargo add nemo-relay@0.6.0
+cargo add nemo-relay-adaptive@0.6.0
 ```
 
 - `nemo-relay` provides the core runtime APIs for scopes, middleware, subscribers, plugins, tool calls, and LLM calls.
@@ -219,7 +219,7 @@ Install the OpenClaw plugin through OpenClaw so OpenClaw can register and manage
 the package:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.5.0
+openclaw plugins install npm:nemo-relay-openclaw@0.6.0
 openclaw gateway restart
 ```
 
@@ -248,7 +248,7 @@ Install the Python package with the supported framework extras when your
 application uses LangChain, LangGraph, or Deep Agents.
 
 ```bash
-uv add "nemo-relay[langchain,langgraph,deepagents]@0.5.0"
+uv add "nemo-relay[langchain,langgraph,deepagents]@0.6.0"
 ```
 
 The extras install the NeMo Relay Python package plus the dependencies needed by

--- a/docs/getting-started/quick-start/python.mdx
+++ b/docs/getting-started/quick-start/python.mdx
@@ -20,7 +20,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-uv add nemo-relay@0.5.0
+uv add nemo-relay@0.6.0
 ```
 
 Run `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/quick-start/rust.mdx
+++ b/docs/getting-started/quick-start/rust.mdx
@@ -18,7 +18,7 @@ local checkout.
 Use the published crates when you are consuming a release:
 
 ```bash
-cargo add nemo-relay@0.5.0
+cargo add nemo-relay@0.6.0
 cargo add serde_json
 cargo add tokio --features macros,rt-multi-thread
 ```
@@ -27,7 +27,7 @@ Install the published NeMo Relay CLI separately when you need coding-agent hook
 and LLM gateway observability:
 
 ```bash
-cargo install nemo-relay-cli@0.5.0
+cargo install nemo-relay-cli@0.6.0
 ```
 
 ### Install from the Repository
@@ -47,7 +47,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 - `nemo-relay-adaptive` is a companion crate for adaptive runtime primitives and
   Redis-backed learning components when you need adaptive behavior later, but it
   is not required for this minimal direct-runtime example.
-- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.5.0`
+- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.6.0`
   when you need the NeMo Relay CLI.
 
 ## Run One Scope, One Tool Call, and One LLM Call

--- a/docs/observability-plugin/configuration.mdx
+++ b/docs/observability-plugin/configuration.mdx
@@ -87,7 +87,7 @@ transport = "http_binary"
 endpoint = "http://localhost:4318/v1/traces"
 service_name = "nemo-relay"
 service_namespace = "agent"
-service_version = "0.5.0"
+service_version = "0.6.0"
 instrumentation_scope = "nemo-relay-observability"
 timeout_millis = 3000
 
@@ -104,7 +104,7 @@ transport = "http_binary"
 endpoint = "http://localhost:6006/v1/traces"
 service_name = "nemo-relay"
 service_namespace = "agent"
-service_version = "0.5.0"
+service_version = "0.6.0"
 instrumentation_scope = "nemo-relay-openinference"
 timeout_millis = 3000
 
@@ -194,7 +194,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:4318/v1/traces",
                     service_name="nemo-relay",
                     service_namespace="agent",
-                    service_version="0.5.0",
+                    service_version="0.6.0",
                     instrumentation_scope="nemo-relay-observability",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -203,7 +203,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:6006/v1/traces",
                     service_name="nemo-relay",
                     service_namespace="agent",
-                    service_version="0.5.0",
+                    service_version="0.6.0",
                     instrumentation_scope="nemo-relay-openinference",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -252,7 +252,7 @@ await plugin.initialize({
         endpoint: "http://localhost:4318/v1/traces",
         service_name: "nemo-relay",
         service_namespace: "agent",
-        service_version: "0.5.0",
+        service_version: "0.6.0",
         instrumentation_scope: "nemo-relay-observability",
         resource_attributes: {
           "deployment.environment": "dev",
@@ -263,7 +263,7 @@ await plugin.initialize({
         endpoint: "http://localhost:6006/v1/traces",
         service_name: "nemo-relay",
         service_namespace: "agent",
-        service_version: "0.5.0",
+        service_version: "0.6.0",
         instrumentation_scope: "nemo-relay-openinference",
         resource_attributes: {
           "deployment.environment": "dev",
@@ -314,7 +314,7 @@ let component = ComponentSpec::new(ObservabilityConfig {
         endpoint: Some("http://localhost:4318/v1/traces".into()),
         service_name: "nemo-relay".into(),
         service_namespace: Some("agent".into()),
-        service_version: Some("0.5.0".into()),
+        service_version: Some("0.6.0".into()),
         instrumentation_scope: Some("nemo-relay-observability".into()),
         resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
         ..OtlpSectionConfig::default()
@@ -324,7 +324,7 @@ let component = ComponentSpec::new(ObservabilityConfig {
         endpoint: Some("http://localhost:6006/v1/traces".into()),
         service_name: "nemo-relay".into(),
         service_namespace: Some("agent".into()),
-        service_version: Some("0.5.0".into()),
+        service_version: Some("0.6.0".into()),
         instrumentation_scope: Some("nemo-relay-openinference".into()),
         resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
         ..OtlpSectionConfig::default()

--- a/docs/supported-integrations/openclaw-plugin.mdx
+++ b/docs/supported-integrations/openclaw-plugin.mdx
@@ -41,7 +41,7 @@ Optional:
 Install the plugin with OpenClaw so OpenClaw can register and manage it:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.5.0
+openclaw plugins install npm:nemo-relay-openclaw@0.6.0
 openclaw gateway restart
 ```
 
@@ -54,7 +54,7 @@ If you manage OpenClaw plugin dependencies directly in a Node.js project,
 install the package with npm:
 
 ```bash
-npm install nemo-relay-openclaw@0.5.0
+npm install nemo-relay-openclaw@0.6.0
 ```
 
 Installing with npm makes the package available to that project. Use

--- a/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
+++ b/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Claude Code hooks that forward canonical lifecycle payloads to nemo-relay.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/coding-agents/codex/.codex-plugin/plugin.json
+++ b/integrations/coding-agents/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Codex hooks that forward canonical lifecycle payloads to nemo-relay.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-openclaw",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "NeMo Relay-authored observability plugin for OpenClaw.",
   "type": "module",
   "repository": {
@@ -63,7 +63,7 @@
     "openclaw": "^2026.5.26"
   },
   "dependencies": {
-    "nemo-relay-node": "0.5.0"
+    "nemo-relay-node": "0.6.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/justfile
+++ b/justfile
@@ -572,7 +572,7 @@ set_project_version() {
     local version="$1"
     set_cargo_workspace_version "$version"
     set_node_package_versions "$version"
-    set_python_package_version "$version"
+    set_python_package_version "$version" false
     set_python_plugin_package_version "$version"
     set_coding_agent_plugin_versions "$version"
 }
@@ -617,24 +617,25 @@ PY
 
 set_python_package_version() {
     local cargo_version="$1"
+    local materialize_version="${2:-true}"
     local version=""
     local python_executable=""
     version="$(semver_to_pep440 "$cargo_version")"
     python_executable="$(uv_python_executable)"
 
-    "$python_executable" - "$version" "$cargo_version" <<'PY'
+    "$python_executable" - "$version" "$materialize_version" <<'PY'
 from pathlib import Path
 import re
 import sys
 
 version = sys.argv[1]
-cargo_version = sys.argv[2]
+materialize_version = sys.argv[2] == "true"
 path = Path("pyproject.toml")
 text = path.read_text()
 
-if 'dynamic = ["version"]' in text:
+if materialize_version and 'dynamic = ["version"]' in text:
     updated = text.replace('dynamic = ["version"]', f'version = "{version}"', 1)
-elif re.search(r'^version = "(.*)"$', text, flags=re.MULTILINE):
+elif materialize_version and re.search(r'^version = "(.*)"$', text, flags=re.MULTILINE):
     updated, count = re.subn(
         r'^version = "(.*)"$',
         f'version = "{version}"',
@@ -644,21 +645,37 @@ elif re.search(r'^version = "(.*)"$', text, flags=re.MULTILINE):
     )
     if count != 1:
         raise SystemExit("Failed to update version in pyproject.toml")
+elif not materialize_version and 'dynamic = ["version"]' in text:
+    updated = text
+elif not materialize_version and re.search(r'^version = "(.*)"$', text, flags=re.MULTILINE):
+    updated, count = re.subn(
+        r'^version = "(.*)"$',
+        'dynamic = ["version"]',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise SystemExit("Failed to restore dynamic version in pyproject.toml")
 else:
-    raise SystemExit("Failed to find dynamic or static version field in pyproject.toml")
+    raise SystemExit("Failed to find version field in pyproject.toml")
 
-path.write_text(updated)
-print(f"pyproject.toml version updated to {version}")
+if updated != text:
+    path.write_text(updated)
+if materialize_version:
+    print(f"pyproject.toml version updated to {version}")
+else:
+    print("pyproject.toml uses the dynamic Cargo version")
 
 path = Path("crates/python/Cargo.toml")
 text = path.read_text()
 
 if "version.workspace = true" in text:
-    updated = text.replace("version.workspace = true", f'version = "{cargo_version}"', 1)
+    updated = text
 elif re.search(r'^version = "(.*)"$', text, flags=re.MULTILINE):
     updated, count = re.subn(
         r'^version = "(.*)"$',
-        f'version = "{cargo_version}"',
+        "version.workspace = true",
         text,
         count=1,
         flags=re.MULTILINE,
@@ -668,8 +685,9 @@ elif re.search(r'^version = "(.*)"$', text, flags=re.MULTILINE):
 else:
     raise SystemExit("Failed to find workspace or static version field in crates/python/Cargo.toml")
 
-path.write_text(updated)
-print(f"crates/python/Cargo.toml version updated to {cargo_version}")
+if updated != text:
+    path.write_text(updated)
+print("crates/python/Cargo.toml uses the workspace version")
 PY
 }
 
@@ -952,6 +970,12 @@ check-python-worker-proto:
     assert pb.SUBSCRIBER == 1
     assert pb.LLM_STREAM_EXECUTION_INTERCEPT == 25
     PY
+
+generate-worker-plugin-lockfile:
+    #!/usr/bin/env bash
+    {{ bash_helpers }}
+    cd "$NEMO_RELAY_REPO_ROOT"
+    cargo generate-lockfile --manifest-path crates/core/tests/fixtures/worker_plugin/Cargo.toml
 
 
 # --set [ci=true|false]
@@ -1564,10 +1588,10 @@ package-python:
         sha="$(head_git_sha)"
         version="$(read_workspace_version)"
         echo "Non-release build: appending commit hash to version"
-        set_python_package_version "${version}+${sha}"
+        set_python_package_version "${version}+${sha}" true
     else
         echo "Using explicit version {{ ref_name }}"
-        set_python_package_version "{{ ref_name }}"
+        set_python_package_version "{{ ref_name }}" true
     fi
     build_args=()
     while IFS= read -r -d '' arg; do

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
     },
     "crates/node": {
       "name": "nemo-relay-node",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -463,10 +463,10 @@
     },
     "integrations/openclaw": {
       "name": "nemo-relay-openclaw",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nemo-relay-node": "0.5.0"
+        "nemo-relay-node": "0.6.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/python/plugin/pyproject.toml
+++ b/python/plugin/pyproject.toml
@@ -8,7 +8,7 @@ backend-path = ["."]
 
 [project]
 name = "nemo-relay-plugin"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python SDK for NeMo Relay dynamic worker plugins."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1496,7 +1496,7 @@ test = [
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "python/plugin" }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
#### Overview

Prepare the 0.5 release freeze from upstream main and advance main to 0.6.0.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Created and pushed the `release/0.5` branch from upstream `main` (`70b7559e`).
- Added `release/0.5` to `.github/nightly-alpha-branches.yaml`.
- Ran `just set-version 0.6.0`, updating Cargo, Node/OpenClaw, Python, coding-agent plugin, `Cargo.lock`, `package-lock.json`, and `uv.lock` surfaces.
- Preserved `version.workspace = true` in `crates/python/Cargo.toml`.
- Preserved `dynamic = ["version"]` in the root `pyproject.toml` for normal builds, while retaining explicit temporary versions for `package-python` wheel builds.
- Added the worker-plugin fixture `Cargo.lock` required by its `--locked` integration-test build and added `just generate-worker-plugin-lockfile` for regeneration after dependency or version changes.
- Updated current `0.5.0` documentation install/package/configuration examples to `0.6.0`; no intentional current-version leftovers remain under `README.md`, `docs`, or `fern`.
- Audited package/version recipes against projects added since 0.4.0: `nemo-relay-types`, `nemo-relay-plugin`, `nemo-relay-worker-proto`, `nemo-relay-worker`, and `nemo-relay-plugin` Python package are all covered.
- Release-bound PRs should now target `release/0.5`; this code-freeze PR targets `main`.

Validation: focused worker-plugin tests (25 passed), `just test-rust`, `just docs`, YAML validation, `git diff --check`, and targeted pre-commit checks passed.

#### Where should the reviewer start?

Start with `generate-worker-plugin-lockfile` in `justfile`, the fixture `Cargo.lock`, `set_python_package_version`, the root `pyproject.toml`, and the version/documentation diff.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the project and related packages/plugins to version **0.6.0**.
  * Updated branch and release configuration to include the new `release/0.5` path.
* **Documentation**
  * Refreshed installation, quick-start, and observability examples to use **0.6.0**.
  * Updated plugin install instructions for the latest release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->