### PR TITLE
docs: fix Switchyard configuration links

### DIFF
--- a/docs/configure-plugins/switchyard/about.mdx
+++ b/docs/configure-plugins/switchyard/about.mdx
@@ -72,9 +72,9 @@ The integration provides the following capabilities:
 
 For more information, refer to the following pages:
 
-- [Switchyard Configuration](/configure-plugins/switchyard/configuration)
+- [Switchyard Configuration](./configuration.mdx)
   is the complete option and deployment reference. Review its
-  [experimental limitations](/configure-plugins/switchyard/configuration#experimental-limitations)
+  [experimental limitations](./configuration.mdx#experimental-limitations)
   before adopting the integration.
 - [Switchyard integration examples](https://github.com/NVIDIA/NeMo-Relay/tree/main/examples/switchyard)
   documents the pinned service worktree and manual compatibility smoke tests.


### PR DESCRIPTION
#### Overview

Fix the Switchyard documentation links that return 404s when the 0.6 release candidate source is viewed on GitHub. File-relative MDX links keep the GitHub targets valid while preserving Fern's public documentation routes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Link the Switchyard configuration page through `./configuration.mdx`.
- Preserve the `#experimental-limitations` deep link on the same page.
- Validation: `just docs`, `just docs-linkcheck`, and the rendered GitHub branch hrefs all pass.
- Breaking changes: None.

#### Where should the reviewer start?

Review the Pages section in `docs/configure-plugins/switchyard/about.mdx`; the only change is the two file-relative link targets.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-528


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Switchyard documentation links to use the correct relative paths.
  * Fixed the link to the experimental limitations section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->