### PR TITLE
ci: exclude generated skill artifacts from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Agent skill contents are managed independently and must not trigger repository checks.
-exclude: '^skills/[^/]+/'
+# Generated agent-skill artifacts are managed independently and must not trigger repository checks.
+exclude: '^skills/[^/]+/(?:BENCHMARK\.md|skill-card\.md|skill\.oms\.sig)$'
 
 repos:
   # SPDX copyright header check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Agent skill contents are managed independently and must not trigger repository checks.
+exclude: '^skills/[^/]+/'
+
 repos:
   # SPDX copyright header check
   - repo: local


### PR DESCRIPTION
#### Overview

Exclude generated agent-skill artifacts from repository pre-commit checks.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add a top-level pre-commit exclusion for `skills/<skill-name>/BENCHMARK.md`, `skill-card.md`, and `skill.oms.sig`.
- Keep `SKILL.md`, references, evals, assets, and `skills/README.md` eligible for checks.

#### Where should the reviewer start?

Review `.pre-commit-config.yaml`; the exact, anchored filename pattern applies in both changed-file and all-files CI modes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository checks to skip generated agent skill artifact files within individual skill directories, reducing unnecessary pre-commit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->