### PR TITLE
fix: redact PII in mark and generic scope events [2/6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,11 +1607,13 @@ version = "0.6.0"
 dependencies = [
  "futures",
  "nemo-relay",
+ "opentelemetry_sdk",
  "regex",
  "schemars",
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/cli/tests/coverage/plugins_tests.rs
+++ b/crates/cli/tests/coverage/plugins_tests.rs
@@ -296,6 +296,7 @@ fn typed_editor_model_contains_pii_redaction_options() {
         &["builtin", "local_model"]
     );
     assert_eq!(schema.field("codec").unwrap().kind, EditorFieldKind::Enum);
+    assert_eq!(schema.field("mark").unwrap().kind, EditorFieldKind::Boolean);
     assert_eq!(
         schema.field("tool_output").unwrap().kind,
         EditorFieldKind::Boolean

--- a/crates/pii-redaction/Cargo.toml
+++ b/crates/pii-redaction/Cargo.toml
@@ -26,6 +26,8 @@ sha2 = "0.11"
 schemars = { version = "0.8", optional = true }
 
 [dev-dependencies]
-nemo-relay = { workspace = true, features = ["openinference"] }
+nemo-relay = { workspace = true, features = ["openinference", "otel"] }
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "sync", "test-util", "rt-multi-thread", "time"] }
+opentelemetry_sdk = { workspace = true, features = ["trace", "testing"] }
+tempfile = "3"

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -9,8 +9,11 @@ use serde::de::DeserializeOwned;
 use serde_json::Value as Json;
 use sha2::{Digest, Sha256};
 
+use nemo_relay::api::event::{CategoryProfile, Event};
 use nemo_relay::api::llm::LlmRequest;
-use nemo_relay::api::runtime::{LlmSanitizeRequestFn, LlmSanitizeResponseFn, ToolSanitizeFn};
+use nemo_relay::api::runtime::{
+    EventSanitizeFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, ToolSanitizeFn,
+};
 use nemo_relay::codec::anthropic::AnthropicMessagesCodec;
 use nemo_relay::codec::openai_chat::OpenAIChatCodec;
 use nemo_relay::codec::openai_responses::OpenAIResponsesCodec;
@@ -254,6 +257,30 @@ impl CompiledBuiltinBackend {
 
 pub(super) fn tool_sanitize_callback(backend: CompiledBuiltinBackend) -> ToolSanitizeFn {
     Arc::new(move |_name: &str, payload: Json| backend.sanitize_json_preorder_dfs(payload))
+}
+
+pub(super) fn event_sanitize_callback(backend: CompiledBuiltinBackend) -> EventSanitizeFn {
+    Arc::new(move |event, mut fields| {
+        if matches!(event, Event::Scope(_))
+            && event
+                .category()
+                .is_some_and(|category| matches!(category.as_str(), "tool" | "llm"))
+        {
+            return fields;
+        }
+
+        fields.data = fields
+            .data
+            .map(|data| backend.sanitize_json_preorder_dfs(data));
+        fields.metadata = fields
+            .metadata
+            .map(|metadata| backend.sanitize_json_preorder_dfs(metadata));
+        fields.category_profile = fields.category_profile.map(|profile| {
+            sanitize_serializable_with_backend::<CategoryProfile>(&backend, profile.clone())
+                .unwrap_or(profile)
+        });
+        fields
+    })
 }
 
 pub(super) fn llm_sanitize_request_callback(

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -275,9 +275,8 @@ pub(super) fn event_sanitize_callback(backend: CompiledBuiltinBackend) -> EventS
         fields.metadata = fields
             .metadata
             .map(|metadata| backend.sanitize_json_preorder_dfs(metadata));
-        fields.category_profile = fields.category_profile.map(|profile| {
-            sanitize_serializable_with_backend::<CategoryProfile>(&backend, profile.clone())
-                .unwrap_or(profile)
+        fields.category_profile = fields.category_profile.and_then(|profile| {
+            sanitize_serializable_with_backend::<CategoryProfile>(&backend, profile).ok()
         });
         fields
     })

--- a/crates/pii-redaction/src/component.rs
+++ b/crates/pii-redaction/src/component.rs
@@ -81,6 +81,9 @@ pub struct PiiRedactionConfig {
     /// Whether to sanitize managed LLM response payloads.
     #[serde(default = "default_true")]
     pub output: bool,
+    /// Whether to sanitize mark event observability fields.
+    #[serde(default = "default_true")]
+    pub mark: bool,
     /// Whether to sanitize managed tool request payloads.
     #[serde(default = "default_true")]
     pub tool_input: bool,
@@ -112,6 +115,7 @@ impl Default for PiiRedactionConfig {
             mode: default_mode(),
             input: true,
             output: true,
+            mark: true,
             tool_input: true,
             tool_output: true,
             priority: default_priority(),
@@ -199,6 +203,7 @@ nemo_relay::editor_config! {
         },
         input => { label: "input", kind: Boolean },
         output => { label: "output", kind: Boolean },
+        mark => { label: "mark", kind: Boolean },
         tool_input => { label: "tool_input", kind: Boolean },
         tool_output => { label: "tool_output", kind: Boolean },
         priority => { label: "priority", kind: Integer },
@@ -423,6 +428,7 @@ fn validate_pii_redaction_plugin_config(
             "mode",
             "input",
             "output",
+            "mark",
             "tool_input",
             "tool_output",
             "priority",
@@ -497,7 +503,7 @@ fn validate_surface_selection(
     policy: &ConfigPolicy,
     config: &PiiRedactionConfig,
 ) {
-    if config.input || config.output || config.tool_input || config.tool_output {
+    if config.input || config.output || config.mark || config.tool_input || config.tool_output {
         return;
     }
 
@@ -725,6 +731,14 @@ fn register_builtin_backend(
     })?;
     let compiled = CompiledBuiltinBackend::new(builtin, config.codec.clone())?;
 
+    if config.mark {
+        ctx.register_mark_sanitize_guardrail(
+            "mark",
+            config.priority,
+            super::builtin::event_sanitize_callback(compiled.clone()),
+        )?;
+    }
+
     if config.tool_input {
         let sanitizer = tool_sanitize_callback(compiled.clone());
         ctx.register_tool_sanitize_request_guardrail("tool_input", config.priority, sanitizer)?;
@@ -734,12 +748,28 @@ fn register_builtin_backend(
         ctx.register_tool_sanitize_response_guardrail("tool_output", config.priority, sanitizer)?;
     }
     if config.input {
-        let sanitizer = llm_sanitize_request_callback(compiled.clone());
-        ctx.register_llm_sanitize_request_guardrail("input", config.priority, sanitizer)?;
+        ctx.register_llm_sanitize_request_guardrail(
+            "input",
+            config.priority,
+            llm_sanitize_request_callback(compiled.clone()),
+        )?;
+        ctx.register_scope_sanitize_start_guardrail(
+            "input",
+            config.priority,
+            super::builtin::event_sanitize_callback(compiled.clone()),
+        )?;
     }
     if config.output {
-        let sanitizer = llm_sanitize_response_callback(compiled);
-        ctx.register_llm_sanitize_response_guardrail("output", config.priority, sanitizer)?;
+        ctx.register_llm_sanitize_response_guardrail(
+            "output",
+            config.priority,
+            llm_sanitize_response_callback(compiled.clone()),
+        )?;
+        ctx.register_scope_sanitize_end_guardrail(
+            "output",
+            config.priority,
+            super::builtin::event_sanitize_callback(compiled),
+        )?;
     }
 
     Ok(())

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -34,6 +34,7 @@ use nemo_relay::observability::openinference::OpenInferenceSubscriber;
 use nemo_relay::observability::otel::OpenTelemetrySubscriber;
 use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SdkTracerProvider};
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -161,6 +162,42 @@ fn event_sanitizer_transforms_data_category_profile_and_metadata_independently()
         Some("[REDACTED]")
     );
     assert_eq!(sanitized.metadata.unwrap()["owner"], "[REDACTED]");
+}
+
+#[test]
+fn event_sanitizer_discards_category_profile_when_sanitization_fails() {
+    let backend = crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            action: "regex_replace".into(),
+            pattern: Some("person@example\\.com".into()),
+            replacement: Some("[REDACTED]".into()),
+            ..BuiltinBackendConfig::default()
+        },
+        None,
+    )
+    .unwrap();
+    let callback = crate::builtin::event_sanitize_callback(backend);
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder().name("mark").build(),
+        None,
+        None,
+    ));
+    let sanitized = callback(
+        &event,
+        EventSanitizeFields {
+            data: None,
+            category_profile: Some(CategoryProfile {
+                extra: BTreeMap::from([(
+                    "annotated_request".to_string(),
+                    json!("invalid annotation"),
+                )]),
+                ..CategoryProfile::default()
+            }),
+            metadata: None,
+        },
+    );
+
+    assert!(sanitized.category_profile.is_none());
 }
 
 #[test]
@@ -676,7 +713,7 @@ fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets()
             "action": "regex_replace",
             "pattern": "sk-[A-Za-z0-9_-]+",
             "replacement": "[REDACTED]",
-            "target_paths": ["/api_key", "/nested/token", "/result/secret"]
+            "target_paths": ["/api_key", "/nested/token", "/result/secret", "/owner", "/reviewer"]
         }
     }))))
     .unwrap();
@@ -692,7 +729,7 @@ fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets()
                     "note": "leave me"
                 }
             }))
-            .metadata(json!({"owner": "person@example.com"}))
+            .metadata(json!({"owner": "sk-universal-metadata"}))
             .build(),
     )
     .unwrap();
@@ -705,7 +742,7 @@ fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets()
                     "public": "ok"
                 }
             }))
-            .metadata(json!({"reviewer": "person@example.com"}))
+            .metadata(json!({"reviewer": "sk-universal-metadata"}))
             .build(),
     )
     .unwrap();
@@ -733,11 +770,11 @@ fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets()
     );
     assert_eq!(
         captured_events[0].metadata().unwrap()["owner"],
-        "person@example.com"
+        "sk-universal-metadata"
     );
     assert_eq!(
         captured_events[1].metadata().unwrap()["reviewer"],
-        "person@example.com"
+        "sk-universal-metadata"
     );
 
     deregister_subscriber("pii-redaction-tool-events").unwrap();
@@ -2320,7 +2357,7 @@ fn builtin_backend_sanitizes_llm_start_payload_via_codec_and_reencodes_provider_
             "action": "regex_replace",
             "pattern": "sk-[A-Za-z0-9_-]+",
             "replacement": "[REDACTED]",
-            "target_paths": ["/messages/0/content", "/messages/1/content"]
+            "target_paths": ["/messages/0/content", "/messages/1/content", "/audit_owner"]
         }
     }))))
     .unwrap();
@@ -2389,7 +2426,7 @@ async fn builtin_backend_sanitizes_llm_end_payload_and_response_codec_decodes_sa
             "action": "regex_replace",
             "pattern": "sk-[A-Za-z0-9_-]+",
             "replacement": "[REDACTED]",
-            "target_paths": ["/choices/0/message/content"]
+            "target_paths": ["/choices/0/message/content", "/audit_owner"]
         }
     })))
     .await

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -5,13 +5,18 @@
 #![allow(clippy::await_holding_lock)]
 
 use super::*;
-use crate::api::event::Event;
+use crate::api::event::{
+    BaseEvent, CategoryProfile, Event, EventSanitizeFields, MarkEvent, ScopeCategory,
+};
 use crate::api::llm::{
     LlmCallExecuteParams, LlmCallParams, LlmRequest, llm_call, llm_call_execute,
 };
 use crate::api::runtime::{
     LlmExecutionNextFn, NemoRelayContextState, create_scope_stack, global_context,
     set_thread_scope_stack,
+};
+use crate::api::scope::{
+    EmitMarkEventParams, PopScopeParams, PushScopeParams, ScopeType, event, pop_scope, push_scope,
 };
 use crate::api::subscriber::{deregister_subscriber, register_subscriber};
 use crate::api::tool::{ToolCallEndParams, ToolCallParams, tool_call, tool_call_end};
@@ -23,6 +28,11 @@ use crate::plugin::{
     ensure_builtin_plugins_registered, initialize_plugins, list_plugin_kinds,
     validate_plugin_config,
 };
+use nemo_relay::observability::atif::{AtifAgentInfo, AtifExporter};
+use nemo_relay::observability::atof::{AtofExporter, AtofExporterConfig};
+use nemo_relay::observability::openinference::OpenInferenceSubscriber;
+use nemo_relay::observability::otel::OpenTelemetrySubscriber;
+use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SdkTracerProvider};
 use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -110,6 +120,50 @@ fn builtin_backend_config_default_matches_documented_action_default() {
 }
 
 #[test]
+fn pii_redaction_defaults_enable_mark_sanitization() {
+    let config = PiiRedactionConfig::default();
+    assert!(config.mark);
+}
+
+#[test]
+fn event_sanitizer_transforms_data_category_profile_and_metadata_independently() {
+    let backend = crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            action: "regex_replace".into(),
+            pattern: Some("person@example\\.com".into()),
+            replacement: Some("[REDACTED]".into()),
+            ..BuiltinBackendConfig::default()
+        },
+        None,
+    )
+    .unwrap();
+    let callback = crate::builtin::event_sanitize_callback(backend);
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder().name("mark").build(),
+        None,
+        None,
+    ));
+    let sanitized = callback(
+        &event,
+        EventSanitizeFields {
+            data: Some(json!({"email": "person@example.com"})),
+            category_profile: Some(
+                CategoryProfile::builder()
+                    .subtype("person@example.com")
+                    .build(),
+            ),
+            metadata: Some(json!({"owner": "person@example.com"})),
+        },
+    );
+    assert_eq!(sanitized.data.unwrap()["email"], "[REDACTED]");
+    assert_eq!(
+        sanitized.category_profile.unwrap().subtype.as_deref(),
+        Some("[REDACTED]")
+    );
+    assert_eq!(sanitized.metadata.unwrap()["owner"], "[REDACTED]");
+}
+
+#[test]
 fn validate_rejects_config_with_no_enabled_surfaces() {
     let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
     reset_runtime();
@@ -122,6 +176,7 @@ fn validate_rejects_config_with_no_enabled_surfaces() {
         },
         "input": false,
         "output": false,
+        "mark": false,
         "tool_input": false,
         "tool_output": false,
     })));
@@ -372,6 +427,239 @@ fn local_backend_provider_is_invoked_for_local_model_mode() {
 }
 
 #[test]
+fn builtin_backend_sanitizes_mark_and_generic_scope_observability_fields() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+    setup_isolated_thread();
+
+    futures::executor::block_on(initialize_plugins(plugin_config(json!({
+        "mode": "builtin",
+        "codec": "openai_chat",
+        "input": true,
+        "output": true,
+        "tool_input": false,
+        "tool_output": false,
+        "builtin": {
+            "action": "regex_replace",
+            "pattern": "person@example\\.com",
+            "replacement": "[REDACTED]"
+        }
+    }))))
+    .unwrap();
+
+    let events = capture_events("pii-redaction-event-fields");
+    event(
+        EmitMarkEventParams::builder()
+            .name("sensitive-mark")
+            .data(json!({"email": "person@example.com"}))
+            .metadata(json!({"owner": "person@example.com"}))
+            .build(),
+    )
+    .unwrap();
+    let scope = push_scope(
+        PushScopeParams::builder()
+            .name("sensitive-scope")
+            .scope_type(ScopeType::Custom)
+            .input(json!({"email": "person@example.com"}))
+            .metadata(json!({"owner": "person@example.com"}))
+            .build(),
+    )
+    .unwrap();
+    pop_scope(
+        PopScopeParams::builder()
+            .handle_uuid(&scope.uuid)
+            .output(json!({"email": "person@example.com"}))
+            .metadata(json!({"reviewer": "person@example.com"}))
+            .build(),
+    )
+    .unwrap();
+
+    let captured = captured_events_snapshot(&events);
+    let mark = captured
+        .iter()
+        .find(|event| event.name() == "sensitive-mark")
+        .unwrap();
+    assert_eq!(mark.data().unwrap()["email"], "[REDACTED]");
+    assert_eq!(mark.metadata().unwrap()["owner"], "[REDACTED]");
+    let start = captured
+        .iter()
+        .find(|event| {
+            event.name() == "sensitive-scope"
+                && event.scope_category() == Some(ScopeCategory::Start)
+        })
+        .unwrap();
+    assert_eq!(start.data().unwrap()["email"], "[REDACTED]");
+    assert_eq!(start.metadata().unwrap()["owner"], "[REDACTED]");
+    let end = captured
+        .iter()
+        .find(|event| {
+            event.name() == "sensitive-scope" && event.scope_category() == Some(ScopeCategory::End)
+        })
+        .unwrap();
+    assert_eq!(end.data().unwrap()["email"], "[REDACTED]");
+    assert_eq!(end.metadata().unwrap()["owner"], "[REDACTED]");
+    assert_eq!(end.metadata().unwrap()["reviewer"], "[REDACTED]");
+
+    deregister_subscriber("pii-redaction-event-fields").unwrap();
+    clear_plugin_configuration().unwrap();
+}
+
+#[test]
+fn mark_false_preserves_mark_fields() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+    setup_isolated_thread();
+
+    futures::executor::block_on(initialize_plugins(plugin_config(json!({
+        "mode": "builtin",
+        "codec": "openai_chat",
+        "input": true,
+        "output": false,
+        "mark": false,
+        "tool_input": false,
+        "tool_output": false,
+        "builtin": {
+            "action": "regex_replace",
+            "pattern": "person@example\\.com",
+            "replacement": "[REDACTED]"
+        }
+    }))))
+    .unwrap();
+
+    let events = capture_events("pii-redaction-mark-opt-out");
+    event(
+        EmitMarkEventParams::builder()
+            .name("raw-mark")
+            .data(json!({"email": "person@example.com"}))
+            .build(),
+    )
+    .unwrap();
+    let captured = captured_events_snapshot(&events);
+    assert_eq!(captured[0].data().unwrap()["email"], "person@example.com");
+
+    deregister_subscriber("pii-redaction-mark-opt-out").unwrap();
+    clear_plugin_configuration().unwrap();
+}
+
+#[test]
+fn sanitized_pii_never_reaches_subscribers_or_exporters() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+    setup_isolated_thread();
+
+    futures::executor::block_on(initialize_plugins(plugin_config(json!({
+        "mode": "builtin",
+        "codec": "openai_chat",
+        "input": true,
+        "output": true,
+        "tool_input": false,
+        "tool_output": false,
+        "builtin": {
+            "action": "redact",
+            "detector": "email"
+        }
+    }))))
+    .unwrap();
+
+    let captured = capture_events("pii-regression-subscriber");
+    let output = tempfile::tempdir().unwrap();
+    let atof = AtofExporter::new(
+        AtofExporterConfig::new()
+            .with_output_directory(output.path())
+            .with_filename("events.jsonl"),
+    )
+    .unwrap();
+    atof.register("pii-regression-atof").unwrap();
+    let atif = AtifExporter::new(
+        "pii-regression".into(),
+        AtifAgentInfo {
+            name: "test-agent".into(),
+            version: "1".into(),
+            model_name: None,
+            tool_definitions: None,
+            extra: None,
+        },
+    );
+    register_subscriber("pii-regression-atif", atif.subscriber()).unwrap();
+
+    let otel_exporter = InMemorySpanExporterBuilder::new().build();
+    let otel_provider = SdkTracerProvider::builder()
+        .with_simple_exporter(otel_exporter.clone())
+        .build();
+    let otel = OpenTelemetrySubscriber::from_tracer_provider(otel_provider, "pii-regression");
+    otel.register("pii-regression-otel").unwrap();
+
+    let openinference_exporter = InMemorySpanExporterBuilder::new().build();
+    let openinference_provider = SdkTracerProvider::builder()
+        .with_simple_exporter(openinference_exporter.clone())
+        .build();
+    let openinference =
+        OpenInferenceSubscriber::from_tracer_provider(openinference_provider, "pii-regression");
+    openinference
+        .register("pii-regression-openinference")
+        .unwrap();
+
+    let raw_pii = "person@example.com";
+    let agent = push_scope(
+        PushScopeParams::builder()
+            .name("hermes-agent")
+            .scope_type(ScopeType::Agent)
+            .input(json!({"prompt": raw_pii}))
+            .metadata(json!({"session_owner": raw_pii}))
+            .build(),
+    )
+    .unwrap();
+    event(
+        EmitMarkEventParams::builder()
+            .name("hermes.checkpoint")
+            .data(json!({"email": raw_pii}))
+            .metadata(json!({"reviewer": raw_pii}))
+            .build(),
+    )
+    .unwrap();
+    pop_scope(
+        PopScopeParams::builder()
+            .handle_uuid(&agent.uuid)
+            .output(json!({"answer": raw_pii}))
+            .metadata(json!({"approver": raw_pii}))
+            .build(),
+    )
+    .unwrap();
+
+    atof.force_flush().unwrap();
+    let trajectory = atif.export().unwrap();
+    otel.force_flush().unwrap();
+    openinference.force_flush().unwrap();
+
+    let subscriber_json = serde_json::to_string(&captured_events_snapshot(&captured)).unwrap();
+    let atof_json = std::fs::read_to_string(atof.path()).unwrap();
+    let atif_json = serde_json::to_string(&trajectory).unwrap();
+    let otel_debug = format!("{:?}", otel_exporter.get_finished_spans().unwrap());
+    let openinference_debug = format!("{:?}", openinference_exporter.get_finished_spans().unwrap());
+    for (surface, output) in [
+        ("subscriber", subscriber_json),
+        ("ATOF", atof_json),
+        ("ATIF", atif_json),
+        ("OpenTelemetry", otel_debug),
+        ("OpenInference", openinference_debug),
+    ] {
+        assert!(
+            !output.contains(raw_pii),
+            "raw PII leaked through {surface}: {output}"
+        );
+    }
+
+    deregister_subscriber("pii-regression-subscriber").unwrap();
+    atof.deregister("pii-regression-atof").unwrap();
+    deregister_subscriber("pii-regression-atif").unwrap();
+    otel.deregister("pii-regression-otel").unwrap();
+    openinference
+        .deregister("pii-regression-openinference")
+        .unwrap();
+    clear_plugin_configuration().unwrap();
+}
+
+#[test]
 fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets() {
     let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
     reset_runtime();
@@ -404,6 +692,7 @@ fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets()
                     "note": "leave me"
                 }
             }))
+            .metadata(json!({"owner": "person@example.com"}))
             .build(),
     )
     .unwrap();
@@ -416,6 +705,7 @@ fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets()
                     "public": "ok"
                 }
             }))
+            .metadata(json!({"reviewer": "person@example.com"}))
             .build(),
     )
     .unwrap();
@@ -440,6 +730,14 @@ fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets()
                 "public": "ok"
             }
         }))
+    );
+    assert_eq!(
+        captured_events[0].metadata().unwrap()["owner"],
+        "person@example.com"
+    );
+    assert_eq!(
+        captured_events[1].metadata().unwrap()["reviewer"],
+        "person@example.com"
     );
 
     deregister_subscriber("pii-redaction-tool-events").unwrap();
@@ -2044,6 +2342,7 @@ fn builtin_backend_sanitizes_llm_start_payload_via_codec_and_reencodes_provider_
         LlmCallParams::builder()
             .name("openai")
             .request(&request)
+            .metadata(json!({"audit_owner": "sk-universal-metadata"}))
             .build(),
     )
     .unwrap();
@@ -2063,6 +2362,10 @@ fn builtin_backend_sanitizes_llm_start_payload_via_codec_and_reencodes_provider_
                 "temperature": 0.2
             }
         }))
+    );
+    assert_eq!(
+        captured_events[0].metadata().unwrap()["audit_owner"],
+        "sk-universal-metadata"
     );
 
     deregister_subscriber("pii-redaction-llm-events").unwrap();
@@ -2129,6 +2432,7 @@ async fn builtin_backend_sanitizes_llm_end_payload_and_response_codec_decodes_sa
             .request(request)
             .func(noop_openai_chat_exec_fn(response.clone()))
             .response_codec(response_codec)
+            .metadata(json!({"audit_owner": "sk-universal-metadata"}))
             .build(),
     )
     .await
@@ -2166,6 +2470,10 @@ async fn builtin_backend_sanitizes_llm_end_payload_and_response_codec_decodes_sa
         .expect("annotated_response should be present");
     assert_eq!(annotated.response_text(), Some("[REDACTED]"));
     assert_eq!(annotated.model.as_deref(), Some("gpt-4o-mini"));
+    assert_eq!(
+        captured_events[1].metadata().unwrap()["audit_owner"],
+        "sk-universal-metadata"
+    );
 
     deregister_subscriber("pii-redaction-llm-end-events").unwrap();
     clear_plugin_configuration().unwrap();


### PR DESCRIPTION
#### Overview

Extends the built-in PII redaction policy onto the event sanitizer infrastructure from PR #371 so raw PII does not escape through marks or generic scope events.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Broadens `input` to LLM requests and non-tool/LLM scope starts.
- Broadens `output` to LLM responses and non-tool/LLM scope ends.
- Adds `mark`, defaulting to `true`, with `mark = false` as the opt-out.
- Sanitizes `data`, `category_profile`, and `metadata` independently.
- Leaves generic tool/LLM scope fields unchanged so specialized sanitizers do not hash or mask twice.
- Updates config validation, schema/editor surfaces, and default behavior tests.
- Adds a Hermes-style regression across subscribers, ATOF, ATIF, OpenTelemetry, and OpenInference.
- Contains no documentation changes; documentation is isolated in a final independent PR.
- Breaking changes: none. The intentional default behavior change protects marks when `mark` is omitted.

Validation: `nemo-relay-pii-redaction` tests and coverage, relevant CLI/config tests, full Rust and binding matrices, and pre-commit.

#### Where should the reviewer start?

Start with `crates/pii-redaction/src/component.rs`, `crates/pii-redaction/src/builtin.rs`, and the cross-exporter PII regression in the component tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes: RELAY-409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new PII redaction surface toggle to mark events (`mark`), defaulting to enabled and configurable via the editor.
  * Extended built-in sanitization to cover additional scope-level guardrails (start/end) alongside existing LLM/tool sanitization.

* **Bug Fixes**
  * Ensured event/category-profile sanitization is handled correctly, including dropping the category profile when sanitization fails.

* **Tests**
  * Added/expanded unit and security regression tests for mark redaction behavior, metadata correctness, and verification that raw PII never appears in subscribers or telemetry exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->