### PR TITLE
docs: document Hermes Agent installation

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -231,8 +231,10 @@ configuration and verification steps.
 
 ### Hermes Agent
 
-After installing the NeMo Relay CLI, install and diagnose the Hermes user
-integration:
+Install Hermes Agent 0.18.2 or newer by following the
+[official Hermes Agent installation guide](https://hermes-agent.nousresearch.com/docs/getting-started/installation).
+After the `hermes` command is available on `PATH` and the NeMo Relay CLI is
+installed, install and diagnose the Hermes user integration:
 
 ```bash
 nemo-relay install hermes

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -233,8 +233,14 @@ configuration and verification steps.
 
 Install Hermes Agent 0.18.2 or newer by following the
 [official Hermes Agent installation guide](https://hermes-agent.nousresearch.com/docs/getting-started/installation).
-After the `hermes` command is available on `PATH` and the NeMo Relay CLI is
-installed, install and diagnose the Hermes user integration:
+Open a new shell after installation and verify that the Hermes CLI is available:
+
+```bash
+hermes --version
+```
+
+After the NeMo Relay CLI is installed, install and diagnose the Hermes user
+integration:
 
 ```bash
 nemo-relay install hermes

--- a/docs/nemo-relay-cli/hermes.mdx
+++ b/docs/nemo-relay-cli/hermes.mdx
@@ -24,14 +24,21 @@ one Hermes process.
 
 ## Install Persistent Capture
 
+Install Hermes Agent 0.18.2 or newer by following the
+[official Hermes Agent installation guide](https://hermes-agent.nousresearch.com/docs/getting-started/installation).
+Open a new shell after installation and verify that the Hermes CLI is available:
+
+```bash
+hermes --version
+```
+
 Install the user-level integration:
 
 ```bash
 nemo-relay install hermes
 ```
 
-Installation requires Hermes Agent 0.18.2 or newer. NeMo Relay checks the
-installed Hermes CLI before it changes any files.
+NeMo Relay checks the installed Hermes CLI before it changes any files.
 
 Relay preserves unrelated Hermes settings and updates the Relay-owned portions
 of the user configuration. Hermes reads this configuration from


### PR DESCRIPTION
#### Overview

This PR documents the Hermes Agent installation prerequisite for NeMo Relay's native Hermes integration. It directs users to the official Hermes Agent installation guide so that platform-specific setup instructions remain aligned with the upstream project, and it adds a simple CLI verification step before users configure NeMo Relay.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Link the Hermes section of the general NeMo Relay installation guide to the official Hermes Agent installation documentation.
- State that Hermes Agent 0.18.2 or newer must be installed and that the `hermes` command must be available on `PATH`.
- Add `hermes --version` as an explicit verification step in the dedicated Hermes Agent guide.
- Preserve the existing `nemo-relay install hermes` and `nemo-relay doctor --plugin hermes` integration flow.
- Keep platform-specific Hermes installation commands in the upstream Hermes documentation, where they can remain current independently of NeMo Relay releases.

Validation:

- `git diff --check`
- Fern configuration check: zero errors; one authentication-only redirect warning
- Fern strict broken-link check: passed
- Documentation style review: no must-fix or should-fix findings

This is a documentation-only change and introduces no breaking API or runtime behavior changes.

#### Where should the reviewer start?

Start with `docs/nemo-relay-cli/hermes.mdx`, which adds the Hermes prerequisite and CLI verification to the native integration workflow. Then review `docs/getting-started/installation.mdx` for the matching entry-point guidance.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-529


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Hermes Agent installation requirements to version 0.18.2 or newer.
  - Added a prerequisite step to verify the Hermes CLI by running `hermes --version` in a newly opened shell.
  - Clarified the installation sequence: install the NeMo Relay CLI first, then run the Hermes user integration setup and diagnosis afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->