### PR TITLE
refactor: resolve Switchyard Sonar findings

### DIFF
--- a/crates/switchyard/src/component.rs
+++ b/crates/switchyard/src/component.rs
@@ -482,6 +482,26 @@ struct SwitchyardRuntime {
     translation: switchyard_translation::TranslationEngine,
 }
 
+enum BufferedAttempt {
+    Complete(Json),
+    Retry((String, String)),
+    Fallback(&'static str),
+}
+
+enum StreamAttempt {
+    Committed(LlmJsonStream),
+    Retry((String, String)),
+    Fallback(&'static str),
+}
+
+fn provider_fallback_reason(error: &FlowError) -> &'static str {
+    if error_is_retryable(error) {
+        "retry_exhausted"
+    } else {
+        "non_retryable_provider_error"
+    }
+}
+
 impl SwitchyardRuntime {
     fn new(config: SwitchyardConfig) -> Result<Self, String> {
         validate_config(&config)?;
@@ -551,70 +571,75 @@ impl SwitchyardRuntime {
         let max_attempts = self.config.max_retries.saturating_add(1);
         let mut previous = None;
         for attempt in 1..=max_attempts {
-            let decided = self
-                .decided_request(inbound, &original, attempt, previous.clone())
-                .await;
-            let (routing_request, decision, routed) = match decided {
-                Ok(value) => value,
-                Err(error) => {
-                    self.emit_error(None, attempt, "decision_api", &error);
+            match self
+                .buffered_attempt(inbound, &original, &next, attempt, previous, max_attempts)
+                .await?
+            {
+                BufferedAttempt::Complete(response) => return Ok(response),
+                BufferedAttempt::Retry(retry) => previous = Some(retry),
+                BufferedAttempt::Fallback(reason) => {
                     return self
-                        .dispatch_fallback_buffered(inbound, original, next, "decision_error")
-                        .await;
-                }
-            };
-            let target_protocol = protocol_from_label(&decision.route.target_protocol_profile)?;
-            match next(routed).await {
-                Ok(response) => {
-                    match translate_response(&self.translation, target_protocol, inbound, &response)
-                    {
-                        Ok(response) => {
-                            self.record_routing_contribution(&decision, attempt, true);
-                            return Ok(response);
-                        }
-                        Err(error) => {
-                            self.emit_error(
-                                Some(&routing_request),
-                                attempt,
-                                "response_translation",
-                                &error.to_string(),
-                            );
-                            return self
-                                .dispatch_fallback_buffered(
-                                    inbound,
-                                    original,
-                                    next,
-                                    "translation_error",
-                                )
-                                .await;
-                        }
-                    }
-                }
-                Err(error) if error_is_retryable(&error) && attempt < max_attempts => {
-                    let retry_reason = provider_error_summary(&error);
-                    self.emit_error(Some(&routing_request), attempt, "provider", &retry_reason);
-                    self.emit_retry(&routing_request, &decision, attempt, &retry_reason);
-                    previous = Some((decision.route.backend_id, retry_reason));
-                }
-                Err(error) => {
-                    let summary = provider_error_summary(&error);
-                    self.emit_error(Some(&routing_request), attempt, "provider", &summary);
-                    return self
-                        .dispatch_fallback_buffered(
-                            inbound,
-                            original,
-                            next,
-                            if error_is_retryable(&error) {
-                                "retry_exhausted"
-                            } else {
-                                "non_retryable_provider_error"
-                            },
-                        )
+                        .dispatch_fallback_buffered(inbound, original, next, reason)
                         .await;
                 }
             }
         }
         unreachable!("routing attempt loop always returns")
+    }
+
+    async fn buffered_attempt(
+        &self,
+        inbound: WireProtocol,
+        original: &LlmRequest,
+        next: &nemo_relay::api::runtime::LlmExecutionNextFn,
+        attempt: u32,
+        previous: Option<(String, String)>,
+        max_attempts: u32,
+    ) -> FlowResult<BufferedAttempt> {
+        let (routing_request, decision, routed) = match self
+            .decided_request(inbound, original, attempt, previous)
+            .await
+        {
+            Ok(value) => value,
+            Err(error) => {
+                self.emit_error(None, attempt, "decision_api", &error);
+                return Ok(BufferedAttempt::Fallback("decision_error"));
+            }
+        };
+        let target_protocol = protocol_from_label(&decision.route.target_protocol_profile)?;
+        match next(routed).await {
+            Ok(response) => {
+                match translate_response(&self.translation, target_protocol, inbound, &response) {
+                    Ok(response) => {
+                        self.record_routing_contribution(&decision, attempt, true);
+                        Ok(BufferedAttempt::Complete(response))
+                    }
+                    Err(error) => {
+                        self.emit_error(
+                            Some(&routing_request),
+                            attempt,
+                            "response_translation",
+                            &error.to_string(),
+                        );
+                        Ok(BufferedAttempt::Fallback("translation_error"))
+                    }
+                }
+            }
+            Err(error) if error_is_retryable(&error) && attempt < max_attempts => {
+                let retry_reason = provider_error_summary(&error);
+                self.emit_error(Some(&routing_request), attempt, "provider", &retry_reason);
+                self.emit_retry(&routing_request, &decision, attempt, &retry_reason);
+                Ok(BufferedAttempt::Retry((
+                    decision.route.backend_id,
+                    retry_reason,
+                )))
+            }
+            Err(error) => {
+                let summary = provider_error_summary(&error);
+                self.emit_error(Some(&routing_request), attempt, "provider", &summary);
+                Ok(BufferedAttempt::Fallback(provider_fallback_reason(&error)))
+            }
+        }
     }
 
     async fn execute_stream(
@@ -655,120 +680,170 @@ impl SwitchyardRuntime {
         let max_attempts = self.config.max_retries.saturating_add(1);
         let mut previous = None;
         for attempt in 1..=max_attempts {
-            let (routing_request, decision, routed) = match self
-                .decided_request(inbound, &original, attempt, previous.clone())
-                .await
+            match self
+                .stream_attempt(inbound, &original, &next, attempt, previous, max_attempts)
+                .await?
             {
-                Ok(value) => value,
-                Err(error) => {
-                    self.emit_error(None, attempt, "decision_api", &error);
+                StreamAttempt::Committed(stream) => return Ok(stream),
+                StreamAttempt::Retry(retry) => previous = Some(retry),
+                StreamAttempt::Fallback(reason) => {
                     return self
-                        .dispatch_fallback_stream(inbound, original, next, "decision_error")
-                        .await;
-                }
-            };
-            let target_protocol = protocol_from_label(&decision.route.target_protocol_profile)?;
-            match next(routed).await {
-                Ok(mut upstream) => match upstream.next().await {
-                    Some(Ok(first)) => {
-                        self.record_routing_contribution(&decision, attempt, true);
-                        let committed = Box::pin(
-                            futures_stream::once(async move { Ok(first) }).chain(upstream),
-                        ) as LlmJsonStream;
-                        let output = if target_protocol == inbound {
-                            committed
-                        } else {
-                            translated_stream(
-                                target_protocol,
-                                inbound,
-                                decision.route.target_model.clone(),
-                                committed,
-                            )
-                        };
-                        return Ok(mark_terminal_stream(
-                            output,
-                            "provider_stream_committed",
-                            self.config.mode.label(),
-                            identity_metadata(&routing_request),
-                        ));
-                    }
-                    Some(Err(error)) if error_is_retryable(&error) && attempt < max_attempts => {
-                        let retry_reason = provider_error_summary(&error);
-                        self.emit_error(
-                            Some(&routing_request),
-                            attempt,
-                            "provider_stream_open",
-                            &retry_reason,
-                        );
-                        self.emit_retry(&routing_request, &decision, attempt, &retry_reason);
-                        previous = Some((decision.route.backend_id, retry_reason));
-                    }
-                    None if attempt < max_attempts => {
-                        self.emit_retry(&routing_request, &decision, attempt, "empty_stream");
-                        previous = Some((decision.route.backend_id, "empty_stream".into()));
-                    }
-                    Some(Err(error)) => {
-                        let summary = provider_error_summary(&error);
-                        self.emit_error(
-                            Some(&routing_request),
-                            attempt,
-                            "provider_stream_open",
-                            &summary,
-                        );
-                        return self
-                            .dispatch_fallback_stream(
-                                inbound,
-                                original,
-                                next,
-                                if error_is_retryable(&error) {
-                                    "retry_exhausted"
-                                } else {
-                                    "non_retryable_provider_error"
-                                },
-                            )
-                            .await;
-                    }
-                    None => {
-                        return self
-                            .dispatch_fallback_stream(inbound, original, next, "empty_stream")
-                            .await;
-                    }
-                },
-                Err(error) if error_is_retryable(&error) && attempt < max_attempts => {
-                    let retry_reason = provider_error_summary(&error);
-                    self.emit_error(
-                        Some(&routing_request),
-                        attempt,
-                        "provider_stream_setup",
-                        &retry_reason,
-                    );
-                    self.emit_retry(&routing_request, &decision, attempt, &retry_reason);
-                    previous = Some((decision.route.backend_id, retry_reason));
-                }
-                Err(error) => {
-                    let summary = provider_error_summary(&error);
-                    self.emit_error(
-                        Some(&routing_request),
-                        attempt,
-                        "provider_stream_setup",
-                        &summary,
-                    );
-                    return self
-                        .dispatch_fallback_stream(
-                            inbound,
-                            original,
-                            next,
-                            if error_is_retryable(&error) {
-                                "retry_exhausted"
-                            } else {
-                                "non_retryable_provider_error"
-                            },
-                        )
+                        .dispatch_fallback_stream(inbound, original, next, reason)
                         .await;
                 }
             }
         }
         unreachable!("stream routing attempt loop always returns")
+    }
+
+    async fn stream_attempt(
+        &self,
+        inbound: WireProtocol,
+        original: &LlmRequest,
+        next: &nemo_relay::api::runtime::LlmStreamExecutionNextFn,
+        attempt: u32,
+        previous: Option<(String, String)>,
+        max_attempts: u32,
+    ) -> FlowResult<StreamAttempt> {
+        let (routing_request, decision, routed) = match self
+            .decided_request(inbound, original, attempt, previous)
+            .await
+        {
+            Ok(value) => value,
+            Err(error) => {
+                self.emit_error(None, attempt, "decision_api", &error);
+                return Ok(StreamAttempt::Fallback("decision_error"));
+            }
+        };
+        let target_protocol = protocol_from_label(&decision.route.target_protocol_profile)?;
+        match next(routed).await {
+            Ok(mut upstream) => {
+                let first = upstream.next().await;
+                Ok(self.classify_open_stream(
+                    inbound,
+                    target_protocol,
+                    routing_request,
+                    decision,
+                    upstream,
+                    first,
+                    attempt,
+                    max_attempts,
+                ))
+            }
+            Err(error) => Ok(self.classify_stream_setup_error(
+                routing_request,
+                decision,
+                error,
+                attempt,
+                max_attempts,
+            )),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn classify_open_stream(
+        &self,
+        inbound: WireProtocol,
+        target_protocol: WireProtocol,
+        routing_request: RoutingRequest,
+        decision: RoutingDecision,
+        upstream: LlmJsonStream,
+        first: Option<FlowResult<Json>>,
+        attempt: u32,
+        max_attempts: u32,
+    ) -> StreamAttempt {
+        match first {
+            Some(Ok(first)) => {
+                self.record_routing_contribution(&decision, attempt, true);
+                let committed =
+                    Box::pin(futures_stream::once(async move { Ok(first) }).chain(upstream))
+                        as LlmJsonStream;
+                let output = if target_protocol == inbound {
+                    committed
+                } else {
+                    translated_stream(
+                        target_protocol,
+                        inbound,
+                        decision.route.target_model.clone(),
+                        committed,
+                    )
+                };
+                StreamAttempt::Committed(mark_terminal_stream(
+                    output,
+                    "provider_stream_committed",
+                    self.config.mode.label(),
+                    identity_metadata(&routing_request),
+                ))
+            }
+            Some(Err(error)) if error_is_retryable(&error) && attempt < max_attempts => self
+                .retry_stream_attempt(
+                    &routing_request,
+                    decision,
+                    attempt,
+                    "provider_stream_open",
+                    provider_error_summary(&error),
+                ),
+            None if attempt < max_attempts => self.retry_stream_attempt(
+                &routing_request,
+                decision,
+                attempt,
+                "provider_stream_open",
+                "empty_stream".into(),
+            ),
+            Some(Err(error)) => {
+                let summary = provider_error_summary(&error);
+                self.emit_error(
+                    Some(&routing_request),
+                    attempt,
+                    "provider_stream_open",
+                    &summary,
+                );
+                StreamAttempt::Fallback(provider_fallback_reason(&error))
+            }
+            None => StreamAttempt::Fallback("empty_stream"),
+        }
+    }
+
+    fn classify_stream_setup_error(
+        &self,
+        routing_request: RoutingRequest,
+        decision: RoutingDecision,
+        error: FlowError,
+        attempt: u32,
+        max_attempts: u32,
+    ) -> StreamAttempt {
+        let summary = provider_error_summary(&error);
+        if error_is_retryable(&error) && attempt < max_attempts {
+            return self.retry_stream_attempt(
+                &routing_request,
+                decision,
+                attempt,
+                "provider_stream_setup",
+                summary,
+            );
+        }
+        self.emit_error(
+            Some(&routing_request),
+            attempt,
+            "provider_stream_setup",
+            &summary,
+        );
+        StreamAttempt::Fallback(provider_fallback_reason(&error))
+    }
+
+    fn retry_stream_attempt(
+        &self,
+        routing_request: &RoutingRequest,
+        decision: RoutingDecision,
+        attempt: u32,
+        error_class: &str,
+        reason: String,
+    ) -> StreamAttempt {
+        if reason != "empty_stream" {
+            self.emit_error(Some(routing_request), attempt, error_class, &reason);
+        }
+        self.emit_retry(routing_request, &decision, attempt, &reason);
+        StreamAttempt::Retry((decision.route.backend_id, reason))
     }
 
     async fn decided_request(
@@ -1239,6 +1314,13 @@ fn validate_atof_endpoint_name(name: Option<&str>) -> Result<Option<&str>, Strin
 }
 
 fn validate_config(config: &SwitchyardConfig) -> Result<(), String> {
+    validate_scalar_config(config)?;
+    validate_decision_api_url(&config.decision_api_url)?;
+    validate_target_bindings(config)?;
+    validate_default_targets(config)
+}
+
+fn validate_scalar_config(config: &SwitchyardConfig) -> Result<(), String> {
     if config.version != 1 {
         return Err(format!(
             "unsupported Switchyard config version {}",
@@ -1261,11 +1343,19 @@ fn validate_config(config: &SwitchyardConfig) -> Result<(), String> {
     if config.context_mode == ContextMode::AtofRequired && atof_endpoint_name.is_none() {
         return Err("atof_required Switchyard profiles require atof_endpoint_name".into());
     }
-    let url = reqwest::Url::parse(&config.decision_api_url)
+    Ok(())
+}
+
+fn validate_decision_api_url(decision_api_url: &str) -> Result<(), String> {
+    let url = reqwest::Url::parse(decision_api_url)
         .map_err(|error| format!("decision_api_url is invalid: {error}"))?;
     if !matches!(url.scheme(), "http" | "https") {
         return Err("decision_api_url must use http or https".into());
     }
+    Ok(())
+}
+
+fn validate_target_bindings(config: &SwitchyardConfig) -> Result<(), String> {
     if config.targets.is_empty() {
         return Err("targets must not be empty".into());
     }
@@ -1303,6 +1393,10 @@ fn validate_config(config: &SwitchyardConfig) -> Result<(), String> {
             ));
         }
     }
+    Ok(())
+}
+
+fn validate_default_targets(config: &SwitchyardConfig) -> Result<(), String> {
     for &protocol in &config.enabled_inbound_profiles {
         let id = config.default_targets.target(protocol);
         let target = config

--- a/crates/switchyard/src/component.rs
+++ b/crates/switchyard/src/component.rs
@@ -494,6 +494,13 @@ enum StreamAttempt {
     Fallback(&'static str),
 }
 
+struct StreamAttemptContext {
+    routing_request: RoutingRequest,
+    decision: RoutingDecision,
+    attempt: u32,
+    max_attempts: u32,
+}
+
 fn provider_fallback_reason(error: &FlowError) -> &'static str {
     if error_is_retryable(error) {
         "retry_exhausted"
@@ -716,42 +723,35 @@ impl SwitchyardRuntime {
             }
         };
         let target_protocol = protocol_from_label(&decision.route.target_protocol_profile)?;
+        let context = StreamAttemptContext {
+            routing_request,
+            decision,
+            attempt,
+            max_attempts,
+        };
         match next(routed).await {
             Ok(mut upstream) => {
                 let first = upstream.next().await;
-                Ok(self.classify_open_stream(
-                    inbound,
-                    target_protocol,
-                    routing_request,
-                    decision,
-                    upstream,
-                    first,
-                    attempt,
-                    max_attempts,
-                ))
+                Ok(self.classify_open_stream(inbound, target_protocol, context, upstream, first))
             }
-            Err(error) => Ok(self.classify_stream_setup_error(
-                routing_request,
-                decision,
-                error,
-                attempt,
-                max_attempts,
-            )),
+            Err(error) => Ok(self.classify_stream_setup_error(context, error)),
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn classify_open_stream(
         &self,
         inbound: WireProtocol,
         target_protocol: WireProtocol,
-        routing_request: RoutingRequest,
-        decision: RoutingDecision,
+        context: StreamAttemptContext,
         upstream: LlmJsonStream,
         first: Option<FlowResult<Json>>,
-        attempt: u32,
-        max_attempts: u32,
     ) -> StreamAttempt {
+        let StreamAttemptContext {
+            routing_request,
+            decision,
+            attempt,
+            max_attempts,
+        } = context;
         match first {
             Some(Ok(first)) => {
                 self.record_routing_contribution(&decision, attempt, true);
@@ -806,12 +806,15 @@ impl SwitchyardRuntime {
 
     fn classify_stream_setup_error(
         &self,
-        routing_request: RoutingRequest,
-        decision: RoutingDecision,
+        context: StreamAttemptContext,
         error: FlowError,
-        attempt: u32,
-        max_attempts: u32,
     ) -> StreamAttempt {
+        let StreamAttemptContext {
+            routing_request,
+            decision,
+            attempt,
+            max_attempts,
+        } = context;
         let summary = provider_error_summary(&error);
         if error_is_retryable(&error) && attempt < max_attempts {
             return self.retry_stream_attempt(


### PR DESCRIPTION
#### Overview

Resolve all three remaining Switchyard Sonar complexity findings without changing routing behavior, validation order, public APIs, or error messages.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Refactor buffered and streaming routing loops around private attempt-result enums.
- Keep decision failures, provider retries, stream commitment, translation failures, and fallback reasons explicit.
- Split configuration validation into scalar, URL, target-binding, and default-target phases while preserving validation order and messages.
- Add no suppressions or analyzer exclusions.

Validation:

- `cargo fmt --all`
- `cargo clippy -p nemo-relay-switchyard --all-targets -- -D warnings`
- `cargo test -p nemo-relay-switchyard`
- `just test-rust`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start in `crates/switchyard/src/component.rs` with `BufferedAttempt`, `StreamAttempt`, and the extracted validation helpers.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry and fallback orchestration for both buffered and streaming LLM decision execution.
  * Ensured fallback is triggered consistently based on the outcome of each attempt, with more reliable retry tracking during streaming.
* **Configuration**
  * Reorganized configuration validation to provide clearer, more consistent checks for URL schemes, target bindings, and default target protocol alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->