### PR TITLE
fix: demote Claude startup probe warning to debug

### DIFF
--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -99,16 +99,6 @@ async fn run_managed_gateway(
     if prep.bypass_managed_pipeline {
         let session_id = prep.session_id.clone();
         let session_finish = prep.session_finish;
-        let model = prep.model_name.as_deref().unwrap_or("<unknown>");
-        log::warn!(
-            target: "nemo_relay.gateway",
-            event = "observability_bypassed",
-            session_id = session_id.as_str(),
-            provider = prep.provider_name.as_str(),
-            model = model,
-            reason = "startup_probe";
-            "Managed observability was bypassed for a startup probe"
-        );
         state
             .sessions
             .finish_gateway_call(&session_id, session_finish)

--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -99,6 +99,16 @@ async fn run_managed_gateway(
     if prep.bypass_managed_pipeline {
         let session_id = prep.session_id.clone();
         let session_finish = prep.session_finish;
+        let model = prep.model_name.as_deref().unwrap_or("<unknown>");
+        log::debug!(
+            target: "nemo_relay.gateway",
+            event = "observability_bypassed",
+            session_id = session_id.as_str(),
+            provider = prep.provider_name.as_str(),
+            model = model,
+            reason = "startup_probe";
+            "Managed observability was bypassed for a startup probe"
+        );
         state
             .sessions
             .finish_gateway_call(&session_id, session_finish)

--- a/crates/cli/tests/architecture_tests.rs
+++ b/crates/cli/tests/architecture_tests.rs
@@ -291,10 +291,6 @@ impl<'ast> Visit<'ast> for LogMacroVisitor {
         let macro_name = path.rsplit("::").next().unwrap_or_default();
         if matches!(macro_name, "info" | "warn" | "error" | "debug" | "trace") {
             let tokens = item.tokens.to_string();
-            if matches!(macro_name, "debug" | "trace") {
-                self.failures
-                    .push(format!("production call site uses {path}!"));
-            }
             let target = string_field(&tokens, "target :");
             if target
                 .as_deref()

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -312,15 +312,21 @@ fn cli_jsonl_logging_records_successful_command_lifecycle_without_leaking_secret
 }
 
 #[test]
-fn cli_claude_startup_probe_bypass_emits_no_warning() {
-    let default_stderr = run_claude_startup_probe();
+fn cli_claude_startup_probe_bypass_is_debug_only() {
+    let default_stderr = run_claude_startup_probe(None);
     assert!(
         !default_stderr.contains(" WARN ") && !default_stderr.contains("observability_bypassed"),
-        "startup probe bypass should not emit a warning: {default_stderr}"
+        "startup probe bypass should not be logged by default: {default_stderr}"
+    );
+
+    let debug_stderr = run_claude_startup_probe(Some("debug"));
+    assert!(
+        debug_stderr.contains(" DEBUG ") && debug_stderr.contains("observability_bypassed"),
+        "startup probe bypass should be logged at debug level: {debug_stderr}"
     );
 }
 
-fn run_claude_startup_probe() -> String {
+fn run_claude_startup_probe(log_level: Option<&str>) -> String {
     let temp = tempfile::tempdir().unwrap();
     let probe = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = probe.local_addr().unwrap();
@@ -333,11 +339,18 @@ fn run_claude_startup_probe() -> String {
         .arg(&upstream_url)
         .env("HOME", temp.path())
         .env("XDG_CONFIG_HOME", temp.path().join("xdg"))
-        .env_remove("NEMO_RELAY_LOG")
         .env_remove("NEMO_RELAY_LOG_STDERR_FORMAT")
         .env_remove("NEMO_RELAY_LOG_CONFIG_PATH")
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
+    match log_level {
+        Some(level) => {
+            command.env("NEMO_RELAY_LOG", level);
+        }
+        None => {
+            command.env_remove("NEMO_RELAY_LOG");
+        }
+    }
     let mut child = command.spawn().unwrap();
 
     let body = r#"{"model":"claude-sonnet-4-5","max_tokens":1,"messages":[{"role":"user","content":"test"}]}"#;

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -312,6 +312,75 @@ fn cli_jsonl_logging_records_successful_command_lifecycle_without_leaking_secret
 }
 
 #[test]
+fn cli_claude_startup_probe_bypass_emits_no_warning() {
+    let default_stderr = run_claude_startup_probe();
+    assert!(
+        !default_stderr.contains(" WARN ") && !default_stderr.contains("observability_bypassed"),
+        "startup probe bypass should not emit a warning: {default_stderr}"
+    );
+}
+
+fn run_claude_startup_probe() -> String {
+    let temp = tempfile::tempdir().unwrap();
+    let probe = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = probe.local_addr().unwrap();
+    drop(probe);
+    let (upstream_url, received) = spawn_single_request_server(200, r#"{"id":"probe"}"#);
+
+    let mut command = Command::new(gateway_bin());
+    command
+        .args(["--bind", &address.to_string(), "--anthropic-base-url"])
+        .arg(&upstream_url)
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("xdg"))
+        .env_remove("NEMO_RELAY_LOG")
+        .env_remove("NEMO_RELAY_LOG_STDERR_FORMAT")
+        .env_remove("NEMO_RELAY_LOG_CONFIG_PATH")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().unwrap();
+
+    let body = r#"{"model":"claude-sonnet-4-5","max_tokens":1,"messages":[{"role":"user","content":"test"}]}"#;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match TcpStream::connect_timeout(&address, Duration::from_millis(100)) {
+            Ok(mut stream) => {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .unwrap();
+                stream
+                    .write_all(
+                        format!(
+                            "POST /v1/messages HTTP/1.1\r\nHost: {address}\r\ncontent-type: application/json\r\nx-api-key: test\r\nx-claude-code-session-id: probe-session\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .unwrap();
+                let mut response = String::new();
+                stream.read_to_string(&mut response).unwrap();
+                assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+                break;
+            }
+            Err(_) if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
+            Err(error) => {
+                let _ = child.kill();
+                let output = wait_child_with_output(child);
+                panic!(
+                    "gateway did not accept the startup probe: {error}; stderr: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+        }
+    }
+
+    let upstream_request = received.recv_timeout(Duration::from_secs(2)).unwrap();
+    assert!(upstream_request.starts_with("POST /v1/messages "));
+    child.kill().unwrap();
+    String::from_utf8(wait_child_with_output(child).stderr).unwrap()
+}
+
+#[test]
 fn cli_logs_final_failure_before_shutdown_and_preserves_user_error() {
     let temp = tempfile::tempdir().unwrap();
     let (config_path, log_path) = write_jsonl_logging_config(temp.path());

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -351,7 +351,7 @@ fn run_claude_startup_probe(log_level: Option<&str>) -> String {
             command.env_remove("NEMO_RELAY_LOG");
         }
     }
-    let mut child = command.spawn().unwrap();
+    let child = ChildGuard::new(command.spawn().unwrap());
 
     let body = r#"{"model":"claude-sonnet-4-5","max_tokens":1,"messages":[{"role":"user","content":"test"}]}"#;
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -377,8 +377,7 @@ fn run_claude_startup_probe(log_level: Option<&str>) -> String {
             }
             Err(_) if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
             Err(error) => {
-                let _ = child.kill();
-                let output = wait_child_with_output(child);
+                let output = child.finish();
                 panic!(
                     "gateway did not accept the startup probe: {error}; stderr: {}",
                     String::from_utf8_lossy(&output.stderr)
@@ -389,8 +388,7 @@ fn run_claude_startup_probe(log_level: Option<&str>) -> String {
 
     let upstream_request = received.recv_timeout(Duration::from_secs(2)).unwrap();
     assert!(upstream_request.starts_with("POST /v1/messages "));
-    child.kill().unwrap();
-    String::from_utf8(wait_child_with_output(child).stderr).unwrap()
+    String::from_utf8(child.finish().stderr).unwrap()
 }
 
 #[test]
@@ -1353,6 +1351,29 @@ fn wait_child(child: &mut Child) -> ExitStatus {
             panic!("child process did not exit within 10 seconds");
         }
         thread::sleep(Duration::from_millis(20));
+    }
+}
+
+struct ChildGuard(Option<Child>);
+
+impl ChildGuard {
+    fn new(child: Child) -> Self {
+        Self(Some(child))
+    }
+
+    fn finish(mut self) -> Output {
+        let mut child = self.0.take().unwrap();
+        let _ = child.kill();
+        wait_child_with_output(child)
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(child) = self.0.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
     }
 }
 

--- a/docs/nemo-relay-cli/claude-code.mdx
+++ b/docs/nemo-relay-cli/claude-code.mdx
@@ -182,8 +182,6 @@ when each span has a real `UserPromptSubmit` payload and assistant output. NeMo
 Relay excludes the known Claude Code startup/preflight probe and late
 uncorrelatable lifecycle hooks from exported user traces so they do not appear
 as synthetic `null`, `user: test`, `idle_timeout`, or lifecycle-only turns.
-Suppressed startup probes are still logged by the gateway as internal pre-turn
-probe bypasses for debugging.
 
 ## Smoke Test
 

--- a/docs/nemo-relay-cli/claude-code.mdx
+++ b/docs/nemo-relay-cli/claude-code.mdx
@@ -182,6 +182,8 @@ when each span has a real `UserPromptSubmit` payload and assistant output. NeMo
 Relay excludes the known Claude Code startup/preflight probe and late
 uncorrelatable lifecycle hooks from exported user traces so they do not appear
 as synthetic `null`, `user: test`, `idle_timeout`, or lifecycle-only turns.
+The gateway records suppressed startup probes as debug-level
+`observability_bypassed` events when debug or trace logging is enabled.
 
 ## Smoke Test
 

--- a/integrations/coding-agents/claude-code/README.md
+++ b/integrations/coding-agents/claude-code/README.md
@@ -42,6 +42,8 @@ when each turn has a real prompt input and assistant output. Known startup
 probes, uncorrelatable late stop hooks, and other lifecycle-only noise are
 excluded from exported user traces so they do not appear as synthetic `null`,
 `user: test`, or `idle_timeout` turns.
+The gateway records suppressed startup probes as debug-level
+`observability_bypassed` events when debug or trace logging is enabled.
 
 ## Transparent Setup
 

--- a/integrations/coding-agents/claude-code/README.md
+++ b/integrations/coding-agents/claude-code/README.md
@@ -41,8 +41,7 @@ root `claude-code-turn` span or ATIF trajectory per user turn. That is expected
 when each turn has a real prompt input and assistant output. Known startup
 probes, uncorrelatable late stop hooks, and other lifecycle-only noise are
 excluded from exported user traces so they do not appear as synthetic `null`,
-`user: test`, or `idle_timeout` turns. Startup probes are still logged by the
-gateway as internal pre-turn probe bypasses for debugging.
+`user: test`, or `idle_timeout` turns.
 
 ## Transparent Setup
 


### PR DESCRIPTION
#### Overview

Demote the gateway event for Claude Code's startup/preflight probe from warning to debug so it no longer overlays the prompt input UI under the default logging configuration. The probe continues to bypass managed observability, remains forwarded upstream, and is still available for diagnostics when debug or trace logging is enabled.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Permit production `debug!` and `trace!` call sites while retaining the existing structured-log requirements: approved subsystem targets, snake-case event names, and privacy-sensitive field rejection.
- Emit the `observability_bypassed` startup-probe event at debug instead of warning.
- Add a CLI integration regression test that sends the exact Claude startup probe through a real gateway, verifies upstream forwarding, confirms no event appears at the default info level, and confirms the structured event appears at debug.
- Update the Claude Code documentation to describe the debug-level diagnostic.
- Validate with `cargo test -p nemo-relay-cli`, workspace Clippy with warnings denied, formatting, Cargo check, and the repository commit hooks. The documentation link check passed; `just test-rust` remains unavailable because `uv` is not installed on this host.

#### Where should the reviewer start?

Start with `crates/cli/tests/architecture_tests.rs` for the relaxed but still-structured logging contract, then review `crates/cli/src/gateway/mod.rs` and `crates/cli/tests/cli_tests.rs` for the debug-level behavior and end-to-end coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes [RELAY-505](https://linear.app/nvidia/issue/RELAY-505/fix-gateway-warning-in-nemo-relay-prompt-input)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated gateway startup-probe bypass logging so `observability_bypassed` is debug-level (not warning) by default, while continuing to complete the bypass and return HTTP 200.

- **Tests**
  - Added a CLI gateway integration test verifying silent-by-default bypass logging and presence under debug/trace, plus the expected upstream request behavior.
  - Relaxed the log-macro architecture contract check to avoid flagging debug/trace call sites.

- **Documentation**
  - Revised Claude Code trace documentation to reflect debug-level `observability_bypassed` events only when debug/trace logging is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->