### PR TITLE
test: allow loaded worker cancellation completion

### DIFF
--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -52,6 +52,7 @@ use tower::service_fn;
 const ACTIVATION_ID: &str = "activation-1";
 const AUTH_TOKEN: &str = "secret-token";
 const PLUGIN_ID: &str = "acme.worker";
+const WORKER_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 const REQUIRED_WORKER_ENVS: &[&str] = &[
     "NEMO_RELAY_WORKER_SOCKET",
     "NEMO_RELAY_HOST_SOCKET",
@@ -288,7 +289,7 @@ async fn worker_service_rejects_duplicate_registration_names_on_one_surface() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
-    let timeout = Duration::from_secs(2);
+    let timeout = WORKER_TEST_TIMEOUT;
     let plugin = Arc::new(CancellationPlugin::default());
     let (handle, mut client) = spawn_worker(plugin.clone(), "http://127.0.0.1:9".into()).await;
     tokio::time::timeout(timeout, register_plugin(&mut client))
@@ -411,7 +412,7 @@ async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn worker_service_cancels_stream_during_async_setup() {
-    let timeout = Duration::from_secs(2);
+    let timeout = WORKER_TEST_TIMEOUT;
     let plugin = Arc::new(CancellationPlugin::default());
     let (handle, mut client) = spawn_worker(plugin.clone(), "http://127.0.0.1:9".into()).await;
     tokio::time::timeout(timeout, register_plugin(&mut client))


### PR DESCRIPTION
#### Overview

This isolates an unrelated Linux CI flake observed while validating #433. The worker cancellation contract succeeded, but its client task exceeded a two-second test deadline under a fully loaded Rust matrix.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Use one named 10-second deadline for both worker cancellation tests. The tests still fail boundedly when cancellation stalls, while allowing scheduling delays on loaded CI hosts. Production behavior is unchanged.

Validation:
- Repeated worker_service_cancels_unary_and_stream_invocations_by_id 30 times.
- cargo clippy -p nemo-relay-worker --test worker_sdk_tests -- -D warnings
- just test-rust
- uv run pre-commit run --all-files

#### Where should the reviewer start?

Review WORKER_TEST_TIMEOUT and its two cancellation-test call sites in crates/worker/tests/worker_sdk_tests.rs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized timeout handling in cancellation-related asynchronous tests.
  * Preserved existing test behavior while improving consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->