### PR TITLE
test: stabilize scope-local subscriber cleanup

### DIFF
--- a/go/nemo_relay/scope_local_test.go
+++ b/go/nemo_relay/scope_local_test.go
@@ -453,10 +453,16 @@ func TestScopeLocalSubscriberCleanupOnPop(t *testing.T) {
 			t.Fatalf(scopeLocalRegisterSubscriberFailed, err)
 		}
 		PopScope(handle)
+		if err := FlushSubscribers(); err != nil {
+			t.Fatalf("FlushSubscribers after PopScope failed: %v", err)
+		}
 		mu.Lock()
 		countAfterPop := eventCount
 		mu.Unlock()
 		EmitEvent("after_pop_event")
+		if err := FlushSubscribers(); err != nil {
+			t.Fatalf("FlushSubscribers after EmitEvent failed: %v", err)
+		}
 		mu.Lock()
 		countAfterEmit := eventCount
 		mu.Unlock()


### PR DESCRIPTION
#### Overview

Stabilize the Go scope-local subscriber cleanup regression test.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Flush queued subscriber callbacks after popping the owning scope before recording the baseline callback count.
- Flush after emitting the outside event before asserting that the removed scope-local subscriber did not receive it.
- This removes the scheduling race that intermittently failed macOS Go CI; no runtime behavior changes.
- Validation: `go test -count=100 -run '^TestScopeLocalSubscriberCleanupOnPop$' .`, `just ci=true test-go`, and pre-commit Go formatting/vet checks.
- Breaking changes: None.

#### Where should the reviewer start?

Review `go/nemo_relay/scope_local_test.go`, specifically `TestScopeLocalSubscriberCleanupOnPop`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test coverage for subscriber cleanup when leaving a local scope.
  - Added explicit delivery synchronization to ensure post-scope events are not received unexpectedly.
  - Clarified failure messages for easier diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->