### PR TITLE
ci: link Fern previews to dev docs

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -163,9 +163,10 @@ jobs:
             echo "::error::Fern docs preview generation failed"
             exit "$fern_exit"
           fi
-          url="$(printf '%s\n' "$OUTPUT" | sed -n 's/^.*Published docs to //p' | tail -n 1)"
+          published_url="$(printf '%s\n' "$OUTPUT" | sed -n 's/^.*Published docs to //p' | tail -n 1)"
+          url="${published_url%%[[:space:]]*}"
           if [[ -n "$url" ]]; then
-            printf 'url=%s\n' "$url" >> "$GITHUB_OUTPUT"
+            printf 'url=%s/dev\n' "${url%/}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Comment preview URL on PR


### PR DESCRIPTION
#### Overview

Fix Fern pull-request preview comments so they link directly to the generated `dev` documentation version.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Extract the canonical first URL from Fern's published-preview output instead of propagating its display-only duplicate URL.
- Normalize an optional trailing slash and append `/dev` before updating the sticky pull-request comment.

#### Where should the reviewer start?

Start with `.github/workflows/fern-docs.yml`, where the preview-generation step now isolates Fern's canonical URL before composing the `dev` preview link.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation preview links by consistently removing trailing slashes and directing them to the `/dev` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->