### PR TITLE
docs: fix generated API reference redirects

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -29,8 +29,40 @@ redirects:
   destination: /nemo/relay/v0.5.0/reference/api/rust-library-reference/nemo-relay/codec/model-pricing
 - source: /nemo/relay/reference/api/rust-library-reference/nemo-relay/plugins/pricing
   destination: /nemo/relay/v0.5.0/reference/api/rust-library-reference/nemo-relay/plugins/model-pricing
-- source: /nemo/relay/reference/api/python-library-reference/:slug*
-  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/:slug*
+# Keep legacy Python modules explicit so these redirects do not shadow the
+# current package-scoped nemo-relay and nemo-relay-plugin reference pages.
+- source: /nemo/relay/reference/api/python-library-reference/adaptive
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/adaptive
+- source: /nemo/relay/reference/api/python-library-reference/codecs
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/codecs
+- source: /nemo/relay/reference/api/python-library-reference/guardrails
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/guardrails
+- source: /nemo/relay/reference/api/python-library-reference/integrations
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/integrations
+- source: /nemo/relay/reference/api/python-library-reference/integrations/:slug*
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/integrations/:slug*
+- source: /nemo/relay/reference/api/python-library-reference/intercepts
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/intercepts
+- source: /nemo/relay/reference/api/python-library-reference/llm
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/llm
+- source: /nemo/relay/reference/api/python-library-reference/model-pricing
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/model-pricing
+- source: /nemo/relay/reference/api/python-library-reference/observability
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/observability
+- source: /nemo/relay/reference/api/python-library-reference/plugin
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/plugin
+- source: /nemo/relay/reference/api/python-library-reference/scope-local
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/scope-local
+- source: /nemo/relay/reference/api/python-library-reference/scope
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/scope
+- source: /nemo/relay/reference/api/python-library-reference/subscribers
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/subscribers
+- source: /nemo/relay/reference/api/python-library-reference/tools
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/tools
+- source: /nemo/relay/reference/api/python-library-reference/typed
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/typed
+- source: /nemo/relay/reference/api/python-library-reference/utils
+  destination: /nemo/relay/v0.5.0/reference/api/python-library-reference/nemo-relay/utils
 - source: /nemo/relay/reference/api/rust-library-reference/nemo-relay/codec/pricing/:slug*
   destination: /nemo/relay/v0.5.0/reference/api/rust-library-reference/nemo-relay/codec/model-pricing/:slug*
 - source: /nemo/relay/reference/api/rust-library-reference/nemo-relay/plugins/pricing/:slug*


### PR DESCRIPTION
#### Overview

Fix the legacy Python API redirect rule that shadows current package-scoped generated reference pages and produces duplicated package slugs followed by 404s.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace the broad legacy Python API catch-all with explicit redirects for the historical top-level modules.
- Preserve the legacy nested integrations redirect without matching current `nemo-relay` and `nemo-relay-plugin` routes.
- Keep all historical redirect destinations on the v0.5.0 documentation.
- Breaking changes: none.

Validation:
- Clicked all 1,223 generated API navigation entries and verified the expected URL and a non-empty rendered page.
- Validated 29,737 generated page-link occurrences: 9,522 internal and 20,215 external.
- Ran `just docs`.
- Ran `just docs-linkcheck`.
- Ran `uv run pre-commit run --all-files`.

#### Where should the reviewer start?

Review the Python API redirect block in `fern/docs.yml`, especially the replacement of the package-shadowing `:slug*` rule.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none
