### PR TITLE
docs: align package READMEs

### DIFF
--- a/crates/plugin/README.md
+++ b/crates/plugin/README.md
@@ -93,4 +93,4 @@ complete example for platform-specific artifact and manifest setup.
 
 - [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
 - [Build Plugins guide](https://docs.nvidia.com/nemo/relay/build-plugins/about)
-- [Rust native plugin example](../../examples/rust-native-plugin/README.md)
+- [Rust native plugin example](https://github.com/NVIDIA/NeMo-Relay/blob/main/examples/rust-native-plugin/README.md)

--- a/crates/plugin/README.md
+++ b/crates/plugin/README.md
@@ -1,0 +1,96 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+[![License](https://img.shields.io/github/license/NVIDIA/NeMo-Relay)](https://github.com/NVIDIA/NeMo-Relay/blob/main/LICENSE)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/NVIDIA/NeMo-Relay/)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/NeMo-Relay?color=green)](https://github.com/NVIDIA/NeMo-Relay/releases)
+[![Codecov](https://codecov.io/gh/NVIDIA/NeMo-Relay/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NVIDIA/NeMo-Relay)
+[![PyPI](https://img.shields.io/pypi/v/nemo-relay?color=4B8BBE&logo=pypi)](https://pypi.org/project/nemo-relay/)
+[![npm node](https://img.shields.io/npm/v/nemo-relay-node?label=nemo-relay-node&color=CC3534&logo=npm)](https://www.npmjs.com/package/nemo-relay-node)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay?label=nemo-relay&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-adaptive?label=nemo-relay-adaptive&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-adaptive)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-cli?label=nemo-relay-cli&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-cli)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/NeMo-Relay)
+
+# NeMo Relay Native Plugin SDK
+
+`nemo-relay-plugin` is the Rust authoring SDK and stable ABI for trusted,
+in-process NeMo Relay dynamic plugins. Use it to build a Rust `cdylib` that
+Relay loads through the versioned native plugin interface.
+
+Native plugins run in the Relay process and are not sandboxed. They should
+depend on this crate rather than the host `nemo-relay` runtime crate, keeping
+the dynamic-library boundary on the stable C-compatible ABI.
+
+## Why Use It?
+
+- **Author native plugins safely**: Implement `NativePlugin` with typed Rust
+  callbacks instead of constructing ABI tables directly.
+- **Register real runtime behavior**: Use `PluginContext` for subscribers,
+  guardrails, and intercepts.
+- **Keep a stable boundary**: Export one versioned native entry point through
+  the `nemo_relay_plugin!` macro.
+- **Use host runtime helpers**: Emit events and manage scope state through the
+  high-level `PluginRuntime` wrapper.
+
+## What You Get
+
+- **`NativePlugin`**: Plugin kind, configuration validation, and registration
+  lifecycle contract.
+- **`PluginContext`**: Component-scoped registration APIs for middleware and
+  subscribers.
+- **`PluginRuntime`**: Typed helpers for Relay-owned scopes and marks.
+- **Stable native ABI v1**: C-compatible host and plugin tables behind the
+  safe Rust authoring interface.
+
+## Installation
+
+Add the SDK to a Rust dynamic-plugin project:
+
+```bash
+cargo add nemo-relay-plugin serde_json
+```
+
+Configure the library as a dynamic library:
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+## Getting Started
+
+Implement `NativePlugin` and export a constructor symbol:
+
+```rust
+use nemo_relay_plugin::{Json, NativePlugin, PluginContext, Result};
+use serde_json::Map;
+
+struct ExamplePlugin;
+
+impl NativePlugin for ExamplePlugin {
+    fn plugin_kind(&self) -> &str {
+        "example.native"
+    }
+
+    fn register(&mut self, _config: &Map<String, Json>, ctx: &mut PluginContext<'_>) -> Result<()> {
+        ctx.register_subscriber("log-events", |event| {
+            eprintln!("{}", event.name());
+        })
+    }
+}
+
+nemo_relay_plugin::nemo_relay_plugin!(nemo_relay_register_plugin, || ExamplePlugin);
+```
+
+Build the `cdylib`, describe its entry symbol and compatibility in a
+`relay-plugin.toml` manifest, then register it through the Relay CLI. See the
+complete example for platform-specific artifact and manifest setup.
+
+## Documentation
+
+- [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
+- [Build Plugins guide](https://docs.nvidia.com/nemo/relay/build-plugins/about)
+- [Rust native plugin example](../../examples/rust-native-plugin/README.md)

--- a/crates/types/README.md
+++ b/crates/types/README.md
@@ -71,4 +71,4 @@ assert_eq!(payload["source"], "my-integration");
 ## Documentation
 
 - [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
-- [NeMo Relay Rust crate](../core/README.md)
+- [NeMo Relay Rust crate](https://github.com/NVIDIA/NeMo-Relay/blob/main/crates/core/README.md)

--- a/crates/types/README.md
+++ b/crates/types/README.md
@@ -1,0 +1,74 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+[![License](https://img.shields.io/github/license/NVIDIA/NeMo-Relay)](https://github.com/NVIDIA/NeMo-Relay/blob/main/LICENSE)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/NVIDIA/NeMo-Relay/)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/NeMo-Relay?color=green)](https://github.com/NVIDIA/NeMo-Relay/releases)
+[![Codecov](https://codecov.io/gh/NVIDIA/NeMo-Relay/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NVIDIA/NeMo-Relay)
+[![PyPI](https://img.shields.io/pypi/v/nemo-relay?color=4B8BBE&logo=pypi)](https://pypi.org/project/nemo-relay/)
+[![npm node](https://img.shields.io/npm/v/nemo-relay-node?label=nemo-relay-node&color=CC3534&logo=npm)](https://www.npmjs.com/package/nemo-relay-node)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay?label=nemo-relay&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-adaptive?label=nemo-relay-adaptive&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-adaptive)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-cli?label=nemo-relay-cli&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-cli)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/NeMo-Relay)
+
+# NeMo Relay Types
+
+`nemo-relay-types` provides the shared serializable data model for NeMo Relay.
+Use it when a Rust integration, plugin SDK, or protocol implementation needs
+the same event, scope, tool, LLM, codec, and plugin-diagnostic types as Relay.
+
+This crate intentionally contains no runtime registries, dynamic loading,
+exporters, or process-global state. Applications normally depend on
+`nemo-relay`; this crate is the lower-level contract shared by the runtime and
+authoring SDKs.
+
+## Why Use It?
+
+- **Keep wire shapes consistent**: Exchange Relay DTOs without duplicating
+  serializable event, request, response, and diagnostic models.
+- **Share one JSON representation**: Use `Json`, an alias for
+  `serde_json::Value`, across Relay-facing payloads.
+- **Build SDKs without the runtime**: Depend on data contracts without pulling
+  in runtime behavior or global state.
+
+## What You Get
+
+- **`api` module**: Event, scope, tool, and LLM DTOs and attributes.
+- **`codec` module**: Normalized LLM request and response annotations.
+- **`plugin` module**: Structured plugin configuration diagnostics.
+- **Optional `schema` feature**: `schemars` implementations for supported
+  serializable types.
+
+## Installation
+
+Add the crate when implementing a Relay-adjacent SDK, protocol, or integration:
+
+```bash
+cargo add nemo-relay-types
+```
+
+Enable JSON Schema support when needed:
+
+```bash
+cargo add nemo-relay-types --features schema
+```
+
+## Getting Started
+
+Use the shared `Json` type for a Relay-compatible payload:
+
+```rust
+use nemo_relay_types::Json;
+use serde_json::json;
+
+let payload: Json = json!({"source": "my-integration"});
+assert_eq!(payload["source"], "my-integration");
+```
+
+## Documentation
+
+- [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
+- [NeMo Relay Rust crate](../core/README.md)

--- a/crates/worker-proto/README.md
+++ b/crates/worker-proto/README.md
@@ -58,12 +58,14 @@ Use the shared protocol identifier and JSON envelope helpers:
 use nemo_relay_worker_proto::{WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, json_envelope};
 use serde_json::{Value, json};
 
-let envelope = json_envelope("example.Payload@1", &json!({"ok": true}))?;
-let payload: Value = decode_json_envelope(&envelope)?;
+fn main() -> Result<(), serde_json::Error> {
+    let envelope = json_envelope("example.Payload@1", &json!({"ok": true}))?;
+    let payload: Value = decode_json_envelope(&envelope)?;
 
-assert_eq!(WORKER_PROTOCOL_GRPC_V1, "grpc-v1");
-assert_eq!(payload["ok"], true);
-# Ok::<(), serde_json::Error>(())
+    assert_eq!(WORKER_PROTOCOL_GRPC_V1, "grpc-v1");
+    assert_eq!(payload["ok"], true);
+    Ok(())
+}
 ```
 
 ## Documentation

--- a/crates/worker-proto/README.md
+++ b/crates/worker-proto/README.md
@@ -70,4 +70,4 @@ assert_eq!(payload["ok"], true);
 
 - [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
 - [Build Plugins guide](https://docs.nvidia.com/nemo/relay/build-plugins/about)
-- [Rust worker SDK](../worker/README.md)
+- [Rust worker SDK](https://github.com/NVIDIA/NeMo-Relay/blob/main/crates/worker/README.md)

--- a/crates/worker-proto/README.md
+++ b/crates/worker-proto/README.md
@@ -1,0 +1,73 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+[![License](https://img.shields.io/github/license/NVIDIA/NeMo-Relay)](https://github.com/NVIDIA/NeMo-Relay/blob/main/LICENSE)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/NVIDIA/NeMo-Relay/)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/NeMo-Relay?color=green)](https://github.com/NVIDIA/NeMo-Relay/releases)
+[![Codecov](https://codecov.io/gh/NVIDIA/NeMo-Relay/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NVIDIA/NeMo-Relay)
+[![PyPI](https://img.shields.io/pypi/v/nemo-relay?color=4B8BBE&logo=pypi)](https://pypi.org/project/nemo-relay/)
+[![npm node](https://img.shields.io/npm/v/nemo-relay-node?label=nemo-relay-node&color=CC3534&logo=npm)](https://www.npmjs.com/package/nemo-relay-node)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay?label=nemo-relay&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-adaptive?label=nemo-relay-adaptive&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-adaptive)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-cli?label=nemo-relay-cli&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-cli)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/NeMo-Relay)
+
+# NeMo Relay Worker Protocol
+
+`nemo-relay-worker-proto` provides the generated Rust bindings for the
+versioned gRPC protocol used by NeMo Relay out-of-process worker plugins. It is
+a protocol dependency for worker SDKs and hosts, not the usual entry point for
+authoring a plugin.
+
+Use `nemo-relay-worker` to author Rust workers. Depend on this crate directly
+only when implementing another worker SDK, a custom host, or protocol-level
+tooling.
+
+## Why Use It?
+
+- **Share the stable transport contract**: Use the `grpc-v1` service and
+  message definitions accepted by Relay worker manifests.
+- **Use generated Tonic bindings**: Access versioned client and server types
+  from `v1` without generating protobuf code in a consumer project.
+- **Keep data ownership clear**: Carry Relay DTOs in JSON envelopes backed by
+  `nemo-relay-types`; protobuf owns transport control flow.
+
+## What You Get
+
+- **`WORKER_PROTOCOL_GRPC_V1`**: The stable `grpc-v1` protocol identifier.
+- **`v1` module**: Generated `PluginWorker` and `RelayHostRuntime` gRPC
+  clients, servers, services, and messages.
+- **JSON envelope helpers**: `json_envelope` and `decode_json_envelope` for
+  serializing Relay DTOs into protocol payloads.
+
+## Installation
+
+Add the protocol crate when building protocol-level integrations:
+
+```bash
+cargo add nemo-relay-worker-proto
+```
+
+## Getting Started
+
+Use the shared protocol identifier and JSON envelope helpers:
+
+```rust
+use nemo_relay_worker_proto::{WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, json_envelope};
+use serde_json::{Value, json};
+
+let envelope = json_envelope("example.Payload@1", &json!({"ok": true}))?;
+let payload: Value = decode_json_envelope(&envelope)?;
+
+assert_eq!(WORKER_PROTOCOL_GRPC_V1, "grpc-v1");
+assert_eq!(payload["ok"], true);
+# Ok::<(), serde_json::Error>(())
+```
+
+## Documentation
+
+- [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
+- [Build Plugins guide](https://docs.nvidia.com/nemo/relay/build-plugins/about)
+- [Rust worker SDK](../worker/README.md)

--- a/crates/worker/README.md
+++ b/crates/worker/README.md
@@ -97,4 +97,4 @@ that arbitrary blocking work started by the callback has stopped.
 
 - [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
 - [Build Plugins guide](https://docs.nvidia.com/nemo/relay/build-plugins/about)
-- [Python gRPC worker plugin example](../../examples/python-grpc-worker-plugin/README.md)
+- [Python gRPC worker plugin example](https://github.com/NVIDIA/NeMo-Relay/blob/main/examples/python-grpc-worker-plugin/README.md)

--- a/crates/worker/README.md
+++ b/crates/worker/README.md
@@ -1,0 +1,100 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+[![License](https://img.shields.io/github/license/NVIDIA/NeMo-Relay)](https://github.com/NVIDIA/NeMo-Relay/blob/main/LICENSE)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/NVIDIA/NeMo-Relay/)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/NeMo-Relay?color=green)](https://github.com/NVIDIA/NeMo-Relay/releases)
+[![Codecov](https://codecov.io/gh/NVIDIA/NeMo-Relay/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NVIDIA/NeMo-Relay)
+[![PyPI](https://img.shields.io/pypi/v/nemo-relay?color=4B8BBE&logo=pypi)](https://pypi.org/project/nemo-relay/)
+[![npm node](https://img.shields.io/npm/v/nemo-relay-node?label=nemo-relay-node&color=CC3534&logo=npm)](https://www.npmjs.com/package/nemo-relay-node)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay?label=nemo-relay&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-adaptive?label=nemo-relay-adaptive&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-adaptive)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-cli?label=nemo-relay-cli&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-cli)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/NeMo-Relay)
+
+# NeMo Relay Worker SDK
+
+`nemo-relay-worker` is the Rust authoring SDK for out-of-process NeMo Relay
+dynamic worker plugins. Use it when plugin code needs process isolation and
+communicates with Relay through the versioned `grpc-v1` worker protocol.
+
+## Why Use It?
+
+- **Isolate plugin code**: Run custom runtime behavior outside the Relay host
+  process.
+- **Use typed registration APIs**: Implement `WorkerPlugin` and register
+  subscribers, guardrails, or intercepts with `PluginContext`.
+- **Call the host runtime**: Emit marks, manage scopes, and invoke middleware
+  continuations through `PluginRuntime`.
+- **Keep lifecycle managed**: Let Relay provide authenticated endpoints and
+  start the worker with `serve_plugin`.
+
+## What You Get
+
+- **`WorkerPlugin`**: The plugin identity, validation, and registration
+  contract.
+- **`PluginContext`**: Typed registrations for all supported worker surfaces.
+- **`PluginRuntime` and continuations**: Host-runtime callbacks and tool/LLM
+  execution-chain helpers.
+- **`serve_plugin`**: Tokio gRPC server startup using the Relay-provided worker
+  environment.
+
+## Installation
+
+Add the SDK and Tokio to the worker project:
+
+```bash
+cargo add nemo-relay-worker
+cargo add tokio --features macros,rt-multi-thread
+```
+
+## Getting Started
+
+Implement a worker and serve it from an async entrypoint:
+
+```rust
+use nemo_relay_worker::{Json, PluginContext, Result, WorkerPlugin, serve_plugin};
+
+struct ExampleWorker;
+
+impl WorkerPlugin for ExampleWorker {
+    fn plugin_id(&self) -> &str {
+        "example.worker"
+    }
+
+    fn register(&self, ctx: &mut PluginContext, _config: &Json) -> Result<()> {
+        ctx.register_tool_request_intercept("tag-request", 0, false, |_name, mut args| {
+            if let Some(object) = args.as_object_mut() {
+                object.insert("checked".into(), true.into());
+            }
+            Ok(args)
+        });
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    serve_plugin(ExampleWorker).await
+}
+```
+
+Relay supplies the socket, activation ID, and authentication token through the
+worker environment. Use `serve_plugin` for Relay-spawned workers; explicit
+server configuration is intended for tests and custom launchers.
+
+## Concurrency and Cancellation
+
+Unary and streaming callbacks run concurrently. Cancellation is cooperative:
+Relay sends `CancelInvocation` when a managed caller is cancelled, times out,
+or stops consuming a stream, and the SDK aborts the matching async callback
+task. An accepted cancellation confirms the task was found; it cannot prove
+that arbitrary blocking work started by the callback has stopped.
+
+## Documentation
+
+- [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
+- [Build Plugins guide](https://docs.nvidia.com/nemo/relay/build-plugins/about)
+- [Python gRPC worker plugin example](../../examples/python-grpc-worker-plugin/README.md)

--- a/python/plugin/README.md
+++ b/python/plugin/README.md
@@ -102,7 +102,7 @@ imports that function and awaits the returned coroutine when it starts the
 worker process.
 
 For a complete manifest and runnable plugin, see the
-[Python gRPC worker plugin example](../../examples/python-grpc-worker-plugin/README.md).
+[Python gRPC worker plugin example](https://github.com/NVIDIA/NeMo-Relay/blob/main/examples/python-grpc-worker-plugin/README.md).
 
 ## Request Intercepts
 
@@ -174,4 +174,4 @@ required gRPC runtime.
 
 - [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
 - [Build Plugins guide](https://docs.nvidia.com/nemo/relay/build-plugins/about)
-- [Python gRPC worker plugin example](../../examples/python-grpc-worker-plugin/README.md)
+- [Python gRPC worker plugin example](https://github.com/NVIDIA/NeMo-Relay/blob/main/examples/python-grpc-worker-plugin/README.md)

--- a/python/plugin/README.md
+++ b/python/plugin/README.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 [![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/NVIDIA/NeMo-Relay/)
 [![Release](https://img.shields.io/github/v/release/NVIDIA/NeMo-Relay?color=green)](https://github.com/NVIDIA/NeMo-Relay/releases)
 [![Codecov](https://codecov.io/gh/NVIDIA/NeMo-Relay/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NVIDIA/NeMo-Relay)
-[![PyPI](https://img.shields.io/pypi/v/nemo-relay?color=4B8BBE&logo=pypi)](https://pypi.org/project/nemo-relay/)
+[![PyPI](https://img.shields.io/pypi/v/nemo-relay-plugin?color=4B8BBE&logo=pypi)](https://pypi.org/project/nemo-relay-plugin/)
 [![npm node](https://img.shields.io/npm/v/nemo-relay-node?label=nemo-relay-node&color=CC3534&logo=npm)](https://www.npmjs.com/package/nemo-relay-node)
 [![Crates.io](https://img.shields.io/crates/v/nemo-relay?label=nemo-relay&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay)
 [![Crates.io](https://img.shields.io/crates/v/nemo-relay-adaptive?label=nemo-relay-adaptive&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-adaptive)

--- a/python/plugin/README.md
+++ b/python/plugin/README.md
@@ -3,16 +3,76 @@ SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All
 SPDX-License-Identifier: Apache-2.0
 -->
 
+[![License](https://img.shields.io/github/license/NVIDIA/NeMo-Relay)](https://github.com/NVIDIA/NeMo-Relay/blob/main/LICENSE)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/NVIDIA/NeMo-Relay/)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/NeMo-Relay?color=green)](https://github.com/NVIDIA/NeMo-Relay/releases)
+[![Codecov](https://codecov.io/gh/NVIDIA/NeMo-Relay/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NVIDIA/NeMo-Relay)
+[![PyPI](https://img.shields.io/pypi/v/nemo-relay?color=4B8BBE&logo=pypi)](https://pypi.org/project/nemo-relay/)
+[![npm node](https://img.shields.io/npm/v/nemo-relay-node?label=nemo-relay-node&color=CC3534&logo=npm)](https://www.npmjs.com/package/nemo-relay-node)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay?label=nemo-relay&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-adaptive?label=nemo-relay-adaptive&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-adaptive)
+[![Crates.io](https://img.shields.io/crates/v/nemo-relay-cli?label=nemo-relay-cli&color=B7410E&logo=rust)](https://crates.io/crates/nemo-relay-cli)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/NeMo-Relay)
+
 # nemo-relay-plugin
 
-Python authoring SDK for NeMo Relay out-of-process dynamic worker plugins.
+`nemo-relay-plugin` is the Python authoring SDK for NeMo Relay out-of-process
+dynamic worker plugins. Use it when plugin code should run in its own Python
+process and communicate with Relay through the versioned `grpc-v1` worker
+protocol.
 
-Declare this package as a dependency of a Python worker project and expose a
-`module:function` entrypoint that calls `serve_plugin`. Register the manifest
-with `nemo-relay plugins add`; Relay creates a per-plugin virtual environment,
-installs `source.manifest_root`, and records that environment for activation.
-Enable it with `nemo-relay plugins enable <plugin_id>` after registration. Python
-workers without a lifecycle-managed environment are rejected.
+## Why Use It?
+
+- **Isolate plugin dependencies**: Run custom policy, middleware, or exporter
+  code outside the Relay host process.
+- **Use the shared runtime contract**: Register subscribers, guardrails, and
+  intercepts through `WorkerPlugin` and `PluginContext`.
+- **Call back into Relay safely**: Emit marks, create scopes, and continue
+  managed execution through the host runtime handle.
+- **Keep worker lifecycle managed**: Let Relay provision the worker environment,
+  start the entrypoint, and supply authenticated local endpoints.
+
+## What You Get
+
+- **`WorkerPlugin` and `PluginContext`**: The plugin validation and registration
+  contract for worker-owned runtime behavior.
+- **`serve_plugin`**: An AsyncIO gRPC server wired to the Relay-managed worker
+  environment.
+- **Typed runtime helpers**: JSON, event, scope, middleware, continuation, and
+  diagnostic types shared with Relay.
+- **Generated transport bindings**: Private protobuf bindings included in built
+  wheels; published-wheel installation does not require `protoc` or
+  `grpcio-tools`.
+
+## Installation
+
+Add the SDK to the Python worker project's dependencies:
+
+```bash
+uv add nemo-relay-plugin
+```
+
+If you are not using `uv`, install it with `pip`:
+
+```bash
+pip install nemo-relay-plugin
+```
+
+Declare a `module:function` entrypoint that starts the worker with
+`serve_plugin`. Register the plugin manifest through the CLI; Relay creates a
+per-plugin virtual environment, installs `source.manifest_root`, and records
+that environment for activation:
+
+```bash
+nemo-relay plugins add ./relay-plugin.toml
+nemo-relay plugins enable <plugin_id>
+```
+
+Python workers cannot be loaded directly from `plugins.toml`. They must be
+registered through `plugins add`, which provisions the required managed
+environment. `plugins remove <plugin_id>` deletes that environment.
+
+## Getting Started
 
 A minimal worker plugin looks like this:
 
@@ -41,6 +101,11 @@ Set `load.entrypoint` to `your_module:main` in `relay-plugin.toml`. Relay
 imports that function and awaits the returned coroutine when it starts the
 worker process.
 
+For a complete manifest and runnable plugin, see the
+[Python gRPC worker plugin example](../../examples/python-grpc-worker-plugin/README.md).
+
+## Request Intercepts
+
 LLM request intercepts return one canonical outcome:
 
 ```python
@@ -61,13 +126,6 @@ When `annotated` is present, it is authoritative for provider-body content:
 leave raw `request["content"]` unchanged, edit normalized fields or provider
 extensions through the annotation, and use `request["headers"]` for transport
 headers.
-
-The SDK owns gRPC serving, JSON envelope conversion, callback dispatch,
-continuations, host runtime calls, and local scope-stack binding. Its private
-protobuf bindings are generated from the canonical Relay schema while the
-package is built; they are included in installed wheels but are not committed
-to the source repository. Installing the published wheel never requires
-`protoc` or `grpcio-tools`.
 
 ## Callback Concurrency
 
@@ -111,3 +169,9 @@ Windows ARM64 is not currently supported because `grpcio` does not publish a
 usable wheel for that platform. The NeMo Relay workspace skips installation and
 tests for this SDK on Windows ARM64 rather than creating a package without its
 required gRPC runtime.
+
+## Documentation
+
+- [NeMo Relay documentation](https://docs.nvidia.com/nemo/relay)
+- [Build Plugins guide](https://docs.nvidia.com/nemo/relay/build-plugins/about)
+- [Python gRPC worker plugin example](../../examples/python-grpc-worker-plugin/README.md)


### PR DESCRIPTION
#### Overview

Align the Python worker SDK and low-level Rust package READMEs with the repository’s standard package documentation structure.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add the shared NeMo Relay badge row and standard package sections to `python/plugin/README.md`.
- Add package READMEs for the types, native plugin, worker, and worker protocol crates.
- Link each README to the relevant public documentation and examples.

#### Where should the reviewer start?

Start with `python/plugin/README.md` for the shared structure, then review the new crate READMEs for package-specific guidance.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new documentation pages for the native plugin SDK, shared Relay types, worker protocol bindings, and the out-of-process worker SDK, including key concepts and “Getting Started” examples.
  * Replaced and expanded the worker SDK README with clearer API overview, a complete startup example, and concurrency/cancellation behavior details.
  * Updated the Python plugin README with a refreshed layout, improved installation guidance, a new “Request Intercepts” section, and links to runnable example implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->