### PR TITLE
ci: stop release 0.5 nightly tags

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,4 +3,3 @@
 
 branches:
   - main
-  - release/0.5


### PR DESCRIPTION
#### Overview

Stop scheduled nightly alpha tag creation for the `release/0.5` branch.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Removed `release/0.5` from `.github/nightly-alpha-branches.yaml`.
- Left `main` as the sole branch in the scheduled nightly alpha tag matrix.

#### Where should the reviewer start?

`.github/nightly-alpha-branches.yaml` contains the complete change.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly alpha builds to run only from the `main` branch.
  * Removed the `release/0.5` branch from the nightly build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->