### PR TITLE
docs: update stale plugin links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ shared runtime for scopes, policy, plugins, and lifecycle events.
 | Instrument app-owned LLM or tool calls | [Quick Start Application](https://docs.nvidia.com/nemo/relay/getting-started/quick-start) |
 | Use LangChain, LangGraph, Deep Agents, or OpenClaw | [Supported Integrations](https://docs.nvidia.com/nemo/relay/supported-integrations/about) |
 | Build a framework or provider integration | [Integrate into Frameworks](https://docs.nvidia.com/nemo/relay/integrate-into-frameworks/about) |
-| Export ATOF, ATIF, OpenTelemetry, or OpenInference | [Observability Plugin](https://docs.nvidia.com/nemo/relay/observability-plugin/about) |
-| Package reusable middleware or exporters | [Build Plugins](https://docs.nvidia.com/nemo/relay/build-plugins/about) |
+| Export ATOF, ATIF, OpenTelemetry, or OpenInference | [Observability Plugin](https://docs.nvidia.com/nemo/relay/configure-plugins/observability/about) |
+| Package reusable middleware or exporters | [Build Plugins](https://docs.nvidia.com/nemo/relay/v0.5.0/build-plugins/about) |
 | Develop or test this repository from source | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -24,17 +24,17 @@ redirects:
 
 # Generated API references
 - source: /nemo/relay/reference/api/python-library-reference/pii-redaction
-  destination: /nemo/relay/reference/api/python-library-reference/nemo-relay/pii-redaction
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/pii-redaction
 - source: /nemo/relay/reference/api/rust-library-reference/nemo-relay/codec/pricing
-  destination: /nemo/relay/reference/api/rust-library-reference/nemo-relay/codec/model-pricing
+  destination: /nemo/relay/v0.5.0/reference/api/rust-library-reference/nemo-relay/codec/model-pricing
 - source: /nemo/relay/reference/api/rust-library-reference/nemo-relay/plugins/pricing
-  destination: /nemo/relay/reference/api/rust-library-reference/nemo-relay/codec/model-pricing
+  destination: /nemo/relay/v0.5.0/reference/api/rust-library-reference/nemo-relay/plugins/model-pricing
 - source: /nemo/relay/reference/api/python-library-reference/:slug*
-  destination: /nemo/relay/reference/api/python-library-reference/nemo-relay/:slug*
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/:slug*
 - source: /nemo/relay/reference/api/rust-library-reference/nemo-relay/codec/pricing/:slug*
-  destination: /nemo/relay/reference/api/rust-library-reference/nemo-relay/codec/model-pricing/:slug*
+  destination: /nemo/relay/v0.5.0/reference/api/rust-library-reference/nemo-relay/codec/model-pricing/:slug*
 - source: /nemo/relay/reference/api/rust-library-reference/nemo-relay/plugins/pricing/:slug*
-  destination: /nemo/relay/reference/api/rust-library-reference/nemo-relay/codec/model-pricing/:slug*
+  destination: /nemo/relay/v0.5.0/reference/api/rust-library-reference/nemo-relay/plugins/model-pricing/:slug*
 
 # Plugin configuration documentation
 - source: /nemo/relay/build-plugins/plugin-configuration-files
@@ -74,9 +74,7 @@ redirects:
 
 # Build plugin guides
 - source: /nemo/relay/build-plugins/basic-guide
-  destination: /nemo/relay/configure-plugins/language-binding/about
-- source: /nemo/relay/build-plugins/:slug*
-  destination: /nemo/relay/configure-plugins/language-binding/:slug*
+  destination: /nemo/relay/build-plugins/language-binding/about
 
 # CLI guides
 - source: /nemo/relay/nemo-relay-cli/cursor


### PR DESCRIPTION
#### Overview

Repairs release/0.5 documentation redirects and README links so they retain their intended destinations and resolve through NVIDIA Docs.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Point the README task guide at the versioned 0.5.0 NVIDIA Docs pages for observability and Build Plugins.
- Stop redirecting all Build Plugins pages into Configure Plugins; retain only the legacy basic-guide redirect to the actual language-binding Build Plugins guide.
- Redirect legacy generated API-reference paths to their versioned 0.5.0 destinations, and preserve the separate codec and plugin model-pricing trees.

#### Where should the reviewer start?

Review `fern/docs.yml` for redirect semantics, then the README task guide links.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several documentation links and redirects to point to the latest versioned pages.
  * Fixed paths for API reference, observability, build plugin, and pricing-related docs so they resolve to the correct locations.
  * Improved navigation consistency for users following older links or bookmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->