### PR TITLE
feat(pii)!: support composable redaction profiles

### DIFF
--- a/crates/pii-redaction/README.md
+++ b/crates/pii-redaction/README.md
@@ -21,6 +21,8 @@ NeMo Relay PII Redaction allows you to:
 
 - Use `PiiRedactionConfig`, the canonical config contract for the top-level
   `pii_redaction` plugin component.
+- Compose multiple ordered built-in or runtime-provided local-model policies
+  inside one singleton component.
 - Install deterministic redaction behavior through the NeMo Relay privacy
   plugin system instead of custom sanitize callbacks.
 - Sanitize emitted tool request or response payloads and supported codec-backed
@@ -73,21 +75,38 @@ configuration that includes a `pii_redaction` component:
 nemo_relay_pii_redaction::component::register_pii_redaction_component()?;
 ```
 
-A minimal config can redact detected emails from emitted tool input payloads:
+A profile-array config can apply multiple policies across every supported
+sanitization surface:
 
 ```toml
 [[components]]
 kind = "pii_redaction"
 
 [components.config]
-mode = "builtin"
-tool_input = true
+codec = "openai_chat"
 
-[components.config.builtin]
+[[components.config.profiles]]
+mode = "builtin"
+priority = 80
+
+[components.config.profiles.builtin]
 action = "redact"
 detector = "email"
-target_paths = []
+
+[[components.config.profiles]]
+mode = "builtin"
+priority = 90
+
+[components.config.profiles.builtin]
+action = "redact"
+detector = "api_key"
 ```
+
+Profiles execute by ascending priority, with array order breaking ties. Relay
+assigns internal positional names such as `profile_0`; no user-supplied ID is
+required. Profile-array mode covers marks, LLM and tool observability, and
+scope metadata automatically. The original single-policy surface flags remain
+available for backward compatibility but cannot be combined with `profiles`.
 
 ## Built-In Backend
 

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -262,24 +262,52 @@ pub(super) fn tool_sanitize_callback(backend: CompiledBuiltinBackend) -> ToolSan
 }
 
 pub(super) fn event_sanitize_callback(backend: CompiledBuiltinBackend) -> EventSanitizeFn {
+    event_sanitize_callback_with_scope_categories(backend, None)
+}
+
+pub(super) fn scope_event_sanitize_callback(
+    backend: CompiledBuiltinBackend,
+    sanitize_llm: bool,
+    sanitize_tool: bool,
+) -> EventSanitizeFn {
+    event_sanitize_callback_with_scope_categories(backend, Some((sanitize_llm, sanitize_tool)))
+}
+
+fn event_sanitize_callback_with_scope_categories(
+    backend: CompiledBuiltinBackend,
+    scope_categories: Option<(bool, bool)>,
+) -> EventSanitizeFn {
     Arc::new(move |event, mut fields| {
-        if matches!(event, Event::Scope(_))
-            && event
-                .category()
-                .is_some_and(|category| matches!(category.as_str(), "tool" | "llm"))
-        {
+        if scope_categories.is_some_and(|(sanitize_llm, sanitize_tool)| {
+            matches!(event, Event::Scope(_))
+                && event
+                    .category()
+                    .is_some_and(|category| match category.as_str() {
+                        "llm" => !sanitize_llm,
+                        "tool" => !sanitize_tool,
+                        _ => false,
+                    })
+        }) {
             return fields;
         }
 
-        fields.data = fields
-            .data
-            .map(|data| backend.sanitize_json_preorder_dfs(data));
+        let specialized_scope = matches!(event, Event::Scope(_))
+            && event
+                .category()
+                .is_some_and(|category| matches!(category.as_str(), "tool" | "llm"));
+
+        if !specialized_scope {
+            fields.data = fields
+                .data
+                .map(|data| backend.sanitize_json_preorder_dfs(data));
+            fields.category_profile = fields.category_profile.and_then(|profile| {
+                sanitize_serializable_with_backend::<CategoryProfile>(&backend, profile).ok()
+            });
+        }
+
         fields.metadata = fields
             .metadata
             .map(|metadata| backend.sanitize_json_preorder_dfs(metadata));
-        fields.category_profile = fields.category_profile.and_then(|profile| {
-            sanitize_serializable_with_backend::<CategoryProfile>(&backend, profile).ok()
-        });
         fields
     })
 }

--- a/crates/pii-redaction/src/component.rs
+++ b/crates/pii-redaction/src/component.rs
@@ -73,31 +73,39 @@ pub struct PiiRedactionConfig {
     #[serde(default = "default_pii_redaction_config_version")]
     pub version: u32,
     /// Backend mode: `builtin` or `local_model`.
-    #[serde(default = "default_mode")]
+    #[serde(default = "default_mode", skip_serializing_if = "is_default_mode")]
     #[cfg_attr(feature = "schema", schemars(schema_with = "mode_schema"))]
     pub mode: String,
     /// Whether to sanitize managed LLM request payloads.
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub input: bool,
     /// Whether to sanitize managed LLM response payloads.
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub output: bool,
     /// Whether to sanitize mark event observability fields.
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub mark: bool,
     /// Whether to sanitize managed tool request payloads.
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub tool_input: bool,
     /// Whether to sanitize managed tool response payloads.
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub tool_output: bool,
     /// Guardrail priority. Lower values run earlier.
-    #[serde(default = "default_priority")]
+    #[serde(
+        default = "default_priority",
+        skip_serializing_if = "is_default_priority"
+    )]
     pub priority: i32,
     /// Provider request/response codec for LLM-managed surfaces.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schema", schemars(schema_with = "codec_schema"))]
     pub codec: Option<String>,
+    /// Ordered redaction profiles. When present, legacy backend and surface
+    /// fields must be omitted and every enabled profile covers all supported
+    /// sanitization surfaces.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub profiles: Vec<PiiRedactionProfile>,
     /// Built-in backend settings used when `mode = "builtin"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub builtin: Option<BuiltinBackendConfig>,
@@ -121,9 +129,44 @@ impl Default for PiiRedactionConfig {
             tool_output: true,
             priority: default_priority(),
             codec: None,
+            profiles: Vec::new(),
             builtin: None,
             local: None,
             policy: ConfigPolicy::default(),
+        }
+    }
+}
+
+/// One ordered redaction policy within the singleton PII component.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PiiRedactionProfile {
+    /// Whether this profile registers runtime sanitizers.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Backend mode: `builtin` or `local_model`.
+    #[serde(default = "default_mode")]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "mode_schema"))]
+    pub mode: String,
+    /// Guardrail priority. Lower values run earlier; array order breaks ties.
+    #[serde(default = "default_priority")]
+    pub priority: i32,
+    /// Built-in backend settings used when `mode = "builtin"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builtin: Option<BuiltinBackendConfig>,
+    /// Local-backend settings used when `mode = "local_model"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local: Option<LocalBackendConfig>,
+}
+
+impl Default for PiiRedactionProfile {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            mode: default_mode(),
+            priority: default_priority(),
+            builtin: None,
+            local: None,
         }
     }
 }
@@ -214,6 +257,7 @@ nemo_relay::editor_config! {
             values: ["openai_chat", "openai_responses", "anthropic_messages"],
             optional: true,
         },
+        profiles => { label: "profiles", kind: List, list: &PII_REDACTION_PROFILE_LIST_ITEM },
         builtin => {
             label: "builtin",
             kind: Section,
@@ -236,6 +280,50 @@ nemo_relay::editor_config! {
         },
     }
 }
+
+nemo_relay::editor_config! {
+    impl PiiRedactionProfile {
+        enabled => { label: "enabled", kind: Boolean },
+        mode => {
+            label: "mode",
+            kind: Enum,
+            values: ["builtin", "local_model"],
+        },
+        priority => { label: "priority", kind: Integer },
+        builtin => {
+            label: "builtin",
+            kind: Section,
+            optional: true,
+            nested: BuiltinBackendConfig,
+            default: BuiltinBackendConfig,
+        },
+        local => {
+            label: "local",
+            kind: Section,
+            optional: true,
+            nested: LocalBackendConfig,
+            default: LocalBackendConfig,
+        },
+    }
+}
+
+fn pii_redaction_profile_editor_schema() -> &'static nemo_relay::config_editor::EditorSchema {
+    <PiiRedactionProfile as nemo_relay::config_editor::EditorConfig>::editor_schema()
+}
+
+fn default_pii_redaction_profile_editor_value() -> Json {
+    serde_json::to_value(PiiRedactionProfile::default())
+        .expect("PII redaction profile should serialize")
+}
+
+static PII_REDACTION_PROFILE_LIST_ITEM: nemo_relay::config_editor::EditorListItemSpec =
+    nemo_relay::config_editor::EditorListItemSpec {
+        kind: nemo_relay::config_editor::EditorFieldKind::Section,
+        schema: Some(pii_redaction_profile_editor_schema),
+        default: Some(default_pii_redaction_profile_editor_value),
+        tagged_union: None,
+        list_item: None,
+    };
 
 nemo_relay::editor_config! {
     impl BuiltinBackendConfig {
@@ -384,12 +472,54 @@ fn register_pii_redaction_backend(
     config: PiiRedactionConfig,
     ctx: &mut PluginRegistrationContext,
 ) -> PluginResult<()> {
+    if !config.profiles.is_empty() {
+        let profiles = config.profiles.clone();
+        for (index, profile) in profiles.into_iter().enumerate() {
+            if !profile.enabled {
+                continue;
+            }
+            let profile_name = format!("profile_{index}");
+            let profile_config = profile_as_legacy_config(&config, profile);
+            register_single_pii_redaction_backend(profile_config, ctx, Some(&profile_name))?;
+        }
+        return Ok(());
+    }
+
+    register_single_pii_redaction_backend(config, ctx, None)
+}
+
+fn register_single_pii_redaction_backend(
+    config: PiiRedactionConfig,
+    ctx: &mut PluginRegistrationContext,
+    profile_name: Option<&str>,
+) -> PluginResult<()> {
     match config.mode.as_str() {
-        "builtin" => register_builtin_backend(config, ctx),
-        "local_model" => register_local_backend(config, ctx),
+        "builtin" => register_builtin_backend(config, ctx, profile_name),
+        "local_model" => register_local_backend(config, ctx, profile_name),
         other => Err(PluginError::InvalidConfig(format!(
             "unsupported PII redaction mode '{other}'"
         ))),
+    }
+}
+
+fn profile_as_legacy_config(
+    component: &PiiRedactionConfig,
+    profile: PiiRedactionProfile,
+) -> PiiRedactionConfig {
+    PiiRedactionConfig {
+        version: component.version,
+        mode: profile.mode,
+        input: true,
+        output: true,
+        mark: true,
+        tool_input: true,
+        tool_output: true,
+        priority: profile.priority,
+        codec: component.codec.clone(),
+        profiles: Vec::new(),
+        builtin: profile.builtin,
+        local: profile.local,
+        policy: component.policy,
     }
 }
 
@@ -434,12 +564,20 @@ fn validate_pii_redaction_plugin_config(
             "tool_output",
             "priority",
             "codec",
+            "profiles",
             "builtin",
             "local",
             "policy",
         ],
     );
     validate_policy_fields(&mut diagnostics, &config.policy, plugin_config);
+    if plugin_config.contains_key("profiles") {
+        validate_profile_configuration(&mut diagnostics, plugin_config, &config);
+        validate_version(&mut diagnostics, &config.policy, config.version);
+        validate_codec_requirements(&mut diagnostics, &config.policy, &config);
+        return diagnostics;
+    }
+
     validate_section_fields(
         &mut diagnostics,
         &config.policy,
@@ -478,6 +616,138 @@ fn validate_pii_redaction_plugin_config(
     validate_local_mode_requirements(&mut diagnostics, &config.policy, plugin_config, &config);
 
     diagnostics
+}
+
+fn validate_profile_configuration(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    plugin_config: &Map<String, Json>,
+    config: &PiiRedactionConfig,
+) {
+    const LEGACY_FIELDS: &[&str] = &[
+        "mode",
+        "input",
+        "output",
+        "mark",
+        "tool_input",
+        "tool_output",
+        "priority",
+        "builtin",
+        "local",
+    ];
+    for field in LEGACY_FIELDS {
+        if plugin_config.contains_key(*field) {
+            push_policy_diag(
+                diagnostics,
+                config.policy.unsupported_value,
+                "pii_redaction.unsupported_value",
+                Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+                Some((*field).to_string()),
+                format!("legacy field '{field}' cannot be combined with profiles"),
+            );
+        }
+    }
+
+    if !config.profiles.iter().any(|profile| profile.enabled) {
+        push_policy_diag(
+            diagnostics,
+            config.policy.unsupported_value,
+            "pii_redaction.unsupported_value",
+            Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+            Some("profiles".to_string()),
+            "profiles must contain at least one enabled redaction profile".to_string(),
+        );
+        return;
+    }
+
+    let raw_profiles = plugin_config
+        .get("profiles")
+        .and_then(Json::as_array)
+        .expect("successfully parsed profiles must be an array");
+    for (index, (profile, raw_profile)) in
+        config.profiles.iter().zip(raw_profiles.iter()).enumerate()
+    {
+        let Json::Object(raw_profile) = raw_profile else {
+            continue;
+        };
+        let profile_config = profile_as_legacy_config(config, profile.clone());
+        let mut profile_diagnostics = Vec::new();
+        validate_unknown_fields(
+            &mut profile_diagnostics,
+            &config.policy,
+            Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+            raw_profile,
+            &["enabled", "mode", "priority", "builtin", "local"],
+        );
+        validate_section_fields(
+            &mut profile_diagnostics,
+            &config.policy,
+            raw_profile,
+            "builtin",
+            &[
+                "action",
+                "target_paths",
+                "pattern",
+                "detector",
+                "replacement",
+                "mask_char",
+                "unmasked_prefix",
+                "unmasked_suffix",
+            ],
+        );
+        validate_section_fields(
+            &mut profile_diagnostics,
+            &config.policy,
+            raw_profile,
+            "local",
+            &[
+                "backend",
+                "model_id",
+                "detector_profile",
+                "allow_network",
+                "max_latency_ms",
+            ],
+        );
+        validate_mode(&mut profile_diagnostics, &config.policy, &profile_config);
+        validate_builtin_mode_requirements(
+            &mut profile_diagnostics,
+            &config.policy,
+            raw_profile,
+            &profile_config,
+        );
+        validate_builtin_action_requirements(
+            &mut profile_diagnostics,
+            &config.policy,
+            &profile_config,
+        );
+        validate_local_mode_requirements(
+            &mut profile_diagnostics,
+            &config.policy,
+            raw_profile,
+            &profile_config,
+        );
+        if profile.mode == "local_model" && !raw_profile.contains_key("local") {
+            push_policy_diag(
+                &mut profile_diagnostics,
+                config.policy.unsupported_value,
+                "pii_redaction.unsupported_value",
+                Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+                Some("local".to_string()),
+                "`local` settings are required for a local-model profile".to_string(),
+            );
+        }
+        prefix_profile_diagnostics(&mut profile_diagnostics, index);
+        diagnostics.extend(profile_diagnostics);
+    }
+}
+
+fn prefix_profile_diagnostics(diagnostics: &mut [ConfigDiagnostic], index: usize) {
+    let prefix = format!("profiles[{index}]");
+    for diagnostic in diagnostics {
+        diagnostic.field = Some(match diagnostic.field.take() {
+            Some(field) => format!("{prefix}.{field}"),
+            None => prefix.clone(),
+        });
+    }
 }
 
 fn validate_mode(
@@ -723,6 +993,7 @@ fn validate_codec_requirements(
 fn register_builtin_backend(
     config: PiiRedactionConfig,
     ctx: &mut PluginRegistrationContext,
+    profile_name: Option<&str>,
 ) -> PluginResult<()> {
     let builtin = config.builtin.clone().ok_or_else(|| {
         PluginError::InvalidConfig("built-in PII redaction config is missing".to_string())
@@ -732,13 +1003,14 @@ fn register_builtin_backend(
         target: "nemo_relay.plugin",
         event = "plugin_resource_validation_completed",
         plugin_kind = PII_REDACTION_PLUGIN_KIND,
+        profile = profile_name.unwrap_or("legacy"),
         resource_count = 0;
         "Plugin resource validation completed"
     );
 
     if config.mark {
         ctx.register_mark_sanitize_guardrail(
-            "mark",
+            &registration_name(profile_name, "mark"),
             config.priority,
             super::builtin::event_sanitize_callback(compiled.clone()),
         )?;
@@ -746,38 +1018,94 @@ fn register_builtin_backend(
 
     if config.tool_input {
         let sanitizer = tool_sanitize_callback(compiled.clone());
-        ctx.register_tool_sanitize_request_guardrail("tool_input", config.priority, sanitizer)?;
+        ctx.register_tool_sanitize_request_guardrail(
+            &registration_name(profile_name, "tool_input"),
+            config.priority,
+            sanitizer,
+        )?;
     }
     if config.tool_output {
         let sanitizer = tool_sanitize_callback(compiled.clone());
-        ctx.register_tool_sanitize_response_guardrail("tool_output", config.priority, sanitizer)?;
+        ctx.register_tool_sanitize_response_guardrail(
+            &registration_name(profile_name, "tool_output"),
+            config.priority,
+            sanitizer,
+        )?;
     }
     if config.input {
         ctx.register_llm_sanitize_request_guardrail(
-            "input",
+            &registration_name(profile_name, "input"),
             config.priority,
             llm_sanitize_request_callback(compiled.clone()),
         )?;
+    }
+    if config.input || config.tool_input {
         ctx.register_scope_sanitize_start_guardrail(
-            "input",
+            &registration_name(
+                profile_name,
+                if profile_name.is_some() {
+                    "scope_start"
+                } else {
+                    "input"
+                },
+            ),
             config.priority,
-            super::builtin::event_sanitize_callback(compiled.clone()),
+            super::builtin::scope_event_sanitize_callback(
+                compiled.clone(),
+                config.input,
+                config.tool_input,
+            ),
         )?;
     }
     if config.output {
         ctx.register_llm_sanitize_response_guardrail(
-            "output",
+            &registration_name(profile_name, "output"),
             config.priority,
             llm_sanitize_response_callback(compiled.clone()),
         )?;
+    }
+    if config.output || config.tool_output {
         ctx.register_scope_sanitize_end_guardrail(
-            "output",
+            &registration_name(
+                profile_name,
+                if profile_name.is_some() {
+                    "scope_end"
+                } else {
+                    "output"
+                },
+            ),
             config.priority,
-            super::builtin::event_sanitize_callback(compiled),
+            super::builtin::scope_event_sanitize_callback(
+                compiled,
+                config.output,
+                config.tool_output,
+            ),
         )?;
     }
 
     Ok(())
+}
+
+fn registration_name(profile_name: Option<&str>, callback_name: &str) -> String {
+    profile_name.map_or_else(
+        || callback_name.to_string(),
+        |profile_name| {
+            format!(
+                "{}/{callback_name}",
+                profile_registration_prefix(profile_name)
+            )
+        },
+    )
+}
+
+pub(super) fn profile_registration_prefix(profile_name: &str) -> String {
+    profile_name
+        .strip_prefix("profile_")
+        .and_then(|index| index.parse::<usize>().ok())
+        .map_or_else(
+            || profile_name.to_string(),
+            |index| format!("profile_{index:020}"),
+        )
 }
 
 fn validate_unknown_fields(
@@ -901,6 +1229,18 @@ fn default_true() -> bool {
 
 fn default_priority() -> i32 {
     100
+}
+
+fn is_default_mode(mode: &str) -> bool {
+    mode == "builtin"
+}
+
+fn is_true(value: &bool) -> bool {
+    *value
+}
+
+fn is_default_priority(priority: &i32) -> bool {
+    *priority == default_priority()
 }
 
 #[cfg(test)]

--- a/crates/pii-redaction/src/local.rs
+++ b/crates/pii-redaction/src/local.rs
@@ -3,9 +3,12 @@
 
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 
-use nemo_relay::plugin::{PluginError, PluginRegistrationContext, Result as PluginResult};
+use nemo_relay::plugin::{
+    PluginError, PluginRegistrationContext, Result as PluginResult, rollback_registrations,
+};
 
 use super::component::PiiRedactionConfig;
+use super::component::profile_registration_prefix;
 
 #[doc(hidden)]
 pub type LocalBackendProvider = Arc<
@@ -41,6 +44,7 @@ pub fn clear_local_backend_provider() -> PluginResult<()> {
 pub(super) fn register_local_backend(
     config: PiiRedactionConfig,
     ctx: &mut PluginRegistrationContext,
+    profile_name: Option<&str>,
 ) -> PluginResult<()> {
     let provider = local_backend_provider_guard()?.clone();
 
@@ -49,6 +53,7 @@ pub(super) fn register_local_backend(
             target: "nemo_relay.plugin",
             event = "plugin_resource_access_failed",
             plugin_kind = "pii_redaction",
+            profile = profile_name.unwrap_or("legacy"),
             resource_kind = "local_model_backend",
             permission = "execute",
             reason = "provider_unavailable";
@@ -62,16 +67,27 @@ pub(super) fn register_local_backend(
         target: "nemo_relay.plugin",
         event = "plugin_resource_access_pending",
         plugin_kind = "pii_redaction",
+        profile = profile_name.unwrap_or("legacy"),
         resource_kind = "local_model_backend",
         permission = "execute";
         "Plugin resource access validation started"
     );
-    match provider(config, ctx) {
+    let mut scoped_context = profile_name.map(|profile_name| {
+        PluginRegistrationContext::with_namespace(
+            ctx.qualify_name(&format!("{}/", profile_registration_prefix(profile_name))),
+        )
+    });
+    let provider_context = scoped_context.as_mut().unwrap_or(ctx);
+    match provider(config, provider_context) {
         Ok(()) => {
+            if let Some(scoped_context) = scoped_context {
+                ctx.extend_registrations(scoped_context.into_registrations());
+            }
             log::info!(
                 target: "nemo_relay.plugin",
                 event = "plugin_resource_access_validated",
                 plugin_kind = "pii_redaction",
+                profile = profile_name.unwrap_or("legacy"),
                 resource_kind = "local_model_backend",
                 permission = "execute";
                 "Plugin resource access validated"
@@ -79,10 +95,15 @@ pub(super) fn register_local_backend(
             Ok(())
         }
         Err(error) => {
+            if let Some(scoped_context) = scoped_context {
+                let mut registrations = scoped_context.into_registrations();
+                rollback_registrations(&mut registrations);
+            }
             log::warn!(
                 target: "nemo_relay.plugin",
                 event = "plugin_resource_access_failed",
                 plugin_kind = "pii_redaction",
+                profile = profile_name.unwrap_or("legacy"),
                 resource_kind = "local_model_backend",
                 permission = "execute",
                 reason = "initialization_failed";

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -6,7 +6,8 @@
 
 use super::*;
 use crate::api::event::{
-    BaseEvent, CategoryProfile, Event, EventSanitizeFields, MarkEvent, ScopeCategory,
+    BaseEvent, CategoryProfile, Event, EventCategory, EventSanitizeFields, MarkEvent,
+    ScopeCategory, ScopeEvent,
 };
 use crate::api::llm::{
     LlmCallExecuteParams, LlmCallParams, LlmRequest, llm_call, llm_call_execute,
@@ -26,7 +27,7 @@ use crate::codec::traits::LlmResponseCodec;
 use crate::plugin::{
     PluginComponentSpec, PluginConfig, PluginError, PluginRegistrationContext,
     clear_plugin_configuration, ensure_builtin_plugins_registered, initialize_plugins,
-    list_plugin_kinds, validate_plugin_config,
+    list_plugin_kinds, rollback_registrations, validate_plugin_config,
 };
 use nemo_relay::observability::atif::{AtifAgentInfo, AtifExporter};
 use nemo_relay::observability::atof::{AtofExporter, AtofExporterConfig};
@@ -137,6 +138,268 @@ fn builtin_backend_config_default_matches_documented_action_default() {
 fn pii_redaction_defaults_enable_mark_sanitization() {
     let config = PiiRedactionConfig::default();
     assert!(config.mark);
+    assert!(config.profiles.is_empty());
+}
+
+#[test]
+fn generated_registration_names_sort_in_profile_array_order() {
+    assert!(
+        registration_name(Some("profile_2"), "mark")
+            < registration_name(Some("profile_10"), "mark")
+    );
+}
+
+#[test]
+fn typed_profile_config_serializes_without_conflicting_legacy_defaults() {
+    let config = PiiRedactionConfig {
+        codec: Some("openai_chat".into()),
+        profiles: vec![PiiRedactionProfile {
+            builtin: Some(BuiltinBackendConfig {
+                action: "redact".into(),
+                detector: Some("email".into()),
+                ..BuiltinBackendConfig::default()
+            }),
+            ..PiiRedactionProfile::default()
+        }],
+        ..PiiRedactionConfig::default()
+    };
+    let serialized = serde_json::to_value(&config).unwrap();
+    let object = serialized.as_object().unwrap();
+    for legacy_field in [
+        "mode",
+        "input",
+        "output",
+        "mark",
+        "tool_input",
+        "tool_output",
+        "priority",
+        "builtin",
+        "local",
+    ] {
+        assert!(!object.contains_key(legacy_field), "{legacy_field}");
+    }
+
+    let report = validate_plugin_config(&plugin_config(serialized));
+    assert!(!report.has_errors(), "{:?}", report.diagnostics);
+}
+
+#[test]
+fn profile_array_executes_every_profile_in_stable_array_order() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+    setup_isolated_thread();
+
+    futures::executor::block_on(initialize_plugins(plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [
+            {
+                "mode": "builtin",
+                "priority": 100,
+                "builtin": {
+                    "action": "regex_replace",
+                    "pattern": "alpha",
+                    "replacement": "beta"
+                }
+            },
+            {
+                "mode": "builtin",
+                "priority": 100,
+                "builtin": {
+                    "action": "regex_replace",
+                    "pattern": "beta",
+                    "replacement": "gamma"
+                }
+            }
+        ]
+    }))))
+    .unwrap();
+
+    let events = capture_events("pii-profile-order");
+    event(
+        EmitMarkEventParams::builder()
+            .name("ordered-profile-mark")
+            .data(json!({"value": "alpha"}))
+            .build(),
+    )
+    .unwrap();
+    let captured = captured_events_snapshot(&events);
+    assert_eq!(captured[0].data().unwrap()["value"], "gamma");
+
+    deregister_subscriber("pii-profile-order").unwrap();
+    clear_plugin_configuration().unwrap();
+}
+
+#[test]
+fn profile_array_rejects_legacy_fields_and_reports_profile_paths() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+
+    let report = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "mark": true,
+        "profiles": [{
+            "mode": "builtin",
+            "builtin": {
+                "action": "regex_replace"
+            },
+            "unexpected": true
+        }]
+    })));
+
+    assert!(report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.field.as_deref() == Some("mark")
+            && diagnostic
+                .message
+                .contains("cannot be combined with profiles")
+    }));
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.field.as_deref() == Some("profiles[0].unexpected") })
+    );
+    assert!(
+        report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref() == Some("profiles[0].builtin.pattern")
+        })
+    );
+}
+
+#[test]
+fn profile_array_requires_at_least_one_profile_and_matching_local_settings() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+
+    let empty = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": []
+    })));
+    assert!(empty.diagnostics.iter().any(|diagnostic| {
+        diagnostic.field.as_deref() == Some("profiles")
+            && diagnostic.message.contains("at least one")
+    }));
+
+    let all_disabled = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [{
+            "enabled": false,
+            "mode": "builtin",
+            "builtin": {"action": "remove"}
+        }]
+    })));
+    assert!(all_disabled.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "pii_redaction.unsupported_value"
+            && diagnostic.field.as_deref() == Some("profiles")
+            && diagnostic.message.contains("at least one enabled")
+    }));
+
+    let missing_local = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [{"mode": "local_model"}]
+    })));
+    assert!(missing_local.diagnostics.iter().any(|diagnostic| {
+        diagnostic.field.as_deref() == Some("profiles[0].local")
+            && diagnostic.message.contains("required")
+    }));
+}
+
+#[test]
+fn disabled_profiles_are_validated_when_an_enabled_profile_exists() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+
+    let report = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [
+            {
+                "enabled": false,
+                "mode": "builtin",
+                "builtin": {
+                    "action": "not-an-action"
+                }
+            },
+            {
+                "mode": "builtin",
+                "builtin": {"action": "remove"}
+            }
+        ]
+    })));
+    assert!(
+        report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref() == Some("profiles[0].builtin.action")
+        })
+    );
+}
+
+#[test]
+fn local_profile_registrations_receive_generated_namespaces() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+
+    register_local_backend_provider(Arc::new(|_, ctx| {
+        ctx.register_mark_sanitize_guardrail("shared", 100, Arc::new(|_, fields| fields))
+    }))
+    .unwrap();
+
+    let plugin = PiiRedactionPlugin;
+    let config = json!({
+        "codec": "openai_chat",
+        "profiles": [
+            {"mode": "local_model", "local": {"backend": "one"}},
+            {"mode": "local_model", "local": {"backend": "two"}}
+        ]
+    });
+    let Json::Object(config) = config else {
+        panic!("component config must be object");
+    };
+    let mut ctx = PluginRegistrationContext::with_namespace("profiles::");
+    futures::executor::block_on(plugin.register(&config, &mut ctx)).unwrap();
+    let mut registrations = ctx.into_registrations();
+    let registrations_debug = format!("{registrations:?}");
+    assert!(registrations_debug.contains("profiles::profile_00000000000000000000/shared"));
+    assert!(registrations_debug.contains("profiles::profile_00000000000000000001/shared"));
+    rollback_registrations(&mut registrations);
+    assert!(registrations.is_empty());
+}
+
+#[test]
+fn failed_later_profile_rolls_back_earlier_profile_registrations() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+    setup_isolated_thread();
+
+    register_local_backend_provider(Arc::new(|_, _| {
+        Err(PluginError::RegistrationFailed(
+            "intentional profile failure".into(),
+        ))
+    }))
+    .unwrap();
+    let activation = futures::executor::block_on(initialize_plugins(plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [
+            {
+                "mode": "builtin",
+                "builtin": {"action": "redact", "detector": "email"}
+            },
+            {
+                "mode": "local_model",
+                "local": {"backend": "failing"}
+            }
+        ]
+    }))));
+    assert!(activation.is_err());
+
+    let events = capture_events("pii-profile-rollback");
+    event(
+        EmitMarkEventParams::builder()
+            .name("raw-after-rollback")
+            .data(json!({"email": "person@example.com"}))
+            .build(),
+    )
+    .unwrap();
+    let captured = captured_events_snapshot(&events);
+    assert_eq!(captured[0].data().unwrap()["email"], "person@example.com");
+    deregister_subscriber("pii-profile-rollback").unwrap();
 }
 
 #[test]
@@ -175,6 +438,100 @@ fn event_sanitizer_transforms_data_category_profile_and_metadata_independently()
         Some("[REDACTED]")
     );
     assert_eq!(sanitized.metadata.unwrap()["owner"], "[REDACTED]");
+}
+
+#[test]
+fn llm_and_tool_scope_metadata_is_sanitized_without_reprocessing_typed_fields() {
+    let backend = crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            action: "redact".into(),
+            detector: Some("email".into()),
+            ..BuiltinBackendConfig::default()
+        },
+        None,
+    )
+    .unwrap();
+    let callback = crate::builtin::event_sanitize_callback(backend);
+
+    for category in [EventCategory::llm(), EventCategory::tool()] {
+        let event = Event::Scope(ScopeEvent::new(
+            BaseEvent::builder().name("typed-scope").build(),
+            ScopeCategory::Start,
+            Vec::new(),
+            category,
+            None,
+        ));
+        let original_profile = CategoryProfile::builder()
+            .subtype("person@example.com")
+            .build();
+        let sanitized = callback(
+            &event,
+            EventSanitizeFields {
+                data: Some(json!({"content": "person@example.com"})),
+                category_profile: Some(original_profile.clone()),
+                metadata: Some(json!({"owner": "person@example.com"})),
+            },
+        );
+
+        assert_eq!(
+            sanitized.data.unwrap()["content"],
+            "person@example.com",
+            "specialized scope data must not be generically sanitized twice"
+        );
+        assert_eq!(sanitized.category_profile.unwrap(), original_profile);
+        assert_eq!(sanitized.metadata.unwrap()["owner"], "[REDACTED]");
+    }
+}
+
+#[test]
+fn scope_event_sanitizer_respects_enabled_llm_and_tool_surfaces() {
+    let backend = crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            action: "redact".into(),
+            detector: Some("email".into()),
+            ..BuiltinBackendConfig::default()
+        },
+        None,
+    )
+    .unwrap();
+
+    for (sanitize_llm, sanitize_tool, expected_llm, expected_tool) in [
+        (true, false, "[REDACTED]", "person@example.com"),
+        (false, true, "person@example.com", "[REDACTED]"),
+    ] {
+        let callback = crate::builtin::scope_event_sanitize_callback(
+            backend.clone(),
+            sanitize_llm,
+            sanitize_tool,
+        );
+        for (category, expected_owner) in [
+            (EventCategory::llm(), expected_llm),
+            (EventCategory::tool(), expected_tool),
+        ] {
+            let event = Event::Scope(ScopeEvent::new(
+                BaseEvent::builder().name("typed-scope").build(),
+                ScopeCategory::Start,
+                Vec::new(),
+                category,
+                None,
+            ));
+            let original_profile = CategoryProfile::builder()
+                .subtype("person@example.com")
+                .build();
+            let sanitized = callback(
+                &event,
+                EventSanitizeFields {
+                    data: Some(json!({"content": "person@example.com"})),
+                    category_profile: Some(original_profile.clone()),
+                    metadata: Some(json!({"owner": "person@example.com"})),
+                },
+            );
+
+            assert_eq!(sanitized.data.unwrap()["content"], "person@example.com");
+            assert_eq!(sanitized.category_profile.unwrap(), original_profile);
+            assert_eq!(sanitized.metadata.unwrap()["owner"], expected_owner);
+        }
+    }
 }
 
 #[test]
@@ -814,11 +1171,11 @@ fn builtin_backend_sanitizes_tool_start_and_end_payloads_with_preorder_targets()
     );
     assert_eq!(
         captured_events[0].metadata().unwrap()["owner"],
-        "sk-universal-metadata"
+        "[REDACTED]"
     );
     assert_eq!(
         captured_events[1].metadata().unwrap()["reviewer"],
-        "sk-universal-metadata"
+        "[REDACTED]"
     );
 
     deregister_subscriber("pii-redaction-tool-events").unwrap();
@@ -2446,7 +2803,7 @@ fn builtin_backend_sanitizes_llm_start_payload_via_codec_and_reencodes_provider_
     );
     assert_eq!(
         captured_events[0].metadata().unwrap()["audit_owner"],
-        "sk-universal-metadata"
+        "[REDACTED]"
     );
 
     deregister_subscriber("pii-redaction-llm-events").unwrap();
@@ -2553,7 +2910,7 @@ async fn builtin_backend_sanitizes_llm_end_payload_and_response_codec_decodes_sa
     assert_eq!(annotated.model.as_deref(), Some("gpt-4o-mini"));
     assert_eq!(
         captured_events[1].metadata().unwrap()["audit_owner"],
-        "sk-universal-metadata"
+        "[REDACTED]"
     );
 
     deregister_subscriber("pii-redaction-llm-end-events").unwrap();

--- a/docs/configure-plugins/pii-redaction/about.mdx
+++ b/docs/configure-plugins/pii-redaction/about.mdx
@@ -75,6 +75,10 @@ The built-in plugin exposes five managed sanitize surfaces:
 - `tool_input`
 - `tool_output`
 
+Legacy single-policy configuration can toggle these surfaces independently.
+When `profiles` is used, every enabled profile covers all five surfaces and
+the associated LLM/tool scope metadata automatically.
+
 The current built-in backend supports five actions:
 
 - `remove`
@@ -92,9 +96,10 @@ The current backend boundary is intentional:
   and `/message`.
 - `mark` sanitizes `data`, `category_profile`, and `metadata` independently on
   every mark event. It defaults to `true`; set `mark = false` to opt out.
-- `input` and `output` also sanitize those three fields on non-tool, non-LLM
-  scope starts and ends. Tool and LLM scope envelopes remain on their
-  specialized sanitizer paths to avoid applying the same mask or hash twice.
+- `input`, `output`, `tool_input`, and `tool_output` sanitize scope metadata on
+  their corresponding lifecycle events. Tool and LLM primary data and typed
+  profiles remain on their specialized sanitizer paths to avoid applying the
+  same mask or hash twice.
 
 ## Observability Boundary
 

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -73,11 +73,22 @@ The top-level PII redaction object contains:
 | `tool_output` | Enables sanitization of emitted tool-response observability payloads. Defaults to `true`. |
 | `priority` | Guardrail priority. Lower values run earlier. Defaults to `100`. |
 | `codec` | Managed LLM provider codec. Required when `input` or `output` is enabled. |
+| `profiles` | Ordered redaction profiles. Each profile selects `builtin` or `local_model`; enabled profiles cover every supported sanitization surface. |
 | `builtin` | Built-in backend settings used when `mode = "builtin"`. |
 | `local` | Local-backend settings used when `mode = "local_model"`. |
 | `policy` | Component-local handling for unknown fields and unsupported values. |
 
 At least one managed redaction surface must be enabled.
+
+Use either the legacy single-policy fields (`mode`, surface flags, `priority`,
+`builtin`, and `local`) or `profiles`, but not both. The component-wide
+`codec`, `version`, and `policy` fields remain valid with `profiles`.
+
+In profile-array mode, profiles execute by ascending priority and use array
+order to break ties. Relay assigns internal names such as `profile_0`, so
+profiles do not require IDs. Disabled profiles are validated but do not
+register callbacks. The complete array is replaced as one value during config
+layering.
 
 ## Backend Support
 
@@ -113,7 +124,7 @@ To use `mode = "builtin"`:
 - `builtin.action` must be `remove`, `redact`, `regex_replace`, `hash`, or `mask`.
 - `builtin.pattern` or `builtin.detector` is required when `builtin.action = "regex_replace"` or `builtin.action = "redact"`.
 
-### `plugins.toml` Example
+### Composed `plugins.toml` Example
 
 You can write this config directly in `plugins.toml`, or create and edit it
 through the CLI with `nemo-relay plugins edit`. For plugin file discovery,
@@ -129,24 +140,23 @@ enabled = true
 
 [components.config]
 version = 1
-mode = "builtin"
 codec = "openai_chat"
-input = true
-output = true
-mark = true
-tool_input = true
-tool_output = true
 
-[components.config.builtin]
-action = "regex_replace"
-pattern = "sk-[A-Za-z0-9_-]+"
-replacement = "[REDACTED]"
-target_paths = [
-  "/messages/0/content",
-  "/message",
-  "/api_key",
-  "/result/secret",
-]
+[[components.config.profiles]]
+mode = "builtin"
+priority = 80
+
+[components.config.profiles.builtin]
+action = "redact"
+detector = "email"
+
+[[components.config.profiles]]
+mode = "builtin"
+priority = 90
+
+[components.config.profiles.builtin]
+action = "redact"
+detector = "api_key"
 
 [components.config.policy]
 unknown_component = "warn"
@@ -154,18 +164,13 @@ unknown_field = "warn"
 unsupported_value = "error"
 ```
 
-This example configures the built-in backend for:
+This example applies email redaction before API-key redaction to marks, LLM
+and tool observability payloads, and scope metadata. `[REDACTED]` is already
+the default replacement for `redact`, so no `replacement` field is needed.
 
-- LLM request redaction from the normalized request path
-  `/messages/0/content`
-- LLM response redaction from the normalized response path `/message`
-- tool argument redaction at `/api_key`
-- tool result redaction at `/result/secret`
-- mark-event and non-tool, non-LLM scope-event redaction at matching target paths within
-  `data`, `category_profile`, and `metadata`
-
-`mark` is enabled when omitted. Set `mark = false` only when marks are known to
-contain no sensitive observability fields or another sanitizer owns that
+Legacy single-policy configurations may still use `mark` and the other
+surface flags. Profile-array configurations intentionally do not expose those
+flags: every enabled profile owns the complete pre-subscriber sanitization
 boundary.
 
 ### CLI Editor Support
@@ -177,7 +182,8 @@ Use the editor when you want to:
 
 - Toggle the component on or off
 - Choose `builtin` or `local_model`
-- Enable or opt out of mark sanitization
+- Add and order multiple redaction profiles
+- Enable or disable individual profiles
 - Set the LLM `codec`
 - Edit `builtin` action settings such as `action`, `target_paths`,
   `pattern`, `detector`, `replacement`, and masking fields


### PR DESCRIPTION
> [!WARNING]
> **BREAKING CHANGE — Rust PII configuration API and serialized configuration:** `PiiRedactionConfig` now includes the public `profiles` field, so downstream exhaustive struct literals must initialize it or use `..Default::default()`. Default-valued legacy fields (`mode`, `input`, `output`, `mark`, `tool_input`, `tool_output`, and `priority`) are now omitted during serialization, so consumers that depend on the previous exact serialized shape must update. Existing TOML and JSON configurations remain accepted. Existing PII-redaction configurations also sanitize LLM and tool scope metadata that was previously left unchanged, so downstream telemetry content may change without a schema change.

#### Overview

Adds ordered, composable profiles to the singleton `pii_redaction` component so one Relay configuration can apply multiple privacy policies consistently across observability surfaces.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds an ordered `components.config.profiles` array supporting the existing built-in and local-model backends.
- Executes enabled profiles by ascending priority, with array order as the deterministic tie-breaker; Relay supplies internal positional names, so user-defined IDs are unnecessary.
- Applies profile-array policies to marks, LLM input/output, tool input/output, and scope metadata before subscriber fan-out.
- Preserves the existing single-policy configuration as a backward-compatible legacy mode while rejecting ambiguous combinations of legacy surface fields and `profiles`.
- Keeps component registration atomic, including rollback after partial profile-registration failures.
- Updates the crate README and Fern configuration reference with composable examples and migration guidance.

This creates the configuration foundation for separately reviewable structure-preserving trajectory redaction without requiring multiple `pii_redaction` components.

#### Where should the reviewer start?

Start in `crates/pii-redaction/src/component.rs`, particularly profile validation and registration. The focused lifecycle and configuration coverage is in `crates/pii-redaction/tests/unit/component_tests.rs`.

Validation performed:

```text
cargo fmt --all -- --check
cargo test -p nemo-relay-pii-redaction --features schema
cargo clippy -p nemo-relay-pii-redaction --all-targets --features schema -- -D warnings
cargo test -p nemo-relay-cli pii_redaction
```

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ordered, multi-profile PII redaction via `profiles`, executed by ascending `priority` (array order breaks ties), with auto-assigned internal profile names.
  * Profiles can be enabled/disabled and configured with built-in or local-model backends; legacy single-policy fields remain non-combinable with `profiles`.
  * Enhanced editor/CLI support to create, order, and toggle multiple profiles in one configuration.
* **Bug Fixes**
  * Improved tool/LLM scope sanitization to avoid double-processing while still redacting scope metadata.
  * Added safe registration rollback so failed later profiles don’t leave earlier registrations active.
* **Documentation**
  * Updated PII redaction docs and examples to make `profiles` the primary configuration mode and clarify legacy mutual exclusivity and sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->