### PR TITLE
fix(switchyard): honor pinned Rust toolchain in real E2E

### DIFF
--- a/examples/switchyard/e2e-common.sh
+++ b/examples/switchyard/e2e-common.sh
@@ -37,12 +37,12 @@ e2e_wait_for() {
   local process_pid="${4:-}"
   local attempt
   for attempt in $(seq 1 "$attempts"); do
-    if curl --fail --silent "$url" >/dev/null 2>&1; then
-      return 0
-    fi
     if [[ -n "$process_pid" ]] && ! kill -0 "$process_pid" 2>/dev/null; then
       echo "process $process_pid exited before $url became ready" >&2
       return 1
+    fi
+    if curl --fail --silent "$url" >/dev/null 2>&1; then
+      return 0
     fi
     sleep "$delay"
   done

--- a/examples/switchyard/e2e-common.sh
+++ b/examples/switchyard/e2e-common.sh
@@ -34,10 +34,15 @@ e2e_wait_for() {
   local url="$1"
   local attempts="${2:-120}"
   local delay="${3:-0.25}"
+  local process_pid="${4:-}"
   local attempt
   for attempt in $(seq 1 "$attempts"); do
     if curl --fail --silent "$url" >/dev/null 2>&1; then
       return 0
+    fi
+    if [[ -n "$process_pid" ]] && ! kill -0 "$process_pid" 2>/dev/null; then
+      echo "process $process_pid exited before $url became ready" >&2
+      return 1
     fi
     sleep "$delay"
   done

--- a/examples/switchyard/run-real-e2e.sh
+++ b/examples/switchyard/run-real-e2e.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 
 relay_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$relay_root/examples/switchyard/e2e-common.sh"
+relay_toolchain=""
+if command -v rustup >/dev/null 2>&1; then
+  relay_toolchain="$(cd "$relay_root" && rustup show active-toolchain)"
+  relay_toolchain="${relay_toolchain%% *}"
+fi
 switchyard_root="${SWITCHYARD_ROOT:-$(cd "$relay_root/.." && pwd)/Switchyard-topic-nemo-relay-integration}"
 switchyard_expected_commit="${SWITCHYARD_EXPECTED_COMMIT:-8f9db9a6a47f848cdff1d262276ba25a8ae9cbc8}"
 work_dir="$(mktemp -d)"
@@ -41,15 +46,19 @@ e2e_add_pid "$!"
 e2e_wait_for http://127.0.0.1:4000/health
 
 (
+  if [[ -n "$relay_toolchain" ]]; then
+    export RUSTUP_TOOLCHAIN="$relay_toolchain"
+  fi
   cd "$work_dir"
   SWITCHYARD_AUTHORIZATION="Bearer $token" cargo run \
     --manifest-path "$relay_root/Cargo.toml" -p nemo-relay-cli --features switchyard -- \
     --plugin-config-path "$relay_root/examples/switchyard/real-e2e-plugins.toml" \
     --bind 127.0.0.1:4041
 ) >"$work_dir/relay.log" 2>&1 &
-e2e_add_pid "$!"
+relay_pid="$!"
+e2e_add_pid "$relay_pid"
 
-e2e_wait_for http://127.0.0.1:4041/healthz
+e2e_wait_for http://127.0.0.1:4041/healthz 120 0.25 "$relay_pid"
 
 request() {
   local request_id="$1"


### PR DESCRIPTION
#### Overview

Ensure the real Switchyard E2E uses the Rust toolchain selected by the NeMo Relay checkout even though Relay is launched from a temporary working directory. Also stop readiness polling promptly when the Relay child exits before `/healthz` becomes available.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Resolve the active Rustup toolchain while the current directory is the Relay root, then export it only inside the Relay child process.
- Preserve the existing plain `cargo` behavior when Rustup is unavailable.
- Extend the shared readiness helper with an optional child PID so startup failures return immediately and the existing cleanup path surfaces `relay.log`.
- Preserve existing readiness behavior for callers that do not provide a PID.

The root cause was Rustup resolving from the temporary working directory instead of the path passed through `--manifest-path`, which selected the user's default Rust 1.96.0 rather than Relay's pinned 1.96.1 toolchain.

Validation:

- Reproduced the original Rust 1.96.0 MSRV failure against Switchyard commit `8f9db9a6a47f848cdff1d262276ba25a8ae9cbc8`.
- Ran the patched full E2E without a global `RUSTUP_TOOLCHAIN` override; it passed with the expected `provider/weak`, `provider/strong`, `provider/strong` route sequence.
- Verified process-exit detection returns in under one second instead of waiting approximately 30 seconds.
- Passed `bash -n` and targeted pre-commit checks for both changed scripts.
- Ran the all-files pre-commit suite. All code checks passed; the Rust attribution hook rewrote the release branch's pre-existing `ATTRIBUTIONS-Rust.md` output despite no Cargo changes, so that unrelated generated change was restored. The initially missing `just` prerequisite was installed temporarily and the Python worker protobuf compatibility hook then passed.

Breaking changes: none.

#### Where should the reviewer start?

Start with `examples/switchyard/run-real-e2e.sh`, specifically the toolchain resolution and Relay child launch. Then review the optional PID handling in `examples/switchyard/e2e-common.sh`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-514](https://linear.app/nvidia/issue/RELAY-514/nemo-relay060-rc2-examplesswitchyardrun-real-e2esh-uses-default-rust)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test startup checks by detecting when a required service exits before becoming ready.
  * Ensured the relay service runs using the currently active Rust toolchain when available.
  * Updated relay startup readiness checks with more precise retry/interval behavior to reduce flaky test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->