### PR TITLE
fix(plugin): layer discovered config for dynamic hosts

### DIFF
--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -1451,10 +1451,18 @@ async fn initialize_plugin_components_catching_panics(
 /// default `version`/`policy`/`enabled` override the file, while `config` bodies
 /// merge field-by-field. Delegates to [`initialize_plugins_exact`].
 pub async fn initialize_plugins(config: PluginConfig) -> Result<ConfigReport> {
+    let config = resolve_plugin_config(config)?;
+    initialize_plugins_exact(config).await
+}
+
+/// Layers `config` over the default discovered `plugins.toml` files.
+///
+/// This is crate-visible so owned dynamic-plugin activation can use the same
+/// one-time configuration resolution as regular harness-native initialization.
+pub(crate) fn resolve_plugin_config(config: PluginConfig) -> Result<PluginConfig> {
     let mut base = resolve_default_file_plugin_config()?;
     layer_config(&mut base, serde_json::to_value(config)?);
-    let config: PluginConfig = serde_json::from_value(base)?;
-    initialize_plugins_exact(config).await
+    Ok(serde_json::from_value(base)?)
 }
 
 /// Resolves the default `plugins.toml` layering into one JSON document, or an

--- a/crates/core/src/plugin/dynamic/host.rs
+++ b/crates/core/src/plugin/dynamic/host.rs
@@ -18,7 +18,7 @@ use serde_json::{Map, Value as Json};
 use crate::plugin::{
     ConfigReport, PluginComponentSpec, PluginConfig, PluginHostLease, Result,
     acquire_plugin_host_lease, clear_plugin_configuration_for_host,
-    ensure_builtin_plugins_registered, initialize_plugins_exact_for_host,
+    ensure_builtin_plugins_registered, initialize_plugins_exact_for_host, resolve_plugin_config,
     run_owned_plugin_mutation,
 };
 
@@ -79,6 +79,32 @@ impl PluginHostActivation {
     {
         let dynamic_plugins = dynamic_plugins.into_iter().collect::<Vec<_>>();
         validate_dynamic_plugin_specs(&dynamic_plugins)?;
+        Self::activate_validated(config, dynamic_plugins).await
+    }
+
+    /// Load dynamic plugins after layering `config` over discovered `plugins.toml` files.
+    ///
+    /// This is the harness-native entrypoint for language and FFI bindings. File
+    /// discovery and merging happen once before activation, and the explicit
+    /// `config` has higher precedence. Hosts such as the Relay CLI that already
+    /// resolved plugin configuration should call [`Self::activate`] instead.
+    pub async fn activate_with_discovered_config<I>(
+        config: PluginConfig,
+        dynamic_plugins: I,
+    ) -> Result<(Self, ConfigReport)>
+    where
+        I: IntoIterator<Item = DynamicPluginActivationSpec>,
+    {
+        let dynamic_plugins = dynamic_plugins.into_iter().collect::<Vec<_>>();
+        validate_dynamic_plugin_specs(&dynamic_plugins)?;
+        let config = resolve_plugin_config(config)?;
+        Self::activate_validated(config, dynamic_plugins).await
+    }
+
+    async fn activate_validated(
+        config: PluginConfig,
+        dynamic_plugins: Vec<DynamicPluginActivationSpec>,
+    ) -> Result<(Self, ConfigReport)> {
         run_owned_plugin_mutation("dynamic plugin activation", move || async move {
             Self::activate_inner(config, dynamic_plugins).await
         })

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -3,6 +3,7 @@
 
 //! Integration coverage for SDK-built native dynamic plugins.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -41,6 +42,39 @@ use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 static NATIVE_PLUGIN_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct PluginDiscoveryTestEnv {
+    previous_cwd: PathBuf,
+    previous_xdg_config_home: Option<OsString>,
+}
+
+impl PluginDiscoveryTestEnv {
+    fn enter(cwd: &Path, xdg_config_home: &Path) -> Self {
+        let guard = Self {
+            previous_cwd: std::env::current_dir().expect("current directory should resolve"),
+            previous_xdg_config_home: std::env::var_os("XDG_CONFIG_HOME"),
+        };
+        std::env::set_current_dir(cwd).expect("test current directory should be set");
+        // SAFETY: native plugin integration tests serialize environment changes
+        // with NATIVE_PLUGIN_TEST_LOCK and this guard restores the prior value.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", xdg_config_home) };
+        guard
+    }
+}
+
+impl Drop for PluginDiscoveryTestEnv {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.previous_cwd);
+        // SAFETY: see PluginDiscoveryTestEnv::enter. The same serialized scope
+        // restores the process environment before releasing the test lock.
+        unsafe {
+            match &self.previous_xdg_config_home {
+                Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+}
 
 struct ReplacementRegistryPlugin;
 
@@ -1181,6 +1215,49 @@ async fn plugin_host_activation_combines_static_base_and_dynamic_components() {
     assert_eq!(STATIC_BASE_DEREGISTRATIONS.load(Ordering::SeqCst), 1);
     assert!(lookup_plugin(STATIC_BASE_PLUGIN_KIND).is_some());
     assert!(lookup_plugin("fixture_native").is_none());
+    assert!(deregister_plugin(STATIC_BASE_PLUGIN_KIND));
+}
+
+#[tokio::test]
+async fn plugin_host_activation_layers_discovered_static_base_with_dynamic_components() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let _ = deregister_plugin(STATIC_BASE_PLUGIN_KIND);
+    STATIC_BASE_REGISTRATIONS.store(0, Ordering::SeqCst);
+    STATIC_BASE_DEREGISTRATIONS.store(0, Ordering::SeqCst);
+    register_plugin(Arc::new(StaticBasePlugin)).expect("static base plugin should register");
+
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let environment = TempDir::new().expect("plugin discovery environment should be created");
+    let project_config_dir = environment.path().join(".nemo-relay");
+    std::fs::create_dir_all(&project_config_dir)
+        .expect("project plugin config directory should be created");
+    std::fs::write(
+        project_config_dir.join("plugins.toml"),
+        format!(
+            "version = 1\n\n[[components]]\nkind = {STATIC_BASE_PLUGIN_KIND:?}\nenabled = true\n"
+        ),
+    )
+    .expect("project plugin config should be written");
+    let xdg_config_home = environment.path().join("xdg");
+    std::fs::create_dir_all(&xdg_config_home)
+        .expect("isolated user config directory should be created");
+    let _environment = PluginDiscoveryTestEnv::enter(environment.path(), &xdg_config_home);
+
+    let (activation, report) = PluginHostActivation::activate_with_discovered_config(
+        PluginConfig::default(),
+        [host_spec("fixture_native", &manifest_ref)],
+    )
+    .await
+    .expect("discovered static and dynamic components should activate together");
+
+    assert!(!report.has_errors());
+    assert_eq!(STATIC_BASE_REGISTRATIONS.load(Ordering::SeqCst), 1);
+    assert!(lookup_plugin(STATIC_BASE_PLUGIN_KIND).is_some());
+    assert!(lookup_plugin("fixture_native").is_some());
+
+    activation.clear().expect("discovered host should clear");
+    assert_eq!(STATIC_BASE_DEREGISTRATIONS.load(Ordering::SeqCst), 1);
     assert!(deregister_plugin(STATIC_BASE_PLUGIN_KIND));
 }
 

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -1258,6 +1258,7 @@ async fn plugin_host_activation_layers_discovered_static_base_with_dynamic_compo
 
     activation.clear().expect("discovered host should clear");
     assert_eq!(STATIC_BASE_DEREGISTRATIONS.load(Ordering::SeqCst), 1);
+    assert!(lookup_plugin("fixture_native").is_none());
     assert!(deregister_plugin(STATIC_BASE_PLUGIN_KIND));
 }
 

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -3,7 +3,6 @@
 
 //! Integration coverage for SDK-built native dynamic plugins.
 
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -42,39 +41,7 @@ use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 static NATIVE_PLUGIN_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-struct PluginDiscoveryTestEnv {
-    previous_cwd: PathBuf,
-    previous_xdg_config_home: Option<OsString>,
-}
-
-impl PluginDiscoveryTestEnv {
-    fn enter(cwd: &Path, xdg_config_home: &Path) -> Self {
-        let guard = Self {
-            previous_cwd: std::env::current_dir().expect("current directory should resolve"),
-            previous_xdg_config_home: std::env::var_os("XDG_CONFIG_HOME"),
-        };
-        std::env::set_current_dir(cwd).expect("test current directory should be set");
-        // SAFETY: native plugin integration tests serialize environment changes
-        // with NATIVE_PLUGIN_TEST_LOCK and this guard restores the prior value.
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", xdg_config_home) };
-        guard
-    }
-}
-
-impl Drop for PluginDiscoveryTestEnv {
-    fn drop(&mut self) {
-        let _ = std::env::set_current_dir(&self.previous_cwd);
-        // SAFETY: see PluginDiscoveryTestEnv::enter. The same serialized scope
-        // restores the process environment before releasing the test lock.
-        unsafe {
-            match &self.previous_xdg_config_home {
-                Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
-                None => std::env::remove_var("XDG_CONFIG_HOME"),
-            }
-        }
-    }
-}
+const PLUGIN_DISCOVERY_TEST_CHILD: &str = "NEMO_RELAY_PLUGIN_DISCOVERY_TEST_CHILD";
 
 struct ReplacementRegistryPlugin;
 
@@ -1220,6 +1187,42 @@ async fn plugin_host_activation_combines_static_base_and_dynamic_components() {
 
 #[tokio::test]
 async fn plugin_host_activation_layers_discovered_static_base_with_dynamic_components() {
+    if std::env::var_os(PLUGIN_DISCOVERY_TEST_CHILD).is_none() {
+        let environment = TempDir::new().expect("plugin discovery environment should be created");
+        let project_config_dir = environment.path().join(".nemo-relay");
+        std::fs::create_dir_all(&project_config_dir)
+            .expect("project plugin config directory should be created");
+        std::fs::write(
+            project_config_dir.join("plugins.toml"),
+            format!(
+                "version = 1\n\n[[components]]\nkind = {STATIC_BASE_PLUGIN_KIND:?}\nenabled = true\n"
+            ),
+        )
+        .expect("project plugin config should be written");
+        let xdg_config_home = environment.path().join("xdg");
+        std::fs::create_dir_all(&xdg_config_home)
+            .expect("isolated user config directory should be created");
+
+        let output = Command::new(std::env::current_exe().expect("test executable should resolve"))
+            .args([
+                "--exact",
+                "plugin_host_activation_layers_discovered_static_base_with_dynamic_components",
+                "--nocapture",
+            ])
+            .current_dir(environment.path())
+            .env("XDG_CONFIG_HOME", &xdg_config_home)
+            .env(PLUGIN_DISCOVERY_TEST_CHILD, "1")
+            .output()
+            .expect("plugin discovery child process should run");
+        assert!(
+            output.status.success(),
+            "plugin discovery child process failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
+
     let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
     let _ = deregister_plugin(STATIC_BASE_PLUGIN_KIND);
     STATIC_BASE_REGISTRATIONS.store(0, Ordering::SeqCst);
@@ -1228,22 +1231,6 @@ async fn plugin_host_activation_layers_discovered_static_base_with_dynamic_compo
 
     let fixture = build_fixture_plugin();
     let manifest_ref = write_manifest(&fixture);
-    let environment = TempDir::new().expect("plugin discovery environment should be created");
-    let project_config_dir = environment.path().join(".nemo-relay");
-    std::fs::create_dir_all(&project_config_dir)
-        .expect("project plugin config directory should be created");
-    std::fs::write(
-        project_config_dir.join("plugins.toml"),
-        format!(
-            "version = 1\n\n[[components]]\nkind = {STATIC_BASE_PLUGIN_KIND:?}\nenabled = true\n"
-        ),
-    )
-    .expect("project plugin config should be written");
-    let xdg_config_home = environment.path().join("xdg");
-    std::fs::create_dir_all(&xdg_config_home)
-        .expect("isolated user config directory should be created");
-    let _environment = PluginDiscoveryTestEnv::enter(environment.path(), &xdg_config_home);
-
     let (activation, report) = PluginHostActivation::activate_with_discovered_config(
         PluginConfig::default(),
         [host_spec("fixture_native", &manifest_ref)],

--- a/go/nemo_relay/scope/error_coverage_test.go
+++ b/go/nemo_relay/scope/error_coverage_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestWithScopeCleanupNoopsWhenPushFails(t *testing.T) {
+	runWithTestScopeStack(t, testWithScopeCleanupNoopsWhenPushFails)
+}
+
+func testWithScopeCleanupNoopsWhenPushFails(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opt  nemo_relay.ScopeOption


### PR DESCRIPTION
## Overview

Adds a shared harness-native activation path that layers explicit plugin configuration over the default discovered plugins.toml files before loading dynamic plugins. The existing exact activation path remains available for hosts such as the Relay CLI that already resolved their configuration.

## Details

- Reuse the same one-time config resolution used by static initialization.
- Add PluginHostActivation::activate_with_discovered_config for language and FFI bindings.
- Keep PluginHostActivation::activate exact and free of implicit discovery.
- Validate that a file-configured static component and a dynamic component activate in one owned transaction.

## Validation

- cargo test -p nemo-relay --test native_plugin_integration (28 passed)
- cargo clippy -p nemo-relay --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Related Issues

Relates to #365, #366, and #368.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plugin activation entrypoint that layers discovered `plugins.toml` configuration with dynamically provided plugin components.
* **Refactor**
  * Improved configuration resolution by centralizing how default/discovered configuration is merged with provided settings before activation.
* **Bug Fixes**
  * Ensured activation cleanup correctly deregisters the discovered static-base plugin kind after clearing, without impacting dynamic registrations.
* **Tests**
  * Added an end-to-end integration test covering combined discovered + dynamic activation and verifying post-clear deregistration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->