### PR TITLE
docs: replace relative links which are broken in documentation builds

### DIFF
--- a/docs/resources/legal/oss.mdx
+++ b/docs/resources/legal/oss.mdx
@@ -12,8 +12,8 @@ NeMo Relay includes open source dependencies across Rust, Python, and Node.js pa
 
 Dependency attribution files live at the repository root:
 
-- [`ATTRIBUTIONS-Rust.md`](../../../ATTRIBUTIONS-Rust.md)
-- [`ATTRIBUTIONS-Python.md`](../../../ATTRIBUTIONS-Python.md)
-- [`ATTRIBUTIONS-Node.md`](../../../ATTRIBUTIONS-Node.md)
+- [`ATTRIBUTIONS-Rust.md`](https://github.com/NVIDIA/NeMo-Relay/blob/main/ATTRIBUTIONS-Rust.md)
+- [`ATTRIBUTIONS-Python.md`](https://github.com/NVIDIA/NeMo-Relay/blob/main/ATTRIBUTIONS-Python.md)
+- [`ATTRIBUTIONS-Node.md`](https://github.com/NVIDIA/NeMo-Relay/blob/main/ATTRIBUTIONS-Node.md)
 
 Use the repository root `LICENSE` file for the NeMo Relay project license.


### PR DESCRIPTION
#### Overview

Replace relative links with github.com links


- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

* These are currently broken in https://docs.nvidia.com/nemo/relay/resources/legal/oss

#### Where should the reviewer start?

* `docs/resources/legal/oss.mdx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated open-source dependency attribution links to point directly to the relevant files in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->