### PR TITLE
chore: track switchyard version updates

### DIFF
--- a/justfile
+++ b/justfile
@@ -468,6 +468,7 @@ local_dependencies = (
     "nemo-relay-plugin",
     "nemo-relay-adaptive",
     "nemo-relay-pii-redaction",
+    "nemo-relay-switchyard",
     "nemo-relay-ffi",
     "nemo-relay-cli",
 )


### PR DESCRIPTION
#### Overview

Track `nemo-relay-switchyard` in the Justfile release version-update validation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Include `nemo-relay-switchyard` in the Justfile Cargo version-update validation.
- Keep the source-only crate out of the package and crates.io publish lists.

#### To-Be-Resolved Problem not addressed in this PR

> is it possible to still publish nemo-relay-cli if we do not publish nemo-relay-switchyard ?

No—not with the current manifest. `nemo-relay-cli` has an optional `nemo-relay-switchyard` dependency. Cargo still resolves it while packaging the CLI, and the package check fails because nemo-relay-switchyard is absent from crates.io. To publish the CLI without publishing Switchyard, we’d need to remove or restructure that optional dependency/feature from the published CLI package.

#### Where should the reviewer start?

Review the Cargo dependency list in `justfile`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace versioning checks to include an additional local component.
  * Ensured its declared version stays aligned with the target workspace version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->