### PR TITLE
refactor: resolve Sonar scan findings

### DIFF
--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -1339,7 +1339,7 @@ pub(crate) fn format_human(report: &DoctorReport) -> String {
     format_human_agents(&mut out, report);
     format_human_host_plugins(&mut out, report);
     format_human_checks(&mut out, "Observability", &report.observability);
-    format_human_checks(&mut out, "Completions", &report.completions);
+    format_human_completion_checks(&mut out, &report.completions);
     format_human_conclusion(&mut out, report);
     out
 }
@@ -1496,6 +1496,14 @@ fn format_human_checks(out: &mut String, title: &str, checks: &[Check]) {
     out.push_str(&format!("  {title}\n"));
     for check in checks {
         out.push_str(&format!("    {:<22}  {}\n", check.name, check.details));
+    }
+    out.push('\n');
+}
+
+fn format_human_completion_checks(out: &mut String, checks: &[Check]) {
+    out.push_str("  Completions\n");
+    for check in checks {
+        out.push_str(&format!("    {}\n", check.details));
     }
     out.push('\n');
 }

--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -1332,11 +1332,27 @@ fn report_has_warn(report: &DoctorReport) -> bool {
 /// pure formatter stays banner-free for tests.
 pub(crate) fn format_human(report: &DoctorReport) -> String {
     let mut out = String::new();
+    format_human_header(&mut out, report);
+    format_human_environment(&mut out, report);
+    format_human_configuration(&mut out, report);
+    format_human_plugin_configuration(&mut out, report);
+    format_human_agents(&mut out, report);
+    format_human_host_plugins(&mut out, report);
+    format_human_checks(&mut out, "Observability", &report.observability);
+    format_human_checks(&mut out, "Completions", &report.completions);
+    format_human_conclusion(&mut out, report);
+    out
+}
+
+fn format_human_header(out: &mut String, report: &DoctorReport) {
     out.push_str(&format!("\n  NeMo Relay {}\n", report.binary_version));
     out.push_str("  ─────────────────────────────────────────────\n");
     if let Some(agent) = &report.target_agent {
         out.push_str(&format!("  Target agent  {agent}\n\n"));
     }
+}
+
+fn format_human_environment(out: &mut String, report: &DoctorReport) {
     out.push_str("  Environment\n");
     out.push_str(&format!(
         "    OS         {}\n",
@@ -1347,7 +1363,9 @@ pub(crate) fn format_human(report: &DoctorReport) -> String {
         out.push_str(&format!("    Shell      {shell}\n"));
     }
     out.push('\n');
+}
 
+fn format_human_configuration(out: &mut String, report: &DoctorReport) {
     out.push_str("  Configuration\n");
     out.push_str(&format!(
         "    Workspace  {}\n",
@@ -1375,7 +1393,9 @@ pub(crate) fn format_human(report: &DoctorReport) -> String {
         ));
     }
     out.push('\n');
+}
 
+fn format_human_plugin_configuration(out: &mut String, report: &DoctorReport) {
     out.push_str("  Plugin configuration\n");
     for plugin in &report.configuration.dynamic_plugins {
         let config_suffix = if matches!(
@@ -1415,7 +1435,9 @@ pub(crate) fn format_human(report: &DoctorReport) -> String {
         }
     }
     out.push('\n');
+}
 
+fn format_human_agents(out: &mut String, report: &DoctorReport) {
     out.push_str("  Agents detected\n");
     for agent in &report.agents {
         let status = format_status(agent.status);
@@ -1441,7 +1463,9 @@ pub(crate) fn format_human(report: &DoctorReport) -> String {
         }
     }
     out.push('\n');
+}
 
+fn format_human_host_plugins(out: &mut String, report: &DoctorReport) {
     out.push_str("  Host plugins\n");
     if report.host_plugins.is_empty() {
         out.push_str("    ·  none installed; run `nemo-relay install <host>` to enable persistent host plugins\n");
@@ -1466,19 +1490,17 @@ pub(crate) fn format_human(report: &DoctorReport) -> String {
         }
     }
     out.push('\n');
+}
 
-    out.push_str("  Observability\n");
-    for check in &report.observability {
+fn format_human_checks(out: &mut String, title: &str, checks: &[Check]) {
+    out.push_str(&format!("  {title}\n"));
+    for check in checks {
         out.push_str(&format!("    {:<22}  {}\n", check.name, check.details));
     }
     out.push('\n');
+}
 
-    out.push_str("  Completions\n");
-    for check in &report.completions {
-        out.push_str(&format!("    {}\n", check.details));
-    }
-    out.push('\n');
-
+fn format_human_conclusion(out: &mut String, report: &DoctorReport) {
     if exit_code(report) == 0 {
         if report_has_warn(report) {
             out.push_str("  All checks passed, but some issued warnings; see details above.\n");
@@ -1488,7 +1510,6 @@ pub(crate) fn format_human(report: &DoctorReport) -> String {
     } else {
         out.push_str("  Some checks FAILED; see details above.\n");
     }
-    out
 }
 
 fn format_layer(layer: &ConfigLayer) -> String {

--- a/crates/cli/src/plugins/config_io.rs
+++ b/crates/cli/src/plugins/config_io.rs
@@ -211,39 +211,55 @@ fn patch_json_value(
     }
     match (raw, original, updated) {
         (toml::Value::Table(raw), Value::Object(original), Value::Object(updated)) => {
-            for key in original.keys() {
-                if !updated.contains_key(key) {
-                    raw.remove(key);
-                }
-            }
-            for (key, updated) in updated {
-                match (raw.get_mut(key), original.get(key)) {
-                    (Some(raw), Some(original)) => patch_json_value(raw, original, updated)?,
-                    _ => {
-                        raw.insert(key.clone(), json_to_toml(updated.clone())?);
-                    }
-                }
-            }
-            Ok(())
+            patch_json_object(raw, original, updated)
         }
         (toml::Value::Array(raw), Value::Array(original), Value::Array(updated))
             if raw.len() == original.len() =>
         {
-            let shared_len = original.len().min(updated.len());
-            for index in 0..shared_len {
-                patch_json_value(&mut raw[index], &original[index], &updated[index])?;
-            }
-            raw.truncate(updated.len());
-            for value in &updated[shared_len..] {
-                raw.push(json_to_toml(value.clone())?);
-            }
-            Ok(())
+            patch_json_array(raw, original, updated)
         }
         (raw, _, updated) => {
             *raw = json_to_toml(updated.clone())?;
             Ok(())
         }
     }
+}
+
+fn patch_json_object(
+    raw: &mut toml::map::Map<String, toml::Value>,
+    original: &Map<String, Value>,
+    updated: &Map<String, Value>,
+) -> Result<(), CliError> {
+    for key in original.keys() {
+        if !updated.contains_key(key) {
+            raw.remove(key);
+        }
+    }
+    for (key, updated) in updated {
+        match (raw.get_mut(key), original.get(key)) {
+            (Some(raw), Some(original)) => patch_json_value(raw, original, updated)?,
+            _ => {
+                raw.insert(key.clone(), json_to_toml(updated.clone())?);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn patch_json_array(
+    raw: &mut Vec<toml::Value>,
+    original: &[Value],
+    updated: &[Value],
+) -> Result<(), CliError> {
+    let shared_len = original.len().min(updated.len());
+    for index in 0..shared_len {
+        patch_json_value(&mut raw[index], &original[index], &updated[index])?;
+    }
+    raw.truncate(updated.len());
+    for value in &updated[shared_len..] {
+        raw.push(json_to_toml(value.clone())?);
+    }
+    Ok(())
 }
 
 fn json_to_toml(value: Value) -> Result<toml::Value, CliError> {

--- a/crates/cli/src/plugins/dynamic_editor.rs
+++ b/crates/cli/src/plugins/dynamic_editor.rs
@@ -433,7 +433,10 @@ fn handle_dynamic_root_menu_response(
                 Ok(false)
             }
             Some(DynamicMenuAction::Back) | None => Ok(true),
-            Some(DynamicMenuAction::EditField(_)) => unreachable!(),
+            Some(DynamicMenuAction::EditField(_)) => {
+                println!("  Select Edit raw configuration to modify settings.");
+                Ok(false)
+            }
         },
         MenuResponse::Shortcut(MenuShortcut::Reset, selected) => {
             if matches!(actions.get(selected), Some(DynamicMenuAction::ResetPlugin)) {

--- a/crates/cli/src/plugins/dynamic_editor.rs
+++ b/crates/cli/src/plugins/dynamic_editor.rs
@@ -381,55 +381,86 @@ fn edit_dynamic_root_menu(
 ) -> Result<(), CliError> {
     let mut selected_index = 0;
     loop {
-        let mut items = Vec::new();
-        let mut actions = Vec::new();
-        if fields.is_empty() {
-            items.push(MenuItem::new(configured_label(
-                state.config.is_some(),
-                "Edit configuration as JSON object",
-            )));
-            actions.push(DynamicMenuAction::EditRawConfig);
-        }
-        items.push(MenuItem::new(shortcut_label(
-            "Reset plugin configuration",
-            "r",
-        )));
-        actions.push(DynamicMenuAction::ResetPlugin);
-        items.push(MenuItem::new(shortcut_label("Back", "q")));
-        actions.push(DynamicMenuAction::Back);
+        let (items, actions) = dynamic_root_menu_items(state, fields);
 
         let selection = prompt_menu(theme, state.label(), &items, selected_index)?;
         if let Some(selected) = menu_response_index(&selection) {
             selected_index = selected;
         }
-        match selection {
-            MenuResponse::Selected(selected) => match actions.get(selected).copied() {
-                Some(DynamicMenuAction::EditRawConfig) => prompt_raw_config(theme, state)?,
-                Some(DynamicMenuAction::ResetPlugin) => state.reset(),
-                Some(DynamicMenuAction::Back) | None => return Ok(()),
-                Some(DynamicMenuAction::EditField(_)) => unreachable!(),
-            },
-            MenuResponse::Shortcut(MenuShortcut::Reset, selected) => {
-                if matches!(actions.get(selected), Some(DynamicMenuAction::ResetPlugin)) {
-                    state.reset();
-                } else {
-                    println!("  Select Reset plugin configuration to remove config.");
-                }
-            }
-            MenuResponse::Shortcut(MenuShortcut::Clear, selected) => {
-                if matches!(
-                    actions.get(selected),
-                    Some(DynamicMenuAction::EditRawConfig)
-                ) {
-                    state.set_raw_config(Map::new());
-                }
-            }
-            MenuResponse::Shortcut(MenuShortcut::Help, _) => super::print_editor_help(),
-            MenuResponse::Shortcut(MenuShortcut::Preview | MenuShortcut::Save, _) => {
-                println!("  Preview and save are available from the main plugins.toml menu.");
-            }
-            MenuResponse::Cancel => return Ok(()),
+        if handle_dynamic_root_menu_response(theme, state, &actions, selection)? {
+            return Ok(());
         }
+    }
+}
+
+fn dynamic_root_menu_items(
+    state: &DynamicPluginEditorState,
+    fields: &[DynamicConfigField],
+) -> (Vec<MenuItem>, Vec<DynamicMenuAction>) {
+    let mut items = Vec::new();
+    let mut actions = Vec::new();
+    if fields.is_empty() {
+        items.push(MenuItem::new(configured_label(
+            state.config.is_some(),
+            "Edit configuration as JSON object",
+        )));
+        actions.push(DynamicMenuAction::EditRawConfig);
+    }
+    items.push(MenuItem::new(shortcut_label(
+        "Reset plugin configuration",
+        "r",
+    )));
+    actions.push(DynamicMenuAction::ResetPlugin);
+    items.push(MenuItem::new(shortcut_label("Back", "q")));
+    actions.push(DynamicMenuAction::Back);
+    (items, actions)
+}
+
+fn handle_dynamic_root_menu_response(
+    theme: &ColorfulTheme,
+    state: &mut DynamicPluginEditorState,
+    actions: &[DynamicMenuAction],
+    selection: MenuResponse,
+) -> Result<bool, CliError> {
+    match selection {
+        MenuResponse::Selected(selected) => match actions.get(selected).copied() {
+            Some(DynamicMenuAction::EditRawConfig) => {
+                prompt_raw_config(theme, state)?;
+                Ok(false)
+            }
+            Some(DynamicMenuAction::ResetPlugin) => {
+                state.reset();
+                Ok(false)
+            }
+            Some(DynamicMenuAction::Back) | None => Ok(true),
+            Some(DynamicMenuAction::EditField(_)) => unreachable!(),
+        },
+        MenuResponse::Shortcut(MenuShortcut::Reset, selected) => {
+            if matches!(actions.get(selected), Some(DynamicMenuAction::ResetPlugin)) {
+                state.reset();
+            } else {
+                println!("  Select Reset plugin configuration to remove config.");
+            }
+            Ok(false)
+        }
+        MenuResponse::Shortcut(MenuShortcut::Clear, selected) => {
+            if matches!(
+                actions.get(selected),
+                Some(DynamicMenuAction::EditRawConfig)
+            ) {
+                state.set_raw_config(Map::new());
+            }
+            Ok(false)
+        }
+        MenuResponse::Shortcut(MenuShortcut::Help, _) => {
+            super::print_editor_help();
+            Ok(false)
+        }
+        MenuResponse::Shortcut(MenuShortcut::Preview | MenuShortcut::Save, _) => {
+            println!("  Preview and save are available from the main plugins.toml menu.");
+            Ok(false)
+        }
+        MenuResponse::Cancel => Ok(true),
     }
 }
 

--- a/crates/cli/src/plugins/schema.rs
+++ b/crates/cli/src/plugins/schema.rs
@@ -342,321 +342,538 @@ fn normalize_local_references(
     path: &Path,
     schema: &mut Value,
 ) -> Result<(), CliError> {
-    fn visit_schema(
-        plugin_id: &str,
-        file_path: &Path,
-        schema: &mut Value,
-        pointer: &str,
-    ) -> Result<(), CliError> {
-        let Some(object) = schema.as_object_mut() else {
-            return Ok(());
-        };
-        if let Some(Value::String(reference)) = object.get_mut("$ref")
-            && reference.starts_with('#')
-        {
-            *reference = canonicalize_local_reference(reference).map_err(|error| {
-                schema_error(
-                    plugin_id,
-                    file_path,
-                    format!(
-                        "invalid local $ref at JSON pointer '{}': {error}",
-                        push_pointer(pointer, "$ref")
-                    ),
-                )
-            })?;
-        }
+    normalize_schema_references(plugin_id, path, schema, "")
+}
 
-        for key in [
-            "additionalItems",
-            "additionalProperties",
-            "contains",
-            "contentSchema",
-            "else",
-            "if",
-            "not",
-            "propertyNames",
-            "then",
-            "unevaluatedItems",
-            "unevaluatedProperties",
-        ] {
-            if let Some(child) = object.get_mut(key) {
-                visit_schema(plugin_id, file_path, child, &push_pointer(pointer, key))?;
-            }
-        }
+fn normalize_schema_references(
+    plugin_id: &str,
+    file_path: &Path,
+    schema: &mut Value,
+    pointer: &str,
+) -> Result<(), CliError> {
+    let Some(object) = schema.as_object_mut() else {
+        return Ok(());
+    };
+    normalize_schema_reference(plugin_id, file_path, object, pointer)?;
+    normalize_schema_value_children(plugin_id, file_path, object, pointer)?;
+    normalize_schema_items(plugin_id, file_path, object, pointer)?;
+    normalize_schema_array_children(plugin_id, file_path, object, pointer)?;
+    normalize_schema_object_children(plugin_id, file_path, object, pointer)?;
+    normalize_schema_dependencies(plugin_id, file_path, object, pointer)
+}
 
-        if let Some(items) = object.get_mut("items") {
-            let items_pointer = push_pointer(pointer, "items");
-            if let Some(items) = items.as_array_mut() {
-                for (index, child) in items.iter_mut().enumerate() {
-                    visit_schema(
-                        plugin_id,
-                        file_path,
-                        child,
-                        &push_pointer(&items_pointer, &index.to_string()),
-                    )?;
-                }
-            } else {
-                visit_schema(plugin_id, file_path, items, &items_pointer)?;
-            }
-        }
-
-        for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
-            if let Some(children) = object.get_mut(key).and_then(Value::as_array_mut) {
-                let children_pointer = push_pointer(pointer, key);
-                for (index, child) in children.iter_mut().enumerate() {
-                    visit_schema(
-                        plugin_id,
-                        file_path,
-                        child,
-                        &push_pointer(&children_pointer, &index.to_string()),
-                    )?;
-                }
-            }
-        }
-
-        for key in [
-            "$defs",
-            "definitions",
-            "dependentSchemas",
-            "patternProperties",
-            "properties",
-        ] {
-            if let Some(children) = object.get_mut(key).and_then(Value::as_object_mut) {
-                let children_pointer = push_pointer(pointer, key);
-                for (name, child) in children {
-                    visit_schema(
-                        plugin_id,
-                        file_path,
-                        child,
-                        &push_pointer(&children_pointer, name),
-                    )?;
-                }
-            }
-        }
-
-        if let Some(dependencies) = object
-            .get_mut("dependencies")
-            .and_then(Value::as_object_mut)
-        {
-            let dependencies_pointer = push_pointer(pointer, "dependencies");
-            for (name, dependency) in dependencies {
-                if dependency.is_object() || dependency.is_boolean() {
-                    visit_schema(
-                        plugin_id,
-                        file_path,
-                        dependency,
-                        &push_pointer(&dependencies_pointer, name),
-                    )?;
-                }
-            }
-        }
-        Ok(())
+fn normalize_schema_reference(
+    plugin_id: &str,
+    file_path: &Path,
+    object: &mut Map<String, Value>,
+    pointer: &str,
+) -> Result<(), CliError> {
+    if let Some(Value::String(reference)) = object.get_mut("$ref")
+        && reference.starts_with('#')
+    {
+        *reference = canonicalize_local_reference(reference).map_err(|error| {
+            schema_error(
+                plugin_id,
+                file_path,
+                format!(
+                    "invalid local $ref at JSON pointer '{}': {error}",
+                    push_pointer(pointer, "$ref")
+                ),
+            )
+        })?;
     }
+    Ok(())
+}
 
-    visit_schema(plugin_id, path, schema, "")
+fn normalize_schema_value_children(
+    plugin_id: &str,
+    file_path: &Path,
+    object: &mut Map<String, Value>,
+    pointer: &str,
+) -> Result<(), CliError> {
+    for key in [
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    ] {
+        if let Some(child) = object.get_mut(key) {
+            normalize_schema_references(plugin_id, file_path, child, &push_pointer(pointer, key))?;
+        }
+    }
+    Ok(())
+}
+
+fn normalize_schema_items(
+    plugin_id: &str,
+    file_path: &Path,
+    object: &mut Map<String, Value>,
+    pointer: &str,
+) -> Result<(), CliError> {
+    let Some(items) = object.get_mut("items") else {
+        return Ok(());
+    };
+    let items_pointer = push_pointer(pointer, "items");
+    if let Some(items) = items.as_array_mut() {
+        for (index, child) in items.iter_mut().enumerate() {
+            normalize_schema_references(
+                plugin_id,
+                file_path,
+                child,
+                &push_pointer(&items_pointer, &index.to_string()),
+            )?;
+        }
+    } else {
+        normalize_schema_references(plugin_id, file_path, items, &items_pointer)?;
+    }
+    Ok(())
+}
+
+fn normalize_schema_array_children(
+    plugin_id: &str,
+    file_path: &Path,
+    object: &mut Map<String, Value>,
+    pointer: &str,
+) -> Result<(), CliError> {
+    for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
+        let Some(children) = object.get_mut(key).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        let children_pointer = push_pointer(pointer, key);
+        for (index, child) in children.iter_mut().enumerate() {
+            normalize_schema_references(
+                plugin_id,
+                file_path,
+                child,
+                &push_pointer(&children_pointer, &index.to_string()),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn normalize_schema_object_children(
+    plugin_id: &str,
+    file_path: &Path,
+    object: &mut Map<String, Value>,
+    pointer: &str,
+) -> Result<(), CliError> {
+    for key in [
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+        "patternProperties",
+        "properties",
+    ] {
+        let Some(children) = object.get_mut(key).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        let children_pointer = push_pointer(pointer, key);
+        for (name, child) in children {
+            normalize_schema_references(
+                plugin_id,
+                file_path,
+                child,
+                &push_pointer(&children_pointer, name),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn normalize_schema_dependencies(
+    plugin_id: &str,
+    file_path: &Path,
+    object: &mut Map<String, Value>,
+    pointer: &str,
+) -> Result<(), CliError> {
+    let Some(dependencies) = object
+        .get_mut("dependencies")
+        .and_then(Value::as_object_mut)
+    else {
+        return Ok(());
+    };
+    let dependencies_pointer = push_pointer(pointer, "dependencies");
+    for (name, dependency) in dependencies {
+        if dependency.is_object() || dependency.is_boolean() {
+            normalize_schema_references(
+                plugin_id,
+                file_path,
+                dependency,
+                &push_pointer(&dependencies_pointer, name),
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn validate_schema_security(plugin_id: &str, path: &Path, schema: &Value) -> Result<(), CliError> {
-    fn visit_schema(
-        plugin_id: &str,
-        file_path: &Path,
-        root: &Value,
-        schema: &Value,
-        pointer: &str,
-        unsupported_secret_context: Option<&str>,
-    ) -> Result<(), CliError> {
-        let Some(object) = schema.as_object() else {
-            return Ok(());
+    validate_schema_security_node(plugin_id, path, schema, schema, "", None)
+}
+
+fn validate_schema_security_node(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    schema: &Value,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    let Some(object) = schema.as_object() else {
+        return Ok(());
+    };
+    validate_schema_reference_security(plugin_id, file_path, object, pointer)?;
+    validate_schema_write_only_security(
+        plugin_id,
+        file_path,
+        root,
+        schema,
+        pointer,
+        unsupported_secret_context,
+    )?;
+    validate_schema_value_children(
+        plugin_id,
+        file_path,
+        root,
+        object,
+        pointer,
+        unsupported_secret_context,
+    )?;
+    validate_schema_context_children(
+        plugin_id,
+        file_path,
+        root,
+        object,
+        pointer,
+        unsupported_secret_context,
+    )?;
+    validate_schema_items(
+        plugin_id,
+        file_path,
+        root,
+        object,
+        pointer,
+        unsupported_secret_context,
+    )?;
+    validate_schema_array_children(
+        plugin_id,
+        file_path,
+        root,
+        object,
+        pointer,
+        unsupported_secret_context,
+    )?;
+    validate_schema_object_children(
+        plugin_id,
+        file_path,
+        root,
+        object,
+        pointer,
+        unsupported_secret_context,
+    )?;
+    validate_schema_dependent_schemas(
+        plugin_id,
+        file_path,
+        root,
+        object,
+        pointer,
+        unsupported_secret_context,
+    )?;
+    validate_schema_dependencies(
+        plugin_id,
+        file_path,
+        root,
+        object,
+        pointer,
+        unsupported_secret_context,
+    )
+}
+
+fn validate_schema_reference_security(
+    plugin_id: &str,
+    file_path: &Path,
+    object: &Map<String, Value>,
+    pointer: &str,
+) -> Result<(), CliError> {
+    if object.contains_key("$dynamicRef") || object.contains_key("$dynamicAnchor") {
+        let keyword = if object.contains_key("$dynamicRef") {
+            "$dynamicRef"
+        } else {
+            "$dynamicAnchor"
         };
-        if object.contains_key("$dynamicRef") || object.contains_key("$dynamicAnchor") {
-            return Err(schema_error(
-                plugin_id,
-                file_path,
-                format!(
-                    "Draft 2020-12 dynamic references are not supported at JSON pointer '{}'",
-                    if object.contains_key("$dynamicRef") {
-                        push_pointer(pointer, "$dynamicRef")
-                    } else {
-                        push_pointer(pointer, "$dynamicAnchor")
-                    }
-                ),
-            ));
-        }
-        if let Some(reference) = object.get("$ref").and_then(Value::as_str)
-            && !reference.starts_with('#')
-        {
-            return Err(schema_error(
-                plugin_id,
-                file_path,
-                format!(
-                    "$ref at JSON pointer '{}' must be a local fragment reference beginning with '#', got '{reference}'",
-                    push_pointer(pointer, "$ref")
-                ),
-            ));
-        }
-        if object.get("writeOnly").and_then(Value::as_bool) == Some(true) {
-            if let Some(keyword) = unsupported_secret_context {
-                return Err(schema_error(
-                    plugin_id,
-                    file_path,
-                    format!(
-                        "writeOnly at JSON pointer '{}' is not supported under '{keyword}'",
-                        push_pointer(pointer, "writeOnly")
-                    ),
-                ));
-            }
-            let mut references = HashSet::new();
-            let mut reference_chain = Vec::new();
-            resolve_schema_chain(root, schema, &mut references, &mut reference_chain).map_err(
-                |error| {
-                    schema_error(
-                        plugin_id,
-                        file_path,
-                        format!(
-                            "writeOnly schema at JSON pointer '{}' cannot be resolved: {error}",
-                            pointer
-                        ),
-                    )
-                },
-            )?;
-            classify_write_only_chain(&reference_chain).map_err(|error| {
-                schema_error(
-                    plugin_id,
-                    file_path,
-                    format!("unsupported writeOnly shape at JSON pointer '{pointer}': {error}"),
-                )
-            })?;
-        }
-
-        for key in ["additionalItems", "additionalProperties", "contains"] {
-            if let Some(child) = object.get(key) {
-                visit_schema(
-                    plugin_id,
-                    file_path,
-                    root,
-                    child,
-                    &push_pointer(pointer, key),
-                    unsupported_secret_context,
-                )?;
-            }
-        }
-
-        for key in [
-            "contentSchema",
-            "else",
-            "if",
-            "not",
-            "propertyNames",
-            "then",
-            "unevaluatedItems",
-            "unevaluatedProperties",
-        ] {
-            if let Some(child) = object.get(key) {
-                visit_schema(
-                    plugin_id,
-                    file_path,
-                    root,
-                    child,
-                    &push_pointer(pointer, key),
-                    unsupported_secret_context.or(Some(key)),
-                )?;
-            }
-        }
-
-        if let Some(items) = object.get("items") {
-            let items_pointer = push_pointer(pointer, "items");
-            if let Some(items) = items.as_array() {
-                for (index, child) in items.iter().enumerate() {
-                    visit_schema(
-                        plugin_id,
-                        file_path,
-                        root,
-                        child,
-                        &push_pointer(&items_pointer, &index.to_string()),
-                        unsupported_secret_context,
-                    )?;
-                }
-            } else {
-                visit_schema(
-                    plugin_id,
-                    file_path,
-                    root,
-                    items,
-                    &items_pointer,
-                    unsupported_secret_context,
-                )?;
-            }
-        }
-
-        for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
-            if let Some(children) = object.get(key).and_then(Value::as_array) {
-                let children_pointer = push_pointer(pointer, key);
-                let child_context = match key {
-                    "anyOf" | "oneOf" => unsupported_secret_context.or(Some(key)),
-                    _ => unsupported_secret_context,
-                };
-                for (index, child) in children.iter().enumerate() {
-                    visit_schema(
-                        plugin_id,
-                        file_path,
-                        root,
-                        child,
-                        &push_pointer(&children_pointer, &index.to_string()),
-                        child_context,
-                    )?;
-                }
-            }
-        }
-
-        for key in ["$defs", "definitions", "patternProperties", "properties"] {
-            if let Some(children) = object.get(key).and_then(Value::as_object) {
-                let children_pointer = push_pointer(pointer, key);
-                for (name, child) in children {
-                    visit_schema(
-                        plugin_id,
-                        file_path,
-                        root,
-                        child,
-                        &push_pointer(&children_pointer, name),
-                        unsupported_secret_context,
-                    )?;
-                }
-            }
-        }
-
-        if let Some(children) = object.get("dependentSchemas").and_then(Value::as_object) {
-            let children_pointer = push_pointer(pointer, "dependentSchemas");
-            for (name, child) in children {
-                visit_schema(
-                    plugin_id,
-                    file_path,
-                    root,
-                    child,
-                    &push_pointer(&children_pointer, name),
-                    unsupported_secret_context.or(Some("dependentSchemas")),
-                )?;
-            }
-        }
-
-        if let Some(dependencies) = object.get("dependencies").and_then(Value::as_object) {
-            let dependencies_pointer = push_pointer(pointer, "dependencies");
-            for (name, dependency) in dependencies {
-                if dependency.is_object() || dependency.is_boolean() {
-                    visit_schema(
-                        plugin_id,
-                        file_path,
-                        root,
-                        dependency,
-                        &push_pointer(&dependencies_pointer, name),
-                        unsupported_secret_context.or(Some("dependencies")),
-                    )?;
-                }
-            }
-        }
-        Ok(())
+        return Err(schema_error(
+            plugin_id,
+            file_path,
+            format!(
+                "Draft 2020-12 dynamic references are not supported at JSON pointer '{}'",
+                push_pointer(pointer, keyword)
+            ),
+        ));
     }
+    if let Some(reference) = object.get("$ref").and_then(Value::as_str)
+        && !reference.starts_with('#')
+    {
+        return Err(schema_error(
+            plugin_id,
+            file_path,
+            format!(
+                "$ref at JSON pointer '{}' must be a local fragment reference beginning with '#', got '{reference}'",
+                push_pointer(pointer, "$ref")
+            ),
+        ));
+    }
+    Ok(())
+}
 
-    visit_schema(plugin_id, path, schema, schema, "", None)
+fn validate_schema_write_only_security(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    schema: &Value,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    if schema.get("writeOnly").and_then(Value::as_bool) != Some(true) {
+        return Ok(());
+    }
+    if let Some(keyword) = unsupported_secret_context {
+        return Err(schema_error(
+            plugin_id,
+            file_path,
+            format!(
+                "writeOnly at JSON pointer '{}' is not supported under '{keyword}'",
+                push_pointer(pointer, "writeOnly")
+            ),
+        ));
+    }
+    let mut references = HashSet::new();
+    let mut reference_chain = Vec::new();
+    resolve_schema_chain(root, schema, &mut references, &mut reference_chain).map_err(|error| {
+        schema_error(
+            plugin_id,
+            file_path,
+            format!(
+                "writeOnly schema at JSON pointer '{}' cannot be resolved: {error}",
+                pointer
+            ),
+        )
+    })?;
+    classify_write_only_chain(&reference_chain).map_err(|error| {
+        schema_error(
+            plugin_id,
+            file_path,
+            format!("unsupported writeOnly shape at JSON pointer '{pointer}': {error}"),
+        )
+    })?;
+    Ok(())
+}
+
+fn validate_schema_value_children(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    object: &Map<String, Value>,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    for key in ["additionalItems", "additionalProperties", "contains"] {
+        if let Some(child) = object.get(key) {
+            validate_schema_security_node(
+                plugin_id,
+                file_path,
+                root,
+                child,
+                &push_pointer(pointer, key),
+                unsupported_secret_context,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_schema_context_children(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    object: &Map<String, Value>,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    for key in [
+        "contentSchema",
+        "else",
+        "if",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    ] {
+        if let Some(child) = object.get(key) {
+            validate_schema_security_node(
+                plugin_id,
+                file_path,
+                root,
+                child,
+                &push_pointer(pointer, key),
+                unsupported_secret_context.or(Some(key)),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_schema_items(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    object: &Map<String, Value>,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    let Some(items) = object.get("items") else {
+        return Ok(());
+    };
+    let items_pointer = push_pointer(pointer, "items");
+    if let Some(items) = items.as_array() {
+        for (index, child) in items.iter().enumerate() {
+            validate_schema_security_node(
+                plugin_id,
+                file_path,
+                root,
+                child,
+                &push_pointer(&items_pointer, &index.to_string()),
+                unsupported_secret_context,
+            )?;
+        }
+    } else {
+        validate_schema_security_node(
+            plugin_id,
+            file_path,
+            root,
+            items,
+            &items_pointer,
+            unsupported_secret_context,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_schema_array_children(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    object: &Map<String, Value>,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
+        let Some(children) = object.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+        let child_context = match key {
+            "anyOf" | "oneOf" => unsupported_secret_context.or(Some(key)),
+            _ => unsupported_secret_context,
+        };
+        let children_pointer = push_pointer(pointer, key);
+        for (index, child) in children.iter().enumerate() {
+            validate_schema_security_node(
+                plugin_id,
+                file_path,
+                root,
+                child,
+                &push_pointer(&children_pointer, &index.to_string()),
+                child_context,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_schema_object_children(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    object: &Map<String, Value>,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    for key in ["$defs", "definitions", "patternProperties", "properties"] {
+        let Some(children) = object.get(key).and_then(Value::as_object) else {
+            continue;
+        };
+        let children_pointer = push_pointer(pointer, key);
+        for (name, child) in children {
+            validate_schema_security_node(
+                plugin_id,
+                file_path,
+                root,
+                child,
+                &push_pointer(&children_pointer, name),
+                unsupported_secret_context,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_schema_dependent_schemas(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    object: &Map<String, Value>,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    let Some(children) = object.get("dependentSchemas").and_then(Value::as_object) else {
+        return Ok(());
+    };
+    let children_pointer = push_pointer(pointer, "dependentSchemas");
+    for (name, child) in children {
+        validate_schema_security_node(
+            plugin_id,
+            file_path,
+            root,
+            child,
+            &push_pointer(&children_pointer, name),
+            unsupported_secret_context.or(Some("dependentSchemas")),
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_schema_dependencies(
+    plugin_id: &str,
+    file_path: &Path,
+    root: &Value,
+    object: &Map<String, Value>,
+    pointer: &str,
+    unsupported_secret_context: Option<&str>,
+) -> Result<(), CliError> {
+    let Some(dependencies) = object.get("dependencies").and_then(Value::as_object) else {
+        return Ok(());
+    };
+    let dependencies_pointer = push_pointer(pointer, "dependencies");
+    for (name, dependency) in dependencies {
+        if dependency.is_object() || dependency.is_boolean() {
+            validate_schema_security_node(
+                plugin_id,
+                file_path,
+                root,
+                dependency,
+                &push_pointer(&dependencies_pointer, name),
+                unsupported_secret_context.or(Some("dependencies")),
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn validate_schema_document(
@@ -1147,7 +1364,7 @@ struct SecretPattern(Vec<SecretSegment>);
 
 impl SecretPattern {
     fn redact(&self, value: &mut Value, offset: usize) {
-        if offset == self.0.len() {
+        self.visit_matching_values(value, offset, &mut |value| {
             // A configuration can contain a schema-invalid value before validation. Once the
             // schema marks this path as secret, its runtime type must not determine whether it
             // is safe to display. Null remains visible because it represents an unset nullable
@@ -1155,58 +1372,7 @@ impl SecretPattern {
             if !value.is_null() {
                 *value = Value::String(REDACTED.to_owned());
             }
-            return;
-        }
-        match &self.0[offset] {
-            SecretSegment::Property(property) => {
-                if let Some(child) = value.get_mut(property) {
-                    self.redact(child, offset + 1);
-                }
-            }
-            SecretSegment::Any => match value {
-                Value::Object(object) => {
-                    for child in object.values_mut() {
-                        self.redact(child, offset + 1);
-                    }
-                }
-                Value::Array(values) => {
-                    for child in values {
-                        self.redact(child, offset + 1);
-                    }
-                }
-                _ => {}
-            },
-            SecretSegment::Pattern(pattern) => {
-                if let Value::Object(object) = value {
-                    for (key, child) in object {
-                        if pattern_matches(pattern, key) {
-                            self.redact(child, offset + 1);
-                        }
-                    }
-                }
-            }
-            SecretSegment::UnmatchedProperties(selector) => {
-                if let Value::Object(object) = value {
-                    for (key, child) in object {
-                        if selector.matches(key) {
-                            self.redact(child, offset + 1);
-                        }
-                    }
-                }
-            }
-            SecretSegment::Index(index) => {
-                if let Some(child) = value.get_mut(*index) {
-                    self.redact(child, offset + 1);
-                }
-            }
-            SecretSegment::Tail(start) => {
-                if let Value::Array(values) = value {
-                    for child in values.iter_mut().skip(*start) {
-                        self.redact(child, offset + 1);
-                    }
-                }
-            }
-        }
+        });
     }
 
     fn redact_for_edit(
@@ -1217,15 +1383,13 @@ impl SecretPattern {
         occupied: &HashSet<String>,
         next_token: &mut usize,
     ) {
-        if offset == self.0.len() {
+        self.visit_matching_values(value, offset, &mut |value| {
             // Tokenize invalid values too, both to keep raw editing safe and to preserve the
             // original value if the user leaves it unchanged.
-            if value.is_null() {
-                return;
-            }
-            if value
-                .as_str()
-                .is_some_and(|candidate| secrets.contains_key(candidate))
+            if value.is_null()
+                || value
+                    .as_str()
+                    .is_some_and(|candidate| secrets.contains_key(candidate))
             {
                 return;
             }
@@ -1238,23 +1402,34 @@ impl SecretPattern {
                 },
             );
             *value = Value::String(token);
+        });
+    }
+
+    fn visit_matching_values(
+        &self,
+        value: &mut Value,
+        offset: usize,
+        visit: &mut impl FnMut(&mut Value),
+    ) {
+        if offset == self.0.len() {
+            visit(value);
             return;
         }
         match &self.0[offset] {
             SecretSegment::Property(property) => {
                 if let Some(child) = value.get_mut(property) {
-                    self.redact_for_edit(child, offset + 1, secrets, occupied, next_token);
+                    self.visit_matching_values(child, offset + 1, visit);
                 }
             }
             SecretSegment::Any => match value {
                 Value::Object(object) => {
                     for child in object.values_mut() {
-                        self.redact_for_edit(child, offset + 1, secrets, occupied, next_token);
+                        self.visit_matching_values(child, offset + 1, visit);
                     }
                 }
                 Value::Array(values) => {
                     for child in values {
-                        self.redact_for_edit(child, offset + 1, secrets, occupied, next_token);
+                        self.visit_matching_values(child, offset + 1, visit);
                     }
                 }
                 _ => {}
@@ -1263,7 +1438,7 @@ impl SecretPattern {
                 if let Value::Object(object) = value {
                     for (key, child) in object {
                         if pattern_matches(pattern, key) {
-                            self.redact_for_edit(child, offset + 1, secrets, occupied, next_token);
+                            self.visit_matching_values(child, offset + 1, visit);
                         }
                     }
                 }
@@ -1272,20 +1447,20 @@ impl SecretPattern {
                 if let Value::Object(object) = value {
                     for (key, child) in object {
                         if selector.matches(key) {
-                            self.redact_for_edit(child, offset + 1, secrets, occupied, next_token);
+                            self.visit_matching_values(child, offset + 1, visit);
                         }
                     }
                 }
             }
             SecretSegment::Index(index) => {
                 if let Some(child) = value.get_mut(*index) {
-                    self.redact_for_edit(child, offset + 1, secrets, occupied, next_token);
+                    self.visit_matching_values(child, offset + 1, visit);
                 }
             }
             SecretSegment::Tail(start) => {
                 if let Value::Array(values) = value {
                     for child in values.iter_mut().skip(*start) {
-                        self.redact_for_edit(child, offset + 1, secrets, occupied, next_token);
+                        self.visit_matching_values(child, offset + 1, visit);
                     }
                 }
             }
@@ -1461,138 +1636,280 @@ fn discover_secret_patterns_in_object(
     output: &mut Vec<SecretPattern>,
 ) -> Result<(), String> {
     let properties = object.get("properties").and_then(Value::as_object);
-    if let Some(properties) = properties {
-        for (property, child_schema) in properties {
-            let mut child_path = instance_path.to_vec();
-            child_path.push(SecretSegment::Property(property.clone()));
-            discover_secret_patterns(root, child_schema, &child_path, references, output)?;
-        }
-    }
+    discover_named_secret_patterns(root, properties, instance_path, references, output)?;
+    let pattern_schemas = collect_secret_pattern_schemas(object)?;
+    discover_additional_secret_patterns(
+        root,
+        object,
+        properties,
+        &pattern_schemas,
+        instance_path,
+        references,
+        output,
+    )?;
+    discover_pattern_property_secret_patterns(
+        root,
+        pattern_schemas,
+        instance_path,
+        references,
+        output,
+    )?;
+    discover_item_secret_patterns(root, object, instance_path, references, output)?;
+    discover_prefix_item_secret_patterns(root, object, instance_path, references, output)?;
+    discover_all_of_secret_patterns(root, object, instance_path, references, output)?;
+    reject_array_applicator_secret_patterns(root, object, instance_path, references)?;
+    reject_value_applicator_secret_patterns(
+        root,
+        object,
+        &["if", "then", "else", "not"],
+        instance_path,
+        references,
+    )?;
+    discover_contains_secret_patterns(root, object, instance_path, references, output)?;
+    reject_value_applicator_secret_patterns(
+        root,
+        object,
+        &["unevaluatedProperties", "unevaluatedItems"],
+        instance_path,
+        references,
+    )?;
+    reject_object_applicator_secret_patterns(
+        root,
+        object,
+        &["dependentSchemas", "dependencies"],
+        instance_path,
+        references,
+    )?;
+    Ok(())
+}
 
+fn discover_named_secret_patterns(
+    root: &Value,
+    properties: Option<&Map<String, Value>>,
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+    output: &mut Vec<SecretPattern>,
+) -> Result<(), String> {
+    let Some(properties) = properties else {
+        return Ok(());
+    };
+    for (property, child_schema) in properties {
+        let mut child_path = instance_path.to_vec();
+        child_path.push(SecretSegment::Property(property.clone()));
+        discover_secret_patterns(root, child_schema, &child_path, references, output)?;
+    }
+    Ok(())
+}
+
+fn collect_secret_pattern_schemas(
+    object: &Map<String, Value>,
+) -> Result<Vec<(SecretPropertyPattern, &Value)>, String> {
+    let Some(patterns) = object.get("patternProperties").and_then(Value::as_object) else {
+        return Ok(Vec::new());
+    };
     let mut pattern_schemas = Vec::new();
-    if let Some(patterns) = object.get("patternProperties").and_then(Value::as_object) {
-        for (pattern, child_schema) in patterns {
-            let matcher = regex::Regex::new(pattern).map_err(|error| {
-                format!("unsupported patternProperties expression {pattern:?}: {error}")
-            })?;
-            pattern_schemas.push((
-                SecretPropertyPattern {
-                    source: pattern.clone(),
-                    matcher,
-                },
-                child_schema,
-            ));
-        }
+    for (pattern, child_schema) in patterns {
+        let matcher = regex::Regex::new(pattern).map_err(|error| {
+            format!("unsupported patternProperties expression {pattern:?}: {error}")
+        })?;
+        pattern_schemas.push((
+            SecretPropertyPattern {
+                source: pattern.clone(),
+                matcher,
+            },
+            child_schema,
+        ));
     }
     pattern_schemas.sort_by(|(left, _), (right, _)| left.cmp(right));
+    Ok(pattern_schemas)
+}
 
-    if let Some(additional) = object.get("additionalProperties")
-        && additional.is_object()
-    {
-        let mut excluded_properties = properties
-            .into_iter()
-            .flat_map(|properties| properties.keys().cloned())
-            .collect::<Vec<_>>();
-        excluded_properties.sort();
-        let mut child_path = instance_path.to_vec();
-        child_path.push(SecretSegment::UnmatchedProperties(
-            SecretUnmatchedProperties {
-                properties: excluded_properties,
-                patterns: pattern_schemas
-                    .iter()
-                    .map(|(pattern, _)| pattern.clone())
-                    .collect(),
-            },
-        ));
-        discover_secret_patterns(root, additional, &child_path, references, output)?;
+fn discover_additional_secret_patterns(
+    root: &Value,
+    object: &Map<String, Value>,
+    properties: Option<&Map<String, Value>>,
+    pattern_schemas: &[(SecretPropertyPattern, &Value)],
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+    output: &mut Vec<SecretPattern>,
+) -> Result<(), String> {
+    let Some(additional) = object.get("additionalProperties") else {
+        return Ok(());
+    };
+    if !additional.is_object() {
+        return Ok(());
     }
+    let mut excluded_properties = properties
+        .into_iter()
+        .flat_map(|properties| properties.keys().cloned())
+        .collect::<Vec<_>>();
+    excluded_properties.sort();
+    let mut child_path = instance_path.to_vec();
+    child_path.push(SecretSegment::UnmatchedProperties(
+        SecretUnmatchedProperties {
+            properties: excluded_properties,
+            patterns: pattern_schemas
+                .iter()
+                .map(|(pattern, _)| pattern.clone())
+                .collect(),
+        },
+    ));
+    discover_secret_patterns(root, additional, &child_path, references, output)
+}
+
+fn discover_pattern_property_secret_patterns(
+    root: &Value,
+    pattern_schemas: Vec<(SecretPropertyPattern, &Value)>,
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+    output: &mut Vec<SecretPattern>,
+) -> Result<(), String> {
     for (pattern, child_schema) in pattern_schemas {
         let mut child_path = instance_path.to_vec();
         child_path.push(SecretSegment::Pattern(pattern));
         discover_secret_patterns(root, child_schema, &child_path, references, output)?;
     }
-    if let Some(items) = object.get("items") {
-        if items.is_object() {
-            let mut child_path = instance_path.to_vec();
-            match object.get("prefixItems").and_then(Value::as_array) {
-                Some(prefix_items) => {
-                    child_path.push(SecretSegment::Tail(prefix_items.len()));
-                }
-                None => child_path.push(SecretSegment::Any),
-            }
-            discover_secret_patterns(root, items, &child_path, references, output)?;
-        } else if let Some(tuple_items) = items.as_array() {
-            for (index, child_schema) in tuple_items.iter().enumerate() {
-                let mut child_path = instance_path.to_vec();
-                child_path.push(SecretSegment::Index(index));
-                discover_secret_patterns(root, child_schema, &child_path, references, output)?;
-            }
-            if let Some(additional_items) = object.get("additionalItems")
-                && additional_items.is_object()
-            {
-                let mut child_path = instance_path.to_vec();
-                child_path.push(SecretSegment::Tail(tuple_items.len()));
-                discover_secret_patterns(root, additional_items, &child_path, references, output)?;
-            }
-        }
+    Ok(())
+}
+
+fn discover_item_secret_patterns(
+    root: &Value,
+    object: &Map<String, Value>,
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+    output: &mut Vec<SecretPattern>,
+) -> Result<(), String> {
+    let Some(items) = object.get("items") else {
+        return Ok(());
+    };
+    if items.is_object() {
+        let mut child_path = instance_path.to_vec();
+        let segment = object
+            .get("prefixItems")
+            .and_then(Value::as_array)
+            .map_or(SecretSegment::Any, |prefix_items| {
+                SecretSegment::Tail(prefix_items.len())
+            });
+        child_path.push(segment);
+        return discover_secret_patterns(root, items, &child_path, references, output);
     }
-    if let Some(prefix_items) = object.get("prefixItems").and_then(Value::as_array) {
-        for (index, child_schema) in prefix_items.iter().enumerate() {
-            let mut child_path = instance_path.to_vec();
-            child_path.push(SecretSegment::Index(index));
-            discover_secret_patterns(root, child_schema, &child_path, references, output)?;
-        }
+    let Some(tuple_items) = items.as_array() else {
+        return Ok(());
+    };
+    for (index, child_schema) in tuple_items.iter().enumerate() {
+        let mut child_path = instance_path.to_vec();
+        child_path.push(SecretSegment::Index(index));
+        discover_secret_patterns(root, child_schema, &child_path, references, output)?;
     }
-    if let Some(branches) = object.get("allOf").and_then(Value::as_array) {
-        for branch in branches {
-            discover_secret_patterns(root, branch, instance_path, references, output)?;
-        }
-    }
-    for keyword in ["anyOf", "oneOf"] {
-        if let Some(branches) = object.get(keyword).and_then(Value::as_array) {
-            for branch in branches {
-                reject_write_only_under_applicator(
-                    root,
-                    keyword,
-                    branch,
-                    instance_path,
-                    references,
-                )?;
-            }
-        }
-    }
-    for keyword in ["if", "then", "else", "not"] {
-        if let Some(branch) = object.get(keyword)
-            && branch.is_object()
-        {
-            reject_write_only_under_applicator(root, keyword, branch, instance_path, references)?;
-        }
-    }
-    if let Some(contains) = object.get("contains")
-        && contains.is_object()
+    if let Some(additional_items) = object.get("additionalItems")
+        && additional_items.is_object()
     {
         let mut child_path = instance_path.to_vec();
-        child_path.push(SecretSegment::Any);
-        discover_secret_patterns(root, contains, &child_path, references, output)?;
+        child_path.push(SecretSegment::Tail(tuple_items.len()));
+        discover_secret_patterns(root, additional_items, &child_path, references, output)?;
     }
-    for keyword in ["unevaluatedProperties", "unevaluatedItems"] {
-        if let Some(branch) = object.get(keyword)
+    Ok(())
+}
+
+fn discover_prefix_item_secret_patterns(
+    root: &Value,
+    object: &Map<String, Value>,
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+    output: &mut Vec<SecretPattern>,
+) -> Result<(), String> {
+    let Some(prefix_items) = object.get("prefixItems").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for (index, child_schema) in prefix_items.iter().enumerate() {
+        let mut child_path = instance_path.to_vec();
+        child_path.push(SecretSegment::Index(index));
+        discover_secret_patterns(root, child_schema, &child_path, references, output)?;
+    }
+    Ok(())
+}
+
+fn discover_all_of_secret_patterns(
+    root: &Value,
+    object: &Map<String, Value>,
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+    output: &mut Vec<SecretPattern>,
+) -> Result<(), String> {
+    let Some(branches) = object.get("allOf").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for branch in branches {
+        discover_secret_patterns(root, branch, instance_path, references, output)?;
+    }
+    Ok(())
+}
+
+fn reject_array_applicator_secret_patterns(
+    root: &Value,
+    object: &Map<String, Value>,
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+) -> Result<(), String> {
+    for keyword in ["anyOf", "oneOf"] {
+        let Some(branches) = object.get(keyword).and_then(Value::as_array) else {
+            continue;
+        };
+        for branch in branches {
+            reject_write_only_under_applicator(root, keyword, branch, instance_path, references)?;
+        }
+    }
+    Ok(())
+}
+
+fn reject_value_applicator_secret_patterns(
+    root: &Value,
+    object: &Map<String, Value>,
+    keywords: &[&str],
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+) -> Result<(), String> {
+    for keyword in keywords {
+        if let Some(branch) = object.get(*keyword)
             && branch.is_object()
         {
             reject_write_only_under_applicator(root, keyword, branch, instance_path, references)?;
         }
     }
-    for keyword in ["dependentSchemas", "dependencies"] {
-        if let Some(branches) = object.get(keyword).and_then(Value::as_object) {
-            for branch in branches.values().filter(|branch| branch.is_object()) {
-                reject_write_only_under_applicator(
-                    root,
-                    keyword,
-                    branch,
-                    instance_path,
-                    references,
-                )?;
-            }
+    Ok(())
+}
+
+fn discover_contains_secret_patterns(
+    root: &Value,
+    object: &Map<String, Value>,
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+    output: &mut Vec<SecretPattern>,
+) -> Result<(), String> {
+    let Some(contains) = object.get("contains") else {
+        return Ok(());
+    };
+    if !contains.is_object() {
+        return Ok(());
+    }
+    let mut child_path = instance_path.to_vec();
+    child_path.push(SecretSegment::Any);
+    discover_secret_patterns(root, contains, &child_path, references, output)
+}
+
+fn reject_object_applicator_secret_patterns(
+    root: &Value,
+    object: &Map<String, Value>,
+    keywords: &[&str],
+    instance_path: &[SecretSegment],
+    references: &HashSet<String>,
+) -> Result<(), String> {
+    for keyword in keywords {
+        let Some(branches) = object.get(*keyword).and_then(Value::as_object) else {
+            continue;
+        };
+        for branch in branches.values().filter(|branch| branch.is_object()) {
+            reject_write_only_under_applicator(root, keyword, branch, instance_path, references)?;
         }
     }
     Ok(())

--- a/crates/cli/tests/coverage/doctor_tests.rs
+++ b/crates/cli/tests/coverage/doctor_tests.rs
@@ -260,6 +260,21 @@ fn format_human_emits_fixed_section_order() {
 }
 
 #[test]
+fn format_human_renders_completion_details_without_check_name() {
+    let mut report = empty_report();
+    report.completions.push(Check {
+        name: "Completions",
+        status: Status::Pass,
+        details: "zsh: /tmp/_nemo-relay".into(),
+    });
+
+    let rendered = format_human(&report);
+
+    assert!(rendered.contains("  Completions\n    zsh: /tmp/_nemo-relay\n"));
+    assert!(!rendered.contains("    Completions"));
+}
+
+#[test]
 fn format_human_distinguishes_plugin_files_from_plugin_resolution() {
     let mut report = empty_report();
     report.configuration.plugin_configs.push(ConfigLayer {

--- a/crates/core/src/plugin/dynamic/registry.rs
+++ b/crates/core/src/plugin/dynamic/registry.rs
@@ -260,67 +260,69 @@ fn validate_record_shape(record: &DynamicPluginRecord) -> Result<()> {
     }
 
     match record.metadata.kind {
-        super::DynamicPluginKind::RustDynamic => {
-            match &record.compatibility {
-                super::DynamicPluginCompatibility::RustDynamic(compatibility) => {
-                    if compatibility.relay.trim().is_empty() {
-                        return Err(PluginError::InvalidConfig(
-                            "dynamic plugin record must declare compat.relay".into(),
-                        ));
-                    }
-                    if compatibility.native_api.trim().is_empty() {
-                        return Err(PluginError::InvalidConfig(
-                            "dynamic rust_dynamic record has invalid compatibility shape".into(),
-                        ));
-                    }
-                }
-                _ => {
-                    return Err(PluginError::InvalidConfig(
-                        "dynamic rust_dynamic record has invalid compatibility shape".into(),
-                    ));
-                }
-            }
-            match &record.load {
-                super::DynamicPluginLoadContract::RustDynamic(load)
-                    if !load.library.trim().is_empty() && !load.symbol.trim().is_empty() => {}
-                _ => {
-                    return Err(PluginError::InvalidConfig(
-                        "dynamic rust_dynamic record has invalid load shape".into(),
-                    ));
-                }
-            }
-        }
-        super::DynamicPluginKind::Worker => {
-            match &record.compatibility {
-                super::DynamicPluginCompatibility::Worker(compatibility) => {
-                    if compatibility.relay.trim().is_empty() {
-                        return Err(PluginError::InvalidConfig(
-                            "dynamic plugin record must declare compat.relay".into(),
-                        ));
-                    }
-                    if compatibility.worker_protocol.trim().is_empty() {
-                        return Err(PluginError::InvalidConfig(
-                            "dynamic worker record has invalid compatibility shape".into(),
-                        ));
-                    }
-                }
-                _ => {
-                    return Err(PluginError::InvalidConfig(
-                        "dynamic worker record has invalid compatibility shape".into(),
-                    ));
-                }
-            }
-            match &record.load {
-                super::DynamicPluginLoadContract::Worker(load)
-                    if !load.entrypoint.trim().is_empty() => {}
-                _ => {
-                    return Err(PluginError::InvalidConfig(
-                        "dynamic worker record has invalid load shape".into(),
-                    ));
-                }
-            }
-        }
+        super::DynamicPluginKind::RustDynamic => validate_rust_dynamic_record(record),
+        super::DynamicPluginKind::Worker => validate_worker_record(record),
     }
+}
 
-    Ok(())
+fn validate_rust_dynamic_record(record: &DynamicPluginRecord) -> Result<()> {
+    let super::DynamicPluginCompatibility::RustDynamic(compatibility) = &record.compatibility
+    else {
+        return Err(PluginError::InvalidConfig(
+            "dynamic rust_dynamic record has invalid compatibility shape".into(),
+        ));
+    };
+    validate_relay_compatibility(&compatibility.relay)?;
+    if compatibility.native_api.trim().is_empty() {
+        return Err(PluginError::InvalidConfig(
+            "dynamic rust_dynamic record has invalid compatibility shape".into(),
+        ));
+    }
+    let valid_load = matches!(
+        &record.load,
+        super::DynamicPluginLoadContract::RustDynamic(load)
+            if !load.library.trim().is_empty() && !load.symbol.trim().is_empty()
+    );
+    if valid_load {
+        Ok(())
+    } else {
+        Err(PluginError::InvalidConfig(
+            "dynamic rust_dynamic record has invalid load shape".into(),
+        ))
+    }
+}
+
+fn validate_worker_record(record: &DynamicPluginRecord) -> Result<()> {
+    let super::DynamicPluginCompatibility::Worker(compatibility) = &record.compatibility else {
+        return Err(PluginError::InvalidConfig(
+            "dynamic worker record has invalid compatibility shape".into(),
+        ));
+    };
+    validate_relay_compatibility(&compatibility.relay)?;
+    if compatibility.worker_protocol.trim().is_empty() {
+        return Err(PluginError::InvalidConfig(
+            "dynamic worker record has invalid compatibility shape".into(),
+        ));
+    }
+    let valid_load = matches!(
+        &record.load,
+        super::DynamicPluginLoadContract::Worker(load) if !load.entrypoint.trim().is_empty()
+    );
+    if valid_load {
+        Ok(())
+    } else {
+        Err(PluginError::InvalidConfig(
+            "dynamic worker record has invalid load shape".into(),
+        ))
+    }
+}
+
+fn validate_relay_compatibility(relay: &str) -> Result<()> {
+    if relay.trim().is_empty() {
+        Err(PluginError::InvalidConfig(
+            "dynamic plugin record must declare compat.relay".into(),
+        ))
+    } else {
+        Ok(())
+    }
 }

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -1648,6 +1648,15 @@ struct StoredScopeHandle {
     scope_stack_id: String,
 }
 
+fn has_active_scope_stack_alias(
+    stacks: &HashMap<String, StoredScopeStack>,
+    handle: &crate::api::runtime::ScopeStackHandle,
+) -> bool {
+    stacks.values().any(|candidate| {
+        candidate.invocation_base_depth.is_some() && Arc::ptr_eq(&candidate.handle, handle)
+    })
+}
+
 struct ScopeStackCleanupGuard<'a> {
     state: &'a WorkerHostRuntimeState,
     handle: crate::api::runtime::ScopeStackHandle,
@@ -1724,47 +1733,7 @@ impl WorkerHostRuntimeState {
     }
 
     fn cleanup_invocation_scope_stack(&self, id: &str) {
-        let unwind = {
-            let Ok(mut stacks) = self.scope_stacks.lock() else {
-                return;
-            };
-            let Some(stored) = stacks.remove(id) else {
-                return;
-            };
-            let Some(mut base_depth) = stored.invocation_base_depth else {
-                return;
-            };
-            let has_active_alias = stacks.values().any(|candidate| {
-                candidate.invocation_base_depth.is_some()
-                    && Arc::ptr_eq(&candidate.handle, &stored.handle)
-            });
-            if let Ok(mut pending) = self.pending_scope_cleanups.lock() {
-                if has_active_alias {
-                    pending.push(PendingScopeCleanup {
-                        handle: stored.handle,
-                        base_depth,
-                    });
-                    None
-                } else {
-                    pending.retain(|cleanup| {
-                        if Arc::ptr_eq(&cleanup.handle, &stored.handle) {
-                            base_depth = base_depth.min(cleanup.base_depth);
-                            false
-                        } else {
-                            true
-                        }
-                    });
-                    if let Ok(mut cleanups) = self.scope_stack_cleanups.lock() {
-                        cleanups.push(stored.handle.clone());
-                        Some((stored.handle, base_depth))
-                    } else {
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        };
+        let unwind = self.take_invocation_scope_cleanup(id);
         if let Some((handle, base_depth)) = unwind {
             let _cleanup = ScopeStackCleanupGuard {
                 state: self,
@@ -1775,6 +1744,40 @@ impl WorkerHostRuntimeState {
         if let Ok(mut handles) = self.scope_handles.lock() {
             handles.retain(|_, handle| handle.scope_stack_id != id);
         }
+    }
+
+    fn take_invocation_scope_cleanup(
+        &self,
+        id: &str,
+    ) -> Option<(crate::api::runtime::ScopeStackHandle, usize)> {
+        let Ok(mut stacks) = self.scope_stacks.lock() else {
+            return None;
+        };
+        let stored = stacks.remove(id)?;
+        let mut base_depth = stored.invocation_base_depth?;
+        let Ok(mut pending) = self.pending_scope_cleanups.lock() else {
+            return None;
+        };
+        if has_active_scope_stack_alias(&stacks, &stored.handle) {
+            pending.push(PendingScopeCleanup {
+                handle: stored.handle,
+                base_depth,
+            });
+            return None;
+        }
+        pending.retain(|cleanup| {
+            if Arc::ptr_eq(&cleanup.handle, &stored.handle) {
+                base_depth = base_depth.min(cleanup.base_depth);
+                false
+            } else {
+                true
+            }
+        });
+        let Ok(mut cleanups) = self.scope_stack_cleanups.lock() else {
+            return None;
+        };
+        cleanups.push(stored.handle.clone());
+        Some((stored.handle, base_depth))
     }
 
     fn unwind_scope_stack(stack: &crate::api::runtime::ScopeStackHandle, base_depth: usize) {

--- a/crates/core/tests/fixtures/worker_plugin/src/main.rs
+++ b/crates/core/tests/fixtures/worker_plugin/src/main.rs
@@ -45,171 +45,165 @@ impl WorkerPlugin for FixtureWorkerPlugin {
     }
 
     fn register(&self, ctx: &mut PluginContext, config: &Json) -> nemo_relay_worker::Result<()> {
-        let register_error = config
-            .get("register_error")
-            .and_then(Json::as_bool)
-            .unwrap_or(false);
-        let exit_in_register = config
-            .get("exit_in_register")
-            .and_then(Json::as_bool)
-            .unwrap_or(false);
-        if exit_in_register {
+        if fixture_flag(config, "exit_in_register") {
             std::process::exit(43);
         }
-        if register_error {
+        if fixture_flag(config, "register_error") {
             return Err(WorkerSdkError::Callback(
                 "fixture registration error requested".into(),
             ));
         }
-
-        let empty_registration_name = config
-            .get("empty_registration_name")
-            .and_then(Json::as_bool)
-            .unwrap_or(false);
-        if empty_registration_name {
+        if fixture_flag(config, "empty_registration_name") {
             ctx.register_subscriber("", |_| {});
             return Ok(());
         }
 
-        let block_tool = config
-            .get("block_tool")
-            .and_then(Json::as_bool)
-            .unwrap_or(false);
-        let tool_request_error = config
-            .get("tool_request_error")
-            .and_then(Json::as_bool)
-            .unwrap_or(false);
-        let llm_request_error = config
-            .get("llm_request_error")
-            .and_then(Json::as_bool)
-            .unwrap_or(false);
-        let llm_stream_open_error = config
-            .get("llm_stream_open_error")
-            .and_then(Json::as_bool)
-            .unwrap_or(false);
-
         let runtime = ctx
             .runtime()
             .ok_or_else(|| WorkerSdkError::Callback("runtime handle missing".into()))?;
+        register_fixture_subscriber(ctx, runtime.clone());
+        register_fixture_tool_hooks(
+            ctx,
+            runtime,
+            fixture_flag(config, "block_tool"),
+            fixture_flag(config, "tool_request_error"),
+        );
+        register_fixture_llm_hooks(
+            ctx,
+            fixture_flag(config, "llm_request_error"),
+            fixture_flag(config, "llm_stream_open_error"),
+        );
+        Ok(())
+    }
+}
 
-        ctx.register_subscriber("fixture_subscriber", {
+fn fixture_flag(config: &Json, key: &str) -> bool {
+    config.get(key).and_then(Json::as_bool).unwrap_or(false)
+}
+
+fn register_fixture_subscriber(ctx: &mut PluginContext, runtime: nemo_relay_worker::PluginRuntime) {
+    ctx.register_subscriber("fixture_subscriber", move |event| {
+        if event.name() == "worker-plugin-test-outer" {
             let runtime = runtime.clone();
-            move |event| {
-                if event.name() == "worker-plugin-test-outer" {
-                    let runtime = runtime.clone();
-                    let _ = tokio::task::block_in_place(|| {
-                        tokio::runtime::Handle::current().block_on(async move {
-                            runtime
-                                .emit_mark(
-                                    "fixture.worker.subscriber.mark",
-                                    Some(json!("subscriber")),
-                                    None,
-                                )
-                                .await
-                        })
-                    });
-                }
-            }
-        });
+            let _ = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async move {
+                    runtime
+                        .emit_mark(
+                            "fixture.worker.subscriber.mark",
+                            Some(json!("subscriber")),
+                            None,
+                        )
+                        .await
+                })
+            });
+        }
+    });
+}
 
-        ctx.register_tool_sanitize_request_guardrail(
-            "fixture_tool_sanitize_request",
-            0,
-            |_name, args| mark_json(args, "worker_plugin_tool_sanitize_request"),
-        );
-        ctx.register_tool_sanitize_response_guardrail(
-            "fixture_tool_sanitize_response",
-            0,
-            |_name, result| mark_json(result, "worker_plugin_tool_sanitize_response"),
-        );
-        ctx.register_tool_conditional_execution_guardrail(
-            "fixture_tool_conditional",
-            0,
-            move |_name, _args| {
-                if block_tool {
-                    Ok(Some("fixture tool blocked".into()))
-                } else {
-                    Ok(None)
-                }
-            },
-        );
-        ctx.register_tool_request_intercept("fixture_rewrite_args", 0, false, {
-            let runtime = runtime.clone();
-            move |_name, args| {
-                if tool_request_error {
-                    return Err(WorkerSdkError::Callback(
-                        "fixture tool request error requested".into(),
-                    ));
-                }
-                let runtime = runtime.clone();
-                tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current().block_on(emit_runtime_events(runtime))
-                })?;
-                Ok(mark_json(args, "worker_plugin"))
+fn register_fixture_tool_hooks(
+    ctx: &mut PluginContext,
+    runtime: nemo_relay_worker::PluginRuntime,
+    block_tool: bool,
+    tool_request_error: bool,
+) {
+    ctx.register_tool_sanitize_request_guardrail(
+        "fixture_tool_sanitize_request",
+        0,
+        |_name, args| mark_json(args, "worker_plugin_tool_sanitize_request"),
+    );
+    ctx.register_tool_sanitize_response_guardrail(
+        "fixture_tool_sanitize_response",
+        0,
+        |_name, result| mark_json(result, "worker_plugin_tool_sanitize_response"),
+    );
+    ctx.register_tool_conditional_execution_guardrail(
+        "fixture_tool_conditional",
+        0,
+        move |_name, _args| {
+            if block_tool {
+                Ok(Some("fixture tool blocked".into()))
+            } else {
+                Ok(None)
             }
-        });
-        ctx.register_tool_execution_intercept(
-            "fixture_tool_execution",
-            0,
-            |_name, args, next: ToolNext| async move {
-                let result = next
-                    .call(mark_json(args, "worker_plugin_tool_execution_request"))
-                    .await?;
-                Ok(
-                    ToolExecutionInterceptOutcome::new(mark_json(
-                        result,
-                        "worker_plugin_tool_execution",
-                    ))
-                    .with_pending_mark(
-                        PendingMarkSpec::builder()
-                            .name("fixture.worker.tool_execution.mark")
-                            .build(),
-                    ),
-                )
-            },
-        );
+        },
+    );
+    ctx.register_tool_request_intercept("fixture_rewrite_args", 0, false, move |_name, args| {
+        if tool_request_error {
+            return Err(WorkerSdkError::Callback(
+                "fixture tool request error requested".into(),
+            ));
+        }
+        let runtime = runtime.clone();
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(emit_runtime_events(runtime))
+        })?;
+        Ok(mark_json(args, "worker_plugin"))
+    });
+    ctx.register_tool_execution_intercept(
+        "fixture_tool_execution",
+        0,
+        |_name, args, next: ToolNext| async move {
+            let result = next
+                .call(mark_json(args, "worker_plugin_tool_execution_request"))
+                .await?;
+            Ok(
+                ToolExecutionInterceptOutcome::new(mark_json(
+                    result,
+                    "worker_plugin_tool_execution",
+                ))
+                .with_pending_mark(
+                    PendingMarkSpec::builder()
+                        .name("fixture.worker.tool_execution.mark")
+                        .build(),
+                ),
+            )
+        },
+    );
+}
 
-        ctx.register_llm_sanitize_request_guardrail(
-            "fixture_llm_sanitize_request",
-            0,
-            |request| mark_llm_request(request, "worker_plugin_llm_sanitize_request"),
-        );
-        ctx.register_llm_sanitize_response_guardrail(
-            "fixture_llm_sanitize_response",
-            0,
-            |response| mark_json(response, "worker_plugin_llm_sanitize_response"),
-        );
-        ctx.register_llm_conditional_execution_guardrail(
-            "fixture_llm_conditional",
-            0,
-            |_request| Ok(None),
-        );
-        ctx.register_llm_request_intercept(
-            "fixture_llm_request_intercept",
-            0,
-            false,
-            move |_name, request, annotated| {
-                if llm_request_error {
-                    return Err(WorkerSdkError::Callback(
-                        "fixture LLM request error requested".into(),
-                    ));
+fn register_fixture_llm_hooks(
+    ctx: &mut PluginContext,
+    llm_request_error: bool,
+    llm_stream_open_error: bool,
+) {
+    ctx.register_llm_sanitize_request_guardrail(
+        "fixture_llm_sanitize_request",
+        0,
+        |request| mark_llm_request(request, "worker_plugin_llm_sanitize_request"),
+    );
+    ctx.register_llm_sanitize_response_guardrail(
+        "fixture_llm_sanitize_response",
+        0,
+        |response| mark_json(response, "worker_plugin_llm_sanitize_response"),
+    );
+    ctx.register_llm_conditional_execution_guardrail(
+        "fixture_llm_conditional",
+        0,
+        |_request| Ok(None),
+    );
+    ctx.register_llm_request_intercept(
+        "fixture_llm_request_intercept",
+        0,
+        false,
+        move |_name, request, annotated| {
+            if llm_request_error {
+                return Err(WorkerSdkError::Callback(
+                    "fixture LLM request error requested".into(),
+                ));
+            }
+            let (request, annotated) = match annotated {
+                Some(mut annotated) => {
+                    annotated
+                        .extra
+                        .insert("worker_plugin_annotated_request".into(), json!(true));
+                    (request, Some(annotated))
                 }
-                let (request, annotated) = match annotated {
-                    Some(mut annotated) => {
-                        annotated
-                            .extra
-                            .insert("worker_plugin_annotated_request".into(), json!(true));
-                        (request, Some(annotated))
-                    }
-                    None => (
-                        mark_llm_request(request, "worker_plugin_llm_request_intercept"),
-                        None,
-                    ),
-                };
-                Ok(nemo_relay_worker::LlmRequestInterceptOutcome::new(
-                    request,
-                    annotated,
-                )
+                None => (
+                    mark_llm_request(request, "worker_plugin_llm_request_intercept"),
+                    None,
+                ),
+            };
+            Ok(nemo_relay_worker::LlmRequestInterceptOutcome::new(request, annotated)
                 .with_pending_mark(
                     PendingMarkSpec::builder()
                         .name("fixture.worker.llm_request.mark")
@@ -217,45 +211,42 @@ impl WorkerPlugin for FixtureWorkerPlugin {
                         .metadata(json!({ "fixture": true }))
                         .build(),
                 ))
-            },
-        );
-        ctx.register_llm_execution_intercept(
-            "fixture_llm_execution",
-            0,
-            |_name, request, next: LlmNext| async move {
-                let response = next
-                    .call(mark_llm_request(
-                        request,
-                        "worker_plugin_llm_execution_request",
-                    ))
-                    .await?;
-                Ok(mark_json(response, "worker_plugin_llm_execution"))
-            },
-        );
-        ctx.register_llm_stream_execution_intercept(
-            "fixture_llm_stream_execution",
-            0,
-            move |_name, request, next: LlmStreamNext| async move {
-                if llm_stream_open_error {
-                    return Err(WorkerSdkError::Callback(
-                        "fixture LLM stream open error requested".into(),
-                    ));
-                }
-                let stream = next
-                    .call(mark_llm_request(
-                        request,
-                        "worker_plugin_llm_stream_execution_request",
-                    ))
-                    .await?;
-                let mapped: JsonStream = Box::pin(tokio_stream::StreamExt::map(stream, |chunk| {
-                    chunk.map(|value| mark_json(value, "worker_plugin_llm_stream_execution"))
-                }));
-                Ok(mapped)
-            },
-        );
-
-        Ok(())
-    }
+        },
+    );
+    ctx.register_llm_execution_intercept(
+        "fixture_llm_execution",
+        0,
+        |_name, request, next: LlmNext| async move {
+            let response = next
+                .call(mark_llm_request(
+                    request,
+                    "worker_plugin_llm_execution_request",
+                ))
+                .await?;
+            Ok(mark_json(response, "worker_plugin_llm_execution"))
+        },
+    );
+    ctx.register_llm_stream_execution_intercept(
+        "fixture_llm_stream_execution",
+        0,
+        move |_name, request, next: LlmStreamNext| async move {
+            if llm_stream_open_error {
+                return Err(WorkerSdkError::Callback(
+                    "fixture LLM stream open error requested".into(),
+                ));
+            }
+            let stream = next
+                .call(mark_llm_request(
+                    request,
+                    "worker_plugin_llm_stream_execution_request",
+                ))
+                .await?;
+            let mapped: JsonStream = Box::pin(tokio_stream::StreamExt::map(stream, |chunk| {
+                chunk.map(|value| mark_json(value, "worker_plugin_llm_stream_execution"))
+            }));
+            Ok(mapped)
+        },
+    );
 }
 
 async fn emit_runtime_events(runtime: nemo_relay_worker::PluginRuntime) -> nemo_relay_worker::Result<()> {

--- a/go/nemo_relay/model_pricing/model_pricing_test.go
+++ b/go/nemo_relay/model_pricing/model_pricing_test.go
@@ -35,14 +35,7 @@ func TestPricingPackageHelpers(t *testing.T) {
 
 func TestPricingPackageSourceAndRateHelpers(t *testing.T) {
 	fileSource := NewFileSource("/tmp/pricing.json")
-	payload, err := json.Marshal(fileSource)
-	if err != nil {
-		t.Fatalf("marshal file source: %v", err)
-	}
-	var parsedSource map[string]any
-	if err := json.Unmarshal(payload, &parsedSource); err != nil {
-		t.Fatalf("unmarshal file source: %v", err)
-	}
+	parsedSource := marshalObject(t, "file source", fileSource)
 	if parsedSource["type"] != "file" || parsedSource["path"] != "/tmp/pricing.json" {
 		t.Fatalf("unexpected file source: %#v", parsedSource)
 	}
@@ -58,25 +51,40 @@ func TestPricingPackageSourceAndRateHelpers(t *testing.T) {
 	tier.MinPromptTokens = &minTokens
 	tier.MaxPromptTokens = &maxTokens
 	schedule := NewPromptTokenThresholdRateSchedule(tier)
-	schedulePayload, err := json.Marshal(schedule)
+	assertPromptTokenThresholdSchedule(t, schedule, minTokens, maxTokens)
+
+	config := NewConfig()
+	component := Component(config)
+	if component.Kind != PluginKind || !component.Enabled {
+		t.Fatalf("unexpected model pricing component: %#v", component)
+	}
+}
+
+func marshalObject(t *testing.T, name string, value any) map[string]any {
+	t.Helper()
+	payload, err := json.Marshal(value)
 	if err != nil {
-		t.Fatalf("marshal rate schedule: %v", err)
+		t.Fatalf("marshal %s: %v", name, err)
 	}
-	var parsedSchedule map[string]any
-	if err := json.Unmarshal(schedulePayload, &parsedSchedule); err != nil {
-		t.Fatalf("unmarshal rate schedule: %v", err)
+	var parsed map[string]any
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		t.Fatalf("unmarshal %s: %v", name, err)
 	}
+	return parsed
+}
+
+func assertPromptTokenThresholdSchedule(
+	t *testing.T,
+	schedule PromptTokenThresholdRateSchedule,
+	minTokens uint64,
+	maxTokens uint64,
+) {
+	t.Helper()
+	parsedSchedule := marshalObject(t, "rate schedule", schedule)
 	if parsedSchedule["type"] != "prompt_token_threshold" || parsedSchedule["applies_to"] != "full_request" {
 		t.Fatalf("unexpected rate schedule: %#v", parsedSchedule)
 	}
-	tiers, ok := parsedSchedule["tiers"].([]any)
-	if !ok || len(tiers) != 1 {
-		t.Fatalf("unexpected rate schedule tiers: %#v", parsedSchedule["tiers"])
-	}
-	parsedTier, ok := tiers[0].(map[string]any)
-	if !ok {
-		t.Fatalf("unexpected rate schedule tier: %#v", tiers[0])
-	}
+	parsedTier := singleScheduleTier(t, parsedSchedule)
 	if parsedTier["min_prompt_tokens"] != float64(minTokens) || parsedTier["max_prompt_tokens"] != float64(maxTokens) {
 		t.Fatalf("unexpected token bounds: %#v", parsedTier)
 	}
@@ -87,10 +95,17 @@ func TestPricingPackageSourceAndRateHelpers(t *testing.T) {
 	if rates["input_per_million"] != float64(3) || rates["output_per_million"] != float64(4) {
 		t.Fatalf("unexpected tier rate values: %#v", rates)
 	}
+}
 
-	config := NewConfig()
-	component := Component(config)
-	if component.Kind != PluginKind || !component.Enabled {
-		t.Fatalf("unexpected model pricing component: %#v", component)
+func singleScheduleTier(t *testing.T, parsedSchedule map[string]any) map[string]any {
+	t.Helper()
+	tiers, ok := parsedSchedule["tiers"].([]any)
+	if !ok || len(tiers) != 1 {
+		t.Fatalf("unexpected rate schedule tiers: %#v", parsedSchedule["tiers"])
 	}
+	parsedTier, ok := tiers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected rate schedule tier: %#v", tiers[0])
+	}
+	return parsedTier
 }

--- a/go/nemo_relay/tools_test.go
+++ b/go/nemo_relay/tools_test.go
@@ -787,19 +787,18 @@ func TestToolExecutionInterceptEmitsPendingMarks(t *testing.T) {
 	mu.Lock()
 	captured := append([]Event(nil), events...)
 	mu.Unlock()
+	assertToolExecutionPendingMarkEvents(t, captured, toolName, markName, category)
+}
 
-	startIndex, endIndex, markIndex := -1, -1, -1
-	var start, mark Event
-	for index, event := range captured {
-		switch {
-		case event.Name() == toolName && event.Kind() == "scope" && event.ScopeCategory() == "start":
-			startIndex, start = index, event
-		case event.Name() == toolName && event.Kind() == "scope" && event.ScopeCategory() == "end":
-			endIndex = index
-		case event.Name() == markName && event.Kind() == "mark":
-			markIndex, mark = index, event
-		}
-	}
+func assertToolExecutionPendingMarkEvents(
+	t *testing.T,
+	events []Event,
+	toolName string,
+	markName string,
+	category string,
+) {
+	t.Helper()
+	startIndex, endIndex, markIndex, start, mark := toolExecutionLifecycleEvents(events, toolName, markName)
 	if startIndex < 0 || endIndex < 0 || markIndex < 0 {
 		t.Fatalf("missing lifecycle events: start=%d end=%d mark=%d", startIndex, endIndex, markIndex)
 	}
@@ -821,6 +820,22 @@ func TestToolExecutionInterceptEmitsPendingMarks(t *testing.T) {
 	if metadata["fixture"] != true {
 		t.Fatalf("unexpected mark metadata: %s", mark.Metadata())
 	}
+}
+
+func toolExecutionLifecycleEvents(events []Event, toolName, markName string) (int, int, int, Event, Event) {
+	startIndex, endIndex, markIndex := -1, -1, -1
+	var start, mark Event
+	for index, event := range events {
+		switch {
+		case event.Name() == toolName && event.Kind() == "scope" && event.ScopeCategory() == "start":
+			startIndex, start = index, event
+		case event.Name() == toolName && event.Kind() == "scope" && event.ScopeCategory() == "end":
+			endIndex = index
+		case event.Name() == markName && event.Kind() == "mark":
+			markIndex, mark = index, event
+		}
+	}
+	return startIndex, endIndex, markIndex, start, mark
 }
 
 func TestToolExecutionInterceptSeesNextError(t *testing.T) {

--- a/go/nemo_relay/tools_test.go
+++ b/go/nemo_relay/tools_test.go
@@ -798,44 +798,51 @@ func assertToolExecutionPendingMarkEvents(
 	category string,
 ) {
 	t.Helper()
-	startIndex, endIndex, markIndex, start, mark := toolExecutionLifecycleEvents(events, toolName, markName)
-	if startIndex < 0 || endIndex < 0 || markIndex < 0 {
-		t.Fatalf("missing lifecycle events: start=%d end=%d mark=%d", startIndex, endIndex, markIndex)
+	lifecycle := toolExecutionLifecycleEvents(events, toolName, markName)
+	if lifecycle.startIndex < 0 || lifecycle.endIndex < 0 || lifecycle.markIndex < 0 {
+		t.Fatalf("missing lifecycle events: start=%d end=%d mark=%d", lifecycle.startIndex, lifecycle.endIndex, lifecycle.markIndex)
 	}
-	if !(startIndex < endIndex && endIndex < markIndex) {
-		t.Fatalf("unexpected lifecycle order: start=%d end=%d mark=%d", startIndex, endIndex, markIndex)
+	if !(lifecycle.startIndex < lifecycle.endIndex && lifecycle.endIndex < lifecycle.markIndex) {
+		t.Fatalf("unexpected lifecycle order: start=%d end=%d mark=%d", lifecycle.startIndex, lifecycle.endIndex, lifecycle.markIndex)
 	}
-	if mark.ParentUUID() != start.UUID() {
-		t.Fatalf("mark parent %q does not match tool UUID %q", mark.ParentUUID(), start.UUID())
+	if lifecycle.mark.ParentUUID() != lifecycle.start.UUID() {
+		t.Fatalf("mark parent %q does not match tool UUID %q", lifecycle.mark.ParentUUID(), lifecycle.start.UUID())
 	}
-	if mark.Category() != category {
-		t.Fatalf("mark category = %q, expected %q", mark.Category(), category)
+	if lifecycle.mark.Category() != category {
+		t.Fatalf("mark category = %q, expected %q", lifecycle.mark.Category(), category)
 	}
-	assertJSONFieldString(t, mark.CategoryProfile(), "subtype", "go.tool.execution")
-	assertJSONFieldString(t, mark.Data(), "source", "go")
+	assertJSONFieldString(t, lifecycle.mark.CategoryProfile(), "subtype", "go.tool.execution")
+	assertJSONFieldString(t, lifecycle.mark.Data(), "source", "go")
 	var metadata map[string]any
-	if err := json.Unmarshal(mark.Metadata(), &metadata); err != nil {
+	if err := json.Unmarshal(lifecycle.mark.Metadata(), &metadata); err != nil {
 		t.Fatalf("decode mark metadata: %v", err)
 	}
 	if metadata["fixture"] != true {
-		t.Fatalf("unexpected mark metadata: %s", mark.Metadata())
+		t.Fatalf("unexpected mark metadata: %s", lifecycle.mark.Metadata())
 	}
 }
 
-func toolExecutionLifecycleEvents(events []Event, toolName, markName string) (int, int, int, Event, Event) {
-	startIndex, endIndex, markIndex := -1, -1, -1
-	var start, mark Event
+type toolExecutionLifecycle struct {
+	startIndex int
+	endIndex   int
+	markIndex  int
+	start      Event
+	mark       Event
+}
+
+func toolExecutionLifecycleEvents(events []Event, toolName, markName string) toolExecutionLifecycle {
+	lifecycle := toolExecutionLifecycle{startIndex: -1, endIndex: -1, markIndex: -1}
 	for index, event := range events {
 		switch {
 		case event.Name() == toolName && event.Kind() == "scope" && event.ScopeCategory() == "start":
-			startIndex, start = index, event
+			lifecycle.startIndex, lifecycle.start = index, event
 		case event.Name() == toolName && event.Kind() == "scope" && event.ScopeCategory() == "end":
-			endIndex = index
+			lifecycle.endIndex = index
 		case event.Name() == markName && event.Kind() == "mark":
-			markIndex, mark = index, event
+			lifecycle.markIndex, lifecycle.mark = index, event
 		}
 	}
-	return startIndex, endIndex, markIndex, start, mark
+	return lifecycle
 }
 
 func TestToolExecutionInterceptSeesNextError(t *testing.T) {

--- a/scripts/test-install-mocks.sh
+++ b/scripts/test-install-mocks.sh
@@ -12,40 +12,53 @@ tests_run=0
 
 cleanup() {
     rm -rf "$test_root"
+    return 0
 }
 trap cleanup EXIT HUP INT TERM
 
 fail() {
     printf 'FAIL: %s\n' "$*" >&2
     exit 1
+    return 1
 }
 
 assert_success() {
     [ "$run_status" -eq 0 ] || fail "expected success, got ${run_status}: ${run_output}"
+    return 0
 }
 
 assert_failure() {
     [ "$run_status" -ne 0 ] || fail "expected failure: ${run_output}"
+    return 0
 }
 
 assert_contains() {
-    printf '%s\n' "$1" | grep -F "$2" >/dev/null || fail "expected '$2' in: $1"
+    assert_actual=$1
+    assert_expected=$2
+    printf '%s\n' "$assert_actual" | grep -F "$assert_expected" >/dev/null || fail "expected '$assert_expected' in: $assert_actual"
+    return 0
 }
 
 assert_file_contains() {
-    grep -F "$2" "$1" >/dev/null || fail "expected '$2' in $1"
+    assert_file=$1
+    assert_expected=$2
+    grep -F "$assert_expected" "$assert_file" >/dev/null || fail "expected '$assert_expected' in $assert_file"
+    return 0
 }
 
 assert_no_temporary_files() {
-    set -- "$1"/.nemo-relay.*
-    [ ! -e "$1" ] || fail "temporary installer file was not cleaned up: $1"
+    assert_directory=$1
+    set -- "$assert_directory"/.nemo-relay.*
+    assert_temporary_file=$1
+    [ ! -e "$assert_temporary_file" ] || fail "temporary installer file was not cleaned up: $assert_temporary_file"
+    return 0
 }
 
 make_mock_commands() {
-    mock_bin=$1
-    mkdir -p "$mock_bin"
+    mock_commands_dir=$1
+    mkdir -p "$mock_commands_dir"
 
-    cat >"${mock_bin}/uname" <<'EOF'
+    cat >"${mock_commands_dir}/uname" <<'EOF'
 #!/bin/sh
 case "${1:-}" in
     -s) printf '%s\n' "$MOCK_UNAME_S" ;;
@@ -54,7 +67,7 @@ case "${1:-}" in
 esac
 EOF
 
-    cat >"${mock_bin}/curl" <<'EOF'
+    cat >"${mock_commands_dir}/curl" <<'EOF'
 #!/bin/sh
 output=""
 url=""
@@ -93,12 +106,12 @@ case "$url" in
 esac
 EOF
 
-    cat >"${mock_bin}/sha256sum" <<'EOF'
+    cat >"${mock_commands_dir}/sha256sum" <<'EOF'
 #!/bin/sh
 printf '%s  %s\n' "$MOCK_ACTUAL_CHECKSUM" "$1"
 EOF
 
-    cat >"${mock_bin}/cygpath" <<'EOF'
+    cat >"${mock_commands_dir}/cygpath" <<'EOF'
 #!/bin/sh
 case "${1:-}" in
     -u) printf '%s\n' "$2" ;;
@@ -107,14 +120,15 @@ case "${1:-}" in
 esac
 EOF
 
-    cat >"${mock_bin}/powershell.exe" <<'EOF'
+    cat >"${mock_commands_dir}/powershell.exe" <<'EOF'
 #!/bin/sh
 [ -n "${NEMO_RELAY_INSTALL_DIR:-}" ] || exit 99
 printf '%s\n' "$NEMO_RELAY_INSTALL_DIR" >>"$MOCK_POWERSHELL_LOG"
 EOF
 
-    chmod +x "${mock_bin}/uname" "${mock_bin}/curl" "${mock_bin}/sha256sum" \
-        "${mock_bin}/cygpath" "${mock_bin}/powershell.exe"
+    chmod +x "${mock_commands_dir}/uname" "${mock_commands_dir}/curl" "${mock_commands_dir}/sha256sum" \
+        "${mock_commands_dir}/cygpath" "${mock_commands_dir}/powershell.exe"
+    return 0
 }
 
 new_case() {
@@ -145,6 +159,7 @@ new_case() {
     export MOCK_UNAME_S MOCK_UNAME_M MOCK_API_RESPONSE
     export MOCK_EXPECTED_CHECKSUM MOCK_ACTUAL_CHECKSUM MOCK_CHECKSUM_MISSING MOCK_GH_TOKEN
     export GH_TOKEN NEMO_RELAY_VERSION HOME PATH MOCK_CURL_LOG MOCK_POWERSHELL_LOG
+    return 0
 }
 
 run_installer() {
@@ -153,6 +168,7 @@ run_installer() {
     else
         run_status=$?
     fi
+    return 0
 }
 
 test_linux_arm64_mapping() {
@@ -162,6 +178,7 @@ test_linux_arm64_mapping() {
     run_installer
     assert_success
     assert_file_contains "$curl_log" "nemo-relay-cli-aarch64-unknown-linux-musl-0.5.0"
+    return 0
 }
 
 test_macos_arm64_mapping() {
@@ -172,6 +189,7 @@ test_macos_arm64_mapping() {
     run_installer
     assert_success
     assert_file_contains "$curl_log" "nemo-relay-cli-aarch64-apple-darwin-0.5.0"
+    return 0
 }
 
 test_git_bash_windows_x86_64_mapping_and_path_update() {
@@ -185,6 +203,7 @@ test_git_bash_windows_x86_64_mapping_and_path_update() {
     assert_file_contains "$curl_log" "nemo-relay-cli-x86_64-pc-windows-msvc-0.5.0.exe"
     [ -f "${LOCALAPPDATA}/nemo-relay/bin/nemo-relay.exe" ] || fail "Windows install did not create nemo-relay.exe"
     assert_file_contains "$powershell_log" "C:${LOCALAPPDATA#/}/nemo-relay/bin"
+    return 0
 }
 
 test_git_bash_windows_arm64_mapping() {
@@ -198,6 +217,7 @@ test_git_bash_windows_arm64_mapping() {
     assert_file_contains "$curl_log" "nemo-relay-cli-aarch64-pc-windows-msvc-0.5.0.exe"
     [ -f "${HOME}/custom-bin/nemo-relay.exe" ] || fail "Windows ARM64 install did not create nemo-relay.exe"
     assert_file_contains "$powershell_log" "C:${HOME#/}/custom-bin"
+    return 0
 }
 
 test_unsupported_platform() {
@@ -209,6 +229,7 @@ test_unsupported_platform() {
     assert_failure
     assert_contains "$run_output" "unsupported platform Darwin/x86_64"
     [ ! -s "$curl_log" ] || fail "unsupported platform attempted a download"
+    return 0
 }
 
 test_malformed_release_response() {
@@ -219,6 +240,7 @@ test_malformed_release_response() {
     run_installer
     assert_failure
     assert_contains "$run_output" "latest release response did not contain a tag name"
+    return 0
 }
 
 test_missing_checksum_fails_closed() {
@@ -230,6 +252,7 @@ test_missing_checksum_fails_closed() {
     assert_contains "$run_output" "could not download"
     [ ! -e "${HOME}/.local/bin/nemo-relay" ] || fail "binary installed without a checksum"
     assert_no_temporary_files "${HOME}/.local/bin"
+    return 0
 }
 
 test_checksum_mismatch_preserves_existing_binary() {
@@ -244,6 +267,7 @@ test_checksum_mismatch_preserves_existing_binary() {
     assert_contains "$run_output" "checksum verification failed"
     assert_file_contains "${install_dir}/nemo-relay" "existing binary"
     assert_no_temporary_files "$install_dir"
+    return 0
 }
 
 test_linux_arm64_mapping

--- a/scripts/test-install-mocks.sh
+++ b/scripts/test-install-mocks.sh
@@ -19,7 +19,6 @@ trap cleanup EXIT HUP INT TERM
 fail() {
     printf 'FAIL: %s\n' "$*" >&2
     exit 1
-    return 1
 }
 
 assert_success() {

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -12,12 +12,14 @@ tests_run=0
 
 cleanup() {
     rm -rf "$test_root"
+    return 0
 }
 trap cleanup EXIT HUP INT TERM
 
 fail() {
     printf 'FAIL: %s\n' "$*" >&2
     exit 1
+    return 1
 }
 
 run_command() {
@@ -26,23 +28,32 @@ run_command() {
     else
         run_status=$?
     fi
+    return 0
 }
 
 assert_success() {
     [ "$run_status" -eq 0 ] || fail "expected success, got ${run_status}: ${run_output}"
+    return 0
 }
 
 assert_failure() {
     [ "$run_status" -ne 0 ] || fail "expected failure: ${run_output}"
+    return 0
 }
 
 assert_contains() {
-    printf '%s\n' "$1" | grep -F "$2" >/dev/null || fail "expected '$2' in: $1"
+    assert_actual=$1
+    assert_expected=$2
+    printf '%s\n' "$assert_actual" | grep -F "$assert_expected" >/dev/null || fail "expected '$assert_expected' in: $assert_actual"
+    return 0
 }
 
 assert_no_temporary_files() {
-    set -- "$1"/.nemo-relay.*
-    [ ! -e "$1" ] || fail "temporary installer file was not cleaned up: $1"
+    assert_directory=$1
+    set -- "$assert_directory"/.nemo-relay.*
+    assert_temporary_file=$1
+    [ ! -e "$assert_temporary_file" ] || fail "temporary installer file was not cleaned up: $assert_temporary_file"
+    return 0
 }
 
 test_interface_validation() {
@@ -67,6 +78,7 @@ test_interface_validation() {
     run_command env -u HOME NEMO_RELAY_VERSION=0.3.0 sh "$installer"
     assert_failure
     assert_contains "$run_output" "install directory must not be empty"
+    return 0
 }
 
 test_live_latest_and_pinned_replacement() {
@@ -84,6 +96,7 @@ test_live_latest_and_pinned_replacement() {
     pinned_version=$("${live_install_dir}/nemo-relay" --version)
     assert_contains "$pinned_version" "nemo-relay 0.3.0"
     assert_no_temporary_files "$live_install_dir"
+    return 0
 }
 
 test_live_asset_404_preserves_existing_binary() {
@@ -96,6 +109,7 @@ test_live_asset_404_preserves_existing_binary() {
     preserved_version=$("${live_install_dir}/nemo-relay" --version)
     assert_contains "$preserved_version" "nemo-relay 0.3.0"
     assert_no_temporary_files "$live_install_dir"
+    return 0
 }
 
 test_live_network_failure() {
@@ -113,6 +127,7 @@ test_live_network_failure() {
     assert_failure
     assert_contains "$run_output" "could not resolve the latest stable release"
     [ ! -e "${network_failure_dir}/nemo-relay" ] || fail "binary installed after network failure"
+    return 0
 }
 
 test_interface_validation

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -19,7 +19,6 @@ trap cleanup EXIT HUP INT TERM
 fail() {
     printf 'FAIL: %s\n' "$*" >&2
     exit 1
-    return 1
 }
 
 run_command() {


### PR DESCRIPTION
#### Overview

Resolves the current Sonar maintainability backlog without changing public APIs or runtime behavior.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Make the POSIX installer tests explicit about successful returns and parameter names.
- Split the flagged Rust schema, CLI, registry, worker-cleanup, and fixture control flows into focused private helpers.
- Extract focused Go test helpers while preserving their existing assertions.

Validation:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-rust`
- `just test-python`
- `just test-go` and `go test ./...`
- `just test-node` (246 passed)
- `uv run pre-commit run --all-files`
- Installer syntax checks plus the mock installer suite (8 passed)

#### Where should the reviewer start?

Start with `crates/cli/src/plugins/schema.rs`, where recursive traversal behavior was separated into smaller helpers while preserving the existing schema semantics.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic “doctor” output formatting, including consistent check row rendering and richer “Completions” details (now includes the check name plus details).
  * Refined dynamic configuration editing flow to better handle repeated selection and cancel/back behavior.
  * Strengthened dynamic plugin configuration/record validation and worker cleanup logic.

* **Tests**
  * Added a unit test covering human-readable doctor rendering for completion details.
  * Refreshed installer/pricing/tool-related tests to use shared helpers and clearer assertions.

* **Chores**
  * Updated test install harness scripts to make success/failure return codes explicit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->