### PR TITLE
test: isolate Go scope lifecycle coverage

### DIFF
--- a/go/nemo_relay/adaptive_plugin_test.go
+++ b/go/nemo_relay/adaptive_plugin_test.go
@@ -300,6 +300,10 @@ func assertClosedContextRegistrationFails(t *testing.T, name string, err error) 
 }
 
 func TestTopLevelPluginValidationAndLifecycle(t *testing.T) {
+	runTestWithScopeStack(t, testTopLevelPluginValidationAndLifecycle)
+}
+
+func testTopLevelPluginValidationAndLifecycle(t *testing.T) {
 	pluginKind := "go.test.plugin"
 	registerCalls := 0
 

--- a/go/nemo_relay/coverage_gap_test.go
+++ b/go/nemo_relay/coverage_gap_test.go
@@ -61,6 +61,10 @@ func TestEventBaseNilPointerFallbacks(t *testing.T) {
 }
 
 func TestPublicAPIErrorAndDefaultCoverage(t *testing.T) {
+	runTestWithScopeStack(t, testPublicAPIErrorAndDefaultCoverage)
+}
+
+func testPublicAPIErrorAndDefaultCoverage(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opt  ScopeOption
@@ -153,6 +157,10 @@ func TestPublicAPIErrorAndDefaultCoverage(t *testing.T) {
 }
 
 func TestWrapperAndCodecFinalizersRun(t *testing.T) {
+	runTestWithScopeStack(t, testWrapperAndCodecFinalizersRun)
+}
+
+func testWrapperAndCodecFinalizersRun(t *testing.T) {
 	scopeHandle, err := PushScope("finalizer_scope", ScopeTypeAgent)
 	if err != nil {
 		t.Fatalf("PushScope failed: %v", err)

--- a/go/nemo_relay/event_sanitizers_test.go
+++ b/go/nemo_relay/event_sanitizers_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestEventSanitizerRegistries(t *testing.T) {
+	runTestWithScopeStack(t, testEventSanitizerRegistries)
+}
+
+func testEventSanitizerRegistries(t *testing.T) {
 	var mu sync.Mutex
 	var events []Event
 	if err := RegisterSubscriber("go-event-sanitize-sub", func(event Event) {
@@ -79,6 +83,10 @@ func TestEventSanitizerRegistries(t *testing.T) {
 }
 
 func TestScopeLocalEventSanitizerInheritanceAndCleanup(t *testing.T) {
+	runTestWithScopeStack(t, testScopeLocalEventSanitizerInheritanceAndCleanup)
+}
+
+func testScopeLocalEventSanitizerInheritanceAndCleanup(t *testing.T) {
 	var mu sync.Mutex
 	seen := map[string]json.RawMessage{}
 	if err := RegisterSubscriber("go-local-event-sub", func(event Event) {

--- a/go/nemo_relay/llm_test.go
+++ b/go/nemo_relay/llm_test.go
@@ -84,6 +84,10 @@ func TestLlmCallWithDataMetadata(t *testing.T) {
 }
 
 func TestLlmCallWithParent(t *testing.T) {
+	runTestWithScopeStack(t, testLlmCallWithParent)
+}
+
+func testLlmCallWithParent(t *testing.T) {
 	parent, _ := PushScope("llm_parent", ScopeTypeAgent)
 	defer PopScope(parent)
 

--- a/go/nemo_relay/scope/shorthand_test.go
+++ b/go/nemo_relay/scope/shorthand_test.go
@@ -23,6 +23,10 @@ type capturedScopeEvent struct {
 }
 
 func TestScopeShorthands(t *testing.T) {
+	runWithTestScopeStack(t, testScopeShorthands)
+}
+
+func testScopeShorthands(t *testing.T) {
 	var sawMark bool
 	var mu sync.Mutex
 
@@ -68,6 +72,10 @@ func TestScopeShorthands(t *testing.T) {
 }
 
 func TestScopeShorthandsForwardTimestamps(t *testing.T) {
+	runWithTestScopeStack(t, testScopeShorthandsForwardTimestamps)
+}
+
+func testScopeShorthandsForwardTimestamps(t *testing.T) {
 	var (
 		events []capturedScopeEvent
 		mu     sync.Mutex
@@ -117,6 +125,18 @@ func TestScopeShorthandsForwardTimestamps(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	assertCapturedScopeEvents(t, events, expected)
+}
+
+func runWithTestScopeStack(t *testing.T, fn func(*testing.T)) {
+	t.Helper()
+
+	stack, err := nemo_relay.NewScopeStack()
+	if err != nil {
+		t.Fatalf("NewScopeStack failed: %v", err)
+	}
+	defer stack.Close()
+
+	stack.Run(func() { fn(t) })
 }
 
 func assertCapturedScopeEvents(t *testing.T, events, expected []capturedScopeEvent) {

--- a/go/nemo_relay/scope_test.go
+++ b/go/nemo_relay/scope_test.go
@@ -230,6 +230,10 @@ func runConcurrentScopePushPopWorker(errCh chan<- error) {
 // ============================================================================
 
 func TestPushPopScope(t *testing.T) {
+	runTestWithScopeStack(t, testPushPopScope)
+}
+
+func testPushPopScope(t *testing.T) {
 	handle, err := PushScope("test_scope", ScopeTypeAgent)
 	if err != nil {
 		t.Fatalf(pushScopeFailed, err)
@@ -259,6 +263,10 @@ func TestPushPopScope(t *testing.T) {
 }
 
 func TestScopeHandleProperties(t *testing.T) {
+	runTestWithScopeStack(t, testScopeHandleProperties)
+}
+
+func testScopeHandleProperties(t *testing.T) {
 	handle, err := PushScope("props_test", ScopeTypeRetriever)
 	if err != nil {
 		t.Fatalf(pushScopeFailed, err)
@@ -277,6 +285,10 @@ func TestScopeHandleProperties(t *testing.T) {
 }
 
 func TestPushScopeWithAttributes(t *testing.T) {
+	runTestWithScopeStack(t, testPushScopeWithAttributes)
+}
+
+func testPushScopeWithAttributes(t *testing.T) {
 	handle, err := PushScope("parallel", ScopeTypeFunction, WithScopeAttributes(ScopeAttrParallel))
 	if err != nil {
 		t.Fatalf(pushScopeFailed, err)
@@ -289,6 +301,10 @@ func TestPushScopeWithAttributes(t *testing.T) {
 }
 
 func TestPushScopeWithParent(t *testing.T) {
+	runTestWithScopeStack(t, testPushScopeWithParent)
+}
+
+func testPushScopeWithParent(t *testing.T) {
 	parent, err := PushScope("parent", ScopeTypeAgent)
 	if err != nil {
 		t.Fatalf("PushScope parent failed: %v", err)
@@ -307,6 +323,10 @@ func TestPushScopeWithParent(t *testing.T) {
 }
 
 func TestNestedScopes(t *testing.T) {
+	runTestWithScopeStack(t, testNestedScopes)
+}
+
+func testNestedScopes(t *testing.T) {
 	s1, _ := PushScope("level1", ScopeTypeAgent)
 	s2, _ := PushScope("level2", ScopeTypeFunction)
 	s3, _ := PushScope("level3", ScopeTypeTool)
@@ -332,6 +352,10 @@ func TestNestedScopes(t *testing.T) {
 }
 
 func TestPopInvalidScopeErrors(t *testing.T) {
+	runTestWithScopeStack(t, testPopInvalidScopeErrors)
+}
+
+func testPopInvalidScopeErrors(t *testing.T) {
 	handle, _ := PushScope("once", ScopeTypeAgent)
 	PopScope(handle)
 	err := PopScope(handle)
@@ -341,6 +365,10 @@ func TestPopInvalidScopeErrors(t *testing.T) {
 }
 
 func TestAllScopeTypes(t *testing.T) {
+	runTestWithScopeStack(t, testAllScopeTypes)
+}
+
+func testAllScopeTypes(t *testing.T) {
 	types := []ScopeType{
 		ScopeTypeAgent, ScopeTypeFunction, ScopeTypeTool, ScopeTypeLlm,
 		ScopeTypeRetriever, ScopeTypeEmbedder, ScopeTypeReranker,
@@ -377,6 +405,10 @@ func TestEmitEventWithData(t *testing.T) {
 }
 
 func TestEmitEventWithParent(t *testing.T) {
+	runTestWithScopeStack(t, testEmitEventWithParent)
+}
+
+func testEmitEventWithParent(t *testing.T) {
 	handle, _ := PushScope("evt_scope", ScopeTypeAgent)
 	defer PopScope(handle)
 
@@ -391,6 +423,10 @@ func TestEmitEventWithParent(t *testing.T) {
 // ============================================================================
 
 func TestSubscriberRegistration(t *testing.T) {
+	runTestWithScopeStack(t, testSubscriberRegistration)
+}
+
+func testSubscriberRegistration(t *testing.T) {
 	count := 0
 	var mu sync.Mutex
 	err := RegisterSubscriber("go_test_sub", func(event Event) {
@@ -465,6 +501,10 @@ func TestDuplicateSubscriberFails(t *testing.T) {
 }
 
 func TestSubscriberEventProperties(t *testing.T) {
+	runTestWithScopeStack(t, testSubscriberEventProperties)
+}
+
+func testSubscriberEventProperties(t *testing.T) {
 	var events []struct {
 		uuid      string
 		name      string
@@ -538,6 +578,10 @@ func TestMarkEvent(t *testing.T) {
 }
 
 func TestEventScopeTypeMatchesEventFamily(t *testing.T) {
+	runTestWithScopeStack(t, testEventScopeTypeMatchesEventFamily)
+}
+
+func testEventScopeTypeMatchesEventFamily(t *testing.T) {
 	contract := &scopeTypeContract{}
 	var mu sync.Mutex
 
@@ -597,6 +641,10 @@ func TestEventScopeTypeMatchesEventFamily(t *testing.T) {
 // ============================================================================
 
 func TestDeeplyNestedScopes(t *testing.T) {
+	runTestWithScopeStack(t, testDeeplyNestedScopes)
+}
+
+func testDeeplyNestedScopes(t *testing.T) {
 	const depth = 15
 	handles := pushDepthScopes(t, depth)
 
@@ -616,6 +664,10 @@ func TestDeeplyNestedScopes(t *testing.T) {
 }
 
 func TestPushScopeWithCombinedAttributes(t *testing.T) {
+	runTestWithScopeStack(t, testPushScopeWithCombinedAttributes)
+}
+
+func testPushScopeWithCombinedAttributes(t *testing.T) {
 	attrs := ScopeAttrParallel | ScopeAttrRelocatable
 	handle, err := PushScope("combined_attrs", ScopeTypeAgent, WithScopeAttributes(attrs))
 	if err != nil {
@@ -632,6 +684,10 @@ func TestPushScopeWithCombinedAttributes(t *testing.T) {
 }
 
 func TestScopeWithDataAndMetadata(t *testing.T) {
+	runTestWithScopeStack(t, testScopeWithDataAndMetadata)
+}
+
+func testScopeWithDataAndMetadata(t *testing.T) {
 	handle, err := PushScope("data_scope", ScopeTypeAgent,
 		WithData(json.RawMessage(`{"user_id": "u123"}`)),
 		WithMetadata(json.RawMessage(`{"trace_id": "t456"}`)),
@@ -663,6 +719,10 @@ func TestScopeWithDataAndMetadata(t *testing.T) {
 }
 
 func TestPopScopeWithEndMetadataMergesWithScopeMetadata(t *testing.T) {
+	runTestWithScopeStack(t, testPopScopeWithEndMetadataMergesWithScopeMetadata)
+}
+
+func testPopScopeWithEndMetadataMergesWithScopeMetadata(t *testing.T) {
 	var capturedMeta json.RawMessage
 	var mu sync.Mutex
 
@@ -748,6 +808,10 @@ func TestConcurrentScopePushPop(t *testing.T) {
 }
 
 func TestSubscriberReceivesAllEventFields(t *testing.T) {
+	runTestWithScopeStack(t, testSubscriberReceivesAllEventFields)
+}
+
+func testSubscriberReceivesAllEventFields(t *testing.T) {
 	type eventData struct {
 		uuid       string
 		name       string

--- a/go/nemo_relay/subscribers/subscribers_test.go
+++ b/go/nemo_relay/subscribers/subscribers_test.go
@@ -55,29 +55,37 @@ func TestSubscriberShorthands(t *testing.T) {
 	var seenStart bool
 	var mu sync.Mutex
 
-	if err := subscriberspkg.Register("subs_global", func(event nemo_relay.Event) {
-		if event.Kind() == "scope" && event.ScopeCategory() == "start" {
-			mu.Lock()
-			seenStart = true
-			mu.Unlock()
-		}
-	}); err != nil {
-		t.Fatalf("Register failed: %v", err)
-	}
-
-	handle, err := nemo_relay.PushScope("subs_scope", nemo_relay.ScopeTypeAgent)
+	stack, err := nemo_relay.NewScopeStack()
 	if err != nil {
-		t.Fatalf("PushScope failed: %v", err)
+		t.Fatalf("NewScopeStack failed: %v", err)
 	}
-	if err := nemo_relay.PopScope(handle); err != nil {
-		t.Fatalf("PopScope failed: %v", err)
-	}
-	if err := subscriberspkg.Deregister("subs_global"); err != nil {
-		t.Fatalf("Deregister failed: %v", err)
-	}
-	if err := subscriberspkg.Flush(); err != nil {
-		t.Fatalf("Flush failed: %v", err)
-	}
+	defer stack.Close()
+
+	stack.Run(func() {
+		if err := subscriberspkg.Register("subs_global", func(event nemo_relay.Event) {
+			if event.Kind() == "scope" && event.ScopeCategory() == "start" {
+				mu.Lock()
+				seenStart = true
+				mu.Unlock()
+			}
+		}); err != nil {
+			t.Fatalf("Register failed: %v", err)
+		}
+
+		handle, err := nemo_relay.PushScope("subs_scope", nemo_relay.ScopeTypeAgent)
+		if err != nil {
+			t.Fatalf("PushScope failed: %v", err)
+		}
+		if err := nemo_relay.PopScope(handle); err != nil {
+			t.Fatalf("PopScope failed: %v", err)
+		}
+		if err := subscriberspkg.Deregister("subs_global"); err != nil {
+			t.Fatalf("Deregister failed: %v", err)
+		}
+		if err := subscriberspkg.Flush(); err != nil {
+			t.Fatalf("Flush failed: %v", err)
+		}
+	})
 
 	mu.Lock()
 	assertSeenStart(t, seenStart)

--- a/go/nemo_relay/test_helpers_test.go
+++ b/go/nemo_relay/test_helpers_test.go
@@ -16,3 +16,8 @@ func runWithTestScopeStack(t *testing.T, fn func()) {
 
 	stack.Run(fn)
 }
+
+func runTestWithScopeStack(t *testing.T, fn func(*testing.T)) {
+	t.Helper()
+	runWithTestScopeStack(t, func() { fn(t) })
+}

--- a/go/nemo_relay/timestamp_test.go
+++ b/go/nemo_relay/timestamp_test.go
@@ -17,6 +17,10 @@ type capturedTimestampEvent struct {
 }
 
 func TestManualLifecycleTimestamps(t *testing.T) {
+	runTestWithScopeStack(t, testManualLifecycleTimestamps)
+}
+
+func testManualLifecycleTimestamps(t *testing.T) {
 	var (
 		events []capturedTimestampEvent
 		mu     sync.Mutex

--- a/go/nemo_relay/tools_test.go
+++ b/go/nemo_relay/tools_test.go
@@ -70,6 +70,10 @@ func TestToolCallWithDataMetadata(t *testing.T) {
 }
 
 func TestToolCallWithParent(t *testing.T) {
+	runTestWithScopeStack(t, testToolCallWithParent)
+}
+
+func testToolCallWithParent(t *testing.T) {
 	parent, _ := PushScope("tool_parent", ScopeTypeAgent)
 	defer PopScope(parent)
 

--- a/go/nemo_relay/top_level_coverage_test.go
+++ b/go/nemo_relay/top_level_coverage_test.go
@@ -31,7 +31,9 @@ func (p coveragePlugin) Register(pluginConfig map[string]any, ctx *PluginContext
 }
 
 func TestTopLevelNemoRelayCoverage(t *testing.T) {
-	assertScopeInputOutputCoverage(t)
+	runWithTestScopeStack(t, func() {
+		assertScopeInputOutputCoverage(t)
+	})
 	assertLlmStreamExecutionCoverage(t)
 	assertCheckedValueFailureCoverage(t)
 	assertCheckedJSONStringFailureCoverage(t)

--- a/go/nemo_relay/wrapper_coverage_test.go
+++ b/go/nemo_relay/wrapper_coverage_test.go
@@ -192,6 +192,10 @@ func TestNewLLMRequestRoundTrip(t *testing.T) {
 }
 
 func TestWrapperHelpersCoverNilAndErrorPaths(t *testing.T) {
+	runTestWithScopeStack(t, testWrapperHelpersCoverNilAndErrorPaths)
+}
+
+func testWrapperHelpersCoverNilAndErrorPaths(t *testing.T) {
 	if got := goString(nil); got != "" {
 		t.Fatalf("expected empty string for nil goString, got %q", got)
 	}


### PR DESCRIPTION
#### Overview

Stabilize Go binding tests that depend on Rust thread-local scope state or FFI last-error state.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Run all multi-call scope lifecycle tests through explicit ScopeStack.Run bindings, including scope shorthand, timestamps, sanitizer, parent-scope, plugin, and coverage cases.
- Make the lastError fallback assertion deterministic by running it after the scope-stack helper establishes and clears the FFI thread-local error state.
- Retain the original subscriber shorthand scope-lifecycle fix.

#### Where should the reviewer start?

Start with go/nemo_relay/test_helpers_test.go and go/nemo_relay/scope_test.go. The shared helper and the core lifecycle tests establish the pattern applied to the remaining test surfaces.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

#### Validation

- GOMAXPROCS=4 go test -race -shuffle=on -count=10 . ./scope (from go/nemo_relay, with the release FFI library path)
- just test-go
- just ci=true test-go
- uv run pre-commit run --files <changed Go test files>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored multiple test cases to execute within an explicit scope lifecycle using shared helpers (`runTestWithScopeStack` / `runWithTestScopeStack`).
  * Kept existing assertions intact, including coverage, wrapper/codec finalizer checks, plugin lifecycle validation, timestamp behavior, event sanitizer inheritance/cleanup, and global scope-start handling.
  * Updated several exported tests to be thin wrappers that delegate the core logic to unexported helper functions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->