### PR TITLE
docs: refresh getting started IA

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,9 @@ End-user documentation lives at
 Important local entry points:
 
 - [Overview](https://docs.nvidia.com/nemo/relay/about-nemo-relay/overview)
+- [Getting Started](https://docs.nvidia.com/nemo/relay/getting-started/about)
 - [Installation](https://docs.nvidia.com/nemo/relay/getting-started/installation)
-- [Agent Runtime Primer](https://docs.nvidia.com/nemo/relay/getting-started/agent-runtime-primer)
+- [Agent Runtime Primer](https://docs.nvidia.com/nemo/relay/about-nemo-relay/agent-runtime-primer)
 - [Testing and Docs](https://docs.nvidia.com/nemo/relay/contribute/testing-and-docs)
 
 For source builds, tests, and contribution workflow, refer to

--- a/README.md
+++ b/README.md
@@ -335,9 +335,8 @@ End-user documentation lives at
 Important local entry points:
 
 - [Overview](https://docs.nvidia.com/nemo/relay/about-nemo-relay/overview)
-- [Getting Started](https://docs.nvidia.com/nemo/relay/getting-started/about)
+- [Getting Started](https://docs.nvidia.com/nemo/relay/getting-started/quick-start)
 - [Installation](https://docs.nvidia.com/nemo/relay/getting-started/installation)
-- [Agent Runtime Primer](https://docs.nvidia.com/nemo/relay/about-nemo-relay/agent-runtime-primer)
 - [Testing and Docs](https://docs.nvidia.com/nemo/relay/contribute/testing-and-docs)
 
 For source builds, tests, and contribution workflow, refer to

--- a/docs/about-nemo-relay/agent-runtime-primer.mdx
+++ b/docs/about-nemo-relay/agent-runtime-primer.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Agent Runtime Primer"
 description: "Learn the NeMo Relay runtime model for scopes, middleware, events, and integration boundaries."
-position: 1
+position: 2
 ---
 import { MermaidStyles } from "@/components/MermaidStyles";
 
@@ -11,7 +11,8 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 NeMo Relay is a portable runtime layer for agent systems that already have an
 application, framework, or model provider. Use this primer when you need to
-understand what NeMo Relay adds before running [Quick Start](/getting-started/quick-start).
+understand what NeMo Relay adds before choosing an installation, quick-start, or
+integration path.
 
 Agent applications usually cross several boundaries in one request: an entry
 point starts work, the agent calls a model, the model asks for tools, tools call
@@ -91,29 +92,4 @@ It does not replace:
 Instead, it gives those systems a shared runtime contract for call boundaries,
 policy hooks, event emission, and export.
 
-## Find the Right Starting Point
-
-Use this section as a router, not a setup checklist. Start from the destination
-or outcome that matches your task; the linked page points you to the setup,
-configuration, and validation steps for that path.
-
-- **Direct Python, Node.js, or Rust application APIs:** Application code owns
-  callback placement, provider authentication, and plugin initialization. Start
-  with [Quick Start](/getting-started/quick-start), then use
-  [Instrument Applications](/instrument-applications/about) when you own the
-  tool or LLM call site.
-- **LangChain, LangGraph, Deep Agents, or OpenClaw:** Start with
-  [Supported Integrations](/supported-integrations/about) to choose the
-  maintained path and support level. Local wiring still belongs to the
-  application, framework, or OpenClaw plugin configuration.
-- **New framework, orchestration, SDK, or provider integration:** The framework
-  or adapter owns scheduling, retries, callbacks, and provider payloads. Start
-  with [Integrate into Frameworks](/integrate-into-frameworks/about).
-- **Local Claude Code, Codex, or Hermes runs:** The coding-agent harness
-  owns invocation while Relay observes hooks, gateway-routed model traffic, and
-  exporter output. Start with [NeMo Relay CLI](/nemo-relay-cli/about).
-- **Reusable runtime behavior across services or teams:** Runtime plugin
-  configuration owns reusable middleware, subscribers, exporters, model pricing,
-  policy, or adaptive behavior. Start with [Build Plugins](/build-plugins/about),
-  use [Observability](/configure-plugins/observability/about) for export setup, and use
-  [Adaptive](/configure-plugins/adaptive/about) after baseline instrumentation is working.
+For setup routing, start with [Getting Started](/getting-started/about).

--- a/docs/about-nemo-relay/architecture.mdx
+++ b/docs/about-nemo-relay/architecture.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecture"
 description: ""
-position: 2
+position: 3
 ---
 import { MermaidStyles } from "@/components/MermaidStyles";
 

--- a/docs/about-nemo-relay/concepts/index.mdx
+++ b/docs/about-nemo-relay/concepts/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Concepts"
 description: ""
-position: 4
+position: 5
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}

--- a/docs/about-nemo-relay/ecosystem.mdx
+++ b/docs/about-nemo-relay/ecosystem.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ecosystem"
 description: "Understand how NeMo Relay fits with agent frameworks, providers, and the NVIDIA NeMo ecosystem."
-position: 3
+position: 4
 ---
 import { MermaidStyles } from "@/components/MermaidStyles";
 

--- a/docs/about-nemo-relay/overview.mdx
+++ b/docs/about-nemo-relay/overview.mdx
@@ -115,7 +115,7 @@ Use the tasks below to build your understanding and set up Relay:
 | Task | Start With |
 |---|---|
 | Install packages | [Installation](/getting-started/installation) |
-| Understand the mental model | [Agent Runtime Primer](/getting-started/agent-runtime-primer) |
+| Understand the mental model | [Agent Runtime Primer](/about-nemo-relay/agent-runtime-primer) |
 | Configure plugin files | [Plugin Configuration Files](/configure-plugins/plugin-configuration-files) |
 | Export traces or trajectories | [Observability](/configure-plugins/observability/about) |
 | Tune performance with adaptive behavior | [Adaptive](/configure-plugins/adaptive/about) |

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Release Notes"
 description: "Read NeMo Relay release notes and find the official release history."
-position: 5
+position: 6
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}

--- a/docs/contribute/runtime-contract-docs.mdx
+++ b/docs/contribute/runtime-contract-docs.mdx
@@ -27,7 +27,8 @@ These pages define or route the shared runtime model:
 - `docs/about-nemo-relay/concepts/events.mdx`
 - `docs/about-nemo-relay/concepts/framework-integrations.mdx`
 - `docs/about-nemo-relay/concepts/codecs.mdx`
-- `docs/getting-started/agent-runtime-primer.mdx`
+- `docs/about-nemo-relay/agent-runtime-primer.mdx`
+- `docs/getting-started/about.mdx`
 - `docs/getting-started/installation.mdx`
 - `docs/getting-started/quick-start/index.mdx`
 - `docs/reference/api/index.mdx`

--- a/docs/getting-started/about.mdx
+++ b/docs/getting-started/about.mdx
@@ -14,7 +14,7 @@ configuration.
 
 <CardGroup cols={1}>
 <Card
-  title="Using an AI coding assistant?"
+  title="Using an AI Coding Assistant?"
   icon="terminal"
   iconPosition="left"
 >

--- a/docs/getting-started/about.mdx
+++ b/docs/getting-started/about.mdx
@@ -1,0 +1,100 @@
+---
+title: "About"
+description: "Choose the right NeMo Relay getting-started path for your agent system."
+position: 1
+---
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Use Getting Started to choose the smallest NeMo Relay path that matches the
+boundary you want to observe or control. Relay can run beside a local
+coding-agent harness, wrap application-owned tool or LLM calls, connect through
+a maintained framework integration, or activate reusable plugin behavior from
+configuration.
+
+<CardGroup cols={1}>
+<Card
+  title="Using an AI coding assistant?"
+  icon="terminal"
+  iconPosition="left"
+>
+
+Install [NVIDIA agent skills](https://docs.nvidia.com/skills) to give
+compatible coding agents product-specific Relay workflows and references. After
+the NeMo Relay skills are published in `nvidia/skills`, install the full Relay
+skill set without cloning the catalog:
+
+```bash
+npx skills add nvidia/skills \
+  --skill nemo-relay-install \
+  --skill nemo-relay-get-started \
+  --skill nemo-relay-instrument-calls \
+  --skill nemo-relay-instrument-context-isolation \
+  --skill nemo-relay-instrument-typed-wrappers \
+  --skill nemo-relay-plugin-observability \
+  --skill nemo-relay-plugin-adaptive-tuning \
+  --skill nemo-relay-plugin-build \
+  --skill nemo-relay-migrate-from-flow \
+  --skill nemo-relay-debug-runtime-integration \
+  --agent codex
+```
+
+Use `--agent claude-code`, `--agent cursor`, or another supported agent target
+when that is where you want the skill installed. To inspect the current NVIDIA
+skill catalog first, run:
+
+```bash
+npx skills add nvidia/skills --list
+```
+
+Agent skills help your coding assistant apply Relay documentation and workflows.
+They do not replace installing NeMo Relay packages, configuring runtime
+plugins, or validating emitted events.
+</Card>
+</CardGroup>
+
+## Find the Right Starting Point
+
+Start with the fastest path that can prove Relay is working, then move toward
+more involved integration and development workflows only when you need them.
+
+- **Try now with the CLI:** Use [NeMo Relay CLI](/nemo-relay-cli/about) when a
+  local Claude Code, Codex, or Hermes coding-agent harness owns invocation.
+  Relay can observe hooks, gateway-routed model traffic, and exporter output
+  without changing application code.
+- **Use a supported integration:** Start with
+  [Supported Integrations](/supported-integrations/about) when LangChain,
+  LangGraph, Deep Agents, or OpenClaw already owns scheduling, callbacks, tool
+  execution, provider payloads, or agent lifecycle hooks.
+- **Instrument application-owned calls:** Start with
+  [Quick Start](/getting-started/quick-start), then use
+  [Instrument Applications](/instrument-applications/about) when your Python,
+  Node.js, or Rust application owns the tool or LLM call site.
+- **Build a custom framework or provider integration:** Use
+  [Integrate into Frameworks](/integrate-into-frameworks/about) when a new
+  framework, orchestration layer, SDK, or provider adapter owns scheduling,
+  retries, callbacks, and provider payloads.
+- **Package reusable runtime behavior:** Use
+  [Build Plugins](/build-plugins/about) for shared middleware, subscribers,
+  exporters, model pricing, policy, or adaptive behavior. Use
+  [Observability](/configure-plugins/observability/about) for export setup and
+  [Adaptive](/configure-plugins/adaptive/about) after baseline instrumentation
+  is working.
+
+## Getting Started Process
+
+Use the pages in this section in order when you are setting up Relay for the
+first time:
+
+1. Review [Prerequisites](/getting-started/prerequisites) for language,
+   package, and repository tooling.
+2. Use [Installation](/getting-started/installation) to install the CLI,
+   language binding, or integration package that matches your boundary.
+3. Use [Configuration](/getting-started/configuration) when you need runtime,
+   plugin, observability, or adaptive setup guidance.
+4. Use [Quick Start](/getting-started/quick-start) to run the smallest
+   working path and confirm Relay emits the expected output.
+
+If you need the conceptual model before setup, read
+[Agent Runtime Primer](/about-nemo-relay/agent-runtime-primer) and
+[Concepts](/about-nemo-relay/concepts).

--- a/docs/getting-started/quick-start/index.mdx
+++ b/docs/getting-started/quick-start/index.mdx
@@ -20,7 +20,7 @@ or [Concepts](/about-nemo-relay/concepts) first.
 
 <CardGroup cols={1}>
 <Card
-  title="Using an AI coding assistant?"
+  title="Using an AI Coding Assistant?"
   icon="terminal"
   iconPosition="left"
 >

--- a/docs/getting-started/quick-start/index.mdx
+++ b/docs/getting-started/quick-start/index.mdx
@@ -15,8 +15,41 @@ or control:
   boundary.
 
 If you still need the shared runtime vocabulary for scopes, middleware, events,
-or plugins, refer to the [Agent Runtime Primer](/getting-started/agent-runtime-primer)
+or plugins, refer to the [Agent Runtime Primer](/about-nemo-relay/agent-runtime-primer)
 or [Concepts](/about-nemo-relay/concepts) first.
+
+<CardGroup cols={1}>
+<Card
+  title="Using an AI coding assistant?"
+  icon="terminal"
+  iconPosition="left"
+>
+
+Install [NVIDIA agent skills](https://docs.nvidia.com/skills) to give
+compatible coding agents product-specific Relay workflows and references. After
+the NeMo Relay skills are published in `nvidia/skills`, install the full Relay
+skill set without cloning the catalog:
+
+```bash
+npx skills add nvidia/skills \
+  --skill nemo-relay-install \
+  --skill nemo-relay-get-started \
+  --skill nemo-relay-instrument-calls \
+  --skill nemo-relay-instrument-context-isolation \
+  --skill nemo-relay-instrument-typed-wrappers \
+  --skill nemo-relay-plugin-observability \
+  --skill nemo-relay-plugin-adaptive-tuning \
+  --skill nemo-relay-plugin-build \
+  --skill nemo-relay-migrate-from-flow \
+  --skill nemo-relay-debug-runtime-integration \
+  --agent codex
+```
+
+Use `--agent claude-code`, `--agent cursor`, or another supported agent target
+when that is where you want the skill installed. To inspect the current NVIDIA
+skill catalog first, run `npx skills add nvidia/skills --list`.
+</Card>
+</CardGroup>
 
 ## Examples by Integration Layer
 

--- a/docs/reference/api/index.mdx
+++ b/docs/reference/api/index.mdx
@@ -19,7 +19,7 @@ semantics such as:
 - Support boundaries
 
 For those topics, start with [Concepts](/about-nemo-relay/concepts), the
-[Agent Runtime Primer](/getting-started/agent-runtime-primer), or the
+[Agent Runtime Primer](/about-nemo-relay/agent-runtime-primer), or the
 workflow-specific documentation path that matches the boundary you own.
 
 Primary binding references:

--- a/docs/resources/troubleshooting/trace-incident-runbook.mdx
+++ b/docs/resources/troubleshooting/trace-incident-runbook.mdx
@@ -14,7 +14,7 @@ baseline scope and call instrumentation path.
 
 For first-time setup problems, start with the
 [Troubleshooting Guide](/resources/troubleshooting). For conceptual grounding,
-refer to [Agent Runtime Primer](/getting-started/agent-runtime-primer),
+refer to [Agent Runtime Primer](/about-nemo-relay/agent-runtime-primer),
 [Scopes](/about-nemo-relay/concepts/scopes), [Events](/about-nemo-relay/concepts/events),
 and [Subscribers](/about-nemo-relay/concepts/subscribers).
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -80,6 +80,10 @@ redirects:
 - source: /nemo/relay/nemo-relay-cli/cursor
   destination: /nemo/relay/nemo-relay-cli/about
 
+# Getting started IA
+- source: /nemo/relay/getting-started/agent-runtime-primer
+  destination: /nemo/relay/about-nemo-relay/agent-runtime-primer
+
 experimental:
   mdx-components:
   - ./components


### PR DESCRIPTION
#### Overview

Reorganizes the getting-started docs so the runtime primer lives with the About NeMo Relay conceptual content, while Getting Started gets a short About entry point and AI-coding-assistant guidance.

This replaces draft PR #443 with a clean branch and a single signed-off docs commit.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests; this supersedes #443 and does not duplicate remaining open work.

#### Details

- Moves Agent Runtime Primer from Getting Started to About NeMo Relay and adds a redirect from the old URL.
- Adds a new Getting Started About page with starting-point guidance ordered from try-now paths to advanced development workflows.
- Adds a "Using an AI coding assistant?" card to Getting Started About and Quick Start with the future no-clone `npx skills add nvidia/skills` path for installing the full Relay user-skill set.
- Updates related docs and README links to the new primer location.

#### Where should the reviewer start?

Start with `docs/getting-started/about.mdx`, then review `docs/about-nemo-relay/agent-runtime-primer.mdx` and `docs/getting-started/quick-start/index.mdx` for the IA changes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to NVIDIA agent skills publication follow-up.
- Supersedes #443.

#### Testing

- `just docs` passed. Fern reported one warning: missing redirects check skipped because this local environment is not authenticated with `fern login` / `FERN_TOKEN`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/expanded NeMo Relay “About” getting-started content, including guidance on selecting the smallest matching path, prerequisites, installation, configuration, and quick-start steps.
  * Updated Quick Start with a new “Using an AI coding assistant?” card, including skill-installation commands and catalog discovery.
  * Refreshed documentation navigation ordering and updated Agent Runtime Primer links across relevant pages.
  * Improved “starting point” routing guidance and adjusted internal doc links.
* **Chores**
  * Added a redirect to keep existing Agent Runtime Primer links working.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->