### PR TITLE
ci: use compatible Cargo client for Artifactory publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,8 @@ stages:
 
 variables:
   NEMO_RELAY_CI_DEBIAN_VERSION: "trixie"
+  # Artifactory 7.133 rejects Cargo 1.96's required octet-stream publish header.
+  NEMO_RELAY_CI_CARGO_PUBLISH_VERSION: "1.93.0"
   NEMO_RELAY_CI_JUST_VERSION: "1.40.0"
   NEMO_RELAY_CI_NODE_VERSION: "24"
   NEMO_RELAY_CI_PYTHON_VERSION: "3.11"
@@ -209,6 +211,7 @@ publish:artifactory:cargo:
       artifacts: true
   before_script:
     - apt-get update -qq && apt-get install -y --no-install-recommends ca-certificates curl git nodejs && rm -rf /var/lib/apt/lists/*
+    - rustup toolchain install --profile minimal "${NEMO_RELAY_CI_CARGO_PUBLISH_VERSION}"
     - cargo install just --version "${NEMO_RELAY_CI_JUST_VERSION}" --locked
     - curl -LsSf https://astral.sh/uv/install.sh -o /tmp/install-uv.sh
     - UV_VERSION="${NEMO_RELAY_CI_UV_VERSION}" sh /tmp/install-uv.sh
@@ -229,6 +232,11 @@ publish:artifactory:cargo:
         echo "Error: no collected GitHub run metadata found." >&2
         exit 1
       fi
+
+      publish_cargo="$(rustup which --toolchain "${NEMO_RELAY_CI_CARGO_PUBLISH_VERSION}" cargo)"
+      publish_rustc="$(rustup which rustc)"
+      "$publish_cargo" --version
+      "$publish_rustc" --version
 
       version="$(
         uv run --no-project python - <<'PY'
@@ -280,7 +288,7 @@ publish:artifactory:cargo:
       )"
 
       for crate in $crates; do
-        cargo publish --package "$crate" --registry artifactory --allow-dirty
+        RUSTC="$publish_rustc" "$publish_cargo" publish --package "$crate" --registry artifactory --allow-dirty
       done
 
 publish:artifactory:npm:


### PR DESCRIPTION
#### Overview

Restore nightly Cargo publishing to Artifactory after its HTTP 415 response to Cargo 1.96 upload requests.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Install Cargo 1.93 only for Artifactory publishing, which retains the upload media type accepted by the current Artifactory deployment.
- Continue to use Rust 1.96.1 as the compiler for Cargo package verification.

#### Where should the reviewer start?

Review `.gitlab-ci.yml`, especially the `publish:artifactory:cargo` job's selected Cargo client and Rust compiler paths.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none