### PR TITLE
chore: add NAT reviewers for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 # Attribution files require dependency approver review due to change in version(s)
 ATTRIBUTIONS-*.md @nvidia/nat-dep-approvers
 
-# Documentation changes must go to technical writers
-docs/ @lvojtku
-fern/ @lvojtku
+# Documentation changes must go to technical writers and NAT developers.
+docs/ @lvojtku @nvidia/NAT-developers
+fern/ @lvojtku @nvidia/NAT-developers


### PR DESCRIPTION
#### Overview

Update documentation CODEOWNERS entries so NAT developers are requested alongside technical writers.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `@nvidia/NAT-developers` to the `docs/` and `fern/` ownership rules.
- Preserve the existing technical-writer reviewer on both rules.

#### Where should the reviewer start?

Review `.github/CODEOWNERS`; it is the only changed file.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation ownership rules for repo docs-related paths.
  * Added an additional owner for `docs/` and `fern/` to broaden review coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->