### PR TITLE
fix: release the GIL during Python plugin teardown

### DIFF
--- a/crates/python/src/py_plugin.rs
+++ b/crates/python/src/py_plugin.rs
@@ -955,8 +955,8 @@ fn initialize_with_dynamic_plugins_py<'py>(
 
 #[pyfunction(name = "clear_plugin_configuration")]
 #[pyo3(signature = () -> "None", text_signature = "() -> None")]
-fn clear_plugin_configuration_py() -> PyResult<()> {
-    clear_plugin_configuration().map_err(to_py_err)
+fn clear_plugin_configuration_py(py: Python<'_>) -> PyResult<()> {
+    py.detach(clear_plugin_configuration).map_err(to_py_err)
 }
 
 #[pyfunction(name = "active_plugin_report")]

--- a/crates/python/tests/coverage/py_plugin_coverage_tests.rs
+++ b/crates/python/tests/coverage/py_plugin_coverage_tests.rs
@@ -577,7 +577,7 @@ async def initialize_plugins(module, config):
 
             let active = active_plugin_report_py(py).unwrap();
             assert!(!active.bind(py).is_none());
-            clear_plugin_configuration_py().unwrap();
+            clear_plugin_configuration_py(py).unwrap();
             assert!(active_plugin_report_py(py).unwrap().bind(py).is_none());
 
             let failing_config = crate::convert::json_to_py(

--- a/python/tests/test_observability_plugin.py
+++ b/python/tests/test_observability_plugin.py
@@ -13,7 +13,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
-from nemo_relay import ScopeType, plugin, scope, subscribers
+from nemo_relay import ScopeType, plugin, scope
 from nemo_relay.observability import (
     OBSERVABILITY_PLUGIN_KIND,
     AtifConfig,
@@ -234,6 +234,7 @@ class TestObservabilityConfigHelpers:
         received: list[bytes] = []
         request_received = threading.Event()
         allow_response = threading.Event()
+        teardown_started = threading.Event()
 
         class CaptureHandler(BaseHTTPRequestHandler):
             def do_POST(self):
@@ -287,13 +288,20 @@ class TestObservabilityConfigHelpers:
                     },
                 )
 
-            subscribers.flush()
-            assert request_received.wait(timeout=2)
-            allow_response.set()
+            def release_response() -> None:
+                teardown_started.wait(timeout=5)
+                request_received.wait(timeout=5)
+                allow_response.set()
+
+            response_thread = threading.Thread(target=release_response, daemon=True)
+            response_thread.start()
+            teardown_started.set()
             started_at = time.monotonic()
             plugin.clear()
             cleared = True
             assert time.monotonic() - started_at < 2
+            response_thread.join(timeout=2)
+            assert not response_thread.is_alive()
 
             file_events = [json.loads(line) for line in (tmp_path / "events.jsonl").read_text().splitlines()]
             stream_events = [json.loads(body) for body in received]

--- a/python/tests/test_observability_plugin.py
+++ b/python/tests/test_observability_plugin.py
@@ -6,11 +6,14 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 import typing
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
-from nemo_relay import ScopeType, plugin, scope
+from nemo_relay import ScopeType, plugin, scope, subscribers
 from nemo_relay.observability import (
     OBSERVABILITY_PLUGIN_KIND,
     AtifConfig,
@@ -202,6 +205,113 @@ class TestObservabilityConfigHelpers:
         assert trajectory["agent"]["tool_definitions"][0]["name"] == "search"
         assert trajectory["agent"]["extra"]["binding"] == "python"
         assert "python-observability-agent" in json.dumps(trajectory["extra"])
+
+    @pytest.mark.parametrize(
+        ("field_name_policy", "expected_data"),
+        [
+            (
+                "preserve",
+                {
+                    "service.name": "relay",
+                    "nested": {"deployment.region": "us-east"},
+                },
+            ),
+            (
+                "replace_dots",
+                {
+                    "service_name": "relay",
+                    "nested": {"deployment_region": "us-east"},
+                },
+            ),
+        ],
+    )
+    async def test_atof_stream_sink_dotted_fields_deliver_during_plugin_clear(
+        self,
+        tmp_path: Path,
+        field_name_policy: typing.Literal["preserve", "replace_dots"],
+        expected_data: dict[str, object],
+    ):
+        received: list[bytes] = []
+        request_received = threading.Event()
+        allow_response = threading.Event()
+
+        class CaptureHandler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                content_length = int(self.headers["Content-Length"])
+                received.append(self.rfile.read(content_length))
+                request_received.set()
+                assert allow_response.wait(timeout=5)
+                self.send_response(204)
+                self.end_headers()
+
+            def log_message(self, format: str, *args: typing.Any) -> None:
+                return None
+
+        server = HTTPServer(("127.0.0.1", 0), CaptureHandler)
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+        cleared = False
+        try:
+            await plugin.initialize(
+                plugin.PluginConfig(
+                    components=[
+                        ComponentSpec(
+                            ObservabilityConfig(
+                                atof=AtofConfig(
+                                    enabled=True,
+                                    sinks=[
+                                        AtofFileSinkConfig(
+                                            output_directory=str(tmp_path),
+                                            filename="events.jsonl",
+                                            mode="overwrite",
+                                        ),
+                                        AtofStreamSinkConfig(
+                                            url=f"http://127.0.0.1:{server.server_port}/events",
+                                            timeout_millis=5000,
+                                            field_name_policy=field_name_policy,
+                                        ),
+                                    ],
+                                )
+                            )
+                        )
+                    ]
+                )
+            )
+            with scope.scope("python-stream-agent", ScopeType.Agent) as handle:
+                scope.event(
+                    "python-dotted-mark",
+                    handle=handle,
+                    data={
+                        "service.name": "relay",
+                        "nested": {"deployment.region": "us-east"},
+                    },
+                )
+
+            subscribers.flush()
+            assert request_received.wait(timeout=2)
+            allow_response.set()
+            started_at = time.monotonic()
+            plugin.clear()
+            cleared = True
+            assert time.monotonic() - started_at < 2
+
+            file_events = [json.loads(line) for line in (tmp_path / "events.jsonl").read_text().splitlines()]
+            stream_events = [json.loads(body) for body in received]
+            assert len(file_events) == len(stream_events) == 3
+            file_mark = next(event for event in file_events if event["name"] == "python-dotted-mark")
+            stream_mark = next(event for event in stream_events if event["name"] == "python-dotted-mark")
+            assert file_mark["data"] == {
+                "service.name": "relay",
+                "nested": {"deployment.region": "us-east"},
+            }
+            assert stream_mark["data"] == expected_data
+        finally:
+            allow_response.set()
+            if not cleared:
+                plugin.clear()
+            server.shutdown()
+            server_thread.join(timeout=5)
+            server.server_close()
 
     async def test_atif_flushes_open_agent_on_clear(self, tmp_path):
         await plugin.initialize(


### PR DESCRIPTION
#### Overview

Release the GIL while synchronous Python plugin teardown waits for ATOF HTTP sink workers.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Run `clear_plugin_configuration` through `py.detach` so other Python threads can service HTTP sink responses during teardown.
- Add coverage for preserve and replace-dots ATOF stream policies using a gated local HTTP capture server and file sink assertions.

#### Where should the reviewer start?

- `crates/python/src/py_plugin.rs`: the GIL release around the blocking teardown call.
- `python/tests/test_observability_plugin.py`: the regression scenario.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Python plugin configuration clearing to use the active Python execution context so clear operations complete promptly even with stream delivery in flight.
  * Verified observability stream sink behavior during `plugin.clear()`, including correct handling/transformation of dotted field names according to the selected policy.
  * Preserved consistent Python exception mapping when clearing fails.
* **Tests**
  * Adjusted coverage tests for updated Python binding signature.
  * Added an end-to-end observability test with an in-process HTTP capture to validate file + stream sink delivery during `plugin.clear()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->