### PR TITLE
test: stabilize ARM runner setup

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -237,9 +237,16 @@ jobs:
       - name: Install musl tools
         if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-musl') || startsWith(matrix.target, 'aarch64-unknown-linux-musl') }}
         run: |
-          set -e
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
+          set -euo pipefail
+          if [ "${{ runner.arch }}" = "ARM64" ]; then
+            for sources in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+              if [ -f "$sources" ]; then
+                sudo sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' "$sources"
+              fi
+            done
+          fi
+          sudo apt-get -o Acquire::Retries=5 update
+          sudo apt-get -o Acquire::Retries=5 install -y musl-tools
 
       - name: Build CLI release binary
         working-directory: ${{ env.NEMO_RELAY_CI_WORKSPACE }}

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -24,6 +24,7 @@ fn gateway_bin() -> &'static str {
 }
 
 const ACTIVE_GENERATION_TOKEN: &str = "active-generation";
+const SIDECAR_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn write_active_generation(temp: &std::path::Path) -> std::path::PathBuf {
     let generation = temp.join("plugin/.nemo-relay-generation");
@@ -1250,7 +1251,7 @@ fn wait_for_port_closed(address: SocketAddr) {
 }
 
 fn wait_for_owned_sidecar(temp: &std::path::Path, previous_pid: Option<u64>) -> serde_json::Value {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + SIDECAR_PUBLICATION_TIMEOUT;
     loop {
         for path in find_runtime_files_matching(temp, "sidecar-", ".owner.json") {
             if let Ok(raw) = std::fs::read(path)


### PR DESCRIPTION
#### Overview

This isolates two unrelated ARM CI failures observed while validating #428: a sidecar-publication timing flake and transient Ubuntu ports package-download failures.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Allow up to 30 seconds for test sidecars to publish ownership state on slower ARM runners.
- Use HTTPS for Ubuntu ports package sources on ARM.
- Retry apt metadata and package downloads up to five times.

No production runtime behavior changes.

Validation:
- Repeated the previously flaky CLI test 10 times.
- cargo clippy -p nemo-relay-cli --test cli_tests -- -D warnings
- just test-rust
- uv run pre-commit run --all-files

#### Where should the reviewer start?

Start with the Install musl tools step in .github/workflows/ci_rust.yml, then review the test-only timeout constant in crates/cli/tests/cli_tests.rs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build reliability for ARM64 and musl-based environments by adding package-manager retries and platform-specific setup handling.

- **Tests**
  - Increased the sidecar publication wait period to 30 seconds, reducing failures caused by slower startup or publishing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->