### PR TITLE
feat(plugin): add owned dynamic host activation

### DIFF
--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -358,9 +358,8 @@ async fn initialize_plugin_host(
         None => PluginConfig::default(),
     };
     #[cfg(feature = "switchyard")]
-    validate_switchyard_atof_configuration(&plugin_config).map_err(|error| {
-        CliError::Config(format!("Switchyard ATOF validation failed: {error}"))
-    })?;
+    validate_switchyard_atof_configuration(&plugin_config)
+        .map_err(|error| CliError::Config(format!("Switchyard ATOF validation failed: {error}")))?;
     if dynamic_plugins.is_empty() {
         initialize_plugins_exact(plugin_config)
             .await

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -12,13 +12,8 @@ use axum::extract::{DefaultBodyLimit, State};
 use axum::http::HeaderMap;
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use nemo_relay::plugin::dynamic::{
-    DynamicPluginKind, NativePluginActivation, NativePluginLoadSpec, WorkerPluginActivation,
-    WorkerPluginLoadSpec, load_native_plugins, load_worker_plugins,
-};
-use nemo_relay::plugin::{
-    PluginComponentSpec, PluginConfig, clear_plugin_configuration, initialize_plugins_exact,
-};
+use nemo_relay::plugin::PluginConfig;
+use nemo_relay::plugin::dynamic::{DynamicPluginActivationSpec, PluginHostActivation};
 use nemo_relay_adaptive::plugin_component::register_adaptive_component;
 use nemo_relay_pii_redaction::component::register_pii_redaction_component;
 #[cfg(feature = "switchyard")]
@@ -156,7 +151,7 @@ async fn serve_listener_with_dynamic_inner(
     shutdown_mode: Option<ShutdownMode>,
 ) -> Result<(), CliError> {
     let plugin_activation =
-        PluginActivation::initialize(config.plugin_config.clone(), dynamic_plugins).await?;
+        initialize_plugin_host(config.plugin_config.clone(), dynamic_plugins).await?;
     let state = AppState::new(config);
     let sessions = state.sessions.clone();
     let last_activity = state.last_activity.clone();
@@ -191,7 +186,13 @@ async fn serve_listener_with_dynamic_inner(
     };
     let close_result = sessions.close_all("gateway_shutdown").await;
     let flush_result = nemo_relay::api::runtime::flush_subscribers().map_err(CliError::from);
-    let clear_result = plugin_activation.clear();
+    let clear_result = plugin_activation
+        .map(|activation| {
+            activation
+                .clear()
+                .map_err(|error| CliError::Config(format!("plugin teardown failed: {error}")))
+        })
+        .unwrap_or(Ok(()));
     if let Err(serve_error) = serve_result {
         if let Err(close_error) = close_result {
             eprintln!("session teardown failed after server error: {close_error}");
@@ -321,137 +322,54 @@ async fn idle_shutdown_future(
     }
 }
 
-struct PluginActivation {
-    active: bool,
-    native: Option<NativePluginActivation>,
-    worker: Option<WorkerPluginActivation>,
-}
-
-impl PluginActivation {
-    async fn initialize(
-        config: Option<Value>,
-        dynamic_plugins: Vec<ActiveDynamicPluginComponent>,
-    ) -> Result<Self, CliError> {
-        if config.is_none() && dynamic_plugins.is_empty() {
-            return Ok(Self {
-                active: false,
-                native: None,
-                worker: None,
-            });
-        };
-        register_adaptive_component().map_err(|error| {
-            CliError::Config(format!("adaptive plugin registration failed: {error}"))
-        })?;
-        register_pii_redaction_component().map_err(|error| {
-            CliError::Config(format!("PII redaction plugin registration failed: {error}"))
-        })?;
-        #[cfg(feature = "switchyard")]
-        register_switchyard_component().map_err(|error| {
-            CliError::Config(format!("Switchyard plugin registration failed: {error}"))
-        })?;
-        let native_specs = dynamic_plugins
-            .iter()
-            .filter(|plugin| plugin.kind == DynamicPluginKind::RustDynamic)
-            .map(|plugin| {
-                let manifest_ref = plugin.manifest_ref.clone().ok_or_else(|| {
-                    CliError::Config(format!(
-                        "native dynamic plugin '{}' has no manifest_ref in lifecycle state",
-                        plugin.plugin_id
-                    ))
-                })?;
-                Ok(NativePluginLoadSpec {
-                    plugin_id: plugin.plugin_id.clone(),
-                    manifest_ref,
-                })
+async fn initialize_plugin_host(
+    config: Option<Value>,
+    dynamic_plugins: Vec<ActiveDynamicPluginComponent>,
+) -> Result<Option<PluginHostActivation>, CliError> {
+    if config.is_none() && dynamic_plugins.is_empty() {
+        return Ok(None);
+    }
+    register_adaptive_component().map_err(|error| {
+        CliError::Config(format!("adaptive plugin registration failed: {error}"))
+    })?;
+    register_pii_redaction_component().map_err(|error| {
+        CliError::Config(format!("PII redaction plugin registration failed: {error}"))
+    })?;
+    #[cfg(feature = "switchyard")]
+    register_switchyard_component().map_err(|error| {
+        CliError::Config(format!("Switchyard plugin registration failed: {error}"))
+    })?;
+    let plugin_config: PluginConfig = match config {
+        Some(config) => serde_json::from_value(config)
+            .map_err(|error| CliError::Config(format!("invalid plugin config: {error}")))?,
+        None => PluginConfig::default(),
+    };
+    #[cfg(feature = "switchyard")]
+    validate_switchyard_atof_configuration(&plugin_config).map_err(|error| {
+        CliError::Config(format!("Switchyard ATOF validation failed: {error}"))
+    })?;
+    let specs = dynamic_plugins
+        .into_iter()
+        .map(|plugin| {
+            let manifest_ref = plugin.manifest_ref.ok_or_else(|| {
+                CliError::Config(format!(
+                    "dynamic plugin '{}' has no manifest_ref in lifecycle state",
+                    plugin.plugin_id
+                ))
+            })?;
+            Ok(DynamicPluginActivationSpec {
+                plugin_id: plugin.plugin_id,
+                kind: plugin.kind,
+                manifest_ref,
+                environment_ref: plugin.environment_ref,
+                config: plugin.config,
             })
-            .collect::<Result<Vec<_>, CliError>>()?;
-        let worker_specs = dynamic_plugins
-            .iter()
-            .filter(|plugin| plugin.kind == DynamicPluginKind::Worker)
-            .map(|plugin| {
-                let manifest_ref = plugin.manifest_ref.clone().ok_or_else(|| {
-                    CliError::Config(format!(
-                        "worker dynamic plugin '{}' has no manifest_ref in lifecycle state",
-                        plugin.plugin_id
-                    ))
-                })?;
-                Ok(WorkerPluginLoadSpec {
-                    plugin_id: plugin.plugin_id.clone(),
-                    manifest_ref,
-                    environment_ref: plugin.environment_ref.clone(),
-                    config: plugin.config.clone(),
-                })
-            })
-            .collect::<Result<Vec<_>, CliError>>()?;
-        let native =
-            if native_specs.is_empty() {
-                None
-            } else {
-                Some(load_native_plugins(native_specs).map_err(|error| {
-                    CliError::Config(format!("native plugin load failed: {error}"))
-                })?)
-            };
-        let worker =
-            if worker_specs.is_empty() {
-                None
-            } else {
-                Some(load_worker_plugins(worker_specs).map_err(|error| {
-                    CliError::Config(format!("worker plugin load failed: {error}"))
-                })?)
-            };
-        // Gateway already resolved its config; activate exactly (no re-discovery).
-        let mut plugin_config: PluginConfig = match config {
-            Some(config) => serde_json::from_value(config)
-                .map_err(|error| CliError::Config(format!("invalid plugin config: {error}")))?,
-            None => PluginConfig::default(),
-        };
-        plugin_config
-            .components
-            .extend(
-                dynamic_plugins
-                    .into_iter()
-                    .map(|plugin| PluginComponentSpec {
-                        kind: plugin.plugin_id,
-                        enabled: true,
-                        config: plugin.config,
-                    }),
-            );
-        #[cfg(feature = "switchyard")]
-        validate_switchyard_atof_configuration(&plugin_config).map_err(|error| {
-            CliError::Config(format!("Switchyard ATOF validation failed: {error}"))
-        })?;
-        initialize_plugins_exact(plugin_config)
-            .await
-            .map_err(|error| CliError::Config(format!("plugin activation failed: {error}")))?;
-        Ok(Self {
-            active: true,
-            native,
-            worker,
         })
-    }
-
-    fn clear(mut self) -> Result<(), CliError> {
-        let result = if self.active {
-            self.active = false;
-            clear_plugin_configuration()
-                .map_err(|error| CliError::Config(format!("plugin teardown failed: {error}")))?;
-            Ok(())
-        } else {
-            Ok(())
-        };
-        self.native.take();
-        self.worker.take();
-        result
-    }
-}
-
-impl Drop for PluginActivation {
-    fn drop(&mut self) {
-        if self.active {
-            let _ = clear_plugin_configuration();
-            self.active = false;
-        }
-    }
+        .collect::<Result<Vec<_>, CliError>>()?;
+    let (activation, _) = PluginHostActivation::activate(plugin_config, specs)
+        .await
+        .map_err(|error| CliError::Config(format!("plugin activation failed: {error}")))?;
+    Ok(Some(activation))
 }
 
 // Normalizes a Codex hook payload, applies all resulting events before responding, and returns the

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -12,8 +12,8 @@ use axum::extract::{DefaultBodyLimit, State};
 use axum::http::HeaderMap;
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use nemo_relay::plugin::PluginConfig;
 use nemo_relay::plugin::dynamic::{DynamicPluginActivationSpec, PluginHostActivation};
+use nemo_relay::plugin::{PluginConfig, clear_plugin_configuration, initialize_plugins_exact};
 use nemo_relay_adaptive::plugin_component::register_adaptive_component;
 use nemo_relay_pii_redaction::component::register_pii_redaction_component;
 #[cfg(feature = "switchyard")]
@@ -187,11 +187,7 @@ async fn serve_listener_with_dynamic_inner(
     let close_result = sessions.close_all("gateway_shutdown").await;
     let flush_result = nemo_relay::api::runtime::flush_subscribers().map_err(CliError::from);
     let clear_result = plugin_activation
-        .map(|activation| {
-            activation
-                .clear()
-                .map_err(|error| CliError::Config(format!("plugin teardown failed: {error}")))
-        })
+        .map(ServerPluginActivation::clear)
         .unwrap_or(Ok(()));
     if let Err(serve_error) = serve_result {
         if let Err(close_error) = close_result {
@@ -322,10 +318,27 @@ async fn idle_shutdown_future(
     }
 }
 
+enum ServerPluginActivation {
+    Static,
+    Dynamic(PluginHostActivation),
+}
+
+impl ServerPluginActivation {
+    fn clear(self) -> Result<(), CliError> {
+        match self {
+            Self::Static => clear_plugin_configuration()
+                .map_err(|error| CliError::Config(format!("plugin teardown failed: {error}"))),
+            Self::Dynamic(activation) => activation
+                .clear()
+                .map_err(|error| CliError::Config(format!("plugin teardown failed: {error}"))),
+        }
+    }
+}
+
 async fn initialize_plugin_host(
     config: Option<Value>,
     dynamic_plugins: Vec<ActiveDynamicPluginComponent>,
-) -> Result<Option<PluginHostActivation>, CliError> {
+) -> Result<Option<ServerPluginActivation>, CliError> {
     if config.is_none() && dynamic_plugins.is_empty() {
         return Ok(None);
     }
@@ -348,6 +361,12 @@ async fn initialize_plugin_host(
     validate_switchyard_atof_configuration(&plugin_config).map_err(|error| {
         CliError::Config(format!("Switchyard ATOF validation failed: {error}"))
     })?;
+    if dynamic_plugins.is_empty() {
+        initialize_plugins_exact(plugin_config)
+            .await
+            .map_err(|error| CliError::Config(format!("plugin activation failed: {error}")))?;
+        return Ok(Some(ServerPluginActivation::Static));
+    }
     let specs = dynamic_plugins
         .into_iter()
         .map(|plugin| {
@@ -369,7 +388,7 @@ async fn initialize_plugin_host(
     let (activation, _) = PluginHostActivation::activate(plugin_config, specs)
         .await
         .map_err(|error| CliError::Config(format!("plugin activation failed: {error}")))?;
-    Ok(Some(activation))
+    Ok(Some(ServerPluginActivation::Dynamic(activation)))
 }
 
 // Normalizes a Codex hook payload, applies all resulting events before responding, and returns the

--- a/crates/cli/tests/coverage/server_tests.rs
+++ b/crates/cli/tests/coverage/server_tests.rs
@@ -1703,6 +1703,37 @@ async fn serve_listener_activates_any_registered_plugin_kind() {
 }
 
 #[tokio::test]
+async fn static_only_cli_configuration_keeps_the_legacy_lifecycle() {
+    let _guard = PLUGIN_CONFIG_TEST_LOCK.lock().await;
+    let _ = nemo_relay::plugin::clear_plugin_configuration();
+    let _ = deregister_plugin(GENERIC_TEST_PLUGIN_KIND);
+    register_plugin(Arc::new(GenericTestPlugin)).unwrap();
+
+    let activation = initialize_plugin_host(
+        Some(json!({
+            "version": 1,
+            "components": [{
+                "kind": GENERIC_TEST_PLUGIN_KIND,
+                "enabled": true,
+                "config": {}
+            }]
+        })),
+        Vec::new(),
+    )
+    .await
+    .expect("static CLI config should initialize")
+    .expect("static CLI config should return a teardown guard");
+    assert!(matches!(&activation, ServerPluginActivation::Static));
+
+    nemo_relay::plugin::clear_plugin_configuration()
+        .expect("legacy clear should remain available for a static-only CLI config");
+    activation
+        .clear()
+        .expect("the static teardown guard should tolerate prior clear");
+    let _ = deregister_plugin(GENERIC_TEST_PLUGIN_KIND);
+}
+
+#[tokio::test]
 async fn serve_listener_activates_adaptive_plugin_config() {
     let _guard = PLUGIN_CONFIG_TEST_LOCK.lock().await;
     let _ = nemo_relay::plugin::clear_plugin_configuration();

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -122,6 +122,10 @@ name = "native_plugin_integration"
 path = "tests/integration/native_plugin_tests.rs"
 
 [[test]]
+name = "plugin_host_builtin_ownership"
+path = "tests/integration/plugin_host_builtin_ownership_tests.rs"
+
+[[test]]
 name = "worker_plugin_integration"
 path = "tests/integration/worker_plugin_tests.rs"
 required-features = ["worker-grpc"]

--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -55,7 +55,7 @@ use crate::observability::{MarkProjection, default_mark_exclude_names};
 use crate::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
     PluginRegistration, PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior,
-    deregister_plugin, register_plugin,
+    deregister_plugin, register_builtin_plugin,
 };
 
 /// The plugin kind registered by the core crate.
@@ -548,13 +548,7 @@ impl Plugin for ObservabilityPlugin {
 /// automatically before listing, looking up, validating, or initializing plugin
 /// components, so applications normally do not need to invoke it directly.
 pub fn register_observability_component() -> PluginResult<()> {
-    match register_plugin(Arc::new(ObservabilityPlugin)) {
-        Ok(()) => Ok(()),
-        Err(PluginError::RegistrationFailed(message)) if message.contains("already registered") => {
-            Ok(())
-        }
-        Err(err) => Err(err),
-    }
+    register_builtin_plugin(Arc::new(ObservabilityPlugin))
 }
 
 /// Deregisters the observability component kind from the core plugin registry.

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -49,15 +49,34 @@ pub use nemo_relay_types::plugin::{ConfigDiagnostic, DiagnosticLevel};
 pub mod dynamic;
 pub use dynamic::*;
 
-type PluginMap = HashMap<String, Arc<dyn Plugin>>;
+type PluginMap = HashMap<String, RegisteredPlugin>;
+
+struct RegisteredPlugin {
+    registration_id: u64,
+    owner: PluginRegistrationOwner,
+    plugin: Arc<dyn Plugin>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PluginRegistrationOwner {
+    Builtin,
+    External,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PluginDeregistrationOutcome {
+    Removed,
+    Missing,
+    Replaced,
+}
 
 static PLUGIN_HANDLERS: LazyLock<RwLock<PluginMap>> = LazyLock::new(|| RwLock::new(HashMap::new()));
 static ACTIVE_PLUGIN_CONFIGURATION: LazyLock<Mutex<Option<ActivePluginConfiguration>>> =
     LazyLock::new(|| Mutex::new(None));
 static PLUGIN_MUTATION_OWNER: LazyLock<Mutex<PluginMutationOwner>> =
     LazyLock::new(|| Mutex::new(PluginMutationOwner::Idle));
+static NEXT_PLUGIN_REGISTRATION_ID: AtomicU64 = AtomicU64::new(1);
 static NEXT_PLUGIN_HOST_OWNER_ID: AtomicU64 = AtomicU64::new(1);
-static BUILTIN_PLUGIN_REGISTRATION: OnceLock<Result<()>> = OnceLock::new();
 static PLUGIN_MUTATION_EXECUTOR: OnceLock<PluginMutationSender> = OnceLock::new();
 
 type PluginMutationJob = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
@@ -830,17 +849,50 @@ pub trait Plugin: Send + Sync + 'static {
 /// # Notes
 /// Registration affects future validation and initialization only.
 pub fn register_plugin(plugin: Arc<dyn Plugin>) -> Result<()> {
+    register_plugin_with_owner(plugin, PluginRegistrationOwner::External).map(|_| ())
+}
+
+pub(crate) fn register_plugin_tracked(plugin: Arc<dyn Plugin>) -> Result<u64> {
+    register_plugin_with_owner(plugin, PluginRegistrationOwner::External)
+}
+
+pub(crate) fn register_builtin_plugin(plugin: Arc<dyn Plugin>) -> Result<()> {
+    register_plugin_with_owner(plugin, PluginRegistrationOwner::Builtin).map(|_| ())
+}
+
+fn register_plugin_with_owner(
+    plugin: Arc<dyn Plugin>,
+    owner: PluginRegistrationOwner,
+) -> Result<u64> {
     let mut guard = PLUGIN_HANDLERS
         .write()
         .map_err(|err| PluginError::Internal(format!("plugin registry lock poisoned: {err}")))?;
     let plugin_kind = plugin.plugin_kind().to_string();
-    if guard.contains_key(&plugin_kind) {
+    if let Some(existing) = guard.get(&plugin_kind) {
+        if owner == PluginRegistrationOwner::Builtin
+            && existing.owner == PluginRegistrationOwner::Builtin
+        {
+            return Ok(existing.registration_id);
+        }
+        let ownership = if owner == PluginRegistrationOwner::Builtin {
+            "reserved builtin "
+        } else {
+            ""
+        };
         return Err(PluginError::RegistrationFailed(format!(
-            "plugin '{plugin_kind}' is already registered"
+            "{ownership}plugin '{plugin_kind}' is already registered"
         )));
     }
-    guard.insert(plugin_kind, plugin);
-    Ok(())
+    let registration_id = NEXT_PLUGIN_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
+    guard.insert(
+        plugin_kind,
+        RegisteredPlugin {
+            registration_id,
+            owner,
+            plugin,
+        },
+    );
+    Ok(registration_id)
 }
 
 /// Registers core-provided plugin kinds.
@@ -848,28 +900,12 @@ pub fn register_plugin(plugin: Arc<dyn Plugin>) -> Result<()> {
 /// Built-in plugins are available to validation and initialization without a
 /// binding or application-specific registration call.
 pub fn ensure_builtin_plugins_registered() -> Result<()> {
-    let register_builtins = || {
-        crate::observability::plugin_component::register_observability_component()?;
-        crate::plugins::nemo_guardrails::component::register_nemo_guardrails_component()?;
-        crate::plugins::model_pricing::register_pricing_component()
-    };
-    match BUILTIN_PLUGIN_REGISTRATION.get_or_init(register_builtins) {
-        Ok(()) => Ok(()),
-        Err(err) => Err(clone_cached_plugin_error(err)),
-    }
-}
-
-fn clone_cached_plugin_error(err: &PluginError) -> PluginError {
-    match err {
-        PluginError::InvalidConfig(message) => PluginError::InvalidConfig(message.clone()),
-        PluginError::Conflict(message) => PluginError::Conflict(message.clone()),
-        PluginError::NotFound(message) => PluginError::NotFound(message.clone()),
-        PluginError::Serialization(err) => PluginError::Internal(err.to_string()),
-        PluginError::Internal(message) => PluginError::Internal(message.clone()),
-        PluginError::RegistrationFailed(message) => {
-            PluginError::RegistrationFailed(message.clone())
-        }
-    }
+    // Registration is idempotent for genuine built-ins. Revalidate on every
+    // call so a removed built-in is restored, a replacement is rejected, and
+    // a corrected ownership conflict can be retried without restarting Relay.
+    crate::observability::plugin_component::register_observability_component()?;
+    crate::plugins::nemo_guardrails::component::register_nemo_guardrails_component()?;
+    crate::plugins::model_pricing::register_pricing_component()
 }
 
 /// Removes a previously registered plugin.
@@ -896,6 +932,23 @@ pub(crate) fn deregister_plugin_checked(plugin_kind: &str) -> Result<bool> {
         .write()
         .map(|mut guard| guard.remove(plugin_kind).is_some())
         .map_err(|err| PluginError::Internal(format!("plugin registry lock poisoned: {err}")))
+}
+
+pub(crate) fn deregister_plugin_registration_checked(
+    plugin_kind: &str,
+    expected_registration_id: u64,
+) -> Result<PluginDeregistrationOutcome> {
+    let mut guard = PLUGIN_HANDLERS
+        .write()
+        .map_err(|err| PluginError::Internal(format!("plugin registry lock poisoned: {err}")))?;
+    match guard.get(plugin_kind) {
+        Some(plugin) if plugin.registration_id == expected_registration_id => {
+            guard.remove(plugin_kind);
+            Ok(PluginDeregistrationOutcome::Removed)
+        }
+        Some(_) => Ok(PluginDeregistrationOutcome::Replaced),
+        None => Ok(PluginDeregistrationOutcome::Missing),
+    }
 }
 
 /// Lists registered plugin kinds in sorted order.
@@ -932,10 +985,11 @@ pub fn list_plugin_kinds() -> Vec<String> {
 /// The returned plugin is shared by [`Arc`], so callers receive a cheap clone.
 pub fn lookup_plugin(plugin_kind: &str) -> Option<Arc<dyn Plugin>> {
     let _ = ensure_builtin_plugins_registered();
-    PLUGIN_HANDLERS
-        .read()
-        .ok()
-        .and_then(|guard| guard.get(plugin_kind).cloned())
+    PLUGIN_HANDLERS.read().ok().and_then(|guard| {
+        guard
+            .get(plugin_kind)
+            .map(|registered| Arc::clone(&registered.plugin))
+    })
 }
 
 /// Validates a plugin configuration document.

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -857,7 +857,37 @@ pub(crate) fn register_plugin_tracked(plugin: Arc<dyn Plugin>) -> Result<u64> {
 }
 
 pub(crate) fn register_builtin_plugin(plugin: Arc<dyn Plugin>) -> Result<()> {
+    let plugin_kind = plugin.plugin_kind();
+    {
+        let guard = PLUGIN_HANDLERS.read().map_err(|err| {
+            PluginError::Internal(format!("plugin registry lock poisoned: {err}"))
+        })?;
+        if let Some(existing) = guard.get(plugin_kind) {
+            if existing.owner == PluginRegistrationOwner::Builtin {
+                return Ok(());
+            }
+            return Err(plugin_already_registered_error(
+                plugin_kind,
+                PluginRegistrationOwner::Builtin,
+            ));
+        }
+    }
+
     register_plugin_with_owner(plugin, PluginRegistrationOwner::Builtin).map(|_| ())
+}
+
+fn plugin_already_registered_error(
+    plugin_kind: &str,
+    owner: PluginRegistrationOwner,
+) -> PluginError {
+    let ownership = if owner == PluginRegistrationOwner::Builtin {
+        "reserved builtin "
+    } else {
+        ""
+    };
+    PluginError::RegistrationFailed(format!(
+        "{ownership}plugin '{plugin_kind}' is already registered"
+    ))
 }
 
 fn register_plugin_with_owner(
@@ -874,14 +904,7 @@ fn register_plugin_with_owner(
         {
             return Ok(existing.registration_id);
         }
-        let ownership = if owner == PluginRegistrationOwner::Builtin {
-            "reserved builtin "
-        } else {
-            ""
-        };
-        return Err(PluginError::RegistrationFailed(format!(
-            "{ownership}plugin '{plugin_kind}' is already registered"
-        )));
+        return Err(plugin_already_registered_error(&plugin_kind, owner));
     }
     let registration_id = NEXT_PLUGIN_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
     guard.insert(
@@ -900,6 +923,26 @@ fn register_plugin_with_owner(
 /// Built-in plugins are available to validation and initialization without a
 /// binding or application-specific registration call.
 pub fn ensure_builtin_plugins_registered() -> Result<()> {
+    let all_registered = {
+        let guard = PLUGIN_HANDLERS.read().map_err(|err| {
+            PluginError::Internal(format!("plugin registry lock poisoned: {err}"))
+        })?;
+        [
+            crate::observability::plugin_component::OBSERVABILITY_PLUGIN_KIND,
+            crate::plugins::nemo_guardrails::component::NEMO_GUARDRAILS_PLUGIN_KIND,
+            crate::plugins::model_pricing::PRICING_PLUGIN_KIND,
+        ]
+        .iter()
+        .all(|kind| {
+            guard
+                .get(*kind)
+                .is_some_and(|plugin| plugin.owner == PluginRegistrationOwner::Builtin)
+        })
+    };
+    if all_registered {
+        return Ok(());
+    }
+
     // Registration is idempotent for genuine built-ins. Revalidate on every
     // call so a removed built-in is restored, a replacement is rejected, and
     // a corrected ownership conflict can be retried without restarting Relay.

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -9,10 +9,13 @@
 //! - plugin registration contexts for middleware/subscriber installation
 //! - rollback bookkeeping for registrations created during plugin setup
 
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::future::Future;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, OnceLock, RwLock};
 
 use serde::{Deserialize, Serialize};
@@ -51,7 +54,25 @@ type PluginMap = HashMap<String, Arc<dyn Plugin>>;
 static PLUGIN_HANDLERS: LazyLock<RwLock<PluginMap>> = LazyLock::new(|| RwLock::new(HashMap::new()));
 static ACTIVE_PLUGIN_CONFIGURATION: LazyLock<Mutex<Option<ActivePluginConfiguration>>> =
     LazyLock::new(|| Mutex::new(None));
+static PLUGIN_MUTATION_OWNER: LazyLock<Mutex<PluginMutationOwner>> =
+    LazyLock::new(|| Mutex::new(PluginMutationOwner::Idle));
+static NEXT_PLUGIN_HOST_OWNER_ID: AtomicU64 = AtomicU64::new(1);
 static BUILTIN_PLUGIN_REGISTRATION: OnceLock<Result<()>> = OnceLock::new();
+static PLUGIN_MUTATION_EXECUTOR: OnceLock<PluginMutationSender> = OnceLock::new();
+
+type PluginMutationJob = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+type PluginMutationSender = tokio::sync::mpsc::UnboundedSender<PluginMutationJob>;
+
+thread_local! {
+    static IN_PLUGIN_MUTATION_EXECUTOR: Cell<bool> = const { Cell::new(false) };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PluginMutationOwner {
+    Idle,
+    Legacy,
+    Host(u64),
+}
 
 /// Error type for generic plugin operations.
 #[derive(Debug, Error)]
@@ -1106,6 +1127,137 @@ pub fn plugin_config_schema() -> Json {
 /// is removed before the new configuration is activated.
 #[doc(hidden)]
 pub async fn initialize_plugins_exact(config: PluginConfig) -> Result<ConfigReport> {
+    run_owned_plugin_mutation("plugin initialization", move || async move {
+        let lease = LegacyPluginMutationLease::acquire()?;
+        let rollback_failures = Arc::new(Mutex::new(Vec::new()));
+        let initialization = tokio::spawn(initialize_plugins_exact_inner(
+            config,
+            Some(Arc::clone(&rollback_failures)),
+        ))
+        .await
+        .map_err(|error| {
+            PluginError::Internal(format!("plugin initialization task failed: {error}"))
+        });
+        let result = initialization.and_then(|result| result);
+        let failures = rollback_failures
+            .lock()
+            .map(|failures| failures.clone())
+            .unwrap_or_else(|lock_error| {
+                vec![format!("rollback failure lock poisoned: {lock_error}")]
+            });
+        match result {
+            Err(error) if !failures.is_empty() => {
+                std::mem::forget(lease);
+                Err(PluginError::RegistrationFailed(format!(
+                    concat!(
+                        "{}; initialization rollback was incomplete: {}; plugin ",
+                        "configuration mutations are disabled for this process because callbacks ",
+                        "may remain registered"
+                    ),
+                    error,
+                    failures.join("; ")
+                )))
+            }
+            result => result,
+        }
+    })
+    .await
+}
+
+pub(crate) async fn run_owned_plugin_mutation<T, F, Fut>(
+    operation_name: &'static str,
+    operation: F,
+) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<T>> + Send + 'static,
+{
+    if IN_PLUGIN_MUTATION_EXECUTOR.get() {
+        return operation().await;
+    }
+
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    plugin_mutation_executor()?
+        .send(Box::pin(async move {
+            let result = tokio::spawn(operation())
+                .await
+                .map_err(|error| {
+                    PluginError::Internal(format!("{operation_name} task failed: {error}"))
+                })
+                .and_then(|result| result);
+            let _ = result_tx.send(result);
+        }))
+        .map_err(|_| {
+            PluginError::Internal(format!(
+                "failed to queue {operation_name}: executor stopped"
+            ))
+        })?;
+    result_rx.await.map_err(|_| {
+        PluginError::Internal(format!(
+            "{operation_name} task stopped before returning a result"
+        ))
+    })?
+}
+
+fn plugin_mutation_executor() -> Result<&'static PluginMutationSender> {
+    if let Some(sender) = PLUGIN_MUTATION_EXECUTOR.get() {
+        return Ok(sender);
+    }
+
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<PluginMutationJob>();
+    let (startup_tx, startup_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("nemo-relay-plugin-host".into())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    let _ = startup_tx.send(Err(error.to_string()));
+                    return;
+                }
+            };
+            let _ = startup_tx.send(Ok(()));
+            IN_PLUGIN_MUTATION_EXECUTOR.set(true);
+            runtime.block_on(async move {
+                while let Some(job) = receiver.recv().await {
+                    job.await;
+                }
+            });
+        })
+        .map_err(|error| {
+            PluginError::Internal(format!("failed to start plugin host executor: {error}"))
+        })?;
+    startup_rx
+        .recv()
+        .map_err(|error| {
+            PluginError::Internal(format!(
+                "plugin host executor stopped during startup: {error}"
+            ))
+        })?
+        .map_err(|error| {
+            PluginError::Internal(format!("failed to start plugin host runtime: {error}"))
+        })?;
+
+    Ok(PLUGIN_MUTATION_EXECUTOR.get_or_init(|| sender))
+}
+
+pub(crate) async fn initialize_plugins_exact_for_host(
+    config: PluginConfig,
+    owner_id: u64,
+    rollback_failures: Arc<Mutex<Vec<String>>>,
+) -> Result<ConfigReport> {
+    verify_plugin_host_owner(owner_id)?;
+    initialize_plugins_exact_inner(config, Some(rollback_failures)).await
+}
+
+async fn initialize_plugins_exact_inner(
+    config: PluginConfig,
+    rollback_failures: Option<Arc<Mutex<Vec<String>>>>,
+) -> Result<ConfigReport> {
     let report = validate_plugin_config(&config);
     if report.has_errors() {
         return Err(PluginError::InvalidConfig(join_error_messages(&report)));
@@ -1119,13 +1271,30 @@ pub async fn initialize_plugins_exact(config: PluginConfig) -> Result<ConfigRepo
     };
 
     if let Some(mut previous_state) = previous {
-        rollback_registrations(&mut previous_state.registrations);
-        match initialize_plugin_components(&config).await {
+        let teardown_errors = rollback_registrations_checked(&mut previous_state.registrations);
+        if !teardown_errors.is_empty() {
+            record_rollback_failures(rollback_failures.as_ref(), teardown_errors.clone());
+            return Err(PluginError::RegistrationFailed(format!(
+                "previous plugin configuration could not be cleared: {}",
+                teardown_errors.join("; ")
+            )));
+        }
+        match initialize_plugin_components_catching_panics(
+            config.clone(),
+            rollback_failures.clone(),
+        )
+        .await
+        {
             Ok(registrations) => {
                 store_active_plugin_configuration(config, report.clone(), registrations)?;
                 Ok(report)
             }
-            Err(err) => match initialize_plugin_components(&previous_state.config).await {
+            Err(err) => match initialize_plugin_components_catching_panics(
+                previous_state.config.clone(),
+                rollback_failures.clone(),
+            )
+            .await
+            {
                 Ok(registrations) => {
                     let previous_report = validate_plugin_config(&previous_state.config);
                     store_active_plugin_configuration(
@@ -1141,10 +1310,24 @@ pub async fn initialize_plugins_exact(config: PluginConfig) -> Result<ConfigRepo
             },
         }
     } else {
-        let registrations = initialize_plugin_components(&config).await?;
+        let registrations =
+            initialize_plugin_components_catching_panics(config.clone(), rollback_failures).await?;
         store_active_plugin_configuration(config, report.clone(), registrations)?;
         Ok(report)
     }
+}
+
+async fn initialize_plugin_components_catching_panics(
+    config: PluginConfig,
+    rollback_failures: Option<Arc<Mutex<Vec<String>>>>,
+) -> Result<Vec<PluginRegistration>> {
+    tokio::spawn(async move { initialize_plugin_components(&config, rollback_failures).await })
+        .await
+        .map_err(|error| {
+            PluginError::Internal(format!(
+                "plugin component initialization task failed: {error}"
+            ))
+        })?
 }
 
 /// Validates and activates `config` layered on top of the discovered
@@ -1294,22 +1477,178 @@ pub fn user_config_dir() -> Option<PathBuf> {
 /// Clearing active configuration does not remove plugin kinds from the global
 /// registry.
 pub fn clear_plugin_configuration() -> Result<()> {
+    let lease = LegacyPluginMutationLease::acquire()?;
+    let outcome = clear_plugin_configuration_inner();
+    if !outcome.callbacks_cleared {
+        // Deregistration callbacks are single-use. If one failed, the process
+        // can no longer prove that replacing configuration is safe.
+        std::mem::forget(lease);
+        return Err(PluginError::RegistrationFailed(format!(
+            concat!(
+                "{}; plugin configuration mutations are disabled for this process because ",
+                "callbacks may remain registered"
+            ),
+            outcome
+                .result
+                .err()
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| "plugin teardown was incomplete".into())
+        )));
+    }
+    outcome.result
+}
+
+pub(crate) fn clear_plugin_configuration_for_host(owner_id: u64) -> PluginHostClearOutcome {
+    if let Err(error) = verify_plugin_host_owner(owner_id) {
+        return PluginHostClearOutcome {
+            result: Err(error),
+            callbacks_cleared: false,
+        };
+    }
+    clear_plugin_configuration_inner()
+}
+
+pub(crate) struct PluginHostClearOutcome {
+    pub(crate) result: Result<()>,
+    pub(crate) callbacks_cleared: bool,
+}
+
+fn clear_plugin_configuration_inner() -> PluginHostClearOutcome {
     let flush_error = crate::api::runtime::flush_subscribers()
         .err()
         .map(|error| error.to_string());
     let previous = {
-        let mut guard = ACTIVE_PLUGIN_CONFIGURATION.lock().map_err(|err| {
-            PluginError::Internal(format!("active plugin configuration lock poisoned: {err}"))
-        })?;
+        let mut guard = match ACTIVE_PLUGIN_CONFIGURATION.lock() {
+            Ok(guard) => guard,
+            Err(err) => {
+                return PluginHostClearOutcome {
+                    result: Err(PluginError::Internal(format!(
+                        "active plugin configuration lock poisoned: {err}"
+                    ))),
+                    callbacks_cleared: false,
+                };
+            }
+        };
         guard.take()
     };
-    if let Some(mut previous_state) = previous {
-        rollback_registrations(&mut previous_state.registrations);
+    let deregistration_errors = previous
+        .map(|mut previous_state| rollback_registrations_checked(&mut previous_state.registrations))
+        .unwrap_or_default();
+    let callbacks_cleared = deregistration_errors.is_empty();
+    let deregistration_error = (!callbacks_cleared).then(|| {
+        PluginError::RegistrationFailed(format!(
+            "plugin teardown failed: {}",
+            deregistration_errors.join("; ")
+        ))
+    });
+    let result = match (flush_error, deregistration_error) {
+        (None, None) => Ok(()),
+        (Some(flush), None) => Err(PluginError::Internal(flush)),
+        (None, Some(deregister)) => Err(deregister),
+        (Some(flush), Some(deregister)) => Err(PluginError::RegistrationFailed(format!(
+            "{deregister}; subscriber flush also failed: {flush}"
+        ))),
+    };
+    PluginHostClearOutcome {
+        result,
+        callbacks_cleared,
     }
-    if let Some(message) = flush_error {
-        return Err(PluginError::Internal(message));
+}
+
+pub(crate) fn plugin_configuration_is_active() -> Result<bool> {
+    ACTIVE_PLUGIN_CONFIGURATION
+        .lock()
+        .map(|guard| guard.is_some())
+        .map_err(|err| {
+            PluginError::Internal(format!("active plugin configuration lock poisoned: {err}"))
+        })
+}
+
+pub(crate) struct PluginHostLease {
+    owner_id: u64,
+}
+
+impl PluginHostLease {
+    pub(crate) fn owner_id(&self) -> u64 {
+        self.owner_id
     }
-    Ok(())
+}
+
+impl Drop for PluginHostLease {
+    fn drop(&mut self) {
+        if let Ok(mut owner) = PLUGIN_MUTATION_OWNER.lock()
+            && *owner == PluginMutationOwner::Host(self.owner_id)
+        {
+            *owner = PluginMutationOwner::Idle;
+        }
+    }
+}
+
+pub(crate) fn acquire_plugin_host_lease() -> Result<PluginHostLease> {
+    let mut owner = PLUGIN_MUTATION_OWNER.lock().map_err(|err| {
+        PluginError::Internal(format!("plugin mutation owner lock poisoned: {err}"))
+    })?;
+    if *owner != PluginMutationOwner::Idle {
+        return Err(plugin_mutation_conflict(*owner));
+    }
+    if plugin_configuration_is_active()? {
+        return Err(PluginError::Conflict(
+            "plugin configuration is already active; clear it before activating dynamic plugins"
+                .into(),
+        ));
+    }
+    let owner_id = NEXT_PLUGIN_HOST_OWNER_ID.fetch_add(1, Ordering::Relaxed);
+    *owner = PluginMutationOwner::Host(owner_id);
+    Ok(PluginHostLease { owner_id })
+}
+
+fn verify_plugin_host_owner(owner_id: u64) -> Result<()> {
+    let owner = PLUGIN_MUTATION_OWNER.lock().map_err(|err| {
+        PluginError::Internal(format!("plugin mutation owner lock poisoned: {err}"))
+    })?;
+    if *owner == PluginMutationOwner::Host(owner_id) {
+        Ok(())
+    } else {
+        Err(PluginError::Conflict(
+            "dynamic plugin host no longer owns plugin configuration".into(),
+        ))
+    }
+}
+
+struct LegacyPluginMutationLease;
+
+impl LegacyPluginMutationLease {
+    fn acquire() -> Result<Self> {
+        let mut owner = PLUGIN_MUTATION_OWNER.lock().map_err(|err| {
+            PluginError::Internal(format!("plugin mutation owner lock poisoned: {err}"))
+        })?;
+        if *owner != PluginMutationOwner::Idle {
+            return Err(plugin_mutation_conflict(*owner));
+        }
+        *owner = PluginMutationOwner::Legacy;
+        Ok(Self)
+    }
+}
+
+impl Drop for LegacyPluginMutationLease {
+    fn drop(&mut self) {
+        if let Ok(mut owner) = PLUGIN_MUTATION_OWNER.lock()
+            && *owner == PluginMutationOwner::Legacy
+        {
+            *owner = PluginMutationOwner::Idle;
+        }
+    }
+}
+
+fn plugin_mutation_conflict(owner: PluginMutationOwner) -> PluginError {
+    let message = match owner {
+        PluginMutationOwner::Idle => "plugin configuration is available",
+        PluginMutationOwner::Legacy => "another plugin configuration mutation is in progress",
+        PluginMutationOwner::Host(_) => {
+            "plugin configuration is owned by an active dynamic plugin host"
+        }
+    };
+    PluginError::Conflict(message.into())
 }
 
 /// Returns the last successfully configured plugin report.
@@ -1335,10 +1674,37 @@ pub fn active_plugin_report() -> Option<ConfigReport> {
 /// This is used internally during failed initialization and by
 /// [`clear_plugin_configuration`].
 pub fn rollback_registrations(registrations: &mut Vec<PluginRegistration>) {
+    let _ = rollback_registrations_checked(registrations);
+}
+
+fn rollback_registrations_checked(registrations: &mut Vec<PluginRegistration>) -> Vec<String> {
+    let mut errors = Vec::new();
     for registration in registrations.iter_mut().rev() {
-        let _ = (registration.deregister)();
+        let failure = match catch_unwind(AssertUnwindSafe(|| (registration.deregister)())) {
+            Ok(Ok(())) => None,
+            Ok(Err(error)) => Some(error.to_string()),
+            Err(payload) => Some(format!(
+                "deregistration panicked: {}",
+                panic_payload_message(payload)
+            )),
+        };
+        if let Some(error) = failure {
+            errors.push(format!(
+                "{} registration '{}' could not be removed: {error}",
+                registration.kind, registration.name
+            ));
+        }
     }
     registrations.clear();
+    errors
+}
+
+fn panic_payload_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|message| (*message).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic payload".into())
 }
 
 struct ActivePluginConfiguration {
@@ -1347,11 +1713,14 @@ struct ActivePluginConfiguration {
     registrations: Vec<PluginRegistration>,
 }
 
-async fn initialize_plugin_components(config: &PluginConfig) -> Result<Vec<PluginRegistration>> {
+async fn initialize_plugin_components(
+    config: &PluginConfig,
+    rollback_failures: Option<Arc<Mutex<Vec<String>>>>,
+) -> Result<Vec<PluginRegistration>> {
     ensure_builtin_plugins_registered()?;
     let totals = plugin_component_totals(config);
     let mut ordinals: HashMap<&str, usize> = HashMap::new();
-    let mut registrations = vec![];
+    let mut registrations = PendingPluginRegistrations::new(rollback_failures.clone());
 
     for component in config
         .components
@@ -1359,7 +1728,6 @@ async fn initialize_plugin_components(config: &PluginConfig) -> Result<Vec<Plugi
         .filter(|component| component.enabled)
     {
         let Some(plugin) = lookup_plugin(&component.kind) else {
-            rollback_registrations(&mut registrations);
             return Err(PluginError::NotFound(format!(
                 "plugin component '{}' is not registered",
                 component.kind
@@ -1376,17 +1744,83 @@ async fn initialize_plugin_components(config: &PluginConfig) -> Result<Vec<Plugi
             totals.get(component.kind.as_str()).copied().unwrap_or(1),
         );
 
-        let mut ctx = PluginRegistrationContext::with_namespace(namespace);
-        if let Err(err) = plugin.register(&component.config, &mut ctx).await {
-            let mut just_registered = ctx.into_registrations();
-            rollback_registrations(&mut just_registered);
-            rollback_registrations(&mut registrations);
-            return Err(err);
-        }
-        registrations.extend(ctx.into_registrations());
+        let mut pending =
+            PendingPluginRegistrationContext::new(namespace, rollback_failures.clone());
+        plugin
+            .register(&component.config, &mut pending.context)
+            .await?;
+        registrations.extend(pending.take());
     }
 
-    Ok(registrations)
+    Ok(registrations.take())
+}
+
+struct PendingPluginRegistrations {
+    registrations: Vec<PluginRegistration>,
+    rollback_failures: Option<Arc<Mutex<Vec<String>>>>,
+}
+
+impl PendingPluginRegistrations {
+    fn new(rollback_failures: Option<Arc<Mutex<Vec<String>>>>) -> Self {
+        Self {
+            registrations: Vec::new(),
+            rollback_failures,
+        }
+    }
+
+    fn extend(&mut self, registrations: Vec<PluginRegistration>) {
+        self.registrations.extend(registrations);
+    }
+
+    fn take(&mut self) -> Vec<PluginRegistration> {
+        std::mem::take(&mut self.registrations)
+    }
+}
+
+impl Drop for PendingPluginRegistrations {
+    fn drop(&mut self) {
+        let errors = rollback_registrations_checked(&mut self.registrations);
+        record_rollback_failures(self.rollback_failures.as_ref(), errors);
+    }
+}
+
+struct PendingPluginRegistrationContext {
+    context: PluginRegistrationContext,
+    rollback_failures: Option<Arc<Mutex<Vec<String>>>>,
+}
+
+impl PendingPluginRegistrationContext {
+    fn new(namespace: String, rollback_failures: Option<Arc<Mutex<Vec<String>>>>) -> Self {
+        Self {
+            context: PluginRegistrationContext::with_namespace(namespace),
+            rollback_failures,
+        }
+    }
+
+    fn take(&mut self) -> Vec<PluginRegistration> {
+        std::mem::take(&mut self.context.registrations)
+    }
+}
+
+impl Drop for PendingPluginRegistrationContext {
+    fn drop(&mut self) {
+        let errors = rollback_registrations_checked(&mut self.context.registrations);
+        record_rollback_failures(self.rollback_failures.as_ref(), errors);
+    }
+}
+
+fn record_rollback_failures(
+    rollback_failures: Option<&Arc<Mutex<Vec<String>>>>,
+    errors: Vec<String>,
+) {
+    if errors.is_empty() {
+        return;
+    }
+    if let Some(rollback_failures) = rollback_failures
+        && let Ok(mut recorded) = rollback_failures.lock()
+    {
+        recorded.extend(errors);
+    }
 }
 
 fn store_active_plugin_configuration(

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -888,11 +888,14 @@ fn clone_cached_plugin_error(err: &PluginError) -> PluginError {
 /// Active component registrations created by previous initialization calls are
 /// not removed by this function.
 pub fn deregister_plugin(plugin_kind: &str) -> bool {
+    deregister_plugin_checked(plugin_kind).unwrap_or(false)
+}
+
+pub(crate) fn deregister_plugin_checked(plugin_kind: &str) -> Result<bool> {
     PLUGIN_HANDLERS
         .write()
-        .ok()
-        .and_then(|mut guard| guard.remove(plugin_kind))
-        .is_some()
+        .map(|mut guard| guard.remove(plugin_kind).is_some())
+        .map_err(|err| PluginError::Internal(format!("plugin registry lock poisoned: {err}")))
 }
 
 /// Lists registered plugin kinds in sorted order.

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -1004,9 +1004,11 @@ pub(crate) fn deregister_plugin_registration_checked(
 ///
 /// # Notes
 /// Disabled or inactive components still appear here when their plugin kind is
-/// registered.
+/// registered. An empty list is returned when built-in registration fails.
 pub fn list_plugin_kinds() -> Vec<String> {
-    let _ = ensure_builtin_plugins_registered();
+    if ensure_builtin_plugins_registered().is_err() {
+        return Vec::new();
+    }
     let mut kinds = PLUGIN_HANDLERS
         .read()
         .map(|guard| guard.keys().cloned().collect::<Vec<_>>())
@@ -1022,12 +1024,16 @@ pub fn list_plugin_kinds() -> Vec<String> {
 ///
 /// # Returns
 /// The registered plugin implementation for `plugin_kind`, or `None` when the
-/// kind is unknown.
+/// kind is unknown or built-in registration fails.
 ///
 /// # Notes
 /// The returned plugin is shared by [`Arc`], so callers receive a cheap clone.
 pub fn lookup_plugin(plugin_kind: &str) -> Option<Arc<dyn Plugin>> {
-    let _ = ensure_builtin_plugins_registered();
+    ensure_builtin_plugins_registered().ok()?;
+    lookup_registered_plugin(plugin_kind)
+}
+
+fn lookup_registered_plugin(plugin_kind: &str) -> Option<Arc<dyn Plugin>> {
     PLUGIN_HANDLERS.read().ok().and_then(|guard| {
         guard
             .get(plugin_kind)
@@ -1051,8 +1057,17 @@ pub fn lookup_plugin(plugin_kind: &str) -> Option<Arc<dyn Plugin>> {
 /// Validation checks host policy, plugin multiplicity rules, unknown component
 /// kinds, and plugin-provided validation hooks.
 pub fn validate_plugin_config(config: &PluginConfig) -> ConfigReport {
-    let _ = ensure_builtin_plugins_registered();
     let mut report = ConfigReport::default();
+    if let Err(error) = ensure_builtin_plugins_registered() {
+        report.diagnostics.push(ConfigDiagnostic {
+            level: DiagnosticLevel::Error,
+            code: "plugin.builtin_registration_failed".to_string(),
+            component: None,
+            field: None,
+            message: format!("built-in plugin registration failed: {error}"),
+        });
+        return report;
+    }
 
     if config.version != 1 {
         push_policy_diag(
@@ -1068,7 +1083,7 @@ pub fn validate_plugin_config(config: &PluginConfig) -> ConfigReport {
     validate_plugin_multiplicity(&mut report, config);
 
     for component in &config.components {
-        let Some(plugin) = lookup_plugin(&component.kind) else {
+        let Some(plugin) = lookup_registered_plugin(&component.kind) else {
             push_policy_diag(
                 &mut report.diagnostics,
                 config.policy.unknown_component,
@@ -1831,7 +1846,7 @@ async fn initialize_plugin_components(
         .iter()
         .filter(|component| component.enabled)
     {
-        let Some(plugin) = lookup_plugin(&component.kind) else {
+        let Some(plugin) = lookup_registered_plugin(&component.kind) else {
             return Err(PluginError::NotFound(format!(
                 "plugin component '{}' is not registered",
                 component.kind
@@ -1972,7 +1987,7 @@ fn validate_plugin_multiplicity(report: &mut ConfigReport, config: &PluginConfig
             continue;
         }
 
-        let allows_multiple = lookup_plugin(&component.kind)
+        let allows_multiple = lookup_registered_plugin(&component.kind)
             .map(|plugin| plugin.allows_multiple_components())
             .unwrap_or(true);
         if !allows_multiple {

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -1650,8 +1650,12 @@ pub(crate) fn acquire_plugin_host_lease() -> Result<PluginHostLease> {
     }
     if plugin_configuration_is_active()? {
         return Err(PluginError::Conflict(
-            "plugin configuration is already active; clear it before activating dynamic plugins"
-                .into(),
+            concat!(
+                "a static plugin configuration is already active; to combine static and ",
+                "dynamic plugins, provide the static components as the base configuration to ",
+                "dynamic plugin activation before calling plugin initialization"
+            )
+            .into(),
         ));
     }
     let owner_id = NEXT_PLUGIN_HOST_OWNER_ID.fetch_add(1, Ordering::Relaxed);

--- a/crates/core/src/plugin/dynamic.rs
+++ b/crates/core/src/plugin/dynamic.rs
@@ -12,6 +12,8 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use strum::{Display, IntoStaticStr};
 
+use crate::plugin::{PluginDeregistrationOutcome, deregister_plugin_registration_checked};
+
 /// Canonical identifier for one dynamic plugin record.
 pub type DynamicPluginId = String;
 
@@ -55,6 +57,37 @@ impl DynamicPluginTeardownOutcome {
         self.errors.extend(other.errors);
         self.safe_to_unload &= other.safe_to_unload;
     }
+}
+
+pub(super) fn deregister_tracked_registrations_checked(
+    registrations: &mut Vec<(String, u64)>,
+    plugin_type: &str,
+) -> DynamicPluginTeardownOutcome {
+    let mut outcome = DynamicPluginTeardownOutcome::success();
+    for (plugin_kind, registration_id) in std::mem::take(registrations).into_iter().rev() {
+        match deregister_plugin_registration_checked(&plugin_kind, registration_id) {
+            Ok(PluginDeregistrationOutcome::Removed) => {}
+            Ok(PluginDeregistrationOutcome::Missing) => outcome.record_error(
+                format!(
+                    "{plugin_type} plugin kind '{plugin_kind}' was not registered during teardown"
+                ),
+                true,
+            ),
+            Ok(PluginDeregistrationOutcome::Replaced) => outcome.record_error(
+                format!(
+                    "{plugin_type} plugin kind '{plugin_kind}' was replaced during teardown and was left registered"
+                ),
+                true,
+            ),
+            Err(error) => outcome.record_error(
+                format!(
+                    "failed to deregister {plugin_type} plugin kind '{plugin_kind}': {error}"
+                ),
+                false,
+            ),
+        }
+    }
+    outcome
 }
 
 /// Plugin execution lane.

--- a/crates/core/src/plugin/dynamic.rs
+++ b/crates/core/src/plugin/dynamic.rs
@@ -18,12 +18,14 @@ pub type DynamicPluginId = String;
 /// Canonical filename for authored Relay plugin manifests.
 pub const DYNAMIC_PLUGIN_MANIFEST_FILENAME: &str = "relay-plugin.toml";
 
+mod host;
 mod manifest;
 mod native;
 mod registry;
 #[cfg(feature = "worker-grpc")]
 mod worker;
 
+pub use host::*;
 pub use manifest::*;
 pub use native::*;
 pub use registry::*;

--- a/crates/core/src/plugin/dynamic.rs
+++ b/crates/core/src/plugin/dynamic.rs
@@ -32,6 +32,31 @@ pub use registry::*;
 #[cfg(feature = "worker-grpc")]
 pub use worker::*;
 
+#[derive(Debug)]
+pub(crate) struct DynamicPluginTeardownOutcome {
+    pub(crate) errors: Vec<String>,
+    pub(crate) safe_to_unload: bool,
+}
+
+impl DynamicPluginTeardownOutcome {
+    pub(crate) fn success() -> Self {
+        Self {
+            errors: Vec::new(),
+            safe_to_unload: true,
+        }
+    }
+
+    pub(crate) fn record_error(&mut self, error: impl Into<String>, safe_to_unload: bool) {
+        self.errors.push(error.into());
+        self.safe_to_unload &= safe_to_unload;
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.errors.extend(other.errors);
+        self.safe_to_unload &= other.safe_to_unload;
+    }
+}
+
 /// Plugin execution lane.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/crates/core/src/plugin/dynamic/host.rs
+++ b/crates/core/src/plugin/dynamic/host.rs
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Owned activation lifecycle for dynamically loaded plugin components.
+
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value as Json};
+
+use crate::plugin::{
+    ConfigReport, PluginComponentSpec, PluginConfig, PluginHostLease, Result,
+    acquire_plugin_host_lease, clear_plugin_configuration_for_host,
+    initialize_plugins_exact_for_host, run_owned_plugin_mutation,
+};
+
+use super::{DynamicPluginKind, NativePluginActivation, NativePluginLoadSpec, load_native_plugins};
+
+#[cfg(feature = "worker-grpc")]
+use super::{WorkerPluginActivation, WorkerPluginLoadSpec, load_worker_plugins};
+
+/// One dynamic plugin component to load and activate in an embedding host.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DynamicPluginActivationSpec {
+    /// Expected plugin identifier from the authored manifest.
+    pub plugin_id: String,
+    /// Plugin execution lane.
+    pub kind: DynamicPluginKind,
+    /// Path or reference to the authored `relay-plugin.toml`.
+    pub manifest_ref: String,
+    /// Relay-managed runtime environment used by Python workers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment_ref: Option<String>,
+    /// Component-local configuration passed to the dynamically loaded plugin.
+    #[serde(default)]
+    pub config: Map<String, Json>,
+}
+
+/// Owns one process-wide dynamic plugin configuration and its loaded runtimes.
+///
+/// The activation keeps native libraries and worker processes alive until after
+/// all callbacks and subscribers registered from them have been removed. Only
+/// one activation may exist in a process at a time.
+#[must_use = "dropping the activation clears and unloads its dynamic plugins"]
+pub struct PluginHostActivation {
+    active: bool,
+    native: Option<NativePluginActivation>,
+    #[cfg(feature = "worker-grpc")]
+    worker: Option<WorkerPluginActivation>,
+    claim: Option<PluginHostLease>,
+}
+
+impl PluginHostActivation {
+    /// Load dynamic plugins and activate them with `config` as one transaction.
+    ///
+    /// Dynamic components are appended to the supplied base configuration in
+    /// specification order. The returned activation must remain alive for as
+    /// long as code may invoke plugin-provided callbacks.
+    pub async fn activate<I>(
+        config: PluginConfig,
+        dynamic_plugins: I,
+    ) -> Result<(Self, ConfigReport)>
+    where
+        I: IntoIterator<Item = DynamicPluginActivationSpec>,
+    {
+        let dynamic_plugins = dynamic_plugins.into_iter().collect::<Vec<_>>();
+        run_owned_plugin_mutation("dynamic plugin activation", move || async move {
+            Self::activate_inner(config, dynamic_plugins).await
+        })
+        .await
+    }
+
+    async fn activate_inner(
+        mut config: PluginConfig,
+        dynamic_plugins: Vec<DynamicPluginActivationSpec>,
+    ) -> Result<(Self, ConfigReport)> {
+        let claim = acquire_plugin_host_lease()?;
+
+        #[cfg(not(feature = "worker-grpc"))]
+        if let Some(plugin) = dynamic_plugins
+            .iter()
+            .find(|plugin| plugin.kind == DynamicPluginKind::Worker)
+        {
+            return Err(crate::plugin::PluginError::InvalidConfig(format!(
+                "worker dynamic plugin '{}' requires the 'worker-grpc' feature",
+                plugin.plugin_id
+            )));
+        }
+
+        let native_specs = dynamic_plugins
+            .iter()
+            .filter(|plugin| plugin.kind == DynamicPluginKind::RustDynamic)
+            .map(|plugin| NativePluginLoadSpec {
+                plugin_id: plugin.plugin_id.clone(),
+                manifest_ref: plugin.manifest_ref.clone(),
+            })
+            .collect::<Vec<_>>();
+        let native = (!native_specs.is_empty())
+            .then(|| {
+                load_native_plugins(native_specs)
+                    .map_err(|error| plugin_error_context("native plugin load failed", error))
+            })
+            .transpose()?;
+
+        #[cfg(feature = "worker-grpc")]
+        let worker = {
+            let worker_specs = dynamic_plugins
+                .iter()
+                .filter(|plugin| plugin.kind == DynamicPluginKind::Worker)
+                .map(|plugin| WorkerPluginLoadSpec {
+                    plugin_id: plugin.plugin_id.clone(),
+                    manifest_ref: plugin.manifest_ref.clone(),
+                    environment_ref: plugin.environment_ref.clone(),
+                    config: plugin.config.clone(),
+                })
+                .collect::<Vec<_>>();
+            (!worker_specs.is_empty())
+                .then(|| {
+                    load_worker_plugins(worker_specs)
+                        .map_err(|error| plugin_error_context("worker plugin load failed", error))
+                })
+                .transpose()?
+        };
+
+        config.components.extend(
+            dynamic_plugins
+                .into_iter()
+                .map(|plugin| PluginComponentSpec {
+                    kind: plugin.plugin_id,
+                    enabled: true,
+                    config: plugin.config,
+                }),
+        );
+        let rollback_failures = Arc::new(Mutex::new(Vec::new()));
+        let owner_id = claim.owner_id();
+        let initialization = tokio::spawn(initialize_plugins_exact_for_host(
+            config,
+            owner_id,
+            Arc::clone(&rollback_failures),
+        ))
+        .await
+        .map_err(|error| {
+            crate::plugin::PluginError::Internal(format!(
+                "dynamic plugin initialization task failed: {error}"
+            ))
+        });
+        let report = match initialization.and_then(|result| result) {
+            Ok(report) => report,
+            Err(error) => {
+                let failures = rollback_failures
+                    .lock()
+                    .map(|failures| failures.clone())
+                    .unwrap_or_else(|lock_error| {
+                        vec![format!("rollback failure lock poisoned: {lock_error}")]
+                    });
+                if failures.is_empty() {
+                    return Err(error);
+                }
+                if let Some(native) = native {
+                    std::mem::forget(native);
+                }
+                #[cfg(feature = "worker-grpc")]
+                if let Some(worker) = worker {
+                    std::mem::forget(worker);
+                }
+                std::mem::forget(claim);
+                return Err(crate::plugin::PluginError::RegistrationFailed(format!(
+                    concat!(
+                        "{}; activation rollback was incomplete: {}; the loaded runtimes ",
+                        "were retained because callbacks may remain registered"
+                    ),
+                    error,
+                    failures.join("; ")
+                )));
+            }
+        };
+
+        Ok((
+            Self {
+                active: true,
+                native,
+                #[cfg(feature = "worker-grpc")]
+                worker,
+                claim: Some(claim),
+            },
+            report,
+        ))
+    }
+
+    /// Returns whether this activation still owns an active plugin host.
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Clear registered callbacks before unloading libraries and workers.
+    pub fn clear(mut self) -> Result<()> {
+        self.clear_inner()
+    }
+
+    fn clear_inner(&mut self) -> Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        self.active = false;
+        let outcome = self
+            .claim
+            .as_ref()
+            .map(|claim| clear_plugin_configuration_for_host(claim.owner_id()))
+            .unwrap_or(crate::plugin::PluginHostClearOutcome {
+                result: Ok(()),
+                callbacks_cleared: true,
+            });
+        if outcome.callbacks_cleared {
+            self.native.take();
+            #[cfg(feature = "worker-grpc")]
+            self.worker.take();
+            self.claim.take();
+        } else {
+            // If core could not prove callbacks were removed, intentionally
+            // retain their code and owner for process lifetime rather than
+            // unload a library or worker that may still be referenced.
+            if let Some(native) = self.native.take() {
+                std::mem::forget(native);
+            }
+            #[cfg(feature = "worker-grpc")]
+            if let Some(worker) = self.worker.take() {
+                std::mem::forget(worker);
+            }
+            if let Some(claim) = self.claim.take() {
+                std::mem::forget(claim);
+            }
+        }
+        if outcome.callbacks_cleared {
+            outcome.result
+        } else {
+            Err(crate::plugin::PluginError::RegistrationFailed(format!(
+                "{}; the loaded runtimes were retained because callbacks may remain registered",
+                outcome
+                    .result
+                    .err()
+                    .map(|error| error.to_string())
+                    .unwrap_or_else(|| "plugin teardown was incomplete".into())
+            )))
+        }
+    }
+}
+
+fn plugin_error_context(
+    prefix: &str,
+    error: crate::plugin::PluginError,
+) -> crate::plugin::PluginError {
+    use crate::plugin::PluginError;
+
+    match error {
+        PluginError::InvalidConfig(message) => {
+            PluginError::InvalidConfig(format!("{prefix}: {message}"))
+        }
+        PluginError::Conflict(message) => PluginError::Conflict(format!("{prefix}: {message}")),
+        PluginError::NotFound(message) => PluginError::NotFound(format!("{prefix}: {message}")),
+        PluginError::Serialization(error) => {
+            PluginError::Internal(format!("{prefix}: serialization error: {error}"))
+        }
+        PluginError::Internal(message) => PluginError::Internal(format!("{prefix}: {message}")),
+        PluginError::RegistrationFailed(message) => {
+            PluginError::RegistrationFailed(format!("{prefix}: {message}"))
+        }
+    }
+}
+
+impl Drop for PluginHostActivation {
+    fn drop(&mut self) {
+        let _ = self.clear_inner();
+    }
+}

--- a/crates/core/src/plugin/dynamic/host.rs
+++ b/crates/core/src/plugin/dynamic/host.rs
@@ -3,6 +3,7 @@
 
 //! Owned activation lifecycle for dynamically loaded plugin components.
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
@@ -11,10 +12,14 @@ use serde_json::{Map, Value as Json};
 use crate::plugin::{
     ConfigReport, PluginComponentSpec, PluginConfig, PluginHostLease, Result,
     acquire_plugin_host_lease, clear_plugin_configuration_for_host,
-    initialize_plugins_exact_for_host, run_owned_plugin_mutation,
+    ensure_builtin_plugins_registered, initialize_plugins_exact_for_host,
+    run_owned_plugin_mutation,
 };
 
-use super::{DynamicPluginKind, NativePluginActivation, NativePluginLoadSpec, load_native_plugins};
+use super::{
+    DynamicPluginKind, DynamicPluginTeardownOutcome, NativePluginActivation, NativePluginLoadSpec,
+    load_native_plugins,
+};
 
 #[cfg(feature = "worker-grpc")]
 use super::{WorkerPluginActivation, WorkerPluginLoadSpec, load_worker_plugins};
@@ -76,6 +81,7 @@ impl PluginHostActivation {
         dynamic_plugins: Vec<DynamicPluginActivationSpec>,
     ) -> Result<(Self, ConfigReport)> {
         let claim = acquire_plugin_host_lease()?;
+        validate_unique_plugin_ids(&dynamic_plugins)?;
 
         #[cfg(not(feature = "worker-grpc"))]
         if let Some(plugin) = dynamic_plugins
@@ -87,6 +93,11 @@ impl PluginHostActivation {
                 plugin.plugin_id
             )));
         }
+
+        // Builtin registration is cached process-wide. It must complete before
+        // a dynamic plugin can claim a reserved builtin kind and permanently
+        // cache a failed builtin registration attempt.
+        ensure_builtin_plugins_registered()?;
 
         let native_specs = dynamic_plugins
             .iter()
@@ -211,39 +222,101 @@ impl PluginHostActivation {
                 result: Ok(()),
                 callbacks_cleared: true,
             });
-        if outcome.callbacks_cleared {
-            self.native.take();
-            #[cfg(feature = "worker-grpc")]
-            self.worker.take();
-            self.claim.take();
-        } else {
+        let mut errors = outcome
+            .result
+            .err()
+            .map(|error| vec![error.to_string()])
+            .unwrap_or_default();
+        if !outcome.callbacks_cleared {
             // If core could not prove callbacks were removed, intentionally
             // retain their code and owner for process lifetime rather than
             // unload a library or worker that may still be referenced.
-            if let Some(native) = self.native.take() {
-                std::mem::forget(native);
-            }
-            #[cfg(feature = "worker-grpc")]
-            if let Some(worker) = self.worker.take() {
-                std::mem::forget(worker);
-            }
-            if let Some(claim) = self.claim.take() {
-                std::mem::forget(claim);
-            }
+            self.retain_loaded_runtimes();
+            return Err(retained_runtime_error(errors));
         }
-        if outcome.callbacks_cleared {
-            outcome.result
+
+        let mut runtime_outcome = DynamicPluginTeardownOutcome::success();
+        if let Some(native) = &mut self.native {
+            runtime_outcome.merge(native.deregister_plugin_kinds_checked());
+        }
+        #[cfg(feature = "worker-grpc")]
+        if let Some(worker) = &mut self.worker {
+            runtime_outcome.merge(worker.deregister_plugin_kinds_checked());
+        }
+
+        // A worker cannot be stopped while its registry adapter might still be
+        // callable. Only begin process shutdown once every kind is known to be
+        // absent from the registry.
+        #[cfg(feature = "worker-grpc")]
+        if runtime_outcome.safe_to_unload
+            && let Some(worker) = &self.worker
+        {
+            runtime_outcome.merge(worker.shutdown_plugins_checked());
+        }
+        errors.extend(runtime_outcome.errors);
+
+        if !runtime_outcome.safe_to_unload {
+            self.retain_loaded_runtimes();
+            return Err(retained_runtime_error(errors));
+        }
+
+        // Callback removal and kind deregistration are now complete. Dropping
+        // the activations unloads libraries and runtimes before releasing the
+        // process-wide host claim.
+        self.native.take();
+        #[cfg(feature = "worker-grpc")]
+        self.worker.take();
+        self.claim.take();
+
+        if errors.is_empty() {
+            Ok(())
         } else {
             Err(crate::plugin::PluginError::RegistrationFailed(format!(
-                "{}; the loaded runtimes were retained because callbacks may remain registered",
-                outcome
-                    .result
-                    .err()
-                    .map(|error| error.to_string())
-                    .unwrap_or_else(|| "plugin teardown was incomplete".into())
+                "dynamic plugin teardown failed: {}",
+                errors.join("; ")
             )))
         }
     }
+
+    fn retain_loaded_runtimes(&mut self) {
+        if let Some(native) = self.native.take() {
+            std::mem::forget(native);
+        }
+        #[cfg(feature = "worker-grpc")]
+        if let Some(worker) = self.worker.take() {
+            std::mem::forget(worker);
+        }
+        if let Some(claim) = self.claim.take() {
+            std::mem::forget(claim);
+        }
+    }
+}
+
+fn validate_unique_plugin_ids(dynamic_plugins: &[DynamicPluginActivationSpec]) -> Result<()> {
+    let mut plugin_ids = HashSet::with_capacity(dynamic_plugins.len());
+    for plugin in dynamic_plugins {
+        if !plugin_ids.insert(plugin.plugin_id.as_str()) {
+            return Err(crate::plugin::PluginError::InvalidConfig(format!(
+                "duplicate dynamic plugin id '{}'",
+                plugin.plugin_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn retained_runtime_error(errors: Vec<String>) -> crate::plugin::PluginError {
+    crate::plugin::PluginError::RegistrationFailed(format!(
+        concat!(
+            "{}; the loaded runtimes and activation owner were retained because safe ",
+            "unloading could not be proven"
+        ),
+        if errors.is_empty() {
+            "dynamic plugin teardown was incomplete".into()
+        } else {
+            errors.join("; ")
+        }
+    ))
 }
 
 fn plugin_error_context(
@@ -271,5 +344,63 @@ fn plugin_error_context(
 impl Drop for PluginHostActivation {
     fn drop(&mut self) {
         let _ = self.clear_inner();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::{PLUGIN_HANDLERS, PLUGIN_MUTATION_OWNER, PluginMutationOwner};
+
+    struct PoisonedRegistryCleanup;
+
+    impl Drop for PoisonedRegistryCleanup {
+        fn drop(&mut self) {
+            PLUGIN_HANDLERS.clear_poison();
+            if let Ok(mut owner) = PLUGIN_MUTATION_OWNER.lock() {
+                *owner = PluginMutationOwner::Idle;
+            }
+        }
+    }
+
+    #[test]
+    fn unsafe_kind_deregistration_retains_runtime_and_owner() {
+        let _guard = crate::shared_runtime::runtime_owner_test_mutex()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let _cleanup = PoisonedRegistryCleanup;
+        let claim = acquire_plugin_host_lease().expect("fixture host should acquire the owner");
+        let owner_id = claim.owner_id();
+        let activation = PluginHostActivation {
+            active: true,
+            native: Some(NativePluginActivation::with_plugin_kind_for_test(
+                "fixture.poisoned",
+            )),
+            #[cfg(feature = "worker-grpc")]
+            worker: None,
+            claim: Some(claim),
+        };
+
+        std::thread::spawn(|| {
+            let _registry = PLUGIN_HANDLERS.write().unwrap();
+            panic!("poison plugin registry for teardown test");
+        })
+        .join()
+        .expect_err("fixture registry writer should panic");
+
+        let error = activation
+            .clear()
+            .expect_err("an uncertain kind deregistration must retain the activation")
+            .to_string();
+        assert!(error.contains("plugin registry lock poisoned"), "{error}");
+        assert!(error.contains("activation owner were retained"), "{error}");
+        assert_eq!(
+            *PLUGIN_MUTATION_OWNER.lock().unwrap(),
+            PluginMutationOwner::Host(owner_id)
+        );
+        assert!(matches!(
+            acquire_plugin_host_lease(),
+            Err(crate::plugin::PluginError::Conflict(_))
+        ));
     }
 }

--- a/crates/core/src/plugin/dynamic/host.rs
+++ b/crates/core/src/plugin/dynamic/host.rs
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Owned activation lifecycle for dynamically loaded plugin components.
+//!
+//! Activation transactions run on Relay's process-wide plugin lifecycle
+//! executor. This keeps registration cancellation-resistant and gives native
+//! and worker plugins a stable Tokio runtime independent of the embedding
+//! caller. Plugin registration therefore must not depend on caller-thread
+//! affinity; the lifecycle executor remains available for the process lifetime.
 
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -59,9 +65,11 @@ pub struct PluginHostActivation {
 impl PluginHostActivation {
     /// Load dynamic plugins and activate them with `config` as one transaction.
     ///
-    /// Dynamic components are appended to the supplied base configuration in
-    /// specification order. The returned activation must remain alive for as
-    /// long as code may invoke plugin-provided callbacks.
+    /// The supplied base configuration may contain statically registered
+    /// components. Dynamic components are appended after them in specification
+    /// order. At least one dynamic plugin is required; static-only callers
+    /// should use the regular plugin initialization API. The returned activation
+    /// must remain alive for as long as code may invoke plugin-provided callbacks.
     pub async fn activate<I>(
         config: PluginConfig,
         dynamic_plugins: I,
@@ -70,6 +78,7 @@ impl PluginHostActivation {
         I: IntoIterator<Item = DynamicPluginActivationSpec>,
     {
         let dynamic_plugins = dynamic_plugins.into_iter().collect::<Vec<_>>();
+        validate_dynamic_plugin_specs(&dynamic_plugins)?;
         run_owned_plugin_mutation("dynamic plugin activation", move || async move {
             Self::activate_inner(config, dynamic_plugins).await
         })
@@ -81,7 +90,6 @@ impl PluginHostActivation {
         dynamic_plugins: Vec<DynamicPluginActivationSpec>,
     ) -> Result<(Self, ConfigReport)> {
         let claim = acquire_plugin_host_lease()?;
-        validate_unique_plugin_ids(&dynamic_plugins)?;
 
         #[cfg(not(feature = "worker-grpc"))]
         if let Some(plugin) = dynamic_plugins
@@ -292,7 +300,16 @@ impl PluginHostActivation {
     }
 }
 
-fn validate_unique_plugin_ids(dynamic_plugins: &[DynamicPluginActivationSpec]) -> Result<()> {
+fn validate_dynamic_plugin_specs(dynamic_plugins: &[DynamicPluginActivationSpec]) -> Result<()> {
+    if dynamic_plugins.is_empty() {
+        return Err(crate::plugin::PluginError::InvalidConfig(
+            concat!(
+                "dynamic plugin activation requires at least one dynamic plugin; ",
+                "use plugin initialization for a static-only configuration"
+            )
+            .into(),
+        ));
+    }
     let mut plugin_ids = HashSet::with_capacity(dynamic_plugins.len());
     for plugin in dynamic_plugins {
         if !plugin_ids.insert(plugin.plugin_id.as_str()) {
@@ -343,7 +360,9 @@ fn plugin_error_context(
 
 impl Drop for PluginHostActivation {
     fn drop(&mut self) {
-        let _ = self.clear_inner();
+        if let Err(error) = self.clear_inner() {
+            eprintln!("nemo_relay: dynamic plugin activation cleanup failed during drop: {error}");
+        }
     }
 }
 

--- a/crates/core/src/plugin/dynamic/host.rs
+++ b/crates/core/src/plugin/dynamic/host.rs
@@ -207,7 +207,11 @@ impl PluginHostActivation {
         ))
     }
 
-    /// Returns whether this activation still owns an active plugin host.
+    /// Returns whether this activation handle has not begun teardown.
+    ///
+    /// `false` means the handle is no longer reusable. It does not guarantee
+    /// that another process-wide activation can start: failed teardown may
+    /// intentionally retain the loaded runtimes and activation owner.
     pub fn is_active(&self) -> bool {
         self.active
     }
@@ -390,7 +394,7 @@ mod tests {
         let _cleanup = PoisonedRegistryCleanup;
         let claim = acquire_plugin_host_lease().expect("fixture host should acquire the owner");
         let owner_id = claim.owner_id();
-        let activation = PluginHostActivation {
+        let mut activation = PluginHostActivation {
             active: true,
             native: Some(NativePluginActivation::with_plugin_kind_for_test(
                 "fixture.poisoned",
@@ -408,11 +412,12 @@ mod tests {
         .expect_err("fixture registry writer should panic");
 
         let error = activation
-            .clear()
+            .clear_inner()
             .expect_err("an uncertain kind deregistration must retain the activation")
             .to_string();
         assert!(error.contains("plugin registry lock poisoned"), "{error}");
         assert!(error.contains("activation owner were retained"), "{error}");
+        assert!(!activation.is_active());
         assert_eq!(
             *PLUGIN_MUTATION_OWNER.lock().unwrap(),
             PluginMutationOwner::Host(owner_id)

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -51,13 +51,13 @@ use crate::api::scope::{event as emit_scope_mark, get_handle, pop_scope, push_sc
 use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
-    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginDeregistrationOutcome, PluginError,
-    PluginRegistrationContext, deregister_plugin_registration_checked, register_plugin_tracked,
+    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
+    deregister_plugin_registration_checked, register_plugin_tracked,
 };
 
 use super::{
     DynamicPluginKind, DynamicPluginManifest, DynamicPluginManifestLoad,
-    DynamicPluginTeardownOutcome,
+    DynamicPluginTeardownOutcome, deregister_tracked_registrations_checked,
 };
 
 /// Native plugin load request derived from host dynamic-plugin state.
@@ -89,30 +89,7 @@ impl NativePluginActivation {
     pub fn clear(self) {}
 
     pub(crate) fn deregister_plugin_kinds_checked(&mut self) -> DynamicPluginTeardownOutcome {
-        let mut outcome = DynamicPluginTeardownOutcome::success();
-        let plugin_registrations = std::mem::take(&mut self.plugin_registrations);
-        for (plugin_kind, registration_id) in plugin_registrations.into_iter().rev() {
-            match deregister_plugin_registration_checked(&plugin_kind, registration_id) {
-                Ok(PluginDeregistrationOutcome::Removed) => {}
-                Ok(PluginDeregistrationOutcome::Missing) => outcome.record_error(
-                    format!(
-                        "native plugin kind '{plugin_kind}' was not registered during teardown"
-                    ),
-                    true,
-                ),
-                Ok(PluginDeregistrationOutcome::Replaced) => outcome.record_error(
-                    format!(
-                        "native plugin kind '{plugin_kind}' was replaced during teardown and was left registered"
-                    ),
-                    true,
-                ),
-                Err(error) => outcome.record_error(
-                    format!("failed to deregister native plugin kind '{plugin_kind}': {error}"),
-                    false,
-                ),
-            }
-        }
-        outcome
+        deregister_tracked_registrations_checked(&mut self.plugin_registrations, "native")
     }
 
     #[cfg(test)]

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -51,8 +51,8 @@ use crate::api::scope::{event as emit_scope_mark, get_handle, pop_scope, push_sc
 use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
-    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
-    deregister_plugin, deregister_plugin_checked, register_plugin,
+    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginDeregistrationOutcome, PluginError,
+    PluginRegistrationContext, deregister_plugin_registration_checked, register_plugin_tracked,
 };
 
 use super::{
@@ -76,7 +76,7 @@ pub struct NativePluginLoadSpec {
 /// runtime callbacks cannot outlive their code.
 pub struct NativePluginActivation {
     plugins: Vec<Arc<NativePluginInstance>>,
-    plugin_kinds: Vec<String>,
+    plugin_registrations: Vec<(String, u64)>,
 }
 
 impl NativePluginActivation {
@@ -90,13 +90,19 @@ impl NativePluginActivation {
 
     pub(crate) fn deregister_plugin_kinds_checked(&mut self) -> DynamicPluginTeardownOutcome {
         let mut outcome = DynamicPluginTeardownOutcome::success();
-        let plugin_kinds = std::mem::take(&mut self.plugin_kinds);
-        for plugin_kind in plugin_kinds.into_iter().rev() {
-            match deregister_plugin_checked(&plugin_kind) {
-                Ok(true) => {}
-                Ok(false) => outcome.record_error(
+        let plugin_registrations = std::mem::take(&mut self.plugin_registrations);
+        for (plugin_kind, registration_id) in plugin_registrations.into_iter().rev() {
+            match deregister_plugin_registration_checked(&plugin_kind, registration_id) {
+                Ok(PluginDeregistrationOutcome::Removed) => {}
+                Ok(PluginDeregistrationOutcome::Missing) => outcome.record_error(
                     format!(
                         "native plugin kind '{plugin_kind}' was not registered during teardown"
+                    ),
+                    true,
+                ),
+                Ok(PluginDeregistrationOutcome::Replaced) => outcome.record_error(
+                    format!(
+                        "native plugin kind '{plugin_kind}' was replaced during teardown and was left registered"
                     ),
                     true,
                 ),
@@ -113,15 +119,15 @@ impl NativePluginActivation {
     pub(super) fn with_plugin_kind_for_test(plugin_kind: impl Into<String>) -> Self {
         Self {
             plugins: Vec::new(),
-            plugin_kinds: vec![plugin_kind.into()],
+            plugin_registrations: vec![(plugin_kind.into(), 0)],
         }
     }
 }
 
 impl Drop for NativePluginActivation {
     fn drop(&mut self) {
-        for plugin_kind in self.plugin_kinds.iter().rev() {
-            let _ = deregister_plugin(plugin_kind);
+        for (plugin_kind, registration_id) in self.plugin_registrations.iter().rev() {
+            let _ = deregister_plugin_registration_checked(plugin_kind, *registration_id);
         }
     }
 }
@@ -136,18 +142,20 @@ where
 {
     let mut activation = NativePluginActivation {
         plugins: Vec::new(),
-        plugin_kinds: Vec::new(),
+        plugin_registrations: Vec::new(),
     };
     for spec in specs {
         let instance = load_one_native_plugin(&spec)?;
         let plugin_kind = instance.plugin_kind.clone();
-        register_plugin(Arc::new(NativePluginAdapter {
+        let registration_id = register_plugin_tracked(Arc::new(NativePluginAdapter {
             plugin_kind: plugin_kind.clone(),
             allows_multiple_components: instance.allows_multiple_components,
             instance: instance.clone(),
         }))?;
         activation.plugins.push(instance);
-        activation.plugin_kinds.push(plugin_kind);
+        activation
+            .plugin_registrations
+            .push((plugin_kind, registration_id));
     }
     Ok(activation)
 }

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -52,10 +52,13 @@ use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
     ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
-    deregister_plugin, register_plugin,
+    deregister_plugin, deregister_plugin_checked, register_plugin,
 };
 
-use super::{DynamicPluginKind, DynamicPluginManifest, DynamicPluginManifestLoad};
+use super::{
+    DynamicPluginKind, DynamicPluginManifest, DynamicPluginManifestLoad,
+    DynamicPluginTeardownOutcome,
+};
 
 /// Native plugin load request derived from host dynamic-plugin state.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,6 +87,35 @@ impl NativePluginActivation {
 
     /// Consumes the activation and deregisters loaded plugin kinds.
     pub fn clear(self) {}
+
+    pub(crate) fn deregister_plugin_kinds_checked(&mut self) -> DynamicPluginTeardownOutcome {
+        let mut outcome = DynamicPluginTeardownOutcome::success();
+        let plugin_kinds = std::mem::take(&mut self.plugin_kinds);
+        for plugin_kind in plugin_kinds.into_iter().rev() {
+            match deregister_plugin_checked(&plugin_kind) {
+                Ok(true) => {}
+                Ok(false) => outcome.record_error(
+                    format!(
+                        "native plugin kind '{plugin_kind}' was not registered during teardown"
+                    ),
+                    true,
+                ),
+                Err(error) => outcome.record_error(
+                    format!("failed to deregister native plugin kind '{plugin_kind}': {error}"),
+                    false,
+                ),
+            }
+        }
+        outcome
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_plugin_kind_for_test(plugin_kind: impl Into<String>) -> Self {
+        Self {
+            plugins: Vec::new(),
+            plugin_kinds: vec![plugin_kind.into()],
+        }
+    }
 }
 
 impl Drop for NativePluginActivation {

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -66,13 +66,13 @@ use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::codec::request::AnnotatedLlmRequest;
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
-    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginDeregistrationOutcome, PluginError,
-    PluginRegistrationContext, deregister_plugin_registration_checked, register_plugin_tracked,
+    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
+    deregister_plugin_registration_checked, register_plugin_tracked,
 };
 
 use super::{
     DynamicPluginKind, DynamicPluginManifest, DynamicPluginManifestLoad,
-    DynamicPluginTeardownOutcome, WorkerRuntime,
+    DynamicPluginTeardownOutcome, WorkerRuntime, deregister_tracked_registrations_checked,
 };
 
 const JSON_SCHEMA: &str = "nemo.relay.Json@1";
@@ -135,30 +135,7 @@ impl WorkerPluginActivation {
     pub fn clear(self) {}
 
     pub(crate) fn deregister_plugin_kinds_checked(&mut self) -> DynamicPluginTeardownOutcome {
-        let mut outcome = DynamicPluginTeardownOutcome::success();
-        let plugin_registrations = std::mem::take(&mut self.plugin_registrations);
-        for (plugin_kind, registration_id) in plugin_registrations.into_iter().rev() {
-            match deregister_plugin_registration_checked(&plugin_kind, registration_id) {
-                Ok(PluginDeregistrationOutcome::Removed) => {}
-                Ok(PluginDeregistrationOutcome::Missing) => outcome.record_error(
-                    format!(
-                        "worker plugin kind '{plugin_kind}' was not registered during teardown"
-                    ),
-                    true,
-                ),
-                Ok(PluginDeregistrationOutcome::Replaced) => outcome.record_error(
-                    format!(
-                        "worker plugin kind '{plugin_kind}' was replaced during teardown and was left registered"
-                    ),
-                    true,
-                ),
-                Err(error) => outcome.record_error(
-                    format!("failed to deregister worker plugin kind '{plugin_kind}': {error}"),
-                    false,
-                ),
-            }
-        }
-        outcome
+        deregister_tracked_registrations_checked(&mut self.plugin_registrations, "worker")
     }
 
     pub(crate) fn shutdown_plugins_checked(&self) -> DynamicPluginTeardownOutcome {

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -66,8 +66,8 @@ use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::codec::request::AnnotatedLlmRequest;
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
-    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
-    deregister_plugin, deregister_plugin_checked, register_plugin,
+    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginDeregistrationOutcome, PluginError,
+    PluginRegistrationContext, deregister_plugin_registration_checked, register_plugin_tracked,
 };
 
 use super::{
@@ -122,7 +122,7 @@ pub struct WorkerPluginLoadSpec {
 /// callbacks cannot outlive the worker activation.
 pub struct WorkerPluginActivation {
     plugins: Vec<Arc<WorkerPluginInstance>>,
-    plugin_kinds: Vec<String>,
+    plugin_registrations: Vec<(String, u64)>,
 }
 
 impl WorkerPluginActivation {
@@ -136,13 +136,19 @@ impl WorkerPluginActivation {
 
     pub(crate) fn deregister_plugin_kinds_checked(&mut self) -> DynamicPluginTeardownOutcome {
         let mut outcome = DynamicPluginTeardownOutcome::success();
-        let plugin_kinds = std::mem::take(&mut self.plugin_kinds);
-        for plugin_kind in plugin_kinds.into_iter().rev() {
-            match deregister_plugin_checked(&plugin_kind) {
-                Ok(true) => {}
-                Ok(false) => outcome.record_error(
+        let plugin_registrations = std::mem::take(&mut self.plugin_registrations);
+        for (plugin_kind, registration_id) in plugin_registrations.into_iter().rev() {
+            match deregister_plugin_registration_checked(&plugin_kind, registration_id) {
+                Ok(PluginDeregistrationOutcome::Removed) => {}
+                Ok(PluginDeregistrationOutcome::Missing) => outcome.record_error(
                     format!(
                         "worker plugin kind '{plugin_kind}' was not registered during teardown"
+                    ),
+                    true,
+                ),
+                Ok(PluginDeregistrationOutcome::Replaced) => outcome.record_error(
+                    format!(
+                        "worker plugin kind '{plugin_kind}' was replaced during teardown and was left registered"
                     ),
                     true,
                 ),
@@ -166,8 +172,8 @@ impl WorkerPluginActivation {
 
 impl Drop for WorkerPluginActivation {
     fn drop(&mut self) {
-        for plugin_kind in self.plugin_kinds.iter().rev() {
-            let _ = deregister_plugin(plugin_kind);
+        for (plugin_kind, registration_id) in self.plugin_registrations.iter().rev() {
+            let _ = deregister_plugin_registration_checked(plugin_kind, *registration_id);
         }
     }
 }
@@ -182,18 +188,20 @@ where
 {
     let mut activation = WorkerPluginActivation {
         plugins: Vec::new(),
-        plugin_kinds: Vec::new(),
+        plugin_registrations: Vec::new(),
     };
     for spec in specs {
         let instance = load_one_worker_plugin(&spec)?;
         let plugin_kind = instance.plugin_kind.clone();
-        register_plugin(Arc::new(WorkerPluginAdapter {
+        let registration_id = register_plugin_tracked(Arc::new(WorkerPluginAdapter {
             plugin_kind: plugin_kind.clone(),
             allows_multiple_components: instance.allows_multiple_components,
             instance: instance.clone(),
         }))?;
         activation.plugins.push(instance);
-        activation.plugin_kinds.push(plugin_kind);
+        activation
+            .plugin_registrations
+            .push((plugin_kind, registration_id));
     }
     Ok(activation)
 }

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -8,6 +8,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
@@ -66,10 +67,13 @@ use crate::codec::request::AnnotatedLlmRequest;
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
     ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
-    deregister_plugin, register_plugin,
+    deregister_plugin, deregister_plugin_checked, register_plugin,
 };
 
-use super::{DynamicPluginKind, DynamicPluginManifest, DynamicPluginManifestLoad, WorkerRuntime};
+use super::{
+    DynamicPluginKind, DynamicPluginManifest, DynamicPluginManifestLoad,
+    DynamicPluginTeardownOutcome, WorkerRuntime,
+};
 
 const JSON_SCHEMA: &str = "nemo.relay.Json@1";
 const EVENT_SCHEMA: &str = "nemo.relay.Event@1";
@@ -129,6 +133,35 @@ impl WorkerPluginActivation {
 
     /// Consumes the activation; deregistration runs from `Drop`.
     pub fn clear(self) {}
+
+    pub(crate) fn deregister_plugin_kinds_checked(&mut self) -> DynamicPluginTeardownOutcome {
+        let mut outcome = DynamicPluginTeardownOutcome::success();
+        let plugin_kinds = std::mem::take(&mut self.plugin_kinds);
+        for plugin_kind in plugin_kinds.into_iter().rev() {
+            match deregister_plugin_checked(&plugin_kind) {
+                Ok(true) => {}
+                Ok(false) => outcome.record_error(
+                    format!(
+                        "worker plugin kind '{plugin_kind}' was not registered during teardown"
+                    ),
+                    true,
+                ),
+                Err(error) => outcome.record_error(
+                    format!("failed to deregister worker plugin kind '{plugin_kind}': {error}"),
+                    false,
+                ),
+            }
+        }
+        outcome
+    }
+
+    pub(crate) fn shutdown_plugins_checked(&self) -> DynamicPluginTeardownOutcome {
+        let mut outcome = DynamicPluginTeardownOutcome::success();
+        for plugin in self.plugins.iter().rev() {
+            outcome.merge(plugin.shutdown_checked());
+        }
+        outcome
+    }
 }
 
 impl Drop for WorkerPluginActivation {
@@ -221,32 +254,165 @@ struct WorkerPluginInstance {
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
     process: Mutex<Option<Child>>,
     activation_dir: PathBuf,
+    teardown_started: AtomicBool,
 }
 
 impl Drop for WorkerPluginInstance {
     fn drop(&mut self) {
+        let _ = self.shutdown_checked();
+    }
+}
+
+impl WorkerPluginInstance {
+    fn shutdown_checked(&self) -> DynamicPluginTeardownOutcome {
+        let mut outcome = DynamicPluginTeardownOutcome::success();
+        if self.teardown_started.swap(true, Ordering::AcqRel) {
+            return outcome;
+        }
+
         let mut client = self.client.clone();
         let request = ShutdownRequest {
             activation_id: self.host_state.activation_id.clone(),
             auth_token: self.host_state.auth_token.clone(),
-            reason: "plugin activation dropped".into(),
+            reason: "plugin activation cleared".into(),
         };
-        let _ = block_on_runtime(self.runtime.runtime(), async move {
-            worker_rpc(client.shutdown(worker_rpc_request(request))).await
-        });
-        if let Ok(mut shutdown) = self.shutdown.lock()
-            && let Some(sender) = shutdown.take()
-        {
-            let _ = sender.send(());
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            block_on_runtime(self.runtime.runtime(), async move {
+                worker_rpc(client.shutdown(worker_rpc_request(request))).await
+            })
+        })) {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => outcome.record_error(
+                format!(
+                    "worker plugin '{}' shutdown RPC failed: {error}",
+                    self.plugin_kind
+                ),
+                true,
+            ),
+            Err(payload) => outcome.record_error(
+                format!(
+                    "worker plugin '{}' shutdown RPC panicked: {}",
+                    self.plugin_kind,
+                    panic_payload_message(payload.as_ref())
+                ),
+                true,
+            ),
         }
-        if let Ok(mut process) = self.process.lock()
-            && let Some(mut child) = process.take()
-        {
-            let _ = child.kill();
-            let _ = child.wait();
+
+        match self.shutdown.lock() {
+            Ok(mut shutdown) => {
+                if let Some(sender) = shutdown.take()
+                    && sender.send(()).is_err()
+                {
+                    outcome.record_error(
+                        format!(
+                            "worker plugin '{}' host runtime shutdown channel was closed",
+                            self.plugin_kind
+                        ),
+                        true,
+                    );
+                }
+            }
+            Err(error) => outcome.record_error(
+                format!(
+                    "worker plugin '{}' host runtime shutdown lock poisoned: {error}",
+                    self.plugin_kind
+                ),
+                true,
+            ),
         }
-        let _ = std::fs::remove_dir_all(&self.activation_dir);
+
+        self.stop_process_checked(&mut outcome);
+        if outcome.safe_to_unload
+            && let Err(error) = std::fs::remove_dir_all(&self.activation_dir)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            outcome.record_error(
+                format!(
+                    "worker plugin '{}' activation directory cleanup failed for '{}': {error}",
+                    self.plugin_kind,
+                    self.activation_dir.display()
+                ),
+                true,
+            );
+        }
+        outcome
     }
+
+    fn stop_process_checked(&self, outcome: &mut DynamicPluginTeardownOutcome) {
+        let mut process = match self.process.lock() {
+            Ok(process) => process,
+            Err(error) => {
+                outcome.record_error(
+                    format!(
+                        "worker plugin '{}' process lock poisoned: {error}",
+                        self.plugin_kind
+                    ),
+                    false,
+                );
+                return;
+            }
+        };
+        let Some(child) = process.as_mut() else {
+            return;
+        };
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                process.take();
+            }
+            Ok(None) => {
+                if let Err(kill_error) = child.kill() {
+                    match child.try_wait() {
+                        Ok(Some(_)) => {
+                            process.take();
+                            outcome.record_error(
+                                format!(
+                                    "worker plugin '{}' process kill failed after exit: {kill_error}",
+                                    self.plugin_kind
+                                ),
+                                true,
+                            );
+                        }
+                        Ok(None) | Err(_) => outcome.record_error(
+                            format!(
+                                "worker plugin '{}' process kill failed: {kill_error}",
+                                self.plugin_kind
+                            ),
+                            false,
+                        ),
+                    }
+                    return;
+                }
+                match child.wait() {
+                    Ok(_) => {
+                        process.take();
+                    }
+                    Err(error) => outcome.record_error(
+                        format!(
+                            "worker plugin '{}' process wait failed after kill: {error}",
+                            self.plugin_kind
+                        ),
+                        false,
+                    ),
+                }
+            }
+            Err(error) => outcome.record_error(
+                format!(
+                    "worker plugin '{}' process status check failed: {error}",
+                    self.plugin_kind
+                ),
+                false,
+            ),
+        }
+    }
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic payload")
 }
 
 fn load_one_worker_plugin(
@@ -426,6 +592,7 @@ fn load_one_worker_plugin(
         shutdown: Mutex::new(Some(shutdown_tx)),
         process: Mutex::new(Some(child.take())),
         activation_dir: activation_dir_guard.keep(),
+        teardown_started: AtomicBool::new(false),
     }))
 }
 

--- a/crates/core/src/plugins/model_pricing.rs
+++ b/crates/core/src/plugins/model_pricing.rs
@@ -14,7 +14,7 @@ use crate::codec::response::{
 };
 use crate::plugin::{
     ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistration,
-    PluginRegistrationContext, Result, register_plugin,
+    PluginRegistrationContext, Result, register_builtin_plugin,
 };
 
 /// Plugin kind used by the model pricing component.
@@ -22,15 +22,7 @@ pub const PRICING_PLUGIN_KIND: &str = "pricing";
 
 /// Registers the built-in model pricing component.
 pub fn register_pricing_component() -> Result<()> {
-    match register_plugin(Arc::new(PricingPlugin)) {
-        Ok(()) => Ok(()),
-        Err(PluginError::RegistrationFailed(message))
-            if message.contains("plugin 'pricing' is already registered") =>
-        {
-            Ok(())
-        }
-        Err(err) => Err(err),
-    }
+    register_builtin_plugin(Arc::new(PricingPlugin))
 }
 
 struct PricingPlugin;

--- a/crates/core/src/plugins/nemo_guardrails/component.rs
+++ b/crates/core/src/plugins/nemo_guardrails/component.rs
@@ -15,7 +15,7 @@ use crate::codec::resolve::supported_codec_names;
 use crate::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
     PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior, deregister_plugin,
-    register_plugin,
+    register_builtin_plugin,
 };
 
 #[path = "local.rs"]
@@ -398,13 +398,7 @@ impl Plugin for NeMoGuardrailsPlugin {
 
 /// Registers the `nemo_guardrails` component kind in the plugin registry.
 pub fn register_nemo_guardrails_component() -> PluginResult<()> {
-    match register_plugin(Arc::new(NeMoGuardrailsPlugin)) {
-        Ok(()) => Ok(()),
-        Err(PluginError::RegistrationFailed(message)) if message.contains("already registered") => {
-            Ok(())
-        }
-        Err(err) => Err(err),
-    }
+    register_builtin_plugin(Arc::new(NeMoGuardrailsPlugin))
 }
 
 /// Deregisters the `nemo_guardrails` component kind from the plugin registry.

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -281,6 +281,23 @@ fn mark_json(mut value: Json, key: &str) -> Json {
 nemo_relay_plugin::nemo_relay_plugin!(nemo_relay_fixture_native_plugin, || FixtureNativePlugin);
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_fixture_observability_collision(
+    host: *const NemoRelayNativeHostApiV1,
+    out: *mut NemoRelayNativePluginV1,
+) -> NemoRelayStatus {
+    unsafe {
+        write_raw_descriptor(
+            host,
+            out,
+            "observability",
+            None,
+            None,
+            Some(raw_noop_register),
+        )
+    }
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nemo_relay_fixture_entry_error(
     host: *const NemoRelayNativeHostApiV1,
     _out: *mut NemoRelayNativePluginV1,

--- a/crates/core/tests/fixtures/worker_plugin/src/main.rs
+++ b/crates/core/tests/fixtures/worker_plugin/src/main.rs
@@ -84,6 +84,7 @@ impl WorkerPlugin for FixtureWorkerPlugin {
             runtime,
             fixture_flag(config, "block_tool"),
             fixture_flag(config, "tool_request_error"),
+            fixture_flag(config, "exit_in_tool_request"),
         );
         register_fixture_llm_hooks(
             ctx,
@@ -129,6 +130,7 @@ fn register_fixture_tool_hooks(
     runtime: nemo_relay_worker::PluginRuntime,
     block_tool: bool,
     tool_request_error: bool,
+    exit_in_tool_request: bool,
 ) {
     ctx.register_tool_sanitize_request_guardrail(
         "fixture_tool_sanitize_request",
@@ -152,6 +154,9 @@ fn register_fixture_tool_hooks(
         },
     );
     ctx.register_tool_request_intercept("fixture_rewrite_args", 0, false, move |_name, args| {
+        if exit_in_tool_request {
+            std::process::exit(44);
+        }
         if tool_request_error {
             return Err(WorkerSdkError::Callback(
                 "fixture tool request error requested".into(),

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -5,6 +5,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use nemo_relay::api::event::{Event, ScopeCategory};
@@ -35,12 +36,85 @@ use nemo_relay::plugin::{
 use serde_json::{Map, Value as Json, json};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
+use tokio::sync::Notify;
 use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 static NATIVE_PLUGIN_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 struct ReplacementRegistryPlugin;
+
+const STATIC_BASE_PLUGIN_KIND: &str = "fixture_static_base";
+static STATIC_BASE_REGISTRATIONS: AtomicUsize = AtomicUsize::new(0);
+static STATIC_BASE_DEREGISTRATIONS: AtomicUsize = AtomicUsize::new(0);
+
+struct StaticBasePlugin;
+
+struct BlockingHostBasePlugin {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+    registered: Arc<Notify>,
+}
+
+impl Plugin for StaticBasePlugin {
+    fn plugin_kind(&self) -> &str {
+        STATIC_BASE_PLUGIN_KIND
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        Vec::new()
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        ctx: &'a mut PluginRegistrationContext,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = PluginResult<()>> + Send + 'a>> {
+        Box::pin(async move {
+            STATIC_BASE_REGISTRATIONS.fetch_add(1, Ordering::SeqCst);
+            ctx.add_registration(nemo_relay::plugin::PluginRegistration::new(
+                "plugin",
+                STATIC_BASE_PLUGIN_KIND,
+                Box::new(|| {
+                    STATIC_BASE_DEREGISTRATIONS.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            ));
+            Ok(())
+        })
+    }
+}
+
+impl Plugin for BlockingHostBasePlugin {
+    fn plugin_kind(&self) -> &str {
+        "fixture_blocking_host_base"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        Vec::new()
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        ctx: &'a mut PluginRegistrationContext,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = PluginResult<()>> + Send + 'a>> {
+        let started = Arc::clone(&self.started);
+        let release = Arc::clone(&self.release);
+        let registered = Arc::clone(&self.registered);
+        Box::pin(async move {
+            started.notify_one();
+            release.notified().await;
+            ctx.add_registration(nemo_relay::plugin::PluginRegistration::new(
+                "plugin",
+                ctx.qualify_name("blocking-host-base"),
+                Box::new(|| Ok(())),
+            ));
+            registered.notify_one();
+            Ok(())
+        })
+    }
+}
 
 impl Plugin for ReplacementRegistryPlugin {
     fn plugin_kind(&self) -> &str {
@@ -1078,6 +1152,187 @@ async fn plugin_host_activation_owns_configuration_until_clear() {
 }
 
 #[tokio::test]
+async fn plugin_host_activation_combines_static_base_and_dynamic_components() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let _ = deregister_plugin(STATIC_BASE_PLUGIN_KIND);
+    STATIC_BASE_REGISTRATIONS.store(0, Ordering::SeqCst);
+    STATIC_BASE_DEREGISTRATIONS.store(0, Ordering::SeqCst);
+    register_plugin(Arc::new(StaticBasePlugin)).expect("static base plugin should register");
+
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let mut base_config = PluginConfig::default();
+    base_config.components.push(PluginComponentSpec {
+        kind: STATIC_BASE_PLUGIN_KIND.into(),
+        enabled: true,
+        config: Map::new(),
+    });
+    let (activation, report) =
+        PluginHostActivation::activate(base_config, [host_spec("fixture_native", &manifest_ref)])
+            .await
+            .expect("static and dynamic components should activate together");
+
+    assert!(!report.has_errors());
+    assert_eq!(STATIC_BASE_REGISTRATIONS.load(Ordering::SeqCst), 1);
+    assert!(lookup_plugin(STATIC_BASE_PLUGIN_KIND).is_some());
+    assert!(lookup_plugin("fixture_native").is_some());
+
+    activation.clear().expect("combined host should clear");
+    assert_eq!(STATIC_BASE_DEREGISTRATIONS.load(Ordering::SeqCst), 1);
+    assert!(lookup_plugin(STATIC_BASE_PLUGIN_KIND).is_some());
+    assert!(lookup_plugin("fixture_native").is_none());
+    assert!(deregister_plugin(STATIC_BASE_PLUGIN_KIND));
+}
+
+#[tokio::test]
+async fn plugin_host_clear_allows_an_in_flight_native_callback_to_finish() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("plugin host should activate");
+
+    let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+    let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    let call_thread = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("in-flight callback runtime should build");
+        runtime.block_on(tool_call_execute(
+            ToolCallExecuteParams::builder()
+                .name("native-fixture-in-flight")
+                .args(json!({ "input": "in-flight" }))
+                .func(Arc::new(move |args| {
+                    let entered_tx = entered_tx.clone();
+                    let release_rx = Arc::clone(&release_rx);
+                    Box::pin(async move {
+                        entered_tx.send(()).map_err(|error| {
+                            nemo_relay::error::FlowError::Internal(error.to_string())
+                        })?;
+                        release_rx
+                            .lock()
+                            .map_err(|error| {
+                                nemo_relay::error::FlowError::Internal(error.to_string())
+                            })?
+                            .recv()
+                            .map_err(|error| {
+                                nemo_relay::error::FlowError::Internal(error.to_string())
+                            })?;
+                        Ok(json!({ "tool_callback": true, "args": args }))
+                    })
+                }))
+                .build(),
+        ))
+    });
+
+    entered_rx
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .expect("native callback should enter its continuation");
+    activation
+        .clear()
+        .expect("host should clear while a callback snapshot remains in flight");
+    let unchanged = tool_request_intercepts("after-clear", json!({ "input": true }))
+        .expect("new calls should observe the cleared registries");
+    assert_eq!(unchanged, json!({ "input": true }));
+
+    release_tx
+        .send(())
+        .expect("in-flight continuation should still be reachable");
+    let result = call_thread
+        .join()
+        .expect("in-flight callback thread should not panic")
+        .expect("in-flight callback should finish after host clear");
+    assert_eq!(result["tool_callback"], true);
+    assert_eq!(result["native_plugin_tool_execution"], true);
+}
+
+#[tokio::test]
+async fn plugin_host_activation_cleans_up_after_caller_cancellation() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let registered = Arc::new(Notify::new());
+    register_plugin(Arc::new(BlockingHostBasePlugin {
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+        registered: Arc::clone(&registered),
+    }))
+    .expect("blocking base plugin should register");
+
+    let caller = tokio::spawn(PluginHostActivation::activate(
+        PluginConfig {
+            components: vec![PluginComponentSpec::new("fixture_blocking_host_base")],
+            ..PluginConfig::default()
+        },
+        [host_spec("fixture_native", &manifest_ref)],
+    ));
+    started.notified().await;
+    caller.abort();
+    match caller.await {
+        Err(error) => assert!(error.is_cancelled()),
+        Ok(_) => panic!("activation caller should be canceled"),
+    }
+    release.notify_one();
+    registered.notified().await;
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if nemo_relay::plugin::active_plugin_report().is_none()
+                && lookup_plugin("fixture_native").is_none()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("canceled activation should clear its completed host result");
+
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("canceled activation must release process ownership");
+    activation.clear().expect("recovered host should clear");
+    assert!(deregister_plugin("fixture_blocking_host_base"));
+}
+
+#[tokio::test]
+async fn plugin_host_rejects_empty_dynamic_specs_without_claiming_ownership() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let error = match PluginHostActivation::activate(
+        PluginConfig::default(),
+        Vec::<DynamicPluginActivationSpec>::new(),
+    )
+    .await
+    {
+        Ok((activation, _)) => {
+            activation
+                .clear()
+                .expect("unexpected empty activation should clear");
+            panic!("an empty dynamic activation must fail");
+        }
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("at least one dynamic plugin"), "{error}");
+    assert!(error.contains("static-only configuration"), "{error}");
+
+    initialize_plugins_exact(PluginConfig::default())
+        .await
+        .expect("empty dynamic rejection must leave static initialization available");
+    clear_plugin_configuration().expect("static configuration should clear");
+}
+
+#[tokio::test]
 async fn plugin_host_activation_drop_releases_owner_and_plugin_kind() {
     let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
     let fixture = build_fixture_plugin();
@@ -1292,13 +1547,15 @@ async fn plugin_host_partial_load_failure_rolls_back_and_releases_owner() {
 #[tokio::test]
 async fn plugin_host_rejects_an_existing_legacy_configuration() {
     let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
     initialize_plugins_exact(PluginConfig::default())
         .await
         .expect("legacy configuration should initialize");
 
     let error = match PluginHostActivation::activate(
         PluginConfig::default(),
-        Vec::<DynamicPluginActivationSpec>::new(),
+        [host_spec("fixture_native", &manifest_ref)],
     )
     .await
     {
@@ -1310,7 +1567,11 @@ async fn plugin_host_rejects_an_existing_legacy_configuration() {
         }
         Err(error) => error.to_string(),
     };
-    assert!(error.contains("already active"), "{error}");
+    assert!(
+        error.contains("static plugin configuration is already active"),
+        "{error}"
+    );
+    assert!(error.contains("base configuration"), "{error}");
     clear_plugin_configuration().expect("legacy configuration should clear");
 }
 
@@ -1340,13 +1601,15 @@ async fn plugin_host_rejects_workers_when_worker_support_is_disabled() {
     };
     assert!(error.contains("worker-grpc"), "{error}");
 
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
     let (activation, _) = PluginHostActivation::activate(
         PluginConfig::default(),
-        Vec::<DynamicPluginActivationSpec>::new(),
+        [host_spec("fixture_native", &manifest_ref)],
     )
     .await
     .expect("failed worker activation must release the owner");
-    activation.clear().expect("empty host should clear");
+    activation.clear().expect("recovered host should clear");
 }
 
 async fn initialize_fixture_native(config: Map<String, Json>) -> nemo_relay::plugin::Result<()> {

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -23,9 +23,13 @@ use nemo_relay::api::scope::{
 use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
 use nemo_relay::api::tool::{ToolCallExecuteParams, tool_call_execute, tool_request_intercepts};
 use nemo_relay::codec::response::AnnotatedLlmResponse;
-use nemo_relay::plugin::dynamic::{NativePluginLoadSpec, load_native_plugins};
+use nemo_relay::plugin::dynamic::{
+    DynamicPluginActivationSpec, DynamicPluginKind, NativePluginLoadSpec, PluginHostActivation,
+    load_native_plugins,
+};
 use nemo_relay::plugin::{
     PluginComponentSpec, PluginConfig, clear_plugin_configuration, initialize_plugins_exact,
+    list_plugin_kinds,
 };
 use serde_json::{Map, Value as Json, json};
 use sha2::{Digest, Sha256};
@@ -1000,6 +1004,182 @@ async fn native_validate_and_register_callback_errors_are_reported() {
     }
 }
 
+#[tokio::test]
+async fn plugin_host_activation_owns_configuration_until_clear() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let (activation, report) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("plugin host should activate");
+
+    assert!(activation.is_active());
+    assert!(!report.has_errors());
+    assert!(
+        list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "fixture_native")
+    );
+    let rewritten = tool_request_intercepts("host-owned-tool", json!({ "input": true }))
+        .expect("host-owned intercept should run");
+    assert_eq!(rewritten["native_plugin"], true);
+
+    let initialize_error = initialize_plugins_exact(PluginConfig::default())
+        .await
+        .expect_err("legacy initialize must not replace a host activation")
+        .to_string();
+    assert!(initialize_error.contains("active dynamic plugin host"));
+    let clear_error = clear_plugin_configuration()
+        .expect_err("legacy clear must not clear a host activation")
+        .to_string();
+    assert!(clear_error.contains("active dynamic plugin host"));
+
+    activation.clear().expect("plugin host should clear");
+    assert!(
+        !list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "fixture_native")
+    );
+    let unchanged = tool_request_intercepts("host-owned-tool", json!({ "input": true }))
+        .expect("cleared intercept chain should be empty");
+    assert_eq!(unchanged, json!({ "input": true }));
+}
+
+#[tokio::test]
+async fn plugin_host_activation_drop_releases_owner_and_plugin_kind() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+
+    {
+        let (activation, _) = PluginHostActivation::activate(
+            PluginConfig::default(),
+            [host_spec("fixture_native", &manifest_ref)],
+        )
+        .await
+        .expect("first plugin host should activate");
+        assert!(activation.is_active());
+    }
+
+    assert!(
+        !list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "fixture_native")
+    );
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("owner should be reusable after drop");
+    activation.clear().expect("second plugin host should clear");
+}
+
+#[tokio::test]
+async fn plugin_host_partial_load_failure_rolls_back_and_releases_owner() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let missing_manifest = manifest_ref.with_file_name("missing-relay-plugin.toml");
+
+    let error = match PluginHostActivation::activate(
+        PluginConfig::default(),
+        [
+            host_spec("fixture_native", &manifest_ref),
+            host_spec("missing_native", &missing_manifest),
+        ],
+    )
+    .await
+    {
+        Ok((activation, _)) => {
+            activation
+                .clear()
+                .expect("unexpected activation should clear");
+            panic!("partial load should fail");
+        }
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("missing-relay-plugin.toml"), "{error}");
+    assert!(
+        !list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "fixture_native")
+    );
+
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("failed activation must release the owner");
+    activation
+        .clear()
+        .expect("recovered activation should clear");
+}
+
+#[tokio::test]
+async fn plugin_host_rejects_an_existing_legacy_configuration() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    initialize_plugins_exact(PluginConfig::default())
+        .await
+        .expect("legacy configuration should initialize");
+
+    let error = match PluginHostActivation::activate(
+        PluginConfig::default(),
+        Vec::<DynamicPluginActivationSpec>::new(),
+    )
+    .await
+    {
+        Ok((activation, _)) => {
+            activation
+                .clear()
+                .expect("unexpected activation should clear");
+            panic!("host activation should reject an existing configuration");
+        }
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("already active"), "{error}");
+    clear_plugin_configuration().expect("legacy configuration should clear");
+}
+
+#[cfg(not(feature = "worker-grpc"))]
+#[tokio::test]
+async fn plugin_host_rejects_workers_when_worker_support_is_disabled() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let error = match PluginHostActivation::activate(
+        PluginConfig::default(),
+        [DynamicPluginActivationSpec {
+            plugin_id: "fixture_worker".into(),
+            kind: DynamicPluginKind::Worker,
+            manifest_ref: "unused-worker-manifest.toml".into(),
+            environment_ref: None,
+            config: Map::new(),
+        }],
+    )
+    .await
+    {
+        Ok((activation, _)) => {
+            activation
+                .clear()
+                .expect("unexpected activation should clear");
+            panic!("worker activation should require worker support");
+        }
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("worker-grpc"), "{error}");
+
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        Vec::<DynamicPluginActivationSpec>::new(),
+    )
+    .await
+    .expect("failed worker activation must release the owner");
+    activation.clear().expect("empty host should clear");
+}
+
 async fn initialize_fixture_native(config: Map<String, Json>) -> nemo_relay::plugin::Result<()> {
     let mut plugin_config = PluginConfig::default();
     plugin_config.components.push(PluginComponentSpec {
@@ -1031,6 +1211,16 @@ fn load_spec(plugin_id: &str, manifest_ref: &Path) -> NativePluginLoadSpec {
     NativePluginLoadSpec {
         plugin_id: plugin_id.into(),
         manifest_ref: manifest_ref.to_string_lossy().into_owned(),
+    }
+}
+
+fn host_spec(plugin_id: &str, manifest_ref: &Path) -> DynamicPluginActivationSpec {
+    DynamicPluginActivationSpec {
+        plugin_id: plugin_id.into(),
+        kind: DynamicPluginKind::RustDynamic,
+        manifest_ref: manifest_ref.to_string_lossy().into_owned(),
+        environment_ref: None,
+        config: Map::new(),
     }
 }
 

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -28,8 +28,9 @@ use nemo_relay::plugin::dynamic::{
     load_native_plugins,
 };
 use nemo_relay::plugin::{
-    PluginComponentSpec, PluginConfig, clear_plugin_configuration, deregister_plugin,
-    initialize_plugins_exact, list_plugin_kinds,
+    ConfigDiagnostic, Plugin, PluginComponentSpec, PluginConfig, PluginRegistrationContext,
+    Result as PluginResult, clear_plugin_configuration, deregister_plugin,
+    initialize_plugins_exact, list_plugin_kinds, lookup_plugin, register_plugin,
 };
 use serde_json::{Map, Value as Json, json};
 use sha2::{Digest, Sha256};
@@ -38,6 +39,34 @@ use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 static NATIVE_PLUGIN_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct ReplacementRegistryPlugin;
+
+impl Plugin for ReplacementRegistryPlugin {
+    fn plugin_kind(&self) -> &str {
+        "fixture_native"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        Vec::new()
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        _ctx: &'a mut PluginRegistrationContext,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = PluginResult<()>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+struct FixtureNativeRegistrationCleanup;
+
+impl Drop for FixtureNativeRegistrationCleanup {
+    fn drop(&mut self) {
+        let _ = deregister_plugin("fixture_native");
+    }
+}
 
 struct ThreadScopeStackRestore(Option<ThreadScopeStackBinding>);
 
@@ -1177,6 +1206,44 @@ async fn plugin_host_clear_surfaces_missing_kind_and_releases_safe_owner() {
     )
     .await
     .expect("a safely absent plugin kind should release the owner");
+    activation.clear().expect("recovered host should clear");
+}
+
+#[tokio::test]
+async fn plugin_host_clear_preserves_a_replacement_registration() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("plugin host should activate");
+
+    assert!(deregister_plugin("fixture_native"));
+    let replacement: Arc<dyn Plugin> = Arc::new(ReplacementRegistryPlugin);
+    register_plugin(Arc::clone(&replacement)).expect("replacement plugin should register");
+    let _cleanup = FixtureNativeRegistrationCleanup;
+
+    let error = activation
+        .clear()
+        .expect_err("replacement during teardown should be surfaced")
+        .to_string();
+    assert!(error.contains("fixture_native"), "{error}");
+    assert!(error.contains("was replaced"), "{error}");
+    assert!(error.contains("left registered"), "{error}");
+
+    let registered = lookup_plugin("fixture_native").expect("replacement must remain registered");
+    assert!(Arc::ptr_eq(&registered, &replacement));
+    assert!(deregister_plugin("fixture_native"));
+
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("safe replacement detection should release the host owner");
     activation.clear().expect("recovered host should clear");
 }
 

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -28,8 +28,8 @@ use nemo_relay::plugin::dynamic::{
     load_native_plugins,
 };
 use nemo_relay::plugin::{
-    PluginComponentSpec, PluginConfig, clear_plugin_configuration, initialize_plugins_exact,
-    list_plugin_kinds,
+    PluginComponentSpec, PluginConfig, clear_plugin_configuration, deregister_plugin,
+    initialize_plugins_exact, list_plugin_kinds,
 };
 use serde_json::{Map, Value as Json, json};
 use sha2::{Digest, Sha256};
@@ -1079,6 +1079,108 @@ async fn plugin_host_activation_drop_releases_owner_and_plugin_kind() {
 }
 
 #[tokio::test]
+async fn plugin_host_reserved_id_failure_does_not_poison_future_activation() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let collision_manifest = write_manifest_with_plugin_id_and_symbol(
+        &fixture,
+        "observability",
+        "nemo_relay_fixture_observability_collision",
+    );
+
+    let error = match PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("observability", &collision_manifest)],
+    )
+    .await
+    {
+        Ok((activation, _)) => {
+            activation
+                .clear()
+                .expect("unexpected collision activation should clear");
+            panic!("a dynamic plugin must not replace a builtin kind");
+        }
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("observability"), "{error}");
+    assert!(error.contains("already registered"), "{error}");
+
+    let manifest_ref = write_manifest(&fixture);
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("a reserved-id failure must not poison later activation");
+    activation
+        .clear()
+        .expect("recovered plugin host should clear");
+}
+
+#[tokio::test]
+async fn plugin_host_rejects_duplicate_ids_before_loading() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let spec = host_spec("fixture_native", &manifest_ref);
+
+    let error =
+        match PluginHostActivation::activate(PluginConfig::default(), [spec.clone(), spec]).await {
+            Ok((activation, _)) => {
+                activation
+                    .clear()
+                    .expect("unexpected duplicate activation should clear");
+                panic!("duplicate dynamic plugin ids should fail");
+            }
+            Err(error) => error.to_string(),
+        };
+    assert!(error.contains("duplicate dynamic plugin id"), "{error}");
+    assert!(error.contains("fixture_native"), "{error}");
+    assert!(
+        !list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "fixture_native")
+    );
+
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("duplicate-id rejection must release the owner");
+    activation.clear().expect("recovered host should clear");
+}
+
+#[tokio::test]
+async fn plugin_host_clear_surfaces_missing_kind_and_releases_safe_owner() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("plugin host should activate");
+
+    assert!(deregister_plugin("fixture_native"));
+    let error = activation
+        .clear()
+        .expect_err("missing plugin-kind deregistration should be surfaced")
+        .to_string();
+    assert!(error.contains("fixture_native"), "{error}");
+    assert!(error.contains("was not registered"), "{error}");
+
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("a safely absent plugin kind should release the owner");
+    activation.clear().expect("recovered host should clear");
+}
+
+#[tokio::test]
 async fn plugin_host_partial_load_failure_rolls_back_and_releases_owner() {
     let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
     let fixture = build_fixture_plugin();
@@ -1334,6 +1436,21 @@ fn write_manifest_with_symbol(fixture: &BuiltFixture, symbol: &str) -> PathBuf {
     write_manifest_text(ManifestOptions {
         manifest_dir: fixture.manifest_dir.path(),
         plugin_id: "fixture_native",
+        relay: &format!("={}", env!("CARGO_PKG_VERSION")),
+        library: &fixture.library_path.to_string_lossy(),
+        symbol,
+        integrity: None,
+    })
+}
+
+fn write_manifest_with_plugin_id_and_symbol(
+    fixture: &BuiltFixture,
+    plugin_id: &str,
+    symbol: &str,
+) -> PathBuf {
+    write_manifest_text(ManifestOptions {
+        manifest_dir: fixture.manifest_dir.path(),
+        plugin_id,
         relay: &format!("={}", env!("CARGO_PKG_VERSION")),
         library: &fixture.library_path.to_string_lossy(),
         symbol,

--- a/crates/core/tests/integration/plugin_host_builtin_ownership_tests.rs
+++ b/crates/core/tests/integration/plugin_host_builtin_ownership_tests.rs
@@ -7,7 +7,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use nemo_relay::plugin::dynamic::{DynamicPluginActivationSpec, PluginHostActivation};
+use nemo_relay::plugin::dynamic::{
+    DynamicPluginActivationSpec, DynamicPluginKind, PluginHostActivation,
+};
 use nemo_relay::plugin::{
     ConfigDiagnostic, Plugin, PluginConfig, PluginRegistrationContext, Result, deregister_plugin,
     register_plugin,
@@ -39,9 +41,16 @@ async fn host_rejects_a_builtin_kind_preclaimed_before_first_ensure() {
     register_plugin(Arc::new(PreclaimedObservabilityPlugin))
         .expect("the fixture must preclaim the builtin kind before first ensure");
 
+    let missing_dynamic_plugin = DynamicPluginActivationSpec {
+        plugin_id: "fixture_missing".into(),
+        kind: DynamicPluginKind::RustDynamic,
+        manifest_ref: "missing-relay-plugin.toml".into(),
+        environment_ref: None,
+        config: Map::new(),
+    };
     let error = match PluginHostActivation::activate(
         PluginConfig::default(),
-        Vec::<DynamicPluginActivationSpec>::new(),
+        [missing_dynamic_plugin.clone()],
     )
     .await
     {
@@ -61,13 +70,11 @@ async fn host_rejects_a_builtin_kind_preclaimed_before_first_ensure() {
     assert!(error.contains("already registered"), "{error}");
     assert!(deregister_plugin("observability"));
 
-    let (activation, _) = PluginHostActivation::activate(
-        PluginConfig::default(),
-        Vec::<DynamicPluginActivationSpec>::new(),
-    )
-    .await
-    .expect("host activation should recover after the conflicting registration is removed");
-    activation
-        .clear()
-        .expect("recovered host activation should clear");
+    let error = PluginHostActivation::activate(PluginConfig::default(), [missing_dynamic_plugin])
+        .await
+        .err()
+        .expect("the missing fixture manifest should fail after builtin registration recovers")
+        .to_string();
+    assert!(error.contains("missing-relay-plugin.toml"), "{error}");
+    assert!(!error.contains("active dynamic plugin host"), "{error}");
 }

--- a/crates/core/tests/integration/plugin_host_builtin_ownership_tests.rs
+++ b/crates/core/tests/integration/plugin_host_builtin_ownership_tests.rs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Isolated regression coverage for builtin plugin ownership.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use nemo_relay::plugin::dynamic::{DynamicPluginActivationSpec, PluginHostActivation};
+use nemo_relay::plugin::{
+    ConfigDiagnostic, Plugin, PluginConfig, PluginRegistrationContext, Result, deregister_plugin,
+    register_plugin,
+};
+use serde_json::{Map, Value as Json};
+
+struct PreclaimedObservabilityPlugin;
+
+impl Plugin for PreclaimedObservabilityPlugin {
+    fn plugin_kind(&self) -> &str {
+        "observability"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        Vec::new()
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        _ctx: &'a mut PluginRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[tokio::test]
+async fn host_rejects_a_builtin_kind_preclaimed_before_first_ensure() {
+    register_plugin(Arc::new(PreclaimedObservabilityPlugin))
+        .expect("the fixture must preclaim the builtin kind before first ensure");
+
+    let error = match PluginHostActivation::activate(
+        PluginConfig::default(),
+        Vec::<DynamicPluginActivationSpec>::new(),
+    )
+    .await
+    {
+        Ok((activation, _)) => {
+            activation
+                .clear()
+                .expect("unexpected host activation should clear");
+            panic!("a preclaimed builtin kind must prevent host activation");
+        }
+        Err(error) => error.to_string(),
+    };
+
+    assert!(
+        error.contains("reserved builtin plugin 'observability'"),
+        "{error}"
+    );
+    assert!(error.contains("already registered"), "{error}");
+    assert!(deregister_plugin("observability"));
+
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        Vec::<DynamicPluginActivationSpec>::new(),
+    )
+    .await
+    .expect("host activation should recover after the conflicting registration is removed");
+    activation
+        .clear()
+        .expect("recovered host activation should clear");
+}

--- a/crates/core/tests/integration/plugin_host_builtin_ownership_tests.rs
+++ b/crates/core/tests/integration/plugin_host_builtin_ownership_tests.rs
@@ -11,8 +11,9 @@ use nemo_relay::plugin::dynamic::{
     DynamicPluginActivationSpec, DynamicPluginKind, PluginHostActivation,
 };
 use nemo_relay::plugin::{
-    ConfigDiagnostic, Plugin, PluginConfig, PluginRegistrationContext, Result, deregister_plugin,
-    register_plugin,
+    ConfigDiagnostic, DiagnosticLevel, Plugin, PluginComponentSpec, PluginConfig,
+    PluginRegistrationContext, Result, deregister_plugin, list_plugin_kinds, lookup_plugin,
+    register_plugin, validate_plugin_config,
 };
 use serde_json::{Map, Value as Json};
 
@@ -40,6 +41,27 @@ impl Plugin for PreclaimedObservabilityPlugin {
 async fn host_rejects_a_builtin_kind_preclaimed_before_first_ensure() {
     register_plugin(Arc::new(PreclaimedObservabilityPlugin))
         .expect("the fixture must preclaim the builtin kind before first ensure");
+
+    let config = PluginConfig {
+        components: vec![PluginComponentSpec::new("observability")],
+        ..PluginConfig::default()
+    };
+    let report = validate_plugin_config(&config);
+    let diagnostic = report
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "plugin.builtin_registration_failed")
+        .expect("validation must surface the builtin ownership conflict");
+    assert_eq!(diagnostic.level, DiagnosticLevel::Error);
+    assert!(
+        diagnostic
+            .message
+            .contains("reserved builtin plugin 'observability'"),
+        "{}",
+        diagnostic.message
+    );
+    assert!(lookup_plugin("observability").is_none());
+    assert!(list_plugin_kinds().is_empty());
 
     let missing_dynamic_plugin = DynamicPluginActivationSpec {
         plugin_id: "fixture_missing".into(),
@@ -69,6 +91,15 @@ async fn host_rejects_a_builtin_kind_preclaimed_before_first_ensure() {
     );
     assert!(error.contains("already registered"), "{error}");
     assert!(deregister_plugin("observability"));
+
+    let report = validate_plugin_config(&config);
+    assert!(!report.has_errors(), "{:#?}", report.diagnostics);
+    assert!(lookup_plugin("observability").is_some());
+    assert!(
+        list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "observability")
+    );
 
     let error = PluginHostActivation::activate(PluginConfig::default(), [missing_dynamic_plugin])
         .await

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -114,7 +114,13 @@ async fn plugin_host_clear_surfaces_worker_shutdown_failure_and_releases_safe_ow
 
     let (activation, _) = PluginHostActivation::activate(
         PluginConfig::default(),
-        Vec::<DynamicPluginActivationSpec>::new(),
+        [DynamicPluginActivationSpec {
+            plugin_id: "fixture_worker".into(),
+            kind: DynamicPluginKind::Worker,
+            manifest_ref: manifest_ref.to_string_lossy().into_owned(),
+            environment_ref: None,
+            config: Map::new(),
+        }],
     )
     .await
     .expect("a stopped worker process should permit owner release");

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -23,10 +23,12 @@ use nemo_relay::codec::request::AnnotatedLlmRequest;
 use nemo_relay::codec::traits::LlmCodec;
 use nemo_relay::error::Result as FlowResult;
 use nemo_relay::plugin::dynamic::{
-    WorkerPluginActivation, WorkerPluginLoadSpec, load_worker_plugins,
+    DynamicPluginActivationSpec, DynamicPluginKind, PluginHostActivation, WorkerPluginActivation,
+    WorkerPluginLoadSpec, load_worker_plugins,
 };
 use nemo_relay::plugin::{
     PluginComponentSpec, PluginConfig, clear_plugin_configuration, initialize_plugins_exact,
+    list_plugin_kinds,
 };
 use serde_json::{Map, Value as Json, json};
 use sha2::{Digest, Sha256};
@@ -41,6 +43,46 @@ fn worker_activation_with_no_specs_is_empty() {
         .expect("empty worker activation should succeed");
     assert!(activation.is_empty());
     activation.clear();
+}
+
+#[tokio::test]
+async fn plugin_host_activation_owns_worker_lifecycle() {
+    let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_worker();
+    let (_manifest_dir, manifest_ref) = write_manifest(fixture.binary_path());
+    let (activation, report) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [DynamicPluginActivationSpec {
+            plugin_id: "fixture_worker".into(),
+            kind: DynamicPluginKind::Worker,
+            manifest_ref: manifest_ref.to_string_lossy().into_owned(),
+            environment_ref: None,
+            config: Map::new(),
+        }],
+    )
+    .await
+    .expect("worker plugin host should activate");
+
+    assert!(activation.is_active());
+    assert!(!report.has_errors());
+    assert!(
+        list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "fixture_worker")
+    );
+    let rewritten = tool_request_intercepts("worker-host-tool", json!({ "input": true }))
+        .expect("worker host intercept should run");
+    assert_eq!(rewritten["worker_plugin"], true);
+
+    activation.clear().expect("worker plugin host should clear");
+    assert!(
+        !list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "fixture_worker")
+    );
+    let unchanged = tool_request_intercepts("worker-host-tool", json!({ "input": true }))
+        .expect("cleared worker intercept chain should be empty");
+    assert_eq!(unchanged, json!({ "input": true }));
 }
 
 #[tokio::test]

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -86,6 +86,42 @@ async fn plugin_host_activation_owns_worker_lifecycle() {
 }
 
 #[tokio::test]
+async fn plugin_host_clear_surfaces_worker_shutdown_failure_and_releases_safe_owner() {
+    let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_worker();
+    let (_manifest_dir, manifest_ref) = write_manifest(fixture.binary_path());
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        [DynamicPluginActivationSpec {
+            plugin_id: "fixture_worker".into(),
+            kind: DynamicPluginKind::Worker,
+            manifest_ref: manifest_ref.to_string_lossy().into_owned(),
+            environment_ref: None,
+            config: Map::from_iter([("exit_in_tool_request".into(), json!(true))]),
+        }],
+    )
+    .await
+    .expect("worker plugin host should activate");
+
+    tool_request_intercepts("terminate-worker", json!({ "input": true }))
+        .expect_err("fixture worker should terminate during callback");
+    let error = activation
+        .clear()
+        .expect_err("worker shutdown failure should be surfaced")
+        .to_string();
+    assert!(error.contains("fixture_worker"), "{error}");
+    assert!(error.contains("shutdown"), "{error}");
+
+    let (activation, _) = PluginHostActivation::activate(
+        PluginConfig::default(),
+        Vec::<DynamicPluginActivationSpec>::new(),
+    )
+    .await
+    .expect("a stopped worker process should permit owner release");
+    activation.clear().expect("recovered host should clear");
+}
+
+#[tokio::test]
 async fn rust_worker_registers_and_invokes_all_current_surfaces() {
     let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
     let loaded = load_and_initialize_fixture(Map::new()).await;

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -1478,6 +1478,7 @@ async fn fake_worker_instance(
             shutdown: Mutex::new(None),
             process: Mutex::new(None),
             activation_dir,
+            teardown_started: AtomicBool::new(false),
         },
         shutdown_tx,
     )

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 use serde_json::json;
+use tokio::sync::Notify;
 
 use crate::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 use crate::api::llm::{llm_conditional_execution, llm_request_intercepts};
@@ -26,6 +27,17 @@ struct RestoreFailPlugin;
 struct RestoreBreakPlugin;
 struct PartialFailPlugin;
 struct VanishingPlugin;
+struct BlockingPlugin {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+    registered: Arc<Notify>,
+}
+struct BackgroundTaskPlugin {
+    release: Arc<Notify>,
+    completed: Arc<Notify>,
+}
+struct PanickingPlugin;
+struct FailingDeregisterPlugin;
 
 static RECORDED_NAMES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 static PARTIAL_FAIL_ROLLBACKS: AtomicUsize = AtomicUsize::new(0);
@@ -289,6 +301,116 @@ impl Plugin for VanishingPlugin {
     }
 }
 
+impl Plugin for BlockingPlugin {
+    fn plugin_kind(&self) -> &str {
+        "blocking.plugin"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        vec![ConfigDiagnostic {
+            level: DiagnosticLevel::Warning,
+            code: "blocking.warning".into(),
+            component: Some("blocking.plugin".into()),
+            field: None,
+            message: "blocking plugin validated".into(),
+        }]
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        ctx: &'a mut PluginRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        let started = Arc::clone(&self.started);
+        let release = Arc::clone(&self.release);
+        let registered = Arc::clone(&self.registered);
+        Box::pin(async move {
+            started.notify_one();
+            release.notified().await;
+            ctx.add_registration(PluginRegistration::new(
+                "plugin",
+                ctx.qualify_name("blocking"),
+                Box::new(|| Ok(())),
+            ));
+            registered.notify_one();
+            Ok(())
+        })
+    }
+}
+
+impl Plugin for BackgroundTaskPlugin {
+    fn plugin_kind(&self) -> &str {
+        "background.task.plugin"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        vec![]
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        _ctx: &'a mut PluginRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        let release = Arc::clone(&self.release);
+        let completed = Arc::clone(&self.completed);
+        Box::pin(async move {
+            tokio::spawn(async move {
+                release.notified().await;
+                completed.notify_one();
+            });
+            Ok(())
+        })
+    }
+}
+
+impl Plugin for PanickingPlugin {
+    fn plugin_kind(&self) -> &str {
+        "panicking.plugin"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        vec![]
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        _ctx: &'a mut PluginRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async { panic!("fixture plugin panicked during registration") })
+    }
+}
+
+impl Plugin for FailingDeregisterPlugin {
+    fn plugin_kind(&self) -> &str {
+        "failing.deregister.plugin"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        vec![]
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        ctx: &'a mut PluginRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            ctx.add_registration(PluginRegistration::new(
+                "fixture",
+                ctx.qualify_name("refuses-deregistration"),
+                Box::new(|| {
+                    Err(PluginError::RegistrationFailed(
+                        "fixture deregistration refused".into(),
+                    ))
+                }),
+            ));
+            Ok(())
+        })
+    }
+}
+
 fn reset_global() {
     crate::shared_runtime::reset_runtime_owner_for_tests();
     let ctx = global_context();
@@ -308,6 +430,10 @@ fn reset_global() {
     let _ = deregister_plugin("restore.break.plugin");
     let _ = deregister_plugin("partial.fail.plugin");
     let _ = deregister_plugin("vanishing.plugin");
+    let _ = deregister_plugin("blocking.plugin");
+    let _ = deregister_plugin("background.task.plugin");
+    let _ = deregister_plugin("panicking.plugin");
+    let _ = deregister_plugin("failing.deregister.plugin");
 }
 
 #[test]
@@ -821,6 +947,16 @@ fn test_rollback_registrations_runs_in_reverse_and_ignores_failures() {
         }),
     ));
 
+    let panic_order = Arc::clone(&call_order);
+    registrations.push(PluginRegistration::new(
+        "plugin",
+        "panicking",
+        Box::new(move || {
+            panic_order.lock().unwrap().push("panicking");
+            panic!("expected rollback panic")
+        }),
+    ));
+
     let second_order = Arc::clone(&call_order);
     registrations.push(PluginRegistration::new(
         "plugin",
@@ -836,7 +972,10 @@ fn test_rollback_registrations_runs_in_reverse_and_ignores_failures() {
     rollback_registrations(&mut registrations);
 
     assert!(registrations.is_empty());
-    assert_eq!(*call_order.lock().unwrap(), vec!["second", "first"]);
+    assert_eq!(
+        *call_order.lock().unwrap(),
+        vec!["second", "panicking", "first"]
+    );
 }
 
 #[test]
@@ -886,6 +1025,46 @@ fn test_initialize_plugins_restores_previous_configuration_after_failed_replacem
 }
 
 #[test]
+fn test_initialize_plugins_restores_previous_configuration_after_replacement_panic() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    register_plugin(Arc::new(RecordingPlugin)).unwrap();
+    register_plugin(Arc::new(PanickingPlugin)).unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime
+        .block_on(initialize_plugins_exact(PluginConfig {
+            components: vec![PluginComponentSpec::new("recording.plugin")],
+            ..PluginConfig::default()
+        }))
+        .unwrap();
+
+    let error = runtime
+        .block_on(initialize_plugins_exact(PluginConfig {
+            components: vec![PluginComponentSpec::new("panicking.plugin")],
+            ..PluginConfig::default()
+        }))
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("fixture plugin panicked"),
+        "{error}"
+    );
+    assert!(active_plugin_report().is_some());
+    assert_eq!(
+        recorded_names().lock().unwrap().as_slice(),
+        [
+            "__nemo_relay_plugin__recording.plugin__subscriber",
+            "__nemo_relay_plugin__recording.plugin__subscriber",
+        ]
+    );
+
+    reset_global();
+}
+
+#[test]
 fn test_initialize_plugins_rolls_back_partial_component_registration_on_failure() {
     let _guard = lock_runtime_owner();
     reset_global();
@@ -911,6 +1090,271 @@ fn test_initialize_plugins_rolls_back_partial_component_registration_on_failure(
 
     assert_eq!(PARTIAL_FAIL_ROLLBACKS.load(Ordering::SeqCst), 1);
     assert!(active_plugin_report().is_none());
+    reset_global();
+}
+
+#[test]
+fn test_initialize_plugins_transaction_finishes_after_caller_cancellation() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    register_plugin(Arc::new(RecordingPlugin)).unwrap();
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let registered = Arc::new(Notify::new());
+    register_plugin(Arc::new(BlockingPlugin {
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+        registered: Arc::clone(&registered),
+    }))
+    .unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        initialize_plugins_exact(PluginConfig {
+            components: vec![PluginComponentSpec::new("recording.plugin")],
+            ..PluginConfig::default()
+        })
+        .await
+        .unwrap();
+
+        let caller = tokio::spawn(initialize_plugins_exact(PluginConfig {
+            components: vec![PluginComponentSpec::new("blocking.plugin")],
+            ..PluginConfig::default()
+        }));
+        started.notified().await;
+        caller.abort();
+        assert!(caller.await.unwrap_err().is_cancelled());
+        release.notify_one();
+        registered.notified().await;
+
+        for _ in 0..100 {
+            if active_plugin_report().is_some_and(|report| {
+                report
+                    .diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.code == "blocking.warning")
+            }) {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("owned initialization transaction did not finish after caller cancellation");
+    });
+
+    reset_global();
+}
+
+#[test]
+fn test_plugin_runtime_continues_driving_background_tasks_after_initialization() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    let release = Arc::new(Notify::new());
+    let completed = Arc::new(Notify::new());
+    register_plugin(Arc::new(BackgroundTaskPlugin {
+        release: Arc::clone(&release),
+        completed: Arc::clone(&completed),
+    }))
+    .unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        initialize_plugins_exact(PluginConfig {
+            components: vec![PluginComponentSpec::new("background.task.plugin")],
+            ..PluginConfig::default()
+        })
+        .await
+        .unwrap();
+
+        release.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(1), completed.notified())
+            .await
+            .expect("plugin runtime should keep driving spawned background tasks");
+    });
+
+    reset_global();
+}
+
+#[test]
+fn test_plugin_host_activation_cleans_up_after_caller_cancellation() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let registered = Arc::new(Notify::new());
+    register_plugin(Arc::new(BlockingPlugin {
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+        registered: Arc::clone(&registered),
+    }))
+    .unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let caller = tokio::spawn(dynamic::PluginHostActivation::activate(
+            PluginConfig {
+                components: vec![PluginComponentSpec::new("blocking.plugin")],
+                ..PluginConfig::default()
+            },
+            Vec::<dynamic::DynamicPluginActivationSpec>::new(),
+        ));
+        started.notified().await;
+        caller.abort();
+        match caller.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("plugin host caller should have been canceled"),
+        }
+        release.notify_one();
+        registered.notified().await;
+        for _ in 0..100 {
+            let owner_idle = PLUGIN_MUTATION_OWNER
+                .lock()
+                .is_ok_and(|owner| *owner == PluginMutationOwner::Idle);
+            if owner_idle && active_plugin_report().is_none() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        // The dropped result must clear its activation and release the lease.
+        initialize_plugins_exact(PluginConfig::default())
+            .await
+            .expect("canceled host caller should not strand ownership");
+    });
+
+    reset_global();
+}
+
+#[test]
+fn test_pending_registration_records_rollback_failures() {
+    let failures = Arc::new(Mutex::new(Vec::new()));
+    {
+        let mut pending = PendingPluginRegistrations::new(Some(Arc::clone(&failures)));
+        pending.extend(vec![PluginRegistration::new(
+            "fixture",
+            "failed-rollback",
+            Box::new(|| {
+                Err(PluginError::RegistrationFailed(
+                    "rollback remained registered".into(),
+                ))
+            }),
+        )]);
+    }
+
+    let failures = failures.lock().unwrap();
+    assert_eq!(failures.len(), 1);
+    assert!(failures[0].contains("failed-rollback"));
+    assert!(failures[0].contains("rollback remained registered"));
+}
+
+#[test]
+fn test_checked_teardown_reports_unremoved_registrations() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    store_active_plugin_configuration(
+        PluginConfig::default(),
+        ConfigReport::default(),
+        vec![PluginRegistration::new(
+            "fixture",
+            "stale-callback",
+            Box::new(|| {
+                Err(PluginError::RegistrationFailed(
+                    "deregistration refused".into(),
+                ))
+            }),
+        )],
+    )
+    .unwrap();
+
+    let outcome = clear_plugin_configuration_inner();
+    assert!(!outcome.callbacks_cleared);
+    let error = outcome.result.unwrap_err().to_string();
+    assert!(error.contains("stale-callback"), "{error}");
+    assert!(error.contains("deregistration refused"), "{error}");
+    assert!(active_plugin_report().is_none());
+    reset_global();
+}
+
+#[test]
+fn test_legacy_clear_retains_mutation_owner_after_incomplete_teardown() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    store_active_plugin_configuration(
+        PluginConfig::default(),
+        ConfigReport::default(),
+        vec![PluginRegistration::new(
+            "fixture",
+            "stale-callback",
+            Box::new(|| panic!("fixture deregistration panicked")),
+        )],
+    )
+    .unwrap();
+
+    let error = clear_plugin_configuration().unwrap_err();
+    assert!(error.to_string().contains("stale-callback"), "{error}");
+    assert!(
+        error
+            .to_string()
+            .contains("fixture deregistration panicked"),
+        "{error}"
+    );
+    assert_eq!(
+        *PLUGIN_MUTATION_OWNER.lock().unwrap(),
+        PluginMutationOwner::Legacy
+    );
+    assert!(matches!(
+        clear_plugin_configuration(),
+        Err(PluginError::Conflict(_))
+    ));
+
+    *PLUGIN_MUTATION_OWNER.lock().unwrap() = PluginMutationOwner::Idle;
+    reset_global();
+}
+
+#[test]
+fn test_legacy_replace_retains_mutation_owner_after_incomplete_teardown() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    register_plugin(Arc::new(FailingDeregisterPlugin)).unwrap();
+    register_plugin(Arc::new(ReplacementPlugin)).unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime
+        .block_on(initialize_plugins_exact(PluginConfig {
+            components: vec![PluginComponentSpec::new("failing.deregister.plugin")],
+            ..PluginConfig::default()
+        }))
+        .unwrap();
+
+    let error = runtime
+        .block_on(initialize_plugins_exact(PluginConfig {
+            components: vec![PluginComponentSpec::new("replacement.plugin")],
+            ..PluginConfig::default()
+        }))
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("fixture deregistration refused"),
+        "{error}"
+    );
+    assert_eq!(REPLACEMENT_REGISTRATIONS.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        *PLUGIN_MUTATION_OWNER.lock().unwrap(),
+        PluginMutationOwner::Legacy
+    );
+    assert!(active_plugin_report().is_none());
+
+    *PLUGIN_MUTATION_OWNER.lock().unwrap() = PluginMutationOwner::Idle;
     reset_global();
 }
 

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -1130,18 +1130,21 @@ fn test_initialize_plugins_transaction_finishes_after_caller_cancellation() {
         release.notify_one();
         registered.notified().await;
 
-        for _ in 0..100 {
-            if active_plugin_report().is_some_and(|report| {
-                report
-                    .diagnostics
-                    .iter()
-                    .any(|diagnostic| diagnostic.code == "blocking.warning")
-            }) {
-                return;
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if active_plugin_report().is_some_and(|report| {
+                    report
+                        .diagnostics
+                        .iter()
+                        .any(|diagnostic| diagnostic.code == "blocking.warning")
+                }) {
+                    break;
+                }
+                tokio::task::yield_now().await;
             }
-            tokio::task::yield_now().await;
-        }
-        panic!("owned initialization transaction did not finish after caller cancellation");
+        })
+        .await
+        .expect("owned initialization transaction did not finish after caller cancellation");
     });
 
     reset_global();

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -38,6 +38,16 @@ struct BackgroundTaskPlugin {
 }
 struct PanickingPlugin;
 struct FailingDeregisterPlugin;
+struct PluginMutationOwnerCleanup;
+
+impl Drop for PluginMutationOwnerCleanup {
+    fn drop(&mut self) {
+        let mut owner = PLUGIN_MUTATION_OWNER
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *owner = PluginMutationOwner::Idle;
+    }
+}
 
 static RECORDED_NAMES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 static PARTIAL_FAIL_ROLLBACKS: AtomicUsize = AtomicUsize::new(0);
@@ -1236,6 +1246,7 @@ fn test_checked_teardown_reports_unremoved_registrations() {
 #[test]
 fn test_legacy_clear_retains_mutation_owner_after_incomplete_teardown() {
     let _guard = lock_runtime_owner();
+    let owner_cleanup = PluginMutationOwnerCleanup;
     reset_global();
     store_active_plugin_configuration(
         PluginConfig::default(),
@@ -1265,13 +1276,14 @@ fn test_legacy_clear_retains_mutation_owner_after_incomplete_teardown() {
         Err(PluginError::Conflict(_))
     ));
 
-    *PLUGIN_MUTATION_OWNER.lock().unwrap() = PluginMutationOwner::Idle;
+    drop(owner_cleanup);
     reset_global();
 }
 
 #[test]
 fn test_legacy_replace_retains_mutation_owner_after_incomplete_teardown() {
     let _guard = lock_runtime_owner();
+    let owner_cleanup = PluginMutationOwnerCleanup;
     reset_global();
     register_plugin(Arc::new(FailingDeregisterPlugin)).unwrap();
     register_plugin(Arc::new(ReplacementPlugin)).unwrap();
@@ -1304,7 +1316,7 @@ fn test_legacy_replace_retains_mutation_owner_after_incomplete_teardown() {
     );
     assert!(active_plugin_report().is_none());
 
-    *PLUGIN_MUTATION_OWNER.lock().unwrap() = PluginMutationOwner::Idle;
+    drop(owner_cleanup);
     reset_global();
 }
 

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -1184,59 +1184,6 @@ fn test_plugin_runtime_continues_driving_background_tasks_after_initialization()
 }
 
 #[test]
-fn test_plugin_host_activation_cleans_up_after_caller_cancellation() {
-    let _guard = lock_runtime_owner();
-    reset_global();
-    let started = Arc::new(Notify::new());
-    let release = Arc::new(Notify::new());
-    let registered = Arc::new(Notify::new());
-    register_plugin(Arc::new(BlockingPlugin {
-        started: Arc::clone(&started),
-        release: Arc::clone(&release),
-        registered: Arc::clone(&registered),
-    }))
-    .unwrap();
-
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-    runtime.block_on(async {
-        let caller = tokio::spawn(dynamic::PluginHostActivation::activate(
-            PluginConfig {
-                components: vec![PluginComponentSpec::new("blocking.plugin")],
-                ..PluginConfig::default()
-            },
-            Vec::<dynamic::DynamicPluginActivationSpec>::new(),
-        ));
-        started.notified().await;
-        caller.abort();
-        match caller.await {
-            Err(error) => assert!(error.is_cancelled()),
-            Ok(_) => panic!("plugin host caller should have been canceled"),
-        }
-        release.notify_one();
-        registered.notified().await;
-        for _ in 0..100 {
-            let owner_idle = PLUGIN_MUTATION_OWNER
-                .lock()
-                .is_ok_and(|owner| *owner == PluginMutationOwner::Idle);
-            if owner_idle && active_plugin_report().is_none() {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-
-        // The dropped result must clear its activation and release the lease.
-        initialize_plugins_exact(PluginConfig::default())
-            .await
-            .expect("canceled host caller should not strand ownership");
-    });
-
-    reset_global();
-}
-
-#[test]
 fn test_pending_registration_records_rollback_failures() {
     let failures = Arc::new(Mutex::new(Vec::new()));
     {


### PR DESCRIPTION
#### Overview

This promotes dynamic-plugin activation from CLI-private orchestration into a core-owned lifecycle for harness-native embedding hosts. It deliberately does not replace the existing static plugin lifecycle: static-only callers continue to use normal plugin initialization, while `PluginHostActivation` requires at least one explicit dynamic plugin specification.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Lifecycle contract

- `initialize_plugins*` / `clear_plugin_configuration` remain the static-only API.
- `PluginHostActivation::activate(base_config, dynamic_specs)` is the owned dynamic API and rejects an empty `dynamic_specs` list with an actionable error.
- The base config may include registered static components. Those initialize first; components contributed by loaded plugins are appended afterward, all in one transaction.
- A process has one active plugin-configuration owner. Calling dynamic activation after static initialization is rejected; mixed users must pass static components in the dynamic activation's base config before initialization.
- Manifest and worker-environment references are explicit paths resolved by the embedding host. Relay reads them during startup activation; this API does not discover installation state or continuously revalidate mutable files.

#### Details

- Add public `PluginHostActivation` and `DynamicPluginActivationSpec` APIs for native and worker plugins.
- Load plugin runtimes, append their configured components, and initialize the complete configuration transactionally.
- Reject duplicate dynamic IDs before loading and protect built-in plugin IDs from preclaimed implementations.
- Track registry registrations by unique ownership ID so teardown removes only the adapter it installed; a replacement is preserved and reported as a conflict.
- Run plugin mutations on a process-wide, cancellation-resistant Relay executor with a stable Tokio runtime. Callers must not rely on activation callbacks running on their thread or runtime.
- Clear callbacks and flush subscribers before deregistering owned plugin kinds, stopping workers, and unloading libraries.
- Retain runtimes and the host owner when cleanup cannot prove safe unloading; otherwise release ownership while surfacing teardown errors.
- Provide explicit `clear()` plus best-effort `Drop` cleanup that logs failures.
- Refactor the CLI server to retain the legacy static lifecycle for static-only configurations and use the owned host only when dynamic specifications are present. CLI discovery and sidecar behavior are unchanged.

#### Where should the reviewer start?

Start with `crates/core/src/plugin/dynamic/host.rs` for the public lifecycle and executor contract, then `crates/core/src/plugin.rs` for ownership and transactional rollback. `crates/cli/src/server.rs` shows the static/dynamic dispatch. Native and worker integration tests cover mixed static/dynamic activation, conflicts, rollback, in-flight callbacks during teardown, cancellation, explicit clear, and drop cleanup.

#### Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nemo-relay --features worker-grpc --all-targets -- -D warnings`
- `cargo clippy -p nemo-relay-cli --all-targets -- -D warnings`
- Native plugin-host integration suite: 13 passed
- Worker shutdown/recovery regression passed
- Built-in ownership regression passed
- Static activation cancellation regression passed
- Static-only CLI lifecycle tests passed

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an owned activation/teardown lifecycle for dynamic native and worker plugins via an activation handle.
  * Introduced tracked plugin ownership and stronger protections for built-in plugin kinds to prevent conflicting activations.
* **Bug Fixes**
  * Made plugin initialization rollback/deregistration panic-safe with more reliable, observable recovery on partial failures.
  * Improved dynamic host clearing and shutdown safety, including safer worker shutdown behavior and clearer error reporting.
* **Tests**
  * Expanded CLI coverage and core integration/unit tests for ownership, builtin reservation, clear semantics, cancellation/rollback, and worker lifecycle.
* **Documentation**
  * —
<!-- end of auto-generated comment: release notes by coderabbit.ai -->