### PR TITLE
fix(switchyard): route same-protocol provider extensions

### DIFF
--- a/crates/switchyard/src/component.rs
+++ b/crates/switchyard/src/component.rs
@@ -542,6 +542,15 @@ impl SwitchyardRuntime {
         })
     }
 
+    // Skip the portability guard when no configured target uses a different protocol: with no
+    // possible cross-protocol translation, provider-specific fields never need to be portable.
+    fn may_translate_protocol(&self, inbound: WireProtocol) -> bool {
+        self.config
+            .targets
+            .values()
+            .any(|target| target.protocol != inbound)
+    }
+
     async fn require_healthy_sidecar(&self) -> Result<(), String> {
         let health_url = switchyard_health_url(&self.config.decision_api_url)?;
         let client = reqwest::Client::builder()
@@ -575,7 +584,9 @@ impl SwitchyardRuntime {
         if !self.config.enabled_inbound_profiles.contains(&inbound) {
             return next(original).await;
         }
-        if let Err(error) = validate_portable_request(&self.translation, inbound, &original) {
+        if self.may_translate_protocol(inbound)
+            && let Err(error) = validate_portable_request(&self.translation, inbound, &original)
+        {
             self.emit_error(
                 None,
                 0,
@@ -690,7 +701,9 @@ impl SwitchyardRuntime {
         if !self.config.enabled_inbound_profiles.contains(&inbound) {
             return next(original).await;
         }
-        if let Err(error) = validate_portable_request(&self.translation, inbound, &original) {
+        if self.may_translate_protocol(inbound)
+            && let Err(error) = validate_portable_request(&self.translation, inbound, &original)
+        {
             self.emit_error(
                 None,
                 0,

--- a/crates/switchyard/tests/unit/component_tests.rs
+++ b/crates/switchyard/tests/unit/component_tests.rs
@@ -1665,3 +1665,75 @@ async fn streaming_never_retries_after_first_item() {
     assert_eq!(dispatches.load(Ordering::SeqCst), 1);
     assert_eq!(decisions.lock().unwrap().len(), 1);
 }
+
+fn responses_config(decision_api_url: String) -> SwitchyardConfig {
+    let targets = BTreeMap::from([
+        (
+            "resp-a".into(),
+            binding(WireProtocol::OpenaiResponses, "model-a"),
+        ),
+        (
+            "resp-b".into(),
+            binding(WireProtocol::OpenaiResponses, "model-b"),
+        ),
+    ]);
+    SwitchyardConfig {
+        decision_api_url,
+        decision_profile_id: "stage_router".into(),
+        request_materialization: RequestMaterialization::SummaryOnly,
+        context_mode: ContextMode::PayloadOnly,
+        decision_timeout_millis: 1_000,
+        targets,
+        default_targets: ProtocolDefaults {
+            openai_chat: String::new(),
+            openai_responses: "resp-a".into(),
+            anthropic_messages: String::new(),
+        },
+        enabled_inbound_profiles: BTreeSet::from([WireProtocol::OpenaiResponses]),
+        ..SwitchyardConfig::default()
+    }
+}
+
+fn responses_decision() -> RoutingDecision {
+    RoutingDecision {
+        route: crate::contract::RoutingTarget {
+            tier: "efficient".into(),
+            target_model: "model-b".into(),
+            backend_id: "resp-b".into(),
+            target_protocol_profile: "openai_responses".into(),
+            target_endpoint: "/v1/responses".into(),
+        },
+        baseline_route: None,
+        ..decision()
+    }
+}
+
+// When every configured target shares the inbound protocol, no cross-protocol translation can
+// occur, so the portability guard is skipped: a non-portable Responses request (real Codex
+// extensions) is routed through the Decision API with its provider-specific fields preserved.
+#[tokio::test]
+async fn same_protocol_targets_route_nonportable_streaming_requests() {
+    let (url, decisions) = decision_server_for(responses_decision()).await;
+    let runtime = SwitchyardRuntime::new(responses_config(url)).unwrap();
+    let mut nonportable = request(WireProtocol::OpenaiResponses);
+    nonportable.content["reasoning"] = json!({"effort": "high"});
+    nonportable.content["store"] = json!(true);
+    let next: LlmStreamExecutionNextFn = Arc::new(|request| {
+        Box::pin(async move {
+            assert_eq!(request.content["model"], "model-b");
+            assert_eq!(request.content["store"], true);
+            assert_eq!(request.content["reasoning"]["effort"], "high");
+            Ok(Box::pin(futures_stream::iter(vec![Ok(
+                json!({"type": "response.output_text.delta", "delta": "ok"}),
+            )])) as LlmJsonStream)
+        })
+    });
+    let output = runtime
+        .execute_stream("openai.responses", nonportable, next)
+        .await
+        .unwrap()
+        .collect::<Vec<_>>()
+        .await;
+    assert_eq!(output.len(), 1);
+    assert_eq!(decisions.lock().unwrap().len(), 1);
+}


### PR DESCRIPTION
#### Overview

Switchyard's portability guard (`validate_portable_request`) runs unconditionally before the Decision API and rejects any request carrying provider-specific fields that cannot be losslessly translated to another protocol, dispatching the trusted same-protocol fallback instead of routing. When every configured target already uses the inbound protocol, no cross-protocol translation can ever occur, so the guard needlessly blocks routing of legitimate same-protocol requests.

Concretely, a stock Codex `/v1/responses` request (`reasoning`, `store`, `include`, `prompt_cache_key`, `client_metadata`, `parallel_tool_calls`) is non-portable and therefore never reaches the Decision API — even for a Responses-only routing profile where no translation is possible. Codex agents cannot be stage-routed at all today.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Gate the portability guard on a new `may_translate_protocol(inbound)` predicate: run `validate_portable_request` only when at least one configured target uses a different wire protocol than the inbound request.

**This deliberately narrows the portability guarantee** — it is a behavior change, not a pure refactor:

- The bypass applies only when **every** configured target matches the inbound protocol. One mixed-protocol target restores the existing guard (conservative: the Decision API contract permits returning any configured backend, so the predicate must consider all of them).
- Decodable same-protocol provider extensions (e.g. `store`, `prompt_cache_key`, `reasoning`) are now forwarded **unchanged** to trusted same-protocol targets. This can surface provider-specific fields to a different same-protocol backend, which maintainers should weigh.
- Requests must still decode/materialize successfully — arbitrary opaque payloads are **not** newly accepted.
- Hermes (`openai_chat`) and all mixed-protocol configurations are unaffected.

One behavioral test added in `crates/switchyard/tests/unit/component_tests.rs`: `same_protocol_targets_route_nonportable_streaming_requests` — a Responses-only config routes a non-portable request (`reasoning` + `store`) through the Decision API and asserts both provider-specific fields reach the backend unchanged. The guard-preserved (mixed-protocol) path is already covered by the existing `execution_bypasses_inapplicable_calls_and_fails_open_on_extensions` test, which continues to pass.

Verified: `cargo test -p nemo-relay-switchyard` (31 passed, 0 failed; the existing `execution_bypasses_inapplicable_calls_and_fails_open_on_extensions` still passes), `cargo fmt --check`, `cargo clippy` clean.

End-to-end evidence (manual, against a real `switchyard-server` + NVIDIA inference API):
- Responses-only routing config: a codex-shaped non-portable `/v1/responses` request → `switchyard.routing.decision=1, error=0, fallback=0` (routed).
- Same request with one added `anthropic_messages` target → `decision=0, error=1, fallback=1` (guard preserved).
- Before this change (same responses-only config): `decision=0`, all requests fell back — stock Codex could not be routed.

#### Where should the reviewer start?

`crates/switchyard/src/component.rs` — the `may_translate_protocol` helper and its use at the two `validate_portable_request` call sites (`execute_buffered`, `execute_stream`). The key design question is whether narrowing the guard to translation-possible configs is acceptable given that same-protocol provider extensions now reach the routed backend unchanged.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #442


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing for requests sent to targets using the same protocol as the inbound request.
  * Provider-specific fields are preserved for compatible streaming requests instead of being unnecessarily rejected or transformed.
  * Portability checks now run only when cross-protocol translation may be required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->