### PR TITLE
test(go): resolve Sonar findings

### DIFF
--- a/go/nemo_relay/adaptive_plugin_test.go
+++ b/go/nemo_relay/adaptive_plugin_test.go
@@ -320,7 +320,18 @@ func testTopLevelPluginValidationAndLifecycle(t *testing.T) {
 		_ = DeregisterPlugin(pluginKind)
 		_ = DeregisterPlugin(streamPluginKind)
 	}()
+	validateLifecyclePluginConfig(t, pluginKind)
+	initializeLifecyclePlugins(t, pluginKind, streamPluginKind, &registerCalls)
+	assertToolPluginPayload(t, pluginKind)
+	assertLlmPluginPayload(t, pluginKind)
+	assertGuardrailError(t, ToolConditionalExecution("blocked-tool", json.RawMessage(`{}`)), "guardrail rejected: blocked tool")
+	assertGuardrailError(t, LlmConditionalExecution(json.RawMessage(`{"headers":{"blocked":true},"content":{"messages":[]}}`)), "guardrail rejected: blocked llm")
+	assertStreamPluginPayload(t, streamPluginKind)
+	exercisePluginEventSanitizers(t)
+}
 
+func validateLifecyclePluginConfig(t *testing.T, pluginKind string) {
+	t.Helper()
 	report, err := ValidatePluginConfig(PluginConfig{
 		Version: 1,
 		Components: []PluginComponentSpec{
@@ -340,7 +351,10 @@ func testTopLevelPluginValidationAndLifecycle(t *testing.T) {
 	if report.Diagnostics[0].Code != "plugin.go_validate" {
 		t.Fatalf("unexpected diagnostic code: %#v", report.Diagnostics)
 	}
+}
 
+func initializeLifecyclePlugins(t *testing.T, pluginKind, streamPluginKind string, registerCalls *int) {
+	t.Helper()
 	config := NewAdaptiveConfig()
 	config.AdaptiveHints = &AdaptiveHintsConfig{
 		Priority:       100,
@@ -348,7 +362,7 @@ func testTopLevelPluginValidationAndLifecycle(t *testing.T) {
 		InjectBodyPath: "nvext.agent_hints",
 	}
 
-	_, err = InitializePlugins(PluginConfig{
+	_, err := InitializePlugins(PluginConfig{
 		Version: 1,
 		Components: []PluginComponentSpec{
 			AdaptiveComponent(config),
@@ -366,16 +380,13 @@ func testTopLevelPluginValidationAndLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitializePlugins failed: %v", err)
 	}
-	if registerCalls != 1 {
-		t.Fatalf("expected plugin register to be called once, got %d", registerCalls)
+	if *registerCalls != 1 {
+		t.Fatalf("expected plugin register to be called once, got %d", *registerCalls)
 	}
+}
 
-	assertToolPluginPayload(t, pluginKind)
-	assertLlmPluginPayload(t, pluginKind)
-	assertGuardrailError(t, ToolConditionalExecution("blocked-tool", json.RawMessage(`{}`)), "guardrail rejected: blocked tool")
-	assertGuardrailError(t, LlmConditionalExecution(json.RawMessage(`{"headers":{"blocked":true},"content":{"messages":[]}}`)), "guardrail rejected: blocked llm")
-	assertStreamPluginPayload(t, streamPluginKind)
-
+func exercisePluginEventSanitizers(t *testing.T) {
+	t.Helper()
 	var mu sync.Mutex
 	var pluginEvents []Event
 	if err := RegisterSubscriber("go-plugin-event-sanitize-test", func(event Event) {
@@ -407,6 +418,11 @@ func testTopLevelPluginValidationAndLifecycle(t *testing.T) {
 	}
 	mu.Lock()
 	defer mu.Unlock()
+	assertPluginSanitizerEvents(t, pluginEvents)
+}
+
+func assertPluginSanitizerEvents(t *testing.T, pluginEvents []Event) {
+	t.Helper()
 	var phases []string
 	for _, event := range pluginEvents {
 		switch event.Name() {

--- a/go/nemo_relay/coverage_gap_test.go
+++ b/go/nemo_relay/coverage_gap_test.go
@@ -65,6 +65,17 @@ func TestPublicAPIErrorAndDefaultCoverage(t *testing.T) {
 }
 
 func testPublicAPIErrorAndDefaultCoverage(t *testing.T) {
+	assertInvalidScopePayloads(t)
+	assertInvalidCallPayloads(t)
+	assertClosedExporterFails(t)
+	assertZeroSubscriberConfigs(t)
+	if got := mustConfigMap(nil); len(got) != 0 {
+		t.Fatalf("expected empty map for nil config payload, got %#v", got)
+	}
+}
+
+func assertInvalidScopePayloads(t *testing.T) {
+	t.Helper()
 	for _, tc := range []struct {
 		name string
 		opt  ScopeOption
@@ -88,7 +99,10 @@ func testPublicAPIErrorAndDefaultCoverage(t *testing.T) {
 	if err := PopScope(handle); err != nil {
 		t.Fatalf("cleanup PopScope failed: %v", err)
 	}
+}
 
+func assertInvalidCallPayloads(t *testing.T) {
+	t.Helper()
 	if _, err := ToolCall("invalid_tool_json", json.RawMessage("{")); err == nil {
 		t.Fatal("expected ToolCall to fail on invalid JSON args")
 	}
@@ -129,7 +143,10 @@ func testPublicAPIErrorAndDefaultCoverage(t *testing.T) {
 	if _, err := LlmRequestIntercepts("invalid_llm_request_intercepts", json.RawMessage("{")); err == nil {
 		t.Fatal("expected LlmRequestIntercepts to fail on invalid JSON")
 	}
+}
 
+func assertClosedExporterFails(t *testing.T) {
+	t.Helper()
 	exporter, err := NewAtifExporter("session-gap", "agent-gap", "1.0.0", "")
 	if err != nil {
 		t.Fatalf("NewAtifExporter failed: %v", err)
@@ -138,7 +155,10 @@ func testPublicAPIErrorAndDefaultCoverage(t *testing.T) {
 	if _, err := exporter.ExportJSON(); err == nil {
 		t.Fatal("expected ExportJSON to fail after Close")
 	}
+}
 
+func assertZeroSubscriberConfigs(t *testing.T) {
+	t.Helper()
 	otel, err := NewOpenTelemetrySubscriber(OpenTelemetryConfig{})
 	if err != nil {
 		t.Fatalf("NewOpenTelemetrySubscriber with zero config failed: %v", err)
@@ -150,10 +170,6 @@ func testPublicAPIErrorAndDefaultCoverage(t *testing.T) {
 		t.Fatalf("NewOpenInferenceSubscriber with zero config failed: %v", err)
 	}
 	openInference.Close()
-
-	if got := mustConfigMap(nil); len(got) != 0 {
-		t.Fatalf("expected empty map for nil config payload, got %#v", got)
-	}
 }
 
 func TestWrapperAndCodecFinalizersRun(t *testing.T) {

--- a/go/nemo_relay/event_sanitizers_test.go
+++ b/go/nemo_relay/event_sanitizers_test.go
@@ -9,6 +9,18 @@ import (
 	"testing"
 )
 
+const (
+	duplicateEventSanitizer = "go-event-duplicate"
+	duplicateToolSanitizer  = "go-tool-duplicate"
+	invalidScopeUUID        = "not-a-uuid"
+)
+
+func registeredClosureCount() int {
+	closureRegistryMu.Lock()
+	defer closureRegistryMu.Unlock()
+	return len(closureRegistry)
+}
+
 func TestEventSanitizerRegistries(t *testing.T) {
 	runTestWithScopeStack(t, testEventSanitizerRegistries)
 }
@@ -16,15 +28,26 @@ func TestEventSanitizerRegistries(t *testing.T) {
 func testEventSanitizerRegistries(t *testing.T) {
 	var mu sync.Mutex
 	var events []Event
+	registerEventSanitizerSubscriber(t, &mu, &events)
+	registerEventSanitizerGuardrails(t)
+	emitSanitizerTestEvents(t)
+	assertSanitizedTestEvents(t, &mu, events)
+}
+
+func registerEventSanitizerSubscriber(t *testing.T, mu *sync.Mutex, events *[]Event) {
+	t.Helper()
 	if err := RegisterSubscriber("go-event-sanitize-sub", func(event Event) {
 		mu.Lock()
-		events = append(events, event)
+		*events = append(*events, event)
 		mu.Unlock()
 	}); err != nil {
 		t.Fatal(err)
 	}
-	defer DeregisterSubscriber("go-event-sanitize-sub")
+	t.Cleanup(func() { _ = DeregisterSubscriber("go-event-sanitize-sub") })
+}
 
+func registerEventSanitizerGuardrails(t *testing.T) {
+	t.Helper()
 	if err := RegisterMarkSanitizeGuardrail("go-mark-sanitize", 0, func(event Event, fields EventSanitizeFields) EventSanitizeFields {
 		if event.Name() != "checkpoint" {
 			t.Fatalf("unexpected event context: %s", event.Name())
@@ -36,21 +59,25 @@ func testEventSanitizerRegistries(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	defer DeregisterMarkSanitizeGuardrail("go-mark-sanitize")
+	t.Cleanup(func() { _ = DeregisterMarkSanitizeGuardrail("go-mark-sanitize") })
 	if err := RegisterScopeSanitizeStartGuardrail("go-scope-start", 0, func(_ Event, fields EventSanitizeFields) EventSanitizeFields {
 		fields.Metadata = json.RawMessage(`{"phase":"start"}`)
 		return fields
 	}); err != nil {
 		t.Fatal(err)
 	}
-	defer DeregisterScopeSanitizeStartGuardrail("go-scope-start")
+	t.Cleanup(func() { _ = DeregisterScopeSanitizeStartGuardrail("go-scope-start") })
 	if err := RegisterScopeSanitizeEndGuardrail("go-scope-end", 0, func(_ Event, fields EventSanitizeFields) EventSanitizeFields {
 		fields.Metadata = json.RawMessage(`{"phase":"end"}`)
 		return fields
 	}); err != nil {
 		t.Fatal(err)
 	}
-	defer DeregisterScopeSanitizeEndGuardrail("go-scope-end")
+	t.Cleanup(func() { _ = DeregisterScopeSanitizeEndGuardrail("go-scope-end") })
+}
+
+func emitSanitizerTestEvents(t *testing.T) {
+	t.Helper()
 	handle, err := PushScope("generic", ScopeTypeCustom)
 	if err != nil {
 		t.Fatal(err)
@@ -65,6 +92,10 @@ func testEventSanitizerRegistries(t *testing.T) {
 	if err := FlushSubscribers(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func assertSanitizedTestEvents(t *testing.T, mu *sync.Mutex, events []Event) {
+	t.Helper()
 	mu.Lock()
 	mark := events[len(events)-1]
 	mu.Unlock()
@@ -152,61 +183,50 @@ func testScopeLocalEventSanitizerInheritanceAndCleanup(t *testing.T) {
 }
 
 func TestEventSanitizerRegistrationErrorsReleaseCallbacks(t *testing.T) {
-	closureRegistryMu.Lock()
-	baseline := len(closureRegistry)
-	closureRegistryMu.Unlock()
+	baseline := registeredClosureCount()
 	passThrough := func(_ Event, fields EventSanitizeFields) EventSanitizeFields { return fields }
 
-	if err := RegisterMarkSanitizeGuardrail("go-event-duplicate", 0, passThrough); err != nil {
+	if err := RegisterMarkSanitizeGuardrail(duplicateEventSanitizer, 0, passThrough); err != nil {
 		t.Fatal(err)
 	}
-	if err := RegisterMarkSanitizeGuardrail("go-event-duplicate", 0, passThrough); err == nil {
+	if err := RegisterMarkSanitizeGuardrail(duplicateEventSanitizer, 0, passThrough); err == nil {
 		t.Fatal("expected duplicate event sanitizer registration to fail")
 	}
-	closureRegistryMu.Lock()
-	afterDuplicate := len(closureRegistry)
-	closureRegistryMu.Unlock()
-	if afterDuplicate != baseline+1 {
+	if afterDuplicate := registeredClosureCount(); afterDuplicate != baseline+1 {
 		t.Fatalf("duplicate registration leaked callback: baseline=%d current=%d", baseline, afterDuplicate)
 	}
-	if err := DeregisterMarkSanitizeGuardrail("go-event-duplicate"); err != nil {
+	if err := DeregisterMarkSanitizeGuardrail(duplicateEventSanitizer); err != nil {
 		t.Fatal(err)
 	}
-	if err := RegisterToolSanitizeRequestGuardrail("go-tool-duplicate", 0, func(_ string, args json.RawMessage) json.RawMessage { return args }); err != nil {
+	if err := RegisterToolSanitizeRequestGuardrail(duplicateToolSanitizer, 0, func(_ string, args json.RawMessage) json.RawMessage { return args }); err != nil {
 		t.Fatal(err)
 	}
-	if err := RegisterToolSanitizeRequestGuardrail("go-tool-duplicate", 0, func(_ string, args json.RawMessage) json.RawMessage { return args }); err == nil {
+	if err := RegisterToolSanitizeRequestGuardrail(duplicateToolSanitizer, 0, func(_ string, args json.RawMessage) json.RawMessage { return args }); err == nil {
 		t.Fatal("expected duplicate tool sanitizer registration to fail")
 	}
-	closureRegistryMu.Lock()
-	afterToolDuplicate := len(closureRegistry)
-	closureRegistryMu.Unlock()
-	if afterToolDuplicate != baseline+1 {
+	if afterToolDuplicate := registeredClosureCount(); afterToolDuplicate != baseline+1 {
 		t.Fatalf("duplicate tool registration leaked callback: baseline=%d current=%d", baseline, afterToolDuplicate)
 	}
-	if err := DeregisterToolSanitizeRequestGuardrail("go-tool-duplicate"); err != nil {
+	if err := DeregisterToolSanitizeRequestGuardrail(duplicateToolSanitizer); err != nil {
 		t.Fatal(err)
 	}
 
 	for name, register := range map[string]func() error{
 		"mark": func() error {
-			return ScopeRegisterMarkSanitizeGuardrail("not-a-uuid", "go-invalid-mark", 0, passThrough)
+			return ScopeRegisterMarkSanitizeGuardrail(invalidScopeUUID, "go-invalid-mark", 0, passThrough)
 		},
 		"scope start": func() error {
-			return ScopeRegisterScopeSanitizeStartGuardrail("not-a-uuid", "go-invalid-start", 0, passThrough)
+			return ScopeRegisterScopeSanitizeStartGuardrail(invalidScopeUUID, "go-invalid-start", 0, passThrough)
 		},
 		"scope end": func() error {
-			return ScopeRegisterScopeSanitizeEndGuardrail("not-a-uuid", "go-invalid-end", 0, passThrough)
+			return ScopeRegisterScopeSanitizeEndGuardrail(invalidScopeUUID, "go-invalid-end", 0, passThrough)
 		},
 	} {
 		if err := register(); err == nil {
 			t.Fatalf("expected invalid UUID for %s registration", name)
 		}
 	}
-	closureRegistryMu.Lock()
-	afterErrors := len(closureRegistry)
-	closureRegistryMu.Unlock()
-	if afterErrors != baseline {
+	if afterErrors := registeredClosureCount(); afterErrors != baseline {
 		t.Fatalf("failed registration leaked callbacks: baseline=%d current=%d", baseline, afterErrors)
 	}
 }

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -1707,7 +1707,9 @@ type AtofFileSinkConfig struct {
 	Filename        string           `json:"filename,omitempty"`
 }
 
-func (AtofFileSinkConfig) atofExporterSink() {}
+func (AtofFileSinkConfig) atofExporterSink() {
+	// This marker method intentionally has no runtime behavior.
+}
 
 // MarshalJSON serializes the fixed file sink discriminator.
 func (config AtofFileSinkConfig) MarshalJSON() ([]byte, error) {
@@ -1750,7 +1752,9 @@ type AtofStreamSinkConfig struct {
 	FieldNamePolicy AtofEndpointFieldNamePolicy `json:"field_name_policy,omitempty"`
 }
 
-func (AtofStreamSinkConfig) atofExporterSink() {}
+func (AtofStreamSinkConfig) atofExporterSink() {
+	// This marker method intentionally has no runtime behavior.
+}
 
 // MarshalJSON serializes the fixed stream sink discriminator.
 func (config AtofStreamSinkConfig) MarshalJSON() ([]byte, error) {

--- a/go/nemo_relay/observability_plugin.go
+++ b/go/nemo_relay/observability_plugin.go
@@ -48,7 +48,9 @@ type ObservabilityAtofFileSinkConfig struct {
 	Mode            string `json:"mode,omitempty"`
 }
 
-func (ObservabilityAtofFileSinkConfig) atofSinkConfig() {}
+func (ObservabilityAtofFileSinkConfig) atofSinkConfig() {
+	// This marker method intentionally has no runtime behavior.
+}
 
 // MarshalJSON serializes the fixed file sink discriminator.
 func (config ObservabilityAtofFileSinkConfig) MarshalJSON() ([]byte, error) {
@@ -70,7 +72,9 @@ type ObservabilityAtofStreamSinkConfig struct {
 	Name            string            `json:"name,omitempty"`
 }
 
-func (ObservabilityAtofStreamSinkConfig) atofSinkConfig() {}
+func (ObservabilityAtofStreamSinkConfig) atofSinkConfig() {
+	// This marker method intentionally has no runtime behavior.
+}
 
 // MarshalJSON serializes the fixed stream sink discriminator.
 func (config ObservabilityAtofStreamSinkConfig) MarshalJSON() ([]byte, error) {

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -78,6 +78,11 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 	if wrapped.Kind != ObservabilityPluginKind || !wrapped.Enabled {
 		t.Fatalf("unexpected component wrapper: %#v", wrapped)
 	}
+	assertWrappedObservabilityConfig(t, wrapped)
+}
+
+func assertWrappedObservabilityConfig(t *testing.T, wrapped PluginComponentSpec) {
+	t.Helper()
 	if _, ok := wrapped.Config["atof"].(map[string]any); !ok {
 		t.Fatalf("expected serialized ATOF config object, got %#v", wrapped.Config)
 	}

--- a/go/nemo_relay/openinference_test.go
+++ b/go/nemo_relay/openinference_test.go
@@ -13,6 +13,14 @@ import (
 	"time"
 )
 
+const (
+	openInferenceServiceName      = "go-agent"
+	tenantAttributeAlias          = "tenant.id"
+	newOpenInferenceErrorFmt      = "NewOpenInferenceSubscriber failed: %v"
+	uniqueSubscriberTimeFormat    = "150405.000000"
+	registerOpenInferenceErrorFmt = "Register failed: %v"
+)
+
 type otelRequest struct {
 	Path        string
 	ContentType string
@@ -45,7 +53,7 @@ func TestNewOpenInferenceConfigDefaults(t *testing.T) {
 func TestOpenInferenceSubscriberLifecycle(t *testing.T) {
 	config := NewOpenInferenceConfig()
 	config.Endpoint = "http://localhost:4318/v1/traces"
-	config.ServiceName = "go-agent"
+	config.ServiceName = openInferenceServiceName
 	config.ServiceNamespace = "agents"
 	config.ServiceVersion = "1.0.0"
 	config.InstrumentationScope = "go-tests"
@@ -54,18 +62,18 @@ func TestOpenInferenceSubscriberLifecycle(t *testing.T) {
 	config.ResourceAttributes["deployment.environment"] = "test"
 	config.AttributeMappings = []OtlpAttributeMapping{{
 		Key:   "openinference.metadata.tenant",
-		Alias: "tenant.id",
+		Alias: tenantAttributeAlias,
 	}}
 
 	subscriber, err := NewOpenInferenceSubscriber(config)
 	if err != nil {
-		t.Fatalf("NewOpenInferenceSubscriber failed: %v", err)
+		t.Fatalf(newOpenInferenceErrorFmt, err)
 	}
 	defer subscriber.Close()
 
-	name := "go_openinference_subscriber_" + time.Now().Format("150405.000000")
+	name := "go_openinference_subscriber_" + time.Now().Format(uniqueSubscriberTimeFormat)
 	if err := subscriber.Register(name); err != nil {
-		t.Fatalf("Register failed: %v", err)
+		t.Fatalf(registerOpenInferenceErrorFmt, err)
 	}
 	if err := subscriber.Deregister(name); err != nil {
 		t.Fatalf("Deregister failed: %v", err)
@@ -93,7 +101,7 @@ func TestOpenInferenceSubscriberRejectsInvalidTransport(t *testing.T) {
 
 func TestOpenInferenceSubscriberRejectsInvalidAttributeMapping(t *testing.T) {
 	config := NewOpenInferenceConfig()
-	config.AttributeMappings = []OtlpAttributeMapping{{Key: "", Alias: "tenant.id"}}
+	config.AttributeMappings = []OtlpAttributeMapping{{Key: "", Alias: tenantAttributeAlias}}
 
 	if _, err := NewOpenInferenceSubscriber(config); err == nil {
 		t.Fatal("expected invalid attribute mapping error")
@@ -107,19 +115,19 @@ func TestOpenInferenceSubscriberExportsScopeLifecycleAndMappedAttributes(t *test
 
 	config := NewOpenInferenceConfig()
 	config.Endpoint = server.URL + "/v1/traces"
-	config.ServiceName = "go-agent"
+	config.ServiceName = openInferenceServiceName
 	config.AttributeMappings = []OtlpAttributeMapping{{
 		Key:   "openinference.metadata.tenant",
-		Alias: "tenant.id",
+		Alias: tenantAttributeAlias,
 	}}
 	subscriber, err := NewOpenInferenceSubscriber(config)
 	if err != nil {
-		t.Fatalf("NewOpenInferenceSubscriber failed: %v", err)
+		t.Fatalf(newOpenInferenceErrorFmt, err)
 	}
 	defer subscriber.Close()
-	name := "go_openinference_e2e_" + time.Now().Format("150405.000000")
+	name := "go_openinference_e2e_" + time.Now().Format(uniqueSubscriberTimeFormat)
 	if err := subscriber.Register(name); err != nil {
-		t.Fatalf("Register failed: %v", err)
+		t.Fatalf(registerOpenInferenceErrorFmt, err)
 	}
 	defer func() { _ = subscriber.Deregister(name) }()
 
@@ -147,7 +155,7 @@ func TestOpenInferenceSubscriberExportsScopeLifecycleAndMappedAttributes(t *test
 	select {
 	case request := <-requests:
 		AssertOpenInferenceRequest(t, request)
-		assertOtlpStringAttribute(t, request.Body, "tenant.id", "go")
+		assertOtlpStringAttribute(t, request.Body, tenantAttributeAlias, "go")
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for OTLP request")
 	}
@@ -173,15 +181,15 @@ func NewRegisteredOpenInferenceSubscriber(t *testing.T, endpoint string) *OpenIn
 	t.Helper()
 	config := NewOpenInferenceConfig()
 	config.Endpoint = endpoint
-	config.ServiceName = "go-agent"
+	config.ServiceName = openInferenceServiceName
 
 	subscriber, err := NewOpenInferenceSubscriber(config)
 	if err != nil {
-		t.Fatalf("NewOpenInferenceSubscriber failed: %v", err)
+		t.Fatalf(newOpenInferenceErrorFmt, err)
 	}
-	name := "go_openinference_e2e_" + time.Now().Format("150405.000000")
+	name := "go_openinference_e2e_" + time.Now().Format(uniqueSubscriberTimeFormat)
 	if err := subscriber.Register(name); err != nil {
-		t.Fatalf("Register failed: %v", err)
+		t.Fatalf(registerOpenInferenceErrorFmt, err)
 	}
 	t.Cleanup(func() { _ = subscriber.Deregister(name) })
 	return subscriber

--- a/go/nemo_relay/otel_test.go
+++ b/go/nemo_relay/otel_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 )
 
+const otelTenantAttributeAlias = "tenant.id"
+
 func assertOtlpStringAttribute(t *testing.T, body []byte, key string, value string) {
 	t.Helper()
 	encoded := append([]byte{0x0a}, binary.AppendUvarint(nil, uint64(len(key)))...)
@@ -63,7 +65,7 @@ func TestOpenTelemetrySubscriberLifecycle(t *testing.T) {
 	config.ResourceAttributes["deployment.environment"] = "test"
 	config.AttributeMappings = []OtlpAttributeMapping{{
 		Key:   "nemo_relay.start.data.tenant",
-		Alias: "tenant.id",
+		Alias: otelTenantAttributeAlias,
 	}}
 
 	subscriber, err := NewOpenTelemetrySubscriber(config)
@@ -102,7 +104,7 @@ func TestOpenTelemetrySubscriberRejectsInvalidTransport(t *testing.T) {
 
 func TestOpenTelemetrySubscriberRejectsInvalidAttributeMapping(t *testing.T) {
 	config := NewOpenTelemetryConfig()
-	config.AttributeMappings = []OtlpAttributeMapping{{Key: "", Alias: "tenant.id"}}
+	config.AttributeMappings = []OtlpAttributeMapping{{Key: "", Alias: otelTenantAttributeAlias}}
 
 	if _, err := NewOpenTelemetrySubscriber(config); err == nil {
 		t.Fatal("expected invalid attribute mapping error")
@@ -136,7 +138,7 @@ func TestOpenTelemetrySubscriberExportsScopeLifecycleAndMarks(t *testing.T) {
 	config.ServiceName = "go-agent"
 	config.AttributeMappings = []OtlpAttributeMapping{{
 		Key:   "nemo_relay.mark.metadata.source",
-		Alias: "tenant.id",
+		Alias: otelTenantAttributeAlias,
 	}}
 
 	subscriber, err := NewOpenTelemetrySubscriber(config)
@@ -183,7 +185,7 @@ func TestOpenTelemetrySubscriberExportsScopeLifecycleAndMarks(t *testing.T) {
 		if len(request.Body) == 0 {
 			t.Fatal("expected non-empty OTLP request body")
 		}
-		assertOtlpStringAttribute(t, request.Body, "tenant.id", "go")
+		assertOtlpStringAttribute(t, request.Body, otelTenantAttributeAlias, "go")
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for OTLP request")
 	}

--- a/go/nemo_relay/plugin_activation_test.go
+++ b/go/nemo_relay/plugin_activation_test.go
@@ -20,6 +20,17 @@ import (
 	"unsafe"
 )
 
+const (
+	pluginFixtureManifest      = "/tmp/relay-plugin.toml"
+	initializePluginsErrorFmt  = "InitializeWithDynamicPlugins() error = %v"
+	closeErrorFmt              = "Close() error = %v"
+	cleanupSequence            = "clear,free"
+	cleanupCallsFmt            = "cleanup calls = %v"
+	pluginTeardownErrorMessage = "teardown failed"
+	clearConfigurationErrorFmt = "ClearPluginConfiguration() error = %v"
+	cargoManifestName          = "Cargo.toml"
+)
+
 var (
 	goNativePluginFixtureOnce sync.Once
 	goNativePluginFixturePath string
@@ -49,77 +60,91 @@ func fixtureDynamicPluginSpecs() []DynamicPluginActivationSpec {
 	return []DynamicPluginActivationSpec{{
 		PluginID:    "fixture.native",
 		Kind:        DynamicPluginKindRustDynamic,
-		ManifestRef: "/tmp/relay-plugin.toml",
+		ManifestRef: pluginFixtureManifest,
 	}}
 }
 
 func TestInitializeWithDynamicPluginsSerializesSpecsAndOwnsCleanup(t *testing.T) {
 	withPluginActivationStubs(t)
-
-	token := new(byte)
-	ptr := unsafe.Pointer(token)
-	var gotConfig PluginConfig
-	var gotSpecs []DynamicPluginActivationSpec
-	initializeWithDynamicPluginsJSON = func(configJSON, specsJSON string) (unsafe.Pointer, string, error) {
-		if err := json.Unmarshal([]byte(configJSON), &gotConfig); err != nil {
-			t.Fatalf("invalid config JSON: %v", err)
-		}
-		if err := json.Unmarshal([]byte(specsJSON), &gotSpecs); err != nil {
-			t.Fatalf("invalid specs JSON: %v", err)
-		}
-		return ptr, `{"diagnostics":[{"level":"warning","code":"fixture.warning","message":"fixture"}]}`, nil
-	}
-	var calls []string
-	clearPluginActivation = func(got unsafe.Pointer) error {
-		if got != ptr {
-			t.Fatalf("clear pointer = %p, want %p", got, ptr)
-		}
-		calls = append(calls, "clear")
-		return nil
-	}
-	freePluginActivation = func(got unsafe.Pointer) {
-		if got != ptr {
-			t.Fatalf("free pointer = %p, want %p", got, ptr)
-		}
-		calls = append(calls, "free")
-	}
-
+	capture := installSerializationPluginStubs(t)
 	environment := "/tmp/fixture-environment"
 	activation, report, err := InitializeWithDynamicPlugins(NewPluginConfig(), []DynamicPluginActivationSpec{
 		{
 			PluginID:       "fixture.worker",
 			Kind:           DynamicPluginKindWorker,
-			ManifestRef:    "/tmp/relay-plugin.toml",
+			ManifestRef:    pluginFixtureManifest,
 			EnvironmentRef: &environment,
 			Config:         map[string]any{"tag": "go"},
 		},
 	})
 	if err != nil {
-		t.Fatalf("InitializeWithDynamicPlugins() error = %v", err)
+		t.Fatalf(initializePluginsErrorFmt, err)
 	}
-	if gotConfig.Version != 1 {
-		t.Fatalf("config version = %d, want 1", gotConfig.Version)
+	assertSerializedPluginActivation(t, capture, activation, report, environment)
+	runtime.KeepAlive(capture.token)
+}
+
+type serializationPluginCapture struct {
+	token     *byte
+	ptr       unsafe.Pointer
+	gotConfig PluginConfig
+	gotSpecs  []DynamicPluginActivationSpec
+	calls     []string
+}
+
+func installSerializationPluginStubs(t *testing.T) *serializationPluginCapture {
+	t.Helper()
+	capture := &serializationPluginCapture{token: new(byte)}
+	capture.ptr = unsafe.Pointer(capture.token)
+	initializeWithDynamicPluginsJSON = func(configJSON, specsJSON string) (unsafe.Pointer, string, error) {
+		if err := json.Unmarshal([]byte(configJSON), &capture.gotConfig); err != nil {
+			t.Fatalf("invalid config JSON: %v", err)
+		}
+		if err := json.Unmarshal([]byte(specsJSON), &capture.gotSpecs); err != nil {
+			t.Fatalf("invalid specs JSON: %v", err)
+		}
+		return capture.ptr, `{"diagnostics":[{"level":"warning","code":"fixture.warning","message":"fixture"}]}`, nil
 	}
-	if len(gotSpecs) != 1 || gotSpecs[0].PluginID != "fixture.worker" {
-		t.Fatalf("specs = %#v", gotSpecs)
+	clearPluginActivation = func(got unsafe.Pointer) error {
+		if got != capture.ptr {
+			t.Fatalf("clear pointer = %p, want %p", got, capture.ptr)
+		}
+		capture.calls = append(capture.calls, "clear")
+		return nil
 	}
-	if gotSpecs[0].EnvironmentRef == nil || *gotSpecs[0].EnvironmentRef != environment {
-		t.Fatalf("environment ref = %#v", gotSpecs[0].EnvironmentRef)
+	freePluginActivation = func(got unsafe.Pointer) {
+		if got != capture.ptr {
+			t.Fatalf("free pointer = %p, want %p", got, capture.ptr)
+		}
+		capture.calls = append(capture.calls, "free")
+	}
+	return capture
+}
+
+func assertSerializedPluginActivation(t *testing.T, capture *serializationPluginCapture, activation *PluginActivation, report ConfigReport, environment string) {
+	t.Helper()
+	if capture.gotConfig.Version != 1 {
+		t.Fatalf("config version = %d, want 1", capture.gotConfig.Version)
+	}
+	if len(capture.gotSpecs) != 1 || capture.gotSpecs[0].PluginID != "fixture.worker" {
+		t.Fatalf("specs = %#v", capture.gotSpecs)
+	}
+	if capture.gotSpecs[0].EnvironmentRef == nil || *capture.gotSpecs[0].EnvironmentRef != environment {
+		t.Fatalf("environment ref = %#v", capture.gotSpecs[0].EnvironmentRef)
 	}
 	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "fixture.warning" {
 		t.Fatalf("report = %#v", report)
 	}
 
 	if err := activation.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
+		t.Fatalf(closeErrorFmt, err)
 	}
 	if err := activation.Close(); err != nil {
 		t.Fatalf("repeated Close() error = %v", err)
 	}
-	if strings.Join(calls, ",") != "clear,free" {
-		t.Fatalf("cleanup calls = %v", calls)
+	if strings.Join(capture.calls, ",") != cleanupSequence {
+		t.Fatalf(cleanupCallsFmt, capture.calls)
 	}
-	runtime.KeepAlive(token)
 }
 
 func TestPluginConfigPublicJSONShapeRemainsCompatible(t *testing.T) {
@@ -178,14 +203,16 @@ func TestInitializeWithDynamicPluginsUsesPrivateConfigWireShape(t *testing.T) {
 		return unsafe.Pointer(token), `{"diagnostics":[]}`, nil
 	}
 	clearPluginActivation = func(unsafe.Pointer) error { return nil }
-	freePluginActivation = func(unsafe.Pointer) {}
+	freePluginActivation = func(unsafe.Pointer) {
+		// The test stub intentionally has no native allocation to release.
+	}
 
 	activation, _, err := InitializeWithDynamicPlugins(config, fixtureDynamicPluginSpecs())
 	if err != nil {
-		t.Fatalf("InitializeWithDynamicPlugins() error = %v", err)
+		t.Fatalf(initializePluginsErrorFmt, err)
 	}
 	if err := activation.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
+		t.Fatalf(closeErrorFmt, err)
 	}
 	runtime.KeepAlive(token)
 }
@@ -263,8 +290,8 @@ func TestInitializeWithDynamicPluginsCleansUpInvalidReport(t *testing.T) {
 	if activation != nil {
 		t.Fatalf("activation = %#v, want nil", activation)
 	}
-	if strings.Join(calls, ",") != "clear,free" {
-		t.Fatalf("cleanup calls = %v", calls)
+	if strings.Join(calls, ",") != cleanupSequence {
+		t.Fatalf(cleanupCallsFmt, calls)
 	}
 	runtime.KeepAlive(token)
 }
@@ -274,7 +301,7 @@ func TestPluginActivationCloseFreesAfterClearFailure(t *testing.T) {
 
 	token := new(byte)
 	ptr := unsafe.Pointer(token)
-	wantErr := errors.New("teardown failed")
+	wantErr := errors.New(pluginTeardownErrorMessage)
 	var calls []string
 	clearPluginActivation = func(unsafe.Pointer) error {
 		calls = append(calls, "clear")
@@ -289,8 +316,8 @@ func TestPluginActivationCloseFreesAfterClearFailure(t *testing.T) {
 	if err := activation.Close(); !errors.Is(err, wantErr) {
 		t.Fatalf("repeated Close() error = %v, want %v", err, wantErr)
 	}
-	if strings.Join(calls, ",") != "clear,free" {
-		t.Fatalf("cleanup calls = %v", calls)
+	if strings.Join(calls, ",") != cleanupSequence {
+		t.Fatalf(cleanupCallsFmt, calls)
 	}
 	runtime.KeepAlive(token)
 }
@@ -299,9 +326,11 @@ func TestPluginActivationFinalizerReportsClearFailure(t *testing.T) {
 	withPluginActivationStubs(t)
 
 	token := new(byte)
-	wantErr := errors.New("teardown failed")
+	wantErr := errors.New(pluginTeardownErrorMessage)
 	clearPluginActivation = func(unsafe.Pointer) error { return wantErr }
-	freePluginActivation = func(unsafe.Pointer) {}
+	freePluginActivation = func(unsafe.Pointer) {
+		// The test stub intentionally has no native allocation to release.
+	}
 	reported := make(chan error, 1)
 	reportPluginActivationCleanupError = func(err error) { reported <- err }
 
@@ -364,7 +393,7 @@ func TestPluginActivationCopiesShareCloseStateAndError(t *testing.T) {
 
 	token := new(byte)
 	ptr := unsafe.Pointer(token)
-	wantErr := errors.New("teardown failed")
+	wantErr := errors.New(pluginTeardownErrorMessage)
 	var callsMu sync.Mutex
 	var calls []string
 	clearPluginActivation = func(got unsafe.Pointer) error {
@@ -411,7 +440,7 @@ func TestPluginActivationCopiesShareCloseStateAndError(t *testing.T) {
 	callsMu.Lock()
 	gotCalls := strings.Join(calls, ",")
 	callsMu.Unlock()
-	if gotCalls != "clear,free" {
+	if gotCalls != cleanupSequence {
 		t.Fatalf("cleanup calls = %s, want clear,free", gotCalls)
 	}
 	runtime.KeepAlive(token)
@@ -472,7 +501,7 @@ wrapperWasCollected:
 	callsMu.Lock()
 	gotCalls = strings.Join(calls, ",")
 	callsMu.Unlock()
-	if gotCalls != "clear,free" {
+	if gotCalls != cleanupSequence {
 		t.Fatalf("cleanup calls = %s, want clear,free", gotCalls)
 	}
 	runtime.KeepAlive(copyValue)
@@ -526,7 +555,7 @@ func TestInitializeWithDynamicPluginsSurfacesSerializationAndActivationErrors(t 
 	invalidSpecs := []DynamicPluginActivationSpec{{
 		PluginID:    "fixture",
 		Kind:        DynamicPluginKindRustDynamic,
-		ManifestRef: "/tmp/relay-plugin.toml",
+		ManifestRef: pluginFixtureManifest,
 		Config:      map[string]any{"invalid": make(chan int)},
 	}}
 	if _, _, err := InitializeWithDynamicPlugins(NewPluginConfig(), invalidSpecs); err == nil {
@@ -553,10 +582,40 @@ func TestNilPluginActivationCloseIsSafe(t *testing.T) {
 
 func TestInitializeWithDynamicPluginsLoadsNativePluginThroughCgo(t *testing.T) {
 	if err := ClearPluginConfiguration(); err != nil {
-		t.Fatalf("ClearPluginConfiguration() error = %v", err)
+		t.Fatalf(clearConfigurationErrorFmt, err)
 	}
 	library := goNativePluginFixture(t)
 	manifest := writeGoNativePluginManifest(t, library)
+	pluginsTOML := configureNativePluginProject(t)
+	staticRegistrations, staticCallbacks := registerStaticFixturePlugin(t)
+
+	activation, report, err := InitializeWithDynamicPlugins(NewPluginConfig(), []DynamicPluginActivationSpec{{
+		PluginID:    "fixture_native",
+		Kind:        DynamicPluginKindRustDynamic,
+		ManifestRef: manifest,
+		Config:      map[string]any{},
+	}})
+	if err != nil {
+		t.Fatalf(initializePluginsErrorFmt, err)
+	}
+	defer func() {
+		if err := activation.Close(); err != nil {
+			t.Errorf("deferred Close() error = %v", err)
+		}
+	}()
+	if len(report.Diagnostics) != 0 {
+		t.Fatalf("activation diagnostics = %#v, want none", report.Diagnostics)
+	}
+	if staticRegistrations.Load() != 1 {
+		t.Fatalf("static registrations = %d, want 1", staticRegistrations.Load())
+	}
+	assertNativePluginInterception(t, pluginsTOML, staticCallbacks)
+	assertNativePluginCleanup(t, activation, pluginsTOML, staticCallbacks)
+	assertMissingNativePluginFails(t)
+}
+
+func configureNativePluginProject(t *testing.T) string {
+	t.Helper()
 	projectDir := t.TempDir()
 	projectConfigDir := filepath.Join(projectDir, ".nemo-relay")
 	if err := os.MkdirAll(projectConfigDir, 0o700); err != nil {
@@ -589,9 +648,14 @@ source = "project-file"
 		}
 	})
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(projectDir, "xdg"))
+	return pluginsTOML
+}
 
-	var staticRegistrations atomic.Int32
-	var staticCallbacks atomic.Int32
+func registerStaticFixturePlugin(t *testing.T) (*atomic.Int32, *atomic.Int32) {
+	t.Helper()
+	const staticKind = "go.fixture.static_base"
+	staticRegistrations := &atomic.Int32{}
+	staticCallbacks := &atomic.Int32{}
 	if err := RegisterPlugin(staticKind, PluginFuncs{
 		RegisterFunc: func(config map[string]any, ctx *PluginContext) error {
 			if config["source"] != "project-file" {
@@ -618,32 +682,16 @@ source = "project-file"
 	}); err != nil {
 		t.Fatalf("RegisterPlugin() error = %v", err)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		if err := DeregisterPlugin(staticKind); err != nil {
 			t.Errorf("DeregisterPlugin() error = %v", err)
 		}
-	}()
+	})
+	return staticRegistrations, staticCallbacks
+}
 
-	activation, report, err := InitializeWithDynamicPlugins(NewPluginConfig(), []DynamicPluginActivationSpec{{
-		PluginID:    "fixture_native",
-		Kind:        DynamicPluginKindRustDynamic,
-		ManifestRef: manifest,
-		Config:      map[string]any{},
-	}})
-	if err != nil {
-		t.Fatalf("InitializeWithDynamicPlugins() error = %v", err)
-	}
-	defer func() {
-		if err := activation.Close(); err != nil {
-			t.Errorf("deferred Close() error = %v", err)
-		}
-	}()
-	if len(report.Diagnostics) != 0 {
-		t.Fatalf("activation diagnostics = %#v, want none", report.Diagnostics)
-	}
-	if got := staticRegistrations.Load(); got != 1 {
-		t.Fatalf("static registrations = %d, want 1", got)
-	}
+func assertNativePluginInterception(t *testing.T, pluginsTOML string, staticCallbacks *atomic.Int32) {
+	t.Helper()
 	// The activation has already resolved its configuration; subsequent file
 	// mutations are neither watched nor reloaded.
 	if err := os.WriteFile(pluginsTOML, []byte("invalid = ["), 0o600); err != nil {
@@ -667,12 +715,15 @@ source = "project-file"
 	if transformedObject["static_saw_dynamic"] != false {
 		t.Fatalf("transformed tool args = %s, want static callback before dynamic callback", transformed)
 	}
-	if got := staticCallbacks.Load(); got != 1 {
-		t.Fatalf("static callbacks = %d, want 1", got)
+	if staticCallbacks.Load() != 1 {
+		t.Fatalf("static callbacks = %d, want 1", staticCallbacks.Load())
 	}
+}
 
+func assertNativePluginCleanup(t *testing.T, activation *PluginActivation, pluginsTOML string, staticCallbacks *atomic.Int32) {
+	t.Helper()
 	if err := activation.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
+		t.Fatalf(closeErrorFmt, err)
 	}
 	afterClose, err := ToolRequestIntercepts("go-native-tool", json.RawMessage(`{"input":true}`))
 	if err != nil {
@@ -681,8 +732,8 @@ source = "project-file"
 	if string(afterClose) != `{"input":true}` {
 		t.Fatalf("tool args after Close = %s, want unchanged args", afterClose)
 	}
-	if got := staticCallbacks.Load(); got != 1 {
-		t.Fatalf("static callbacks after Close = %d, want 1", got)
+	if staticCallbacks.Load() != 1 {
+		t.Fatalf("static callbacks after Close = %d, want 1", staticCallbacks.Load())
 	}
 	kinds, err := ListPluginKinds()
 	if err != nil {
@@ -696,8 +747,11 @@ source = "project-file"
 	if err := os.Remove(pluginsTOML); err != nil {
 		t.Fatalf("Remove(plugins.toml) error = %v", err)
 	}
+}
 
-	_, _, err = InitializeWithDynamicPlugins(NewPluginConfig(), []DynamicPluginActivationSpec{{
+func assertMissingNativePluginFails(t *testing.T) {
+	t.Helper()
+	_, _, err := InitializeWithDynamicPlugins(NewPluginConfig(), []DynamicPluginActivationSpec{{
 		PluginID:    "fixture_missing",
 		Kind:        DynamicPluginKindRustDynamic,
 		ManifestRef: filepath.Join(t.TempDir(), "missing-relay-plugin.toml"),
@@ -709,7 +763,7 @@ source = "project-file"
 
 func TestInitializeWithDynamicPluginsLoadsWorkerPluginThroughCgo(t *testing.T) {
 	if err := ClearPluginConfiguration(); err != nil {
-		t.Fatalf("ClearPluginConfiguration() error = %v", err)
+		t.Fatalf(clearConfigurationErrorFmt, err)
 	}
 
 	executable := goWorkerPluginFixture(t)
@@ -721,7 +775,7 @@ func TestInitializeWithDynamicPluginsLoadsWorkerPluginThroughCgo(t *testing.T) {
 		Config:      map[string]any{},
 	}})
 	if err != nil {
-		t.Fatalf("InitializeWithDynamicPlugins() error = %v", err)
+		t.Fatalf(initializePluginsErrorFmt, err)
 	}
 	defer func() {
 		if err := activation.Close(); err != nil {
@@ -745,7 +799,7 @@ func TestInitializeWithDynamicPluginsLoadsWorkerPluginThroughCgo(t *testing.T) {
 	}
 
 	if err := activation.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
+		t.Fatalf(closeErrorFmt, err)
 	}
 	afterClose, err := ToolRequestIntercepts("go-worker-tool", json.RawMessage(`{"input":true}`))
 	if err != nil {
@@ -758,7 +812,7 @@ func TestInitializeWithDynamicPluginsLoadsWorkerPluginThroughCgo(t *testing.T) {
 
 func TestPluginActivationFinalizerReleasesHostOwnership(t *testing.T) {
 	if err := ClearPluginConfiguration(); err != nil {
-		t.Fatalf("ClearPluginConfiguration() error = %v", err)
+		t.Fatalf(clearConfigurationErrorFmt, err)
 	}
 	library := goNativePluginFixture(t)
 	manifest := writeGoNativePluginManifest(t, library)
@@ -794,7 +848,7 @@ func createUnclosedPluginActivation(t *testing.T, specs []DynamicPluginActivatio
 	t.Helper()
 	activation, _, err := InitializeWithDynamicPlugins(NewPluginConfig(), specs)
 	if err != nil {
-		t.Fatalf("InitializeWithDynamicPlugins() error = %v", err)
+		t.Fatalf(initializePluginsErrorFmt, err)
 	}
 	runtime.KeepAlive(activation)
 }
@@ -802,68 +856,60 @@ func createUnclosedPluginActivation(t *testing.T, specs []DynamicPluginActivatio
 func goNativePluginFixture(t *testing.T) string {
 	t.Helper()
 	goNativePluginFixtureOnce.Do(func() {
-		repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
-		if err != nil {
-			goNativePluginFixtureErr = err
-			return
-		}
-		sourceRoot, err := os.MkdirTemp("", "nemo-relay-go-native-plugin-")
-		if err != nil {
-			goNativePluginFixtureErr = err
-			return
-		}
-		defer os.RemoveAll(sourceRoot)
-		fixtureRoot := filepath.Join(sourceRoot, "native_plugin")
-		if err := os.MkdirAll(filepath.Join(fixtureRoot, "src"), 0o700); err != nil {
-			goNativePluginFixtureErr = err
-			return
-		}
-		fixtureSource := filepath.Join(repoRoot, "crates", "core", "tests", "fixtures", "native_plugin")
-		manifestBytes, err := os.ReadFile(filepath.Join(fixtureSource, "Cargo.toml"))
-		if err != nil {
-			goNativePluginFixtureErr = err
-			return
-		}
-		pluginPath := filepath.Join(repoRoot, "crates", "plugin")
-		manifestContents := strings.Replace(
-			string(manifestBytes),
-			`nemo-relay-plugin = { path = "../../../../plugin" }`,
-			fmt.Sprintf("nemo-relay-plugin = { path = %q }", pluginPath),
-			1,
-		)
-		manifest := filepath.Join(fixtureRoot, "Cargo.toml")
-		if err := os.WriteFile(manifest, []byte(manifestContents), 0o600); err != nil {
-			goNativePluginFixtureErr = err
-			return
-		}
-		librarySource, err := os.ReadFile(filepath.Join(fixtureSource, "src", "lib.rs"))
-		if err != nil {
-			goNativePluginFixtureErr = err
-			return
-		}
-		if err := os.WriteFile(filepath.Join(fixtureRoot, "src", "lib.rs"), librarySource, 0o600); err != nil {
-			goNativePluginFixtureErr = err
-			return
-		}
-		target := filepath.Join(repoRoot, "target")
-		cargo := os.Getenv("CARGO")
-		if cargo == "" {
-			cargo = "cargo"
-		}
-		command := exec.Command(cargo, "build", "--quiet", "--manifest-path", manifest, "--target-dir", target)
-		if output, err := command.CombinedOutput(); err != nil {
-			goNativePluginFixtureErr = fmt.Errorf("build native plugin fixture: %w\n%s", err, output)
-			return
-		}
-		goNativePluginFixturePath = filepath.Join(target, "debug", goNativeLibraryName())
-		if _, err := os.Stat(goNativePluginFixturePath); err != nil {
-			goNativePluginFixtureErr = fmt.Errorf("native plugin fixture output: %w", err)
-		}
+		goNativePluginFixturePath, goNativePluginFixtureErr = buildGoNativePluginFixture()
 	})
 	if goNativePluginFixtureErr != nil {
 		t.Fatal(goNativePluginFixtureErr)
 	}
 	return goNativePluginFixturePath
+}
+
+func buildGoNativePluginFixture() (string, error) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		return "", err
+	}
+	sourceRoot, err := os.MkdirTemp("", "nemo-relay-go-native-plugin-")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(sourceRoot)
+	fixtureRoot := filepath.Join(sourceRoot, "native_plugin")
+	if err := os.MkdirAll(filepath.Join(fixtureRoot, "src"), 0o700); err != nil {
+		return "", err
+	}
+	fixtureSource := filepath.Join(repoRoot, "crates", "core", "tests", "fixtures", "native_plugin")
+	manifestBytes, err := os.ReadFile(filepath.Join(fixtureSource, cargoManifestName))
+	if err != nil {
+		return "", err
+	}
+	pluginPath := filepath.Join(repoRoot, "crates", "plugin")
+	manifestContents := strings.Replace(string(manifestBytes), `nemo-relay-plugin = { path = "../../../../plugin" }`, fmt.Sprintf("nemo-relay-plugin = { path = %q }", pluginPath), 1)
+	manifest := filepath.Join(fixtureRoot, cargoManifestName)
+	if err := os.WriteFile(manifest, []byte(manifestContents), 0o600); err != nil {
+		return "", err
+	}
+	librarySource, err := os.ReadFile(filepath.Join(fixtureSource, "src", "lib.rs"))
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(fixtureRoot, "src", "lib.rs"), librarySource, 0o600); err != nil {
+		return "", err
+	}
+	target := filepath.Join(repoRoot, "target")
+	cargo := os.Getenv("CARGO")
+	if cargo == "" {
+		cargo = "cargo"
+	}
+	command := exec.Command(cargo, "build", "--quiet", "--manifest-path", manifest, "--target-dir", target)
+	if output, err := command.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build native plugin fixture: %w\n%s", err, output)
+	}
+	fixturePath := filepath.Join(target, "debug", goNativeLibraryName())
+	if _, err := os.Stat(fixturePath); err != nil {
+		return "", fmt.Errorf("native plugin fixture output: %w", err)
+	}
+	return fixturePath, nil
 }
 
 func goWorkerPluginFixture(t *testing.T) string {
@@ -874,7 +920,7 @@ func goWorkerPluginFixture(t *testing.T) string {
 			goWorkerPluginFixtureErr = err
 			return
 		}
-		manifest := filepath.Join(repoRoot, "crates", "core", "tests", "fixtures", "worker_plugin", "Cargo.toml")
+		manifest := filepath.Join(repoRoot, "crates", "core", "tests", "fixtures", "worker_plugin", cargoManifestName)
 		target := filepath.Join(repoRoot, "target")
 		cargo := os.Getenv("CARGO")
 		if cargo == "" {
@@ -964,7 +1010,7 @@ func relayWorkspaceVersion(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("resolve repository root: %v", err)
 	}
-	payload, err := os.ReadFile(filepath.Join(repoRoot, "Cargo.toml"))
+	payload, err := os.ReadFile(filepath.Join(repoRoot, cargoManifestName))
 	if err != nil {
 		t.Fatalf("read workspace Cargo.toml: %v", err)
 	}

--- a/go/nemo_relay/subscribers/subscribers_test.go
+++ b/go/nemo_relay/subscribers/subscribers_test.go
@@ -61,35 +61,37 @@ func TestSubscriberShorthands(t *testing.T) {
 	}
 	defer stack.Close()
 
-	stack.Run(func() {
-		if err := subscriberspkg.Register("subs_global", func(event nemo_relay.Event) {
-			if event.Kind() == "scope" && event.ScopeCategory() == "start" {
-				mu.Lock()
-				seenStart = true
-				mu.Unlock()
-			}
-		}); err != nil {
-			t.Fatalf("Register failed: %v", err)
-		}
-
-		handle, err := nemo_relay.PushScope("subs_scope", nemo_relay.ScopeTypeAgent)
-		if err != nil {
-			t.Fatalf("PushScope failed: %v", err)
-		}
-		if err := nemo_relay.PopScope(handle); err != nil {
-			t.Fatalf("PopScope failed: %v", err)
-		}
-		if err := subscriberspkg.Deregister("subs_global"); err != nil {
-			t.Fatalf("Deregister failed: %v", err)
-		}
-		if err := subscriberspkg.Flush(); err != nil {
-			t.Fatalf("Flush failed: %v", err)
-		}
-	})
+	stack.Run(func() { exerciseGlobalSubscriber(t, &mu, &seenStart) })
 
 	mu.Lock()
 	assertSeenStart(t, seenStart)
 	mu.Unlock()
+}
+
+func exerciseGlobalSubscriber(t *testing.T, mu *sync.Mutex, seenStart *bool) {
+	t.Helper()
+	if err := subscriberspkg.Register("subs_global", func(event nemo_relay.Event) {
+		if event.Kind() == "scope" && event.ScopeCategory() == "start" {
+			mu.Lock()
+			*seenStart = true
+			mu.Unlock()
+		}
+	}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	handle, err := nemo_relay.PushScope("subs_scope", nemo_relay.ScopeTypeAgent)
+	if err != nil {
+		t.Fatalf("PushScope failed: %v", err)
+	}
+	if err := nemo_relay.PopScope(handle); err != nil {
+		t.Fatalf("PopScope failed: %v", err)
+	}
+	if err := subscriberspkg.Deregister("subs_global"); err != nil {
+		t.Fatalf("Deregister failed: %v", err)
+	}
+	if err := subscriberspkg.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
 }
 
 func TestScopeSubscriberShorthands(t *testing.T) {


### PR DESCRIPTION
#### Overview

- [x] This is a **new feature**, **refactoring**, or **tests**
- [ ] This is a **bug fix**

#### Details

Resolves all 35 Go findings in the main-branch Sonar backlog. Complex tests are decomposed into narrowly scoped setup, protocol, fixture, and assertion helpers; repeated literals are named file-local constants; unnecessary temporaries are inlined; and intentionally empty interface-marker/test callbacks now explain why they have no behavior.

Validation:
- `gofmt` on every changed Go file
- `go vet ./...`
- `just test-go`
- local cognitive-complexity check for every Sonar-identified function
- `uv run pre-commit run --all-files`

No public API, ABI, or runtime behavior changes are intended.

#### Where should the reviewer start?

Start with `go/nemo_relay/plugin_activation_test.go`, especially the native-plugin fixture builder and activation lifecycle helpers, then review the smaller constants and marker comments.

#### Related Issues:

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded and reorganized coverage for plugin validation, lifecycle handling, event sanitization, observability, subscribers, and OpenTelemetry integrations.
  - Added checks for invalid configurations, cleanup behavior, callback leaks, serialization, and repeated shutdown operations.
  - Standardized test fixtures, assertions, and shared values to improve consistency and maintainability.

- **Refactor**
  - Simplified internal test setup and lifecycle verification without changing runtime behavior.
  - Clarified internal configuration markers while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->