### PR TITLE
fix(cli): route Codex access tokens to ChatGPT

### DIFF
--- a/crates/cli/src/alignment/codex.rs
+++ b/crates/cli/src/alignment/codex.rs
@@ -18,8 +18,8 @@ use crate::alignment::{
 };
 use crate::model::{AgentKind, SessionEvent, SubagentEvent};
 
-// ChatGPT backend base URL used by Codex when authenticated with ChatGPT-Plus OAuth. This mirrors
-// Codex's own `CHATGPT_CODEX_BASE_URL`; API-key auth continues through the normal OpenAI base.
+// ChatGPT backend base URL used by Codex when authenticated with ChatGPT. This mirrors Codex's own
+// `CHATGPT_CODEX_BASE_URL`; API-key auth continues through the normal OpenAI base.
 const CHATGPT_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 
 // The Codex fields needed to turn a child thread into a parent-owned subagent scope. Optional
@@ -58,22 +58,22 @@ pub(crate) fn prompt_cache_session_id(body: &Value, route: GatewayRouteKind) -> 
     json_string_at(body, &[&["prompt_cache_key"][..]])
 }
 
-// Gives the gateway a Codex-native upstream only when the inbound token is the ChatGPT OAuth JWT
-// shape and no `OPENAI_API_KEY` is available to substitute. The gateway stays generic by asking
-// alignment for an optional override instead of knowing Codex backend URLs.
+// Gives the gateway a Codex-native upstream only when the inbound token is a recognized ChatGPT
+// auth token and no `OPENAI_API_KEY` is available to substitute. The gateway stays generic by
+// asking alignment for an optional override instead of knowing Codex backend URLs.
 pub(crate) fn chatgpt_upstream_url_if_needed(
     headers: &HeaderMap,
     route: GatewayRouteKind,
     path_and_query: &str,
     has_replacement_key: bool,
 ) -> Option<String> {
-    (is_openai_route(route) && has_chatgpt_oauth_jwt(headers) && !has_replacement_key)
+    (is_openai_route(route) && has_chatgpt_auth_token(headers) && !has_replacement_key)
         .then(|| chatgpt_upstream_url(path_and_query))
 }
 
-// Removes Codex ChatGPT OAuth JWTs from OpenAI-family routes when the gateway has a real API key
+// Removes Codex ChatGPT auth tokens from OpenAI-family routes when the gateway has a real API key
 // to inject. Real provider keys and non-OpenAI routes are preserved.
-pub(crate) fn strip_chatgpt_oauth_for_openai_route(
+pub(crate) fn strip_chatgpt_auth_for_openai_route(
     headers: &HeaderMap,
     route: GatewayRouteKind,
     has_replacement_key: bool,
@@ -82,7 +82,7 @@ pub(crate) fn strip_chatgpt_oauth_for_openai_route(
         return headers.clone();
     }
     let mut out = headers.clone();
-    if has_chatgpt_oauth_jwt(&out) {
+    if has_chatgpt_auth_token(&out) {
         out.remove(http::header::AUTHORIZATION);
     }
     out
@@ -95,16 +95,16 @@ fn chatgpt_upstream_url(path_and_query: &str) -> String {
     format!("{CHATGPT_CODEX_BASE_URL}{path}")
 }
 
-// Codex stores ChatGPT-Plus OAuth tokens in `~/.codex/auth.json`; the access token is a JWT whose
-// bearer value starts with `eyJ`. Provider API keys (`sk-...`) and opaque tokens do not match.
-fn has_chatgpt_oauth_jwt(headers: &HeaderMap) -> bool {
+// Codex can authenticate to the ChatGPT backend with either an OAuth JWT (`eyJ...`) or a Codex
+// access token (`at-...`). Provider API keys (`sk-...`) and unrelated opaque tokens do not match.
+fn has_chatgpt_auth_token(headers: &HeaderMap) -> bool {
     headers
         .get(http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.starts_with("Bearer eyJ"))
+        .is_some_and(|value| value.starts_with("Bearer eyJ") || value.starts_with("Bearer at-"))
 }
 
-// The ChatGPT OAuth transport fallback applies only to OpenAI-family routes. Anthropic routes use
+// The ChatGPT auth transport fallback applies only to OpenAI-family routes. Anthropic routes use
 // a different auth scheme and should never be redirected through Codex's ChatGPT backend.
 fn is_openai_route(route: GatewayRouteKind) -> bool {
     matches!(

--- a/crates/cli/src/alignment/mod.rs
+++ b/crates/cli/src/alignment/mod.rs
@@ -523,8 +523,8 @@ fn openai_body_session_id(body: &Value, route: GatewayRouteKind) -> Option<Strin
 
 /// Select an agent-native upstream before falling back to configured providers.
 ///
-/// Codex uses this for ChatGPT OAuth tokens that target the ChatGPT backend
-/// instead of the public OpenAI API.
+/// Codex uses this for ChatGPT auth tokens that target the ChatGPT backend instead
+/// of the public OpenAI API.
 pub(crate) fn gateway_upstream_url_override(
     headers: &HeaderMap,
     route: GatewayRouteKind,
@@ -541,14 +541,14 @@ pub(crate) fn gateway_upstream_url_override(
 
 /// Remove or preserve agent-native auth before generic provider auth injection.
 ///
-/// Codex strips ChatGPT OAuth JWTs only when an OpenAI API key is available to
+/// Codex strips ChatGPT auth tokens only when an OpenAI API key is available to
 /// replace them.
 pub(crate) fn gateway_forward_headers(
     headers: &HeaderMap,
     route: GatewayRouteKind,
     has_openai_replacement_key: bool,
 ) -> HeaderMap {
-    codex::strip_chatgpt_oauth_for_openai_route(headers, route, has_openai_replacement_key)
+    codex::strip_chatgpt_auth_for_openai_route(headers, route, has_openai_replacement_key)
 }
 
 /// Read the explicit subagent header from a gateway request.

--- a/crates/cli/src/gateway.rs
+++ b/crates/cli/src/gateway.rs
@@ -1016,7 +1016,7 @@ fn normalize_openai_path_for_base(base: &str, path_and_query: &str) -> String {
 }
 
 // Gives alignment adapters a chance to choose an agent-native upstream before default provider
-// routing runs. Today this supports Codex ChatGPT OAuth; future harness fallbacks should stay in
+// routing runs. Today this supports Codex ChatGPT auth; future harness fallbacks should stay in
 // alignment rather than adding provider-shaped checks here.
 fn gateway_upstream_url_override(
     route: ProviderRoute,

--- a/crates/cli/src/launcher.rs
+++ b/crates/cli/src/launcher.rs
@@ -770,10 +770,11 @@ fn codex_gateway_provider_config(gateway_url: &str) -> String {
     //
     // `requires_openai_auth=true` so Codex's `resolve_provider_auth` (`codex-rs/model-provider/
     // src/auth.rs`) attaches credentials via `BearerAuthProvider`. When the auth mode is
-    // `Chatgpt` the token is an OAuth JWT; when `ApiKey` it is the `OPENAI_API_KEY` value.
+    // `Chatgpt` the token is an OAuth JWT or Codex access token; when `ApiKey` it is the
+    // `OPENAI_API_KEY` value.
     // The gateway inspects the inbound `Authorization` header: if `OPENAI_API_KEY` is set in the
-    // environment the JWT is replaced (see `gateway.rs::strip_chatgpt_oauth_for_openai_route`
-    // and `inject_provider_auth`); otherwise the JWT is forwarded to the ChatGPT backend.
+    // environment the ChatGPT token is replaced (see `alignment::gateway_forward_headers` and
+    // `gateway.rs::inject_provider_auth`); otherwise it is forwarded to the ChatGPT backend.
     format!(
         "model_providers.nemo-relay-openai={{name=\"NeMo Relay OpenAI\",base_url={},wire_api=\"responses\",requires_openai_auth=true,supports_websockets=false}}",
         toml_string(gateway_url)

--- a/crates/cli/tests/coverage/alignment_codex_tests.rs
+++ b/crates/cli/tests/coverage/alignment_codex_tests.rs
@@ -63,7 +63,7 @@ fn prompt_cache_session_id_requires_codex_responses_metadata() {
 }
 
 #[test]
-fn chatgpt_backend_override_requires_jwt_and_missing_replacement_key() {
+fn chatgpt_backend_override_accepts_oauth_jwt_without_replacement_key() {
     let mut headers = axum::http::HeaderMap::new();
     headers.insert(
         "authorization",
@@ -101,24 +101,61 @@ fn chatgpt_backend_override_requires_jwt_and_missing_replacement_key() {
 }
 
 #[test]
-fn chatgpt_oauth_strip_preserves_provider_keys_and_non_openai_routes() {
+fn chatgpt_backend_override_accepts_codex_access_token() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "authorization",
+        axum::http::HeaderValue::from_static("Bearer at-test-codex-access-token"),
+    );
+
+    assert_eq!(
+        chatgpt_upstream_url_if_needed(
+            &headers,
+            GatewayRouteKind::OpenAiResponses,
+            "/v1/responses",
+            false,
+        )
+        .as_deref(),
+        Some("https://chatgpt.com/backend-api/codex/responses")
+    );
+}
+
+#[test]
+fn chatgpt_auth_strip_allows_api_key_substitution_for_codex_access_token() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "authorization",
+        axum::http::HeaderValue::from_static("Bearer at-test-codex-access-token"),
+    );
+
+    let stripped =
+        strip_chatgpt_auth_for_openai_route(&headers, GatewayRouteKind::OpenAiResponses, true);
+    assert!(stripped.get("authorization").is_none());
+
+    let preserved =
+        strip_chatgpt_auth_for_openai_route(&headers, GatewayRouteKind::OpenAiResponses, false);
+    assert_eq!(
+        preserved.get("authorization").unwrap(),
+        "Bearer at-test-codex-access-token"
+    );
+}
+
+#[test]
+fn chatgpt_auth_strip_preserves_provider_keys_and_non_openai_routes() {
     let mut jwt_headers = axum::http::HeaderMap::new();
     jwt_headers.insert(
         "authorization",
         axum::http::HeaderValue::from_static("Bearer eyJhbGciOiJIUzI1NiJ9.deadbeef.signature"),
     );
     let stripped =
-        strip_chatgpt_oauth_for_openai_route(&jwt_headers, GatewayRouteKind::OpenAiResponses, true);
+        strip_chatgpt_auth_for_openai_route(&jwt_headers, GatewayRouteKind::OpenAiResponses, true);
     assert!(stripped.get("authorization").is_none());
 
-    let preserved_without_replacement = strip_chatgpt_oauth_for_openai_route(
-        &jwt_headers,
-        GatewayRouteKind::OpenAiResponses,
-        false,
-    );
+    let preserved_without_replacement =
+        strip_chatgpt_auth_for_openai_route(&jwt_headers, GatewayRouteKind::OpenAiResponses, false);
     assert!(preserved_without_replacement.get("authorization").is_some());
 
-    let preserved_non_openai = strip_chatgpt_oauth_for_openai_route(
+    let preserved_non_openai = strip_chatgpt_auth_for_openai_route(
         &jwt_headers,
         GatewayRouteKind::AnthropicMessages,
         true,
@@ -131,7 +168,7 @@ fn chatgpt_oauth_strip_preserves_provider_keys_and_non_openai_routes() {
         axum::http::HeaderValue::from_static("Bearer sk-real-provider-key"),
     );
     let preserved_key =
-        strip_chatgpt_oauth_for_openai_route(&key_headers, GatewayRouteKind::OpenAiResponses, true);
+        strip_chatgpt_auth_for_openai_route(&key_headers, GatewayRouteKind::OpenAiResponses, true);
     assert_eq!(
         preserved_key.get("authorization").unwrap(),
         "Bearer sk-real-provider-key"

--- a/crates/cli/tests/coverage/alignment_codex_tests.rs
+++ b/crates/cli/tests/coverage/alignment_codex_tests.rs
@@ -118,6 +118,24 @@ fn chatgpt_backend_override_accepts_codex_access_token() {
         .as_deref(),
         Some("https://chatgpt.com/backend-api/codex/responses")
     );
+    assert_eq!(
+        chatgpt_upstream_url_if_needed(
+            &headers,
+            GatewayRouteKind::AnthropicMessages,
+            "/v1/messages",
+            false,
+        ),
+        None
+    );
+    assert_eq!(
+        chatgpt_upstream_url_if_needed(
+            &headers,
+            GatewayRouteKind::OpenAiResponses,
+            "/v1/responses",
+            true,
+        ),
+        None
+    );
 }
 
 #[test]

--- a/crates/cli/tests/coverage/gateway_tests.rs
+++ b/crates/cli/tests/coverage/gateway_tests.rs
@@ -492,7 +492,7 @@ fn strips_chatgpt_plus_jwt_from_openai_route_inbound() {
 #[test]
 fn preserves_real_bearer_keys_on_openai_route() {
     // Real provider keys (Hermes's `sk-...` against NVIDIA, an actual OpenAI dev key, etc.)
-    // must pass through untouched — only the consumer JWT shape (`Bearer eyJ...`) is stripped.
+    // must pass through untouched — only recognized ChatGPT auth tokens are stripped.
     let mut inbound = HeaderMap::new();
     inbound.insert(
         "authorization",
@@ -644,7 +644,7 @@ fn chatgpt_jwt_routes_to_chatgpt_backend_when_no_api_key() {
 }
 
 #[test]
-fn no_jwt_does_not_trigger_chatgpt_backend() {
+fn provider_key_does_not_trigger_chatgpt_backend() {
     let mut headers = HeaderMap::new();
     headers.insert(
         "authorization",


### PR DESCRIPTION
#### Overview

Route Codex access tokens through the ChatGPT Codex backend in transparent gateway mode.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Recognize `Bearer at-...` Codex access tokens alongside ChatGPT OAuth JWTs.
- Reuse the same classifier when choosing the ChatGPT Codex upstream and when stripping ChatGPT auth before `OPENAI_API_KEY` substitution.
- Keep provider API keys and unrelated bearer tokens unchanged.
- Add focused regression coverage for access-token routing and replacement-key behavior.
- No breaking changes.

Tested with:

- `cargo fmt --all -- --check`
- `cargo test -p nemo-relay-cli chatgpt_ --no-fail-fast` (9 passed)
- `cargo test -p nemo-relay-cli --no-fail-fast` (718 passed)

#### Where should the reviewer start?

`crates/cli/src/alignment/codex.rs`, specifically `has_chatgpt_auth_token`, centralizes the added token classification used by both routing and auth substitution.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened ChatGPT authentication handling to recognize both OAuth JWTs and Codex access tokens.
  * Improved OpenAI-family route header handling: recognized ChatGPT auth tokens are stripped/redirected appropriately, while provider API keys are preserved.
  * Updated gateway routing to ensure ChatGPT-backed requests select the correct upstream based on the newer auth-token format.
* **Documentation**
  * Updated comments and gateway documentation to refer to “ChatGPT auth tokens” instead of “ChatGPT OAuth tokens.”
* **Tests**
  * Expanded and generalized coverage for backend selection and header-stripping behavior across OpenAI and non-OpenAI routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->