### PR TITLE
fix: return middleware-translated buffered responses

### DIFF
--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -81,7 +81,7 @@ pub(crate) async fn passthrough(
 
 // Captures upstream HTTP status and response headers from inside the managed `func`. The runtime's
 // LLM execution callback returns only a Json (or Json stream), so the outer gateway needs a side
-// channel to recover the bytes the client expects.
+// channel to recover transport metadata that is not represented in the runtime response.
 type UpstreamResponseInfo = Arc<Mutex<Option<(StatusCode, HeaderMap)>>>;
 
 // Captures the original `reqwest::Error` from an upstream send failure so the gateway can return
@@ -214,6 +214,19 @@ async fn run_managed_buffered(
         .await;
     match result {
         Ok(response_json) => {
+            let response_body = match response_bytes
+                .lock()
+                .expect("response bytes lock poisoned")
+                .take()
+            {
+                Some(bytes) => match serde_json::from_slice::<Value>(&bytes) {
+                    Ok(upstream_json) if upstream_json != response_json => {
+                        Body::from(response_json.to_string())
+                    }
+                    _ => Body::from(bytes),
+                },
+                None => Body::from(response_json.to_string()),
+            };
             state
                 .sessions
                 .record_gateway_response_hints(&session_id, owner_subagent_id, response_json)
@@ -227,12 +240,7 @@ async fn run_managed_buffered(
                 .expect("upstream info lock poisoned")
                 .take()
                 .unwrap_or((StatusCode::OK, HeaderMap::new()));
-            let bytes = response_bytes
-                .lock()
-                .expect("response bytes lock poisoned")
-                .take()
-                .unwrap_or_default();
-            build_response(status, headers, Body::from(bytes))
+            build_response(status, headers, response_body)
         }
         Err(error) => {
             state

--- a/crates/cli/tests/switchyard_process_e2e.rs
+++ b/crates/cli/tests/switchyard_process_e2e.rs
@@ -43,7 +43,7 @@ async fn decide(
         requests.push((headers, request));
         requests.len()
     };
-    if call == 3 {
+    if call == 4 {
         return Response::builder()
             .status(StatusCode::SERVICE_UNAVAILABLE)
             .body(Body::from("decision API unavailable"))
@@ -236,7 +236,7 @@ base_url = "{provider_url}"
     let client = reqwest::Client::new();
     wait_for_gateway(&client, &gateway_url, &mut gateway.0).await;
 
-    let send = |request_id: &'static str, stream: bool| {
+    let send_chat = |request_id: &'static str, stream: bool| {
         client
             .post(format!("{gateway_url}/v1/chat/completions"))
             .header("x-nemo-relay-session-id", "ci-process-session")
@@ -254,24 +254,40 @@ base_url = "{provider_url}"
             .send()
     };
 
-    let buffered = send("buffered-request", false).await.unwrap();
+    let buffered = send_chat("buffered-request", false).await.unwrap();
     assert!(buffered.status().is_success());
     let buffered: Value = buffered.json().await.unwrap();
     assert_eq!(buffered["model"], "provider/selected");
 
-    let streaming = send("stream-request", true).await.unwrap();
+    let translated = client
+        .post(format!("{gateway_url}/v1/responses"))
+        .header("x-nemo-relay-session-id", "ci-process-session")
+        .header("x-nemo-relay-request-id", "translated-request")
+        .json(&json!({
+            "model": "client/model",
+            "stream": false,
+            "input": "process boundary response translation"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(translated.status().is_success());
+    let translated: Value = translated.json().await.unwrap();
+    assert_eq!(translated["object"], "response");
+
+    let streaming = send_chat("stream-request", true).await.unwrap();
     assert!(streaming.status().is_success());
     let streaming = streaming.text().await.unwrap();
     assert!(streaming.contains("streamed"));
     assert!(streaming.contains("[DONE]"));
 
-    let fallback = send("fallback-request", false).await.unwrap();
+    let fallback = send_chat("fallback-request", false).await.unwrap();
     assert!(fallback.status().is_success());
     let fallback: Value = fallback.json().await.unwrap();
     assert_eq!(fallback["model"], "provider/fallback");
 
     let decisions = decision_requests.lock().unwrap();
-    assert_eq!(decisions.len(), 3);
+    assert_eq!(decisions.len(), 4);
     for (headers, body) in decisions.iter() {
         assert!(!headers.contains_key("x-nemo-relay-internal-dispatch-url"));
         assert!(!headers.contains_key("x-nemo-relay-internal-dispatch-route"));
@@ -298,9 +314,12 @@ base_url = "{provider_url}"
         vec![
             "provider/selected",
             "provider/selected",
+            "provider/selected",
             "provider/fallback"
         ]
     );
+    assert!(providers[1].1["messages"].is_array());
+    assert!(providers[1].1.get("input").is_none());
     for (headers, _) in providers.iter() {
         assert!(!headers.contains_key("x-nemo-relay-internal-dispatch-url"));
         assert!(!headers.contains_key("x-nemo-relay-internal-dispatch-route"));

--- a/crates/cli/tests/switchyard_process_e2e.rs
+++ b/crates/cli/tests/switchyard_process_e2e.rs
@@ -320,6 +320,11 @@ base_url = "{provider_url}"
     );
     assert!(providers[1].1["messages"].is_array());
     assert!(providers[1].1.get("input").is_none());
+    assert_eq!(providers[1].1["messages"][0]["role"], "user");
+    assert_eq!(
+        providers[1].1["messages"][0]["content"],
+        "process boundary response translation"
+    );
     for (headers, _) in providers.iter() {
         assert!(!headers.contains_key("x-nemo-relay-internal-dispatch-url"));
         assert!(!headers.contains_key("x-nemo-relay-internal-dispatch-route"));


### PR DESCRIPTION
#### Overview

Fix the buffered CLI gateway so clients receive the final JSON returned by LLM middleware, including Switchyard response translations, instead of always receiving the raw upstream bytes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Serialize the final runtime JSON when middleware changes the upstream response or short-circuits without an upstream response.
- Preserve the original upstream bytes when the semantic JSON is unchanged or the upstream body is non-JSON.
- Preserve the actual upstream status and filtered headers.
- Extend the Switchyard process E2E test with a non-streaming `/v1/responses` request, assert that the provider receives a translated Chat Completions request, and assert that the client receives an OpenAI Responses payload.
- Keep the existing buffered, streaming, and fail-open process coverage.
- No public API, binding, documentation, or breaking changes.

Validation:

- `cargo test -p nemo-relay-cli --features switchyard --test switchyard_process_e2e -- --nocapture`
- `cargo test -p nemo-relay-cli --features switchyard -- --test-threads=1`
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p nemo-relay-cli --all-targets --features switchyard -- -D warnings`
- `just test-rust` ran the Rust matrix; one unrelated CLI test encountered shared temporary plugin configuration from a concurrent test and passed when rerun independently.
- `uv run pre-commit run --all-files`; all applicable checks passed except the baseline Rust attribution generator, which rewrites the unrelated checked-in `md-5` license entry. A final all-files run with only that generator skipped passed.

#### Where should the reviewer start?

Start with `crates/cli/src/gateway/mod.rs` in `run_managed_buffered`, then review the process-level regression in `crates/cli/tests/switchyard_process_e2e.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-510


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-streaming managed gateway behavior to keep response bodies consistent with the latest processed output when discrepancies are detected, while using the original upstream body when compatible.
  * Added more robust fallback handling when buffered upstream bytes are unavailable or can’t be parsed.
* **Improvements**
  * Enhanced reliability across mixed buffered, streaming, fallback, and translated `/v1/responses` flows to better align requests and responses.
* **Tests**
  * Updated end-to-end test sequencing and strengthened assertions for translated provider request formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->