### PR TITLE
fix: persist Hermes session state across runs

### DIFF
--- a/crates/cli/src/agents/hermes/launch.rs
+++ b/crates/cli/src/agents/hermes/launch.rs
@@ -75,13 +75,16 @@ fn create_overlay(
 
 fn ensure_durable_state_paths(source_home: &Path) -> Result<(), CliError> {
     std::fs::create_dir_all(source_home.join("sessions"))?;
+    let state_db = source_home.join("state.db");
     match std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(source_home.join("state.db"))
+        .open(&state_db)
     {
         Ok(_) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists && state_db.is_file() => {
+            Ok(())
+        }
         Err(error) => Err(CliError::Io(error)),
     }
 }

--- a/crates/cli/src/agents/hermes/launch.rs
+++ b/crates/cli/src/agents/hermes/launch.rs
@@ -55,6 +55,7 @@ fn create_overlay(
     source_config: &Path,
     gateway_url: &str,
 ) -> Result<PathBuf, CliError> {
+    ensure_durable_state_paths(source_home)?;
     let overlay = source_home
         .parent()
         .filter(|parent| parent.is_dir())
@@ -70,6 +71,19 @@ fn create_overlay(
         return Err(error);
     }
     Ok(overlay)
+}
+
+fn ensure_durable_state_paths(source_home: &Path) -> Result<(), CliError> {
+    std::fs::create_dir_all(source_home.join("sessions"))?;
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(source_home.join("state.db"))
+    {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(CliError::Io(error)),
+    }
 }
 
 pub(crate) fn populate_overlay(

--- a/crates/cli/tests/coverage/agents/launcher_tests.rs
+++ b/crates/cli/tests/coverage/agents/launcher_tests.rs
@@ -1072,6 +1072,54 @@ fn sequential_hermes_runs_preserve_state_from_a_fresh_home() {
     assert!(source_home.join("sessions/session.json").exists());
 }
 
+#[test]
+fn rejects_state_db_directory_before_populating_hermes_overlay() {
+    let temp = tempfile::tempdir().unwrap();
+    let source_home = temp.path().join("hermes-home");
+    let state_db = source_home.join("state.db");
+    let hooks_path = source_home.join("config.yaml");
+    std::fs::create_dir_all(&state_db).unwrap();
+    let resolved = ResolvedConfig {
+        agents: AgentConfigs {
+            hermes: AgentCommandConfig {
+                hooks_path: Some(hooks_path.clone()),
+                ..AgentCommandConfig::default()
+            },
+            ..AgentConfigs::default()
+        },
+        ..ResolvedConfig::default()
+    };
+
+    let result = PreparedAgentLaunch::new(
+        CodingAgent::Hermes,
+        vec!["hermes".into(), "chat".into()],
+        "http://127.0.0.1:1234",
+        &resolved,
+        false,
+    );
+    let error = match result {
+        Ok(prepared) => {
+            prepared.restore().unwrap();
+            panic!("state.db directories must be rejected")
+        }
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CliError::Io(ref error) if error.kind() == std::io::ErrorKind::AlreadyExists
+    ));
+    assert!(state_db.is_dir());
+    assert!(!hooks_path.exists());
+    assert!(std::fs::read_dir(temp.path()).unwrap().all(|entry| {
+        !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".nemo-relay-hermes-home")
+    }));
+}
+
 #[cfg(unix)]
 #[test]
 fn process_private_directories_are_owner_only() {

--- a/crates/cli/tests/coverage/agents/launcher_tests.rs
+++ b/crates/cli/tests/coverage/agents/launcher_tests.rs
@@ -1105,10 +1105,7 @@ fn rejects_state_db_directory_before_populating_hermes_overlay() {
         Err(error) => error,
     };
 
-    assert!(matches!(
-        error,
-        CliError::Io(ref error) if error.kind() == std::io::ErrorKind::AlreadyExists
-    ));
+    assert!(matches!(error, CliError::Io(_)));
     assert!(state_db.is_dir());
     assert!(!hooks_path.exists());
     assert!(std::fs::read_dir(temp.path()).unwrap().all(|entry| {

--- a/crates/cli/tests/coverage/agents/launcher_tests.rs
+++ b/crates/cli/tests/coverage/agents/launcher_tests.rs
@@ -972,6 +972,10 @@ fn prepares_hermes_hook_environment() {
     ));
     assert!(overlay.join("state.db").exists());
     assert_eq!(
+        std::fs::read_to_string(overlay.join("state.db")).unwrap(),
+        "state"
+    );
+    assert_eq!(
         std::fs::read_to_string(overlay.join("cache/entry")).unwrap(),
         "cached"
     );
@@ -989,6 +993,83 @@ fn prepares_hermes_hook_environment() {
     prepared.restore().unwrap();
     assert!(hooks_path.exists());
     assert!(!overlay.exists());
+}
+
+#[test]
+fn sequential_hermes_runs_preserve_state_from_a_fresh_home() {
+    let _guard = current_dir_lock().lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let source_home = temp.path().join("hermes-home");
+    let hooks_path = source_home.join("config.yaml");
+    let resolved = ResolvedConfig {
+        gateway: GatewayConfig::default(),
+        agents: AgentConfigs {
+            hermes: AgentCommandConfig {
+                command: None,
+                hooks_path: Some(hooks_path),
+            },
+            ..AgentConfigs::default()
+        },
+        dynamic_plugins: Vec::new(),
+        ..ResolvedConfig::default()
+    };
+    let prepare = || {
+        PreparedAgentLaunch::new(
+            CodingAgent::Hermes,
+            vec!["hermes".into(), "chat".into()],
+            "http://127.0.0.1:1234",
+            &resolved,
+            false,
+        )
+        .unwrap()
+    };
+    let overlay = |prepared: &PreparedAgentLaunch| {
+        prepared
+            .env
+            .iter()
+            .find_map(|(name, value)| (name == "HERMES_HOME").then(|| PathBuf::from(value)))
+            .expect("Hermes overlay path")
+    };
+
+    let first = prepare();
+    let first_overlay = overlay(&first);
+    std::fs::write(first_overlay.join("state.db"), "session state").unwrap();
+    std::fs::create_dir_all(first_overlay.join("sessions")).unwrap();
+    std::fs::write(
+        first_overlay.join("sessions/session.json"),
+        "session details",
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(source_home.join("state.db"))
+            .expect("state.db should be linked to the caller's Hermes home"),
+        "session state"
+    );
+    assert_eq!(
+        std::fs::read_to_string(source_home.join("sessions/session.json"))
+            .expect("sessions should be linked to the caller's Hermes home"),
+        "session details"
+    );
+
+    first.restore().unwrap();
+    assert!(!first_overlay.exists());
+
+    let second = prepare();
+    let second_overlay = overlay(&second);
+    assert_eq!(
+        std::fs::read_to_string(second_overlay.join("state.db")).unwrap(),
+        "session state"
+    );
+    assert_eq!(
+        std::fs::read_to_string(second_overlay.join("sessions/session.json")).unwrap(),
+        "session details"
+    );
+
+    second.restore().unwrap();
+    assert!(!second_overlay.exists());
+    assert!(source_home.join("state.db").exists());
+    assert!(source_home.join("sessions/session.json").exists());
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
#### Overview

Fix Hermes session resume across separate `nemo-relay run --agent hermes` processes when the caller starts with a fresh `HERMES_HOME`.

Hermes Agent v0.18.2 stores session metadata in `$HERMES_HOME/state.db`. Relay's temporary Hermes overlay previously linked only entries that already existed in the caller's home. A database first created inside the overlay was therefore deleted with that overlay, causing the next process to fail with `Session not found`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Create the caller-owned `HERMES_HOME` and durable `sessions/` directory before populating the temporary overlay.
- Create an empty caller-owned `state.db` only when it is absent, using `create_new(true)` so existing state is never truncated and a concurrent creator is tolerated.
- Populate the existing per-process overlay afterward, allowing its symlink/junction/hard-link behavior to bind `state.db` and `sessions/` back to the durable home.
- Preserve side-effect-free `--dry-run` behavior and per-run `config.yaml` isolation.
- Add regression coverage that starts with a nonexistent Hermes home, writes simulated state through the first overlay, removes it, and verifies a second overlay sees the same caller-owned state.
- Strengthen existing coverage to prove a pre-existing `state.db` is not truncated.

No public CLI or API surface changes. The Switchyard example and documentation are unchanged because seeding the database there would mask the general launcher defect.

##### Validation

Passed:

- `cargo test -p nemo-relay-cli sequential_hermes_runs_preserve_state_from_a_fresh_home`
- `cargo test -p nemo-relay-cli hermes_`
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --all-files` with only the unrelated `attributions-rust` hook skipped; all remaining hooks passed, including Cargo formatting, clippy, check, deny, FFI synchronization, Python, Go, Node, and documentation checks.
- Live Hermes Agent v0.18.2 validation against local Ollama: a first Relay process created session `20260720_133907_e11614`; a second Relay process resumed the same ID, and the caller-owned SQLite row remained with four messages after both temporary overlays were removed.

Known environment limitations:

- `just test-rust` completed all Hermes and launcher coverage successfully, including this regression. The two full-suite attempts were not fully green because unrelated tests flaked under suite load: one temporary dynamic-plugin manifest lookup on the first run, then eight loopback HTTP/MCP health timeouts on the second. The first failure passed immediately in isolation.
- The standalone `attributions-rust` hook rewrites an unrelated `md-5` license entry already present on `release/0.6`; that generated change was restored and excluded from this PR.
- The exact Docker-backed Switchyard three-query smoke could not run because the local Docker Desktop VM had remounted its internal ext4 filesystem read-only after I/O/no-space errors. Docker data was not reset or modified. A clean Switchyard checkout at `8f9db9a6a47f848cdff1d262276ba25a8ae9cbc8` and both required Ollama models were otherwise available.

#### Where should the reviewer start?

Start with `ensure_durable_state_paths` in `crates/cli/src/agents/hermes/launch.rs`, then review `sequential_hermes_runs_preserve_state_from_a_fresh_home` in `crates/cli/tests/coverage/agents/launcher_tests.rs` for the cross-process lifecycle being protected.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hermes launches now reliably pre-create durable state artifacts, preserving session data and the state database across sequential runs.
  * Hermes setup now validates the expected durable state contents and handles conflicting `state.db` paths safely before overlay population.
  * Failed Hermes setup no longer leaves partial hooks or overlay leftovers behind.

* **Tests**
  * Added coverage for state persistence across multiple Hermes runs, exact `state.db` contents, and failure behavior when `state.db` is an existing directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->