### PR TITLE
test: make mock listener sockets blocking

### DIFF
--- a/crates/cli/tests/coverage/shared/bootstrap_tests.rs
+++ b/crates/cli/tests/coverage/shared/bootstrap_tests.rs
@@ -104,6 +104,7 @@ fn foreign_and_incompatible_listeners_are_never_adopted() {
                 }
                 match listener.accept() {
                     Ok((mut stream, _)) => {
+                        stream.set_nonblocking(false).unwrap();
                         stream
                             .set_read_timeout(Some(Duration::from_secs(5)))
                             .unwrap();


### PR DESCRIPTION
#### Overview

This isolates an unrelated macOS CI flake observed while validating #430. A test listener is nonblocking, but its accepted socket was read as though it were blocking; macOS returned WouldBlock and the test helper panicked.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Reset the accepted mock HTTP socket to blocking mode before applying its bounded read timeout. This matches the shared accept_bounded test helper and changes test infrastructure only.

Validation:
- Repeated foreign_and_incompatible_listeners_are_never_adopted 30 times.
- cargo clippy -p nemo-relay-cli --lib -- -D warnings
- just test-rust
- uv run pre-commit run --all-files

#### Where should the reviewer start?

Review the accepted-socket setup in crates/cli/tests/coverage/shared/bootstrap_tests.rs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test server connection handling to ensure reliable blocking I/O during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->