### PR TITLE
fix: restore task-local Python scope stacks

### DIFF
--- a/python/nemo_relay/_context.py
+++ b/python/nemo_relay/_context.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private helpers for synchronizing Python and native scope context."""
+
+from __future__ import annotations
+
+
+def ensure_scope_stack() -> None:
+    """Ensure the current Python context's stack is active in the native runtime.
+
+    A ``ContextVar`` owns the stack for asyncio tasks. Native code uses a
+    thread-local fallback outside its Tokio tasks, so concurrent Python tasks
+    must re-synchronize that fallback before each context-sensitive call.
+    Explicit worker-thread bindings remain untouched when no ``ContextVar`` is
+    present.
+    """
+    import nemo_relay
+
+    stack = nemo_relay._scope_stack_var.get(None)
+    if stack is not None:
+        nemo_relay._sync_thread_scope_stack(stack)
+        return
+
+    if nemo_relay._native_scope_stack_active():
+        return
+
+    nemo_relay.get_scope_stack()

--- a/python/nemo_relay/llm.py
+++ b/python/nemo_relay/llm.py
@@ -33,6 +33,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from nemo_relay._context import ensure_scope_stack
 from nemo_relay._native import (
     LLMRequest,
     LlmStream,
@@ -119,6 +120,7 @@ def call(
             metadata={"status": "success"},
         )
     """
+    ensure_scope_stack()
     return _native_llm_call(
         name,
         request,
@@ -169,6 +171,7 @@ def call_end(
         ``timestamp`` must be a timezone-aware ``datetime``; strings and naive
         datetimes are rejected.
     """
+    ensure_scope_stack()
     return _native_llm_call_end(
         handle,
         response,
@@ -256,6 +259,7 @@ def execute(
             response_codec=nemo_relay.codecs.OpenAIChatCodec(),
         )
     """
+    ensure_scope_stack()
     return _native_llm_call_execute(
         name,
         request,
@@ -353,6 +357,7 @@ def stream_execute(
         async for chunk in stream:
             print(chunk)
     """
+    ensure_scope_stack()
     return _native_llm_stream_call_execute(
         name,
         request,
@@ -385,6 +390,7 @@ def request_intercepts(name, request):
         This runs only the request-intercept chain. It does not execute
         guardrails, codecs, provider callbacks, or stream handling.
     """
+    ensure_scope_stack()
     return _native_llm_request_intercepts(name, request)
 
 
@@ -403,6 +409,7 @@ def conditional_execution(request):
         This helper evaluates only conditional-execution guardrails and does
         not invoke request intercepts, codecs, or provider execution.
     """
+    ensure_scope_stack()
     return _native_llm_conditional_execution(request)
 
 

--- a/python/nemo_relay/scope.py
+++ b/python/nemo_relay/scope.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from typing import Iterator
 
 from nemo_relay import Json
+from nemo_relay._context import ensure_scope_stack as _ensure_scope_stack
 from nemo_relay._native import (
     ScopeAttributes,
     ScopeHandle,
@@ -38,35 +39,6 @@ from nemo_relay._native import (
 from nemo_relay._native import (
     push_scope as _native_push_scope,
 )
-
-
-def _ensure_scope_stack() -> None:
-    """Ensure the current context's scope stack is active on the Rust thread-local.
-
-    Three cases:
-
-    1. **ContextVar is set** (normal async tasks, or after ``push_node_scope``
-       installed a branch stack): always re-sync it to the Rust thread-local.
-       This is critical because concurrent async tasks share a single OS thread
-       and the thread-local may have been overwritten by another task.
-    2. **ContextVar is empty but thread-local is set** (worker threads that
-       called ``set_thread_scope_stack``): keep the thread-local as-is.
-    3. **Neither is set**: create a new scope stack via ``get_scope_stack()``.
-    """
-    import nemo_relay
-
-    # Case 1: ContextVar owns a stack — re-sync it to the Rust thread-local.
-    stack = nemo_relay._scope_stack_var.get(None)
-    if stack is not None:
-        nemo_relay._sync_thread_scope_stack(stack)
-        return
-
-    # Case 2: Worker thread with explicit set_thread_scope_stack — don't clobber.
-    if nemo_relay._native_scope_stack_active():
-        return
-
-    # Case 3: Fresh context — create and register a new stack.
-    nemo_relay.get_scope_stack()
 
 
 def get_handle() -> ScopeHandle:
@@ -285,7 +257,7 @@ def scope(
             metadata = {"otel.status_code": status_code}
             if status_message is not None:
                 metadata["otel.status_description"] = status_message
-            _native_pop_scope(pushed_handle, metadata=metadata, timestamp=end_timestamp)
+            pop(pushed_handle, metadata=metadata, timestamp=end_timestamp)
 
 
 __all__ = ["event", "get_handle", "pop", "push", "scope"]

--- a/python/nemo_relay/tools.py
+++ b/python/nemo_relay/tools.py
@@ -22,6 +22,7 @@ Example::
 
 from datetime import datetime
 
+from nemo_relay._context import ensure_scope_stack
 from nemo_relay._native import (
     tool_call as _native_tool_call,
 )
@@ -95,6 +96,7 @@ def call(
             metadata={"status": "success"},
         )
     """
+    ensure_scope_stack()
     return _native_tool_call(
         name,
         args,
@@ -127,6 +129,7 @@ def call_end(handle, result, *, data=None, metadata=None, timestamp: datetime | 
         ``timestamp`` must be a timezone-aware ``datetime``; strings and naive
         datetimes are rejected.
     """
+    ensure_scope_stack()
     return _native_tool_call_end(handle, result, data=data, metadata=metadata, timestamp=timestamp)
 
 
@@ -179,6 +182,7 @@ def execute(name, args, func, *, handle=None, attributes=None, data=None, metada
         )
         assert result["count"] == 3
     """
+    ensure_scope_stack()
     return _native_tool_call_execute(
         name, args, func, handle=handle, attributes=attributes, data=data, metadata=metadata
     )
@@ -198,6 +202,7 @@ def request_intercepts(name, args):
         This runs only the request-intercept chain. It does not execute
         conditional guardrails, sanitize guardrails, or the tool callback.
     """
+    ensure_scope_stack()
     return _native_tool_request_intercepts(name, args)
 
 
@@ -216,6 +221,7 @@ def conditional_execution(name, args):
         This helper evaluates only the conditional-execution guardrail chain
         and does not invoke request intercepts or tool execution.
     """
+    ensure_scope_stack()
     return _native_tool_conditional_execution(name, args)
 
 

--- a/python/tests/test_context_isolation.py
+++ b/python/tests/test_context_isolation.py
@@ -45,6 +45,162 @@ def test_get_scope_stack_different_across_tasks():
     assert results["a"] != results["b"], "Tasks should have different scope stacks"
 
 
+def test_scope_context_manager_closes_on_its_own_task_stack():
+    """Concurrent scope exits restore the stack owned by the exiting task."""
+    completed = []
+
+    async def run_scope(name):
+        token = nemo_relay._scope_stack_var.set(nemo_relay.create_scope_stack())
+        try:
+            with nemo_relay.scope.scope(name, nemo_relay.ScopeType.Agent):
+                await asyncio.sleep(0)
+            completed.append(name)
+        finally:
+            nemo_relay._scope_stack_var.reset(token)
+
+    async def main():
+        await asyncio.gather(run_scope("agent-a"), run_scope("agent-b"))
+
+    asyncio.run(main())
+    assert completed == ["agent-a", "agent-b"]
+
+
+def test_concurrent_tool_lifecycle_uses_owning_task_stack(subscribed_events):
+    """Tool lifecycle helpers preserve task-local middleware and event ancestry."""
+
+    async def run_tool(owner):
+        token = nemo_relay._scope_stack_var.set(nemo_relay.create_scope_stack())
+        try:
+            with nemo_relay.scope.scope(f"tool-scope-{owner}", nemo_relay.ScopeType.Agent) as handle:
+                scope_local = nemo_relay.scope_local
+                scope_local.register_tool_request(
+                    handle,
+                    f"tool-request-{owner}",
+                    1,
+                    False,
+                    lambda name, args: {**args, "intercepted_by": owner},
+                )
+                scope_local.register_tool_conditional_execution(
+                    handle,
+                    f"tool-condition-{owner}",
+                    1,
+                    lambda name, args: None if args["owner"] == owner else "wrong task scope",
+                )
+
+                await asyncio.sleep(0)
+                args = nemo_relay.tools.request_intercepts("task-tool", {"owner": owner})
+                nemo_relay.tools.conditional_execution("task-tool", args)
+
+                manual_handle = nemo_relay.tools.call(f"manual-tool-{owner}", args)
+                await asyncio.sleep(0)
+                nemo_relay.tools.call_end(manual_handle, {"owner": owner})
+
+                result = await nemo_relay.tools.execute(
+                    f"managed-tool-{owner}",
+                    {"owner": owner},
+                    lambda managed_args: managed_args,
+                )
+                return handle.uuid, result
+        finally:
+            nemo_relay._scope_stack_var.reset(token)
+
+    async def main():
+        return await asyncio.gather(run_tool("agent-a"), run_tool("agent-b"))
+
+    results = asyncio.run(main())
+    nemo_relay.subscribers.flush()
+
+    for owner, (scope_uuid, result) in zip(("agent-a", "agent-b"), results, strict=True):
+        assert result == {"owner": owner, "intercepted_by": owner}
+        for tool_name in (f"manual-tool-{owner}", f"managed-tool-{owner}"):
+            tool_events = [
+                event
+                for event in subscribed_events
+                if isinstance(event, nemo_relay.ScopeEvent) and event.category == "tool" and event.name == tool_name
+            ]
+            assert {event.scope_category for event in tool_events} == {"start", "end"}
+            assert {event.parent_uuid for event in tool_events} == {scope_uuid}
+
+
+def test_concurrent_llm_lifecycle_uses_owning_task_stack(subscribed_events):
+    """LLM lifecycle helpers preserve task-local middleware and event ancestry."""
+
+    async def run_llm(owner):
+        token = nemo_relay._scope_stack_var.set(nemo_relay.create_scope_stack())
+        try:
+            with nemo_relay.scope.scope(f"llm-scope-{owner}", nemo_relay.ScopeType.Agent) as handle:
+                scope_local = nemo_relay.scope_local
+
+                def intercept(name, request, annotated):
+                    return nemo_relay.LLMRequestInterceptOutcome(
+                        nemo_relay.LLMRequest(request.headers, {**request.content, "intercepted_by": owner}),
+                        annotated,
+                    )
+
+                scope_local.register_llm_request(handle, f"llm-request-{owner}", 1, False, intercept)
+                scope_local.register_llm_conditional_execution(
+                    handle,
+                    f"llm-condition-{owner}",
+                    1,
+                    lambda request: None if request.content["owner"] == owner else "wrong task scope",
+                )
+
+                request = nemo_relay.LLMRequest({}, {"messages": [], "owner": owner})
+                await asyncio.sleep(0)
+                intercepted = nemo_relay.llm.request_intercepts("task-llm", request)
+                assert intercepted.request.content["intercepted_by"] == owner
+                nemo_relay.llm.conditional_execution(request)
+
+                manual_handle = nemo_relay.llm.call(f"manual-llm-{owner}", request)
+                await asyncio.sleep(0)
+                nemo_relay.llm.call_end(manual_handle, {"owner": owner})
+
+                result = await nemo_relay.llm.execute(
+                    f"managed-llm-{owner}",
+                    request,
+                    lambda managed_request: managed_request.content,
+                )
+
+                collected = []
+
+                async def stream_func(stream_request):
+                    yield {
+                        "owner": stream_request.content["owner"],
+                        "intercepted_by": stream_request.content["intercepted_by"],
+                    }
+
+                stream = await nemo_relay.llm.stream_execute(
+                    f"stream-llm-{owner}",
+                    request,
+                    stream_func,
+                    collected.append,
+                    lambda: {"count": len(collected)},
+                )
+                chunks = [chunk async for chunk in stream]
+                return handle.uuid, result, chunks
+        finally:
+            nemo_relay._scope_stack_var.reset(token)
+
+    async def main():
+        return await asyncio.gather(run_llm("agent-a"), run_llm("agent-b"))
+
+    results = asyncio.run(main())
+    nemo_relay.subscribers.flush()
+
+    for owner, (scope_uuid, result, chunks) in zip(("agent-a", "agent-b"), results, strict=True):
+        expected = {"messages": [], "owner": owner, "intercepted_by": owner}
+        assert result == expected
+        assert chunks == [{"owner": owner, "intercepted_by": owner}]
+        for llm_name in (f"manual-llm-{owner}", f"managed-llm-{owner}", f"stream-llm-{owner}"):
+            llm_events = [
+                event
+                for event in subscribed_events
+                if isinstance(event, nemo_relay.ScopeEvent) and event.category == "llm" and event.name == llm_name
+            ]
+            assert {event.scope_category for event in llm_events} == {"start", "end"}
+            assert {event.parent_uuid for event in llm_events} == {scope_uuid}
+
+
 def test_scope_stack_repr():
     """ScopeStack has a meaningful repr."""
     stack = nemo_relay.create_scope_stack()


### PR DESCRIPTION
#### Overview

Restore the active task's Python scope stack before every context-sensitive native lifecycle call. This prevents concurrent asyncio tasks from closing scopes or invoking tool/LLM middleware against a sibling task's stack.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Centralize ContextVar-to-native stack synchronization in a private helper.
- Apply synchronization to scope, tool, and LLM lifecycle wrappers, including managed and streaming execution.
- Close context-manager scopes through the synchronized `pop()` wrapper.
- Add concurrent asyncio regressions for scope cleanup, middleware isolation, lifecycle helpers, and event ancestry.

#### Where should the reviewer start?

Start with `python/nemo_relay/_context.py`, then `python/tests/test_context_isolation.py` for the concurrent task coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope and context handling for concurrent operations.
  * Ensured tool and LLM lifecycle events remain associated with the correct task.
  * Improved cleanup when scoped operations complete, including status metadata handling.

* **Tests**
  * Added coverage for concurrent tool and LLM operations.
  * Added validation for task-local scope restoration and event ancestry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->