### PR TITLE
chore: prepare 0.6 code freeze

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,3 +3,4 @@
 
 branches:
   - main
+  - release/0.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-adaptive"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "log",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-ffi"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-node"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "napi",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-pii-redaction"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "futures",
  "log",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nemo-relay-types",
  "serde",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-python"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-switchyard"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "futures-util",
  "hyper-util",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker-proto"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,23 +21,23 @@ exclude = [".tmp", ".uv-cache"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/NeMo-Relay"
 
 [workspace.dependencies]
-nemo-relay = { version = "0.6.0", path = "crates/core", default-features = false }
-nemo-relay-types = { version = "0.6.0", path = "crates/types" }
-nemo-relay-plugin = { version = "0.6.0", path = "crates/plugin" }
-nemo-relay-worker-proto = { version = "0.6.0", path = "crates/worker-proto" }
-nemo-relay-worker = { version = "0.6.0", path = "crates/worker" }
-nemo-relay-adaptive = { version = "0.6.0", path = "crates/adaptive" }
-nemo-relay-pii-redaction = { version = "0.6.0", path = "crates/pii-redaction" }
-nemo-relay-switchyard = { version = "0.6.0", path = "crates/switchyard" }
+nemo-relay = { version = "0.7.0", path = "crates/core", default-features = false }
+nemo-relay-types = { version = "0.7.0", path = "crates/types" }
+nemo-relay-plugin = { version = "0.7.0", path = "crates/plugin" }
+nemo-relay-worker-proto = { version = "0.7.0", path = "crates/worker-proto" }
+nemo-relay-worker = { version = "0.7.0", path = "crates/worker" }
+nemo-relay-adaptive = { version = "0.7.0", path = "crates/adaptive" }
+nemo-relay-pii-redaction = { version = "0.7.0", path = "crates/pii-redaction" }
+nemo-relay-switchyard = { version = "0.7.0", path = "crates/switchyard" }
 switchyard-translation = "0.1.0"
-nemo-relay-ffi = { version = "0.6.0", path = "crates/ffi" }
-nemo-relay-cli = { version = "0.6.0", path = "crates/cli" }
+nemo-relay-ffi = { version = "0.7.0", path = "crates/ffi" }
+nemo-relay-cli = { version = "0.7.0", path = "crates/cli" }
 opentelemetry = { version = "0.31", default-features = false }
 opentelemetry_sdk = { version = "0.31", default-features = false }
 uuid = "=1.18.1"

--- a/crates/core/tests/fixtures/worker_plugin/Cargo.lock
+++ b/crates/core/tests/fixtures/worker_plugin/Cargo.lock
@@ -100,9 +100,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -115,15 +115,15 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -507,9 +507,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -519,9 +519,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -536,7 +536,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "futures-util",
  "hyper-util",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker-proto"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -824,9 +824,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
@@ -933,9 +933,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys",
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",
@@ -1367,6 +1367,6 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-node",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Node.js bindings for the NeMo Relay agent runtime.",
   "keywords": [
     "agents",

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -96,7 +96,7 @@ transport = "http_binary"
 endpoint = "http://localhost:4318/v1/traces"
 service_name = "nemo-relay"
 service_namespace = "agent"
-service_version = "0.6.0"
+service_version = "0.7.0"
 instrumentation_scope = "nemo-relay-observability"
 timeout_millis = 3000
 
@@ -113,7 +113,7 @@ transport = "http_binary"
 endpoint = "http://localhost:6006/v1/traces"
 service_name = "nemo-relay"
 service_namespace = "agent"
-service_version = "0.6.0"
+service_version = "0.7.0"
 instrumentation_scope = "nemo-relay-openinference"
 timeout_millis = 3000
 
@@ -234,7 +234,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:4318/v1/traces",
                     service_name="nemo-relay",
                     service_namespace="agent",
-                    service_version="0.6.0",
+                    service_version="0.7.0",
                     instrumentation_scope="nemo-relay-observability",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -243,7 +243,7 @@ config = plugin.PluginConfig(
                     endpoint="http://localhost:6006/v1/traces",
                     service_name="nemo-relay",
                     service_namespace="agent",
-                    service_version="0.6.0",
+                    service_version="0.7.0",
                     instrumentation_scope="nemo-relay-openinference",
                     resource_attributes={"deployment.environment": "dev"},
                 ),
@@ -307,7 +307,7 @@ void (async () => {
           endpoint: "http://localhost:4318/v1/traces",
           service_name: "nemo-relay",
           service_namespace: "agent",
-          service_version: "0.6.0",
+          service_version: "0.7.0",
           instrumentation_scope: "nemo-relay-observability",
           resource_attributes: {
             "deployment.environment": "dev",
@@ -318,7 +318,7 @@ void (async () => {
           endpoint: "http://localhost:6006/v1/traces",
           service_name: "nemo-relay",
           service_namespace: "agent",
-          service_version: "0.6.0",
+          service_version: "0.7.0",
           instrumentation_scope: "nemo-relay-openinference",
           resource_attributes: {
             "deployment.environment": "dev",
@@ -389,7 +389,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             endpoint: Some("http://localhost:4318/v1/traces".into()),
             service_name: "nemo-relay".into(),
             service_namespace: Some("agent".into()),
-            service_version: Some("0.6.0".into()),
+            service_version: Some("0.7.0".into()),
             instrumentation_scope: Some("nemo-relay-observability".into()),
             resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
             ..OtlpSectionConfig::default()
@@ -399,7 +399,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             endpoint: Some("http://localhost:6006/v1/traces".into()),
             service_name: "nemo-relay".into(),
             service_namespace: Some("agent".into()),
-            service_version: Some("0.6.0".into()),
+            service_version: Some("0.7.0".into()),
             instrumentation_scope: Some("nemo-relay-openinference".into()),
             resource_attributes: [("deployment.environment".into(), "dev".into())].into(),
             ..OtlpSectionConfig::default()

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -101,7 +101,7 @@ asset is published.
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | NEMO_RELAY_VERSION=0.6.0 sh
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | NEMO_RELAY_VERSION=0.7.0 sh
 ```
 
 Install into another directory:
@@ -125,7 +125,7 @@ Set the same environment variable before invoking the installer to install a
 specific version:
 
 ```powershell
-$env:NEMO_RELAY_VERSION = '0.6.0'
+$env:NEMO_RELAY_VERSION = '0.7.0'
 irm https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.ps1 | iex
 ```
 
@@ -179,7 +179,7 @@ Install the Python package when your application uses NeMo Relay through the
 Python wrapper and owns the tool or LLM call boundary.
 
 ```bash
-uv add nemo-relay@0.6.0
+uv add nemo-relay@0.7.0
 ```
 
 Use `uv add` from an application project that has a `pyproject.toml`; it records
@@ -202,8 +202,8 @@ npm install nemo-relay-node
 Add the Rust crates when your application uses NeMo Relay directly from Rust.
 
 ```bash
-cargo add nemo-relay@0.6.0
-cargo add nemo-relay-adaptive@0.6.0
+cargo add nemo-relay@0.7.0
+cargo add nemo-relay-adaptive@0.7.0
 ```
 
 - `nemo-relay` provides the core runtime APIs for scopes, middleware, subscribers, plugins, tool calls, and LLM calls.
@@ -220,7 +220,7 @@ Install the OpenClaw plugin through OpenClaw so OpenClaw can register and manage
 the package:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.6.0
+openclaw plugins install npm:nemo-relay-openclaw@0.7.0
 openclaw gateway restart
 ```
 
@@ -250,7 +250,7 @@ Install the Python package with the supported framework extras when your
 application uses LangChain, LangGraph, or Deep Agents.
 
 ```bash
-uv add "nemo-relay[langchain,langgraph,deepagents]@0.6.0"
+uv add "nemo-relay[langchain,langgraph,deepagents]@0.7.0"
 ```
 
 The extras install the NeMo Relay Python package plus the dependencies needed by

--- a/docs/getting-started/quick-start/python.mdx
+++ b/docs/getting-started/quick-start/python.mdx
@@ -20,7 +20,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-uv add nemo-relay@0.6.0
+uv add nemo-relay@0.7.0
 ```
 
 Run `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/quick-start/rust.mdx
+++ b/docs/getting-started/quick-start/rust.mdx
@@ -18,7 +18,7 @@ local checkout.
 Use the published crates when you are consuming a release:
 
 ```bash
-cargo add nemo-relay@0.6.0
+cargo add nemo-relay@0.7.0
 cargo add serde_json
 cargo add tokio --features macros,rt-multi-thread
 ```
@@ -27,7 +27,7 @@ Install the published NeMo Relay CLI separately when you need coding-agent hook
 and LLM gateway observability:
 
 ```bash
-cargo install nemo-relay-cli@0.6.0
+cargo install nemo-relay-cli@0.7.0
 ```
 
 ### Install from the Repository
@@ -47,7 +47,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 - `nemo-relay-adaptive` is a companion crate for adaptive runtime primitives and
   Redis-backed learning components when you need adaptive behavior later, but it
   is not required for this minimal direct-runtime example.
-- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.6.0`
+- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.7.0`
   when you need the NeMo Relay CLI.
 
 ## Run One Scope, One Tool Call, and One LLM Call

--- a/docs/supported-integrations/openclaw-plugin.mdx
+++ b/docs/supported-integrations/openclaw-plugin.mdx
@@ -41,7 +41,7 @@ Optional:
 Install the plugin with OpenClaw so OpenClaw can register and manage it:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.6.0
+openclaw plugins install npm:nemo-relay-openclaw@0.7.0
 openclaw gateway restart
 ```
 
@@ -54,7 +54,7 @@ If you manage OpenClaw plugin dependencies directly in a Node.js project,
 install the package with npm:
 
 ```bash
-npm install nemo-relay-openclaw@0.6.0
+npm install nemo-relay-openclaw@0.7.0
 ```
 
 Installing with npm makes the package available to that project. Use

--- a/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
+++ b/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Native Relay gateway lifecycle and Claude Code hooks for complete local observability.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/coding-agents/codex/.codex-plugin/plugin.json
+++ b/integrations/coding-agents/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Native Relay gateway lifecycle and Codex hooks for complete local observability.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-openclaw",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "NeMo Relay-authored observability plugin for OpenClaw.",
   "type": "module",
   "repository": {
@@ -63,7 +63,7 @@
     "openclaw": "^2026.7.1"
   },
   "dependencies": {
-    "nemo-relay-node": "0.6.0"
+    "nemo-relay-node": "0.7.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
     },
     "crates/node": {
       "name": "nemo-relay-node",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -463,10 +463,10 @@
     },
     "integrations/openclaw": {
       "name": "nemo-relay-openclaw",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nemo-relay-node": "0.6.0"
+        "nemo-relay-node": "0.7.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/python/plugin/pyproject.toml
+++ b/python/plugin/pyproject.toml
@@ -8,7 +8,7 @@ backend-path = ["."]
 
 [project]
 name = "nemo-relay-plugin"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python SDK for NeMo Relay dynamic worker plugins."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1496,7 +1496,7 @@ test = [
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "python/plugin" }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
#### Overview

Prepare the 0.6 code-freeze follow-up on `main`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- The `release/0.6` branch is managed separately; this PR intentionally does not create or push it.
- Add `release/0.6` to the nightly alpha branch configuration.
- Run `just set-version 0.7.0` to advance Cargo, Node/OpenClaw, Python-plugin, coding-agent plugin, and lockfile metadata on `main`.
- Update current `0.6.0` install, quick-start, OpenClaw, and observability configuration examples to `0.7.0`; no current-version `0.6.0` references remain under `README.md`, `docs`, or `fern`.
- Release-bound PRs should now target `release/0.6`; this code-freeze PR targets `main`.

Validation:

- `cargo check --workspace` (with Python 3.12)
- `just docs`
- `npx fern check --warnings`
- `npx fern docs broken-links --strict`
- YAML, `uv.lock`, documentation-version audit, `git diff --check`, and pre-commit hooks

#### Where should the reviewer start?

Start with `.github/nightly-alpha-branches.yaml`, then review the version and current-documentation updates in `Cargo.toml` and `docs/getting-started/installation.mdx`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated NeMo Relay and related plugins to version **0.7.0**.
  * Added support for nightly builds from the `release/0.6` branch.

* **Documentation**
  * Updated installation, quick-start, integration, and observability examples to reference version **0.7.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->