### PR TITLE
test: avoid interactive plugin editor in dispatch test

### DIFF
--- a/crates/cli/tests/coverage/commands/main_tests.rs
+++ b/crates/cli/tests/coverage/commands/main_tests.rs
@@ -9,8 +9,8 @@ use super::serve::ServerArgs;
 use super::*;
 use crate::commands::model_pricing::{PricingSubcommand, PricingValidateCommand};
 use crate::commands::plugins::{
-    PluginsCommand, PluginsEditCommand, PluginsInspectCommand, PluginsListCommand,
-    PluginsSubcommand, PluginsValidateCommand,
+    PluginsCommand, PluginsInspectCommand, PluginsListCommand, PluginsSubcommand,
+    PluginsValidateCommand,
 };
 
 #[test]
@@ -262,16 +262,6 @@ fn safe_dispatch_helpers_cover_completions_and_plugins_paths() {
         .unwrap(),
         ExitCode::SUCCESS
     );
-
-    let error = run_plugins(
-        PluginsCommand {
-            command: PluginsSubcommand::Edit(PluginsEditCommand::default()),
-        },
-        &server,
-    )
-    .unwrap_err()
-    .to_string();
-    assert!(error.contains("interactive terminal") || error.contains("TTY"));
 
     assert_eq!(
         run_plugins(


### PR DESCRIPTION
#### Overview

Prevent the CLI test suite from entering the interactive plugin editor when run from a terminal.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Remove the direct `plugins edit` dispatch from the general CLI helper test. That in-process call inherited the developer's terminal and could open the real editor instead of returning the expected TTY error.
- Keep the helper test focused on non-interactive plugin commands.
- Retain the existing CLI subprocess test as the deterministic coverage for `plugins edit` rejecting non-TTY execution.

#### Where should the reviewer start?

Start with `crates/cli/tests/coverage/commands/main_tests.rs`, where the interactive `PluginsSubcommand::Edit` invocation is removed from `safe_dispatch_helpers_cover_completions_and_plugins_paths`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated command coverage tests by removing outdated plugin-edit scenarios.
  * Continued validating plugin listing, inspection, and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->