### PR TITLE
fix: route Relay headers through ChatNVIDIA transport

### DIFF
--- a/docs/supported-integrations/langchain.mdx
+++ b/docs/supported-integrations/langchain.mdx
@@ -88,6 +88,10 @@ final_message = result["messages"][-1]
 print(f"Final response: {final_message.content}")
 ```
 
+When the agent uses `ChatNVIDIA`, NeMo Relay forwards request headers, including
+Dynamo session lineage, as HTTP headers. They are not added to the NIM request
+body.
+
 ## Verify the Integration
 
 The integration works correctly when:

--- a/python/nemo_relay/integrations/langchain/_serialization.py
+++ b/python/nemo_relay/integrations/langchain/_serialization.py
@@ -235,6 +235,23 @@ def model_request_to_payload(model_name: str | None, request: ModelRequest[Any])
     return payload
 
 
+def _chat_nvidia_with_relay_headers(model: Any, headers: dict[str, Any]) -> Any | None:
+    """Return a per-request ChatNVIDIA model carrying Relay headers over HTTP."""
+    try:
+        from langchain_nvidia_ai_endpoints import ChatNVIDIA
+    except ImportError:
+        return None
+
+    if not isinstance(model, ChatNVIDIA):
+        return None
+
+    relay_headers = {
+        key: value if isinstance(value, str) else json.dumps(value, separators=(",", ":"))
+        for key, value in headers.items()
+    }
+    return model.model_copy(update={"default_headers": {**model.default_headers, **relay_headers}})
+
+
 def payload_to_model_request(
     original: ModelRequest[Any],
     llm_request: LLMRequest,
@@ -264,8 +281,12 @@ def payload_to_model_request(
         extra_headers = {}
 
     if len(llm_request.headers) > 0:
-        extra_headers.update(llm_request.headers)
-        overrides["model_settings"]["extra_headers"] = extra_headers
+        model_with_headers = _chat_nvidia_with_relay_headers(original.model, llm_request.headers)
+        if model_with_headers is not None:
+            overrides["model"] = model_with_headers
+        else:
+            extra_headers.update(llm_request.headers)
+            overrides["model_settings"]["extra_headers"] = extra_headers
 
     if "tool_choice" in llm_request.content:
         overrides["tool_choice"] = llm_request.content["tool_choice"]

--- a/python/nemo_relay/integrations/langchain/_serialization.py
+++ b/python/nemo_relay/integrations/langchain/_serialization.py
@@ -249,7 +249,11 @@ def _chat_nvidia_with_relay_headers(model: Any, headers: dict[str, Any]) -> Any 
         key: value if isinstance(value, str) else json.dumps(value, separators=(",", ":"))
         for key, value in headers.items()
     }
-    return model.model_copy(update={"default_headers": {**model.default_headers, **relay_headers}})
+    relay_header_names = {key.lower() for key in relay_headers}
+    default_headers = {
+        key: value for key, value in model.default_headers.items() if key.lower() not in relay_header_names
+    }
+    return model.model_copy(update={"default_headers": {**default_headers, **relay_headers}})
 
 
 def payload_to_model_request(

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -242,6 +242,77 @@ def test_langchain_model_request_codec_round_trips_messages(model_request: Model
     round_tripped = payload_to_model_request(model_request, encoded)
 
     assert round_tripped.messages[0].content == "hello from intercept"
+
+
+def test_payload_to_model_request_moves_relay_headers_to_chat_nvidia_transport(model_request: ModelRequest[Any]):
+    from nemo_relay.integrations.langchain._serialization import (
+        model_request_to_payload,
+        payload_to_model_request,
+    )
+
+    ChatNVIDIA = pytest.importorskip("langchain_nvidia_ai_endpoints").ChatNVIDIA
+    original_model = ChatNVIDIA.model_construct(default_headers={"x-existing": "existing", "x-shared": "provider"})
+    original = model_request.override(model=original_model)
+    relay_request = nemo_relay.LLMRequest(
+        {
+            "x-dynamo-session-id": "session-1",
+            "x-shared": "relay",
+            "x-json": {"enabled": True},
+        },
+        model_request_to_payload("mock-model", original),
+    )
+
+    converted = payload_to_model_request(original, relay_request)
+
+    assert converted.model is not original_model
+    assert cast(Any, converted.model).default_headers == {
+        "x-existing": "existing",
+        "x-shared": "relay",
+        "x-dynamo-session-id": "session-1",
+        "x-json": '{"enabled":true}',
+    }
+    assert original_model.default_headers == {"x-existing": "existing", "x-shared": "provider"}
+    assert converted.model_settings == {"temperature": 1.0}
+
+
+def test_payload_to_model_request_leaves_chat_nvidia_model_unchanged_without_relay_headers(
+    model_request: ModelRequest[Any],
+):
+    from nemo_relay.integrations.langchain._serialization import (
+        model_request_to_payload,
+        payload_to_model_request,
+    )
+
+    ChatNVIDIA = pytest.importorskip("langchain_nvidia_ai_endpoints").ChatNVIDIA
+    original_model = ChatNVIDIA.model_construct(default_headers={"x-existing": "existing"})
+    original = model_request.override(model=original_model)
+    converted = payload_to_model_request(
+        original,
+        nemo_relay.LLMRequest({}, model_request_to_payload("mock-model", original)),
+    )
+
+    assert converted.model is original_model
+    assert converted.model_settings == {"temperature": 1.0}
+
+
+def test_payload_to_model_request_keeps_generic_model_headers_in_model_settings(model_request: ModelRequest[Any]):
+    from nemo_relay.integrations.langchain._serialization import (
+        model_request_to_payload,
+        payload_to_model_request,
+    )
+
+    relay_request = nemo_relay.LLMRequest(
+        {"x-relay-header": "value"},
+        model_request_to_payload("mock-model", model_request),
+    )
+
+    converted = payload_to_model_request(model_request, relay_request)
+
+    assert converted.model is model_request.model
+    assert converted.model_settings == {
+        "temperature": 1.0,
+        "extra_headers": {"x-relay-header": "value"},
+    }
 
 
 def test_langchain_model_response_codec_decodes_text_and_tool_calls():

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -251,7 +251,7 @@ def test_payload_to_model_request_moves_relay_headers_to_chat_nvidia_transport(m
     )
 
     ChatNVIDIA = pytest.importorskip("langchain_nvidia_ai_endpoints").ChatNVIDIA
-    original_model = ChatNVIDIA.model_construct(default_headers={"x-existing": "existing", "x-shared": "provider"})
+    original_model = ChatNVIDIA.model_construct(default_headers={"x-existing": "existing", "X-Shared": "provider"})
     original = model_request.override(model=original_model)
     relay_request = nemo_relay.LLMRequest(
         {
@@ -271,7 +271,7 @@ def test_payload_to_model_request_moves_relay_headers_to_chat_nvidia_transport(m
         "x-dynamo-session-id": "session-1",
         "x-json": '{"enabled":true}',
     }
-    assert original_model.default_headers == {"x-existing": "existing", "x-shared": "provider"}
+    assert original_model.default_headers == {"x-existing": "existing", "X-Shared": "provider"}
     assert converted.model_settings == {"temperature": 1.0}
 
 


### PR DESCRIPTION
#### Overview

Route Relay request headers for `ChatNVIDIA` through its HTTP transport so they are not sent as unsupported NIM request-body fields.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Clone `ChatNVIDIA` per request with Relay headers merged into `default_headers`, preserving provider headers while allowing Relay values to take precedence.
- Keep other LangChain models on the existing `extra_headers` path.
- Add focused integration coverage and document the HTTP-header behavior.

#### Where should the reviewer start?

Start with `python/nemo_relay/integrations/langchain/_serialization.py`, then review the focused cases in `python/tests/integrations/langchain_tests/test_middleware.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LangChain `ChatNVIDIA` integration now forwards NeMo Relay request headers via HTTP transport.
  * Header handling now prefers embedding relay headers into the `ChatNVIDIA` model when possible; otherwise it uses model settings.
  * Non-string header values are automatically JSON-serialized.
* **Documentation**
  * Clarified that forwarded headers (including Dynamo session lineage) are sent as HTTP headers and are not included in the NIM request body.
* **Tests**
  * Added coverage for header embedding, fallback behavior, and generic model handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->