### PR TITLE
feat(pii)!: redact trajectory content while preserving structure

### DIFF
--- a/crates/cli/tests/coverage/shared/plugins_tests.rs
+++ b/crates/cli/tests/coverage/shared/plugins_tests.rs
@@ -310,6 +310,14 @@ fn typed_editor_model_contains_pii_redaction_options() {
     );
 
     let builtin = schema.field("builtin").unwrap().schema().unwrap();
+    assert_eq!(builtin.field("preset").unwrap().kind, EditorFieldKind::Enum);
+    assert!(
+        builtin
+            .field("preset")
+            .unwrap()
+            .enum_values
+            .contains(&"trajectory_context")
+    );
     assert_eq!(builtin.field("action").unwrap().kind, EditorFieldKind::Enum);
     assert!(
         builtin
@@ -321,6 +329,17 @@ fn typed_editor_model_contains_pii_redaction_options() {
     assert_eq!(
         builtin.field("target_paths").unwrap().kind,
         EditorFieldKind::List
+    );
+    assert_eq!(
+        builtin.field("custom_mark_payload_policy").unwrap().kind,
+        EditorFieldKind::Enum
+    );
+    assert!(
+        builtin
+            .field("custom_mark_payload_policy")
+            .unwrap()
+            .enum_values
+            .contains(&"redact_all_leaves")
     );
     assert_eq!(
         builtin.field("detector").unwrap().kind,

--- a/crates/pii-redaction/README.md
+++ b/crates/pii-redaction/README.md
@@ -34,6 +34,8 @@ NeMo Relay PII Redaction allows you to:
   structured secrets, and cloud credentials.
 - Handle codec-aware LLMs with overlay support for `openai_chat`,
   `openai_responses`, and `anthropic_messages`.
+- Remove conversational trajectory content while preserving event structure,
+  tool-call identity, model attribution, routing, usage, and cost analytics.
 - Use the `local_model` config contract and provider registration surface for
   future model-backed implementations.
 
@@ -107,6 +109,54 @@ assigns internal positional names such as `profile_0`; no user-supplied ID is
 required. Profile-array mode covers marks, LLM and tool observability, and
 scope metadata automatically. The original single-policy surface flags remain
 available for backward compatibility but cannot be combined with `profiles`.
+
+### Structure-Preserving Trajectory Export
+
+Use the `trajectory_context` preset when exported trajectories must retain
+their analytical structure without retaining chat, reasoning, tool, or
+multimodal content. Pair it with a later email profile so email addresses are
+also removed from otherwise-preserved metadata and custom marks:
+
+```toml
+[[components]]
+kind = "pii_redaction"
+enabled = true
+
+[components.config]
+version = 1
+codec = "anthropic_messages"
+
+[[components.config.profiles]]
+mode = "builtin"
+priority = 80
+
+[components.config.profiles.builtin]
+preset = "trajectory_context"
+custom_mark_payload_policy = "redact_all_leaves"
+
+[[components.config.profiles]]
+mode = "builtin"
+priority = 90
+
+[components.config.profiles.builtin]
+action = "redact"
+detector = "email"
+```
+
+`custom_mark_payload_policy = "preserve"` is the default and leaves unknown
+plugin mark payloads intact for analysis. Use `redact_all_leaves` when opaque
+plugins may emit content: scalar leaves in data, metadata, and opaque category
+profile fields are replaced while typed category identity remains valid.
+Strings become `[REDACTED]`, numbers become `0`, booleans become `false`, and
+nulls, keys, arrays, and object shape are retained.
+Known Relay marks are sanitized semantically so their structural and analytical
+fields remain usable. This choice affects canonical event fields before
+subscriber fan-out; exporter-owned resource attributes are outside this
+boundary.
+
+The preset defines its own action and therefore cannot be combined with
+`action`, `detector`, `pattern`, `target_paths`, or mask-specific fields. Its
+optional `replacement` defaults to `[REDACTED]`.
 
 ## Built-In Backend
 

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -23,6 +23,7 @@ use nemo_relay::plugin::{PluginError, Result as PluginResult};
 use super::component::BuiltinBackendConfig;
 use super::detectors::BuiltinDetector;
 use super::overlay::BuiltinCodecName;
+use super::trajectory::{CustomMarkPayloadPolicy, TrajectorySanitizer};
 
 #[derive(Clone)]
 pub(super) struct CompiledBuiltinBackend {
@@ -31,6 +32,7 @@ pub(super) struct CompiledBuiltinBackend {
     request_codec: Option<Arc<dyn LlmCodec>>,
     response_codec: Option<Arc<dyn LlmResponseCodec>>,
     codec_name: Option<BuiltinCodecName>,
+    trajectory: Option<TrajectorySanitizer>,
 }
 
 #[derive(Clone)]
@@ -71,6 +73,48 @@ impl CompiledBuiltinBackend {
         config: BuiltinBackendConfig,
         codec_name: Option<String>,
     ) -> PluginResult<Self> {
+        let trajectory = match config.preset.as_deref() {
+            Some("trajectory_context") => {
+                if config.detector.is_some()
+                    || config.pattern.is_some()
+                    || !config.target_paths.is_empty()
+                    || config.mask_char.is_some()
+                    || config.unmasked_prefix.is_some()
+                    || config.unmasked_suffix.is_some()
+                {
+                    return Err(PluginError::InvalidConfig(
+                        "builtin.preset cannot be combined with matcher, target-path, or mask fields"
+                            .to_string(),
+                    ));
+                }
+                let policy = CustomMarkPayloadPolicy::parse(&config.custom_mark_payload_policy)
+                    .ok_or_else(|| {
+                        PluginError::InvalidConfig(format!(
+                            "unsupported custom-mark payload policy '{}'",
+                            config.custom_mark_payload_policy
+                        ))
+                    })?;
+                Some(TrajectorySanitizer::new(
+                    config
+                        .replacement
+                        .clone()
+                        .unwrap_or_else(|| "[REDACTED]".to_string()),
+                    policy,
+                ))
+            }
+            Some(other) => {
+                return Err(PluginError::InvalidConfig(format!(
+                    "unsupported builtin preset '{other}'"
+                )));
+            }
+            None => None,
+        };
+        if trajectory.is_none() && config.custom_mark_payload_policy != "preserve" {
+            return Err(PluginError::InvalidConfig(
+                "builtin.custom_mark_payload_policy requires builtin.preset = 'trajectory_context'"
+                    .to_string(),
+            ));
+        }
         let detector = config
             .detector
             .as_deref()
@@ -127,6 +171,7 @@ impl CompiledBuiltinBackend {
             request_codec: surface.map(build_request_codec),
             response_codec: surface.map(build_response_codec),
             codec_name: surface.map(BuiltinCodecName::from_provider_surface),
+            trajectory,
         })
     }
 
@@ -258,7 +303,12 @@ impl CompiledBuiltinBackend {
 }
 
 pub(super) fn tool_sanitize_callback(backend: CompiledBuiltinBackend) -> ToolSanitizeFn {
-    Arc::new(move |_name: &str, payload: Json| backend.sanitize_json_preorder_dfs(payload))
+    Arc::new(
+        move |_name: &str, payload: Json| match backend.trajectory.as_ref() {
+            Some(trajectory) => trajectory.sanitize_tool_payload(payload),
+            None => backend.sanitize_json_preorder_dfs(payload),
+        },
+    )
 }
 
 pub(super) fn event_sanitize_callback(backend: CompiledBuiltinBackend) -> EventSanitizeFn {
@@ -291,6 +341,9 @@ fn event_sanitize_callback_with_scope_categories(
             return fields;
         }
 
+        if let Some(trajectory) = backend.trajectory.as_ref() {
+            return trajectory.sanitize_event_fields(event, fields);
+        }
         let specialized_scope = matches!(event, Event::Scope(_))
             && event
                 .category()
@@ -316,6 +369,10 @@ pub(super) fn llm_sanitize_request_callback(
     backend: CompiledBuiltinBackend,
 ) -> LlmSanitizeRequestFn {
     Arc::new(move |mut request: LlmRequest| {
+        if let Some(trajectory) = backend.trajectory.as_ref() {
+            request.content = trajectory.sanitize_provider_payload(request.content);
+            return request;
+        }
         if let Some(encoded) = backend.sanitize_request_with_codec(&request) {
             return encoded;
         }
@@ -328,6 +385,9 @@ pub(super) fn llm_sanitize_response_callback(
     backend: CompiledBuiltinBackend,
 ) -> LlmSanitizeResponseFn {
     Arc::new(move |payload: Json| {
+        if let Some(trajectory) = backend.trajectory.as_ref() {
+            return trajectory.sanitize_provider_payload(payload);
+        }
         if backend.target_paths.is_empty() {
             return backend.sanitize_json_preorder_dfs(payload);
         }

--- a/crates/pii-redaction/src/component.rs
+++ b/crates/pii-redaction/src/component.rs
@@ -175,8 +175,15 @@ impl Default for PiiRedactionProfile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct BuiltinBackendConfig {
+    /// Optional semantic sanitization preset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "builtin_preset_schema"))]
+    pub preset: Option<String>,
     /// Action applied to matching string leaves.
-    #[serde(default = "default_builtin_action")]
+    #[serde(
+        default = "default_builtin_action",
+        skip_serializing_if = "is_default_builtin_action"
+    )]
     #[cfg_attr(feature = "schema", schemars(schema_with = "builtin_action_schema"))]
     pub action: String,
     /// Exact JSON-pointer paths to sanitize. Empty means every string leaf.
@@ -200,11 +207,22 @@ pub struct BuiltinBackendConfig {
     /// Number of trailing characters to keep when `action = "mask"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unmasked_suffix: Option<usize>,
+    /// How the trajectory preset handles opaque custom-mark payloads.
+    #[serde(
+        default = "default_custom_mark_payload_policy",
+        skip_serializing_if = "is_default_custom_mark_payload_policy"
+    )]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(schema_with = "custom_mark_payload_policy_schema")
+    )]
+    pub custom_mark_payload_policy: String,
 }
 
 impl Default for BuiltinBackendConfig {
     fn default() -> Self {
         Self {
+            preset: None,
             action: default_builtin_action(),
             target_paths: Vec::new(),
             pattern: None,
@@ -213,6 +231,7 @@ impl Default for BuiltinBackendConfig {
             mask_char: None,
             unmasked_prefix: None,
             unmasked_suffix: None,
+            custom_mark_payload_policy: default_custom_mark_payload_policy(),
         }
     }
 }
@@ -327,6 +346,12 @@ static PII_REDACTION_PROFILE_LIST_ITEM: nemo_relay::config_editor::EditorListIte
 
 nemo_relay::editor_config! {
     impl BuiltinBackendConfig {
+        preset => {
+            label: "preset",
+            kind: Enum,
+            values: ["trajectory_context"],
+            optional: true,
+        },
         action => {
             label: "action",
             kind: Enum,
@@ -359,6 +384,11 @@ nemo_relay::editor_config! {
         mask_char => { label: "mask_char", kind: String, optional: true },
         unmasked_prefix => { label: "unmasked_prefix", kind: Integer, optional: true },
         unmasked_suffix => { label: "unmasked_suffix", kind: Integer, optional: true },
+        custom_mark_payload_policy => {
+            label: "custom_mark_payload_policy",
+            kind: Enum,
+            values: ["preserve", "redact_all_leaves"],
+        },
     }
 }
 
@@ -436,6 +466,24 @@ fn builtin_action_schema(
         generator,
         &["remove", "redact", "regex_replace", "hash", "mask"],
         Some("remove"),
+    )
+}
+
+#[cfg(feature = "schema")]
+fn builtin_preset_schema(
+    generator: &mut schemars::r#gen::SchemaGenerator,
+) -> schemars::schema::Schema {
+    string_enum_schema(generator, &["trajectory_context"], None)
+}
+
+#[cfg(feature = "schema")]
+fn custom_mark_payload_policy_schema(
+    generator: &mut schemars::r#gen::SchemaGenerator,
+) -> schemars::schema::Schema {
+    string_enum_schema(
+        generator,
+        &["preserve", "redact_all_leaves"],
+        Some("preserve"),
     )
 }
 
@@ -584,6 +632,7 @@ fn validate_pii_redaction_plugin_config(
         plugin_config,
         "builtin",
         &[
+            "preset",
             "action",
             "target_paths",
             "pattern",
@@ -592,6 +641,7 @@ fn validate_pii_redaction_plugin_config(
             "mask_char",
             "unmasked_prefix",
             "unmasked_suffix",
+            "custom_mark_payload_policy",
         ],
     );
     validate_section_fields(
@@ -612,7 +662,7 @@ fn validate_pii_redaction_plugin_config(
     validate_surface_selection(&mut diagnostics, &config.policy, &config);
     validate_codec_requirements(&mut diagnostics, &config.policy, &config);
     validate_builtin_mode_requirements(&mut diagnostics, &config.policy, plugin_config, &config);
-    validate_builtin_action_requirements(&mut diagnostics, &config.policy, &config);
+    validate_builtin_action_requirements(&mut diagnostics, &config.policy, plugin_config, &config);
     validate_local_mode_requirements(&mut diagnostics, &config.policy, plugin_config, &config);
 
     diagnostics
@@ -684,6 +734,7 @@ fn validate_profile_configuration(
             raw_profile,
             "builtin",
             &[
+                "preset",
                 "action",
                 "target_paths",
                 "pattern",
@@ -692,6 +743,7 @@ fn validate_profile_configuration(
                 "mask_char",
                 "unmasked_prefix",
                 "unmasked_suffix",
+                "custom_mark_payload_policy",
             ],
         );
         validate_section_fields(
@@ -717,6 +769,7 @@ fn validate_profile_configuration(
         validate_builtin_action_requirements(
             &mut profile_diagnostics,
             &config.policy,
+            raw_profile,
             &profile_config,
         );
         validate_local_mode_requirements(
@@ -848,11 +901,77 @@ fn validate_builtin_mode_requirements(
 fn validate_builtin_action_requirements(
     diagnostics: &mut Vec<ConfigDiagnostic>,
     policy: &ConfigPolicy,
+    plugin_config: &Map<String, Json>,
     config: &PiiRedactionConfig,
 ) {
     let Some(builtin) = config.builtin.as_ref() else {
         return;
     };
+
+    if let Some(preset) = builtin.preset.as_deref() {
+        if preset != "trajectory_context" {
+            push_policy_diag(
+                diagnostics,
+                policy.unsupported_value,
+                "pii_redaction.unsupported_value",
+                Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+                Some("builtin.preset".to_string()),
+                "builtin.preset must be 'trajectory_context'".to_string(),
+            );
+        }
+        if !matches!(
+            builtin.custom_mark_payload_policy.as_str(),
+            "preserve" | "redact_all_leaves"
+        ) {
+            push_policy_diag(
+                diagnostics,
+                policy.unsupported_value,
+                "pii_redaction.unsupported_value",
+                Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+                Some("builtin.custom_mark_payload_policy".to_string()),
+                "builtin.custom_mark_payload_policy must be 'preserve' or 'redact_all_leaves'"
+                    .to_string(),
+            );
+        }
+        let raw_builtin = plugin_config.get("builtin").and_then(Json::as_object);
+        for field in [
+            "action",
+            "detector",
+            "pattern",
+            "target_paths",
+            "mask_char",
+            "unmasked_prefix",
+            "unmasked_suffix",
+        ] {
+            if raw_builtin.is_some_and(|raw| raw.contains_key(field)) {
+                push_policy_diag(
+                    diagnostics,
+                    policy.unsupported_value,
+                    "pii_redaction.unsupported_value",
+                    Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+                    Some(format!("builtin.{field}")),
+                    format!("builtin.{field} cannot be combined with builtin.preset"),
+                );
+            }
+        }
+        return;
+    }
+
+    let custom_policy_configured = plugin_config
+        .get("builtin")
+        .and_then(Json::as_object)
+        .is_some_and(|builtin| builtin.contains_key("custom_mark_payload_policy"));
+    if custom_policy_configured {
+        push_policy_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "pii_redaction.unsupported_value",
+            Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+            Some("builtin.custom_mark_payload_policy".to_string()),
+            "builtin.custom_mark_payload_policy requires builtin.preset = 'trajectory_context'"
+                .to_string(),
+        );
+    }
 
     if !matches!(
         builtin.action.as_str(),
@@ -1223,6 +1342,10 @@ fn default_builtin_action() -> String {
     "remove".to_string()
 }
 
+fn default_custom_mark_payload_policy() -> String {
+    "preserve".to_string()
+}
+
 fn default_true() -> bool {
     true
 }
@@ -1233,6 +1356,14 @@ fn default_priority() -> i32 {
 
 fn is_default_mode(mode: &str) -> bool {
     mode == "builtin"
+}
+
+fn is_default_builtin_action(action: &str) -> bool {
+    action == "remove"
+}
+
+fn is_default_custom_mark_payload_policy(policy: &str) -> bool {
+    policy == "preserve"
 }
 
 fn is_true(value: &bool) -> bool {

--- a/crates/pii-redaction/src/lib.rs
+++ b/crates/pii-redaction/src/lib.rs
@@ -13,6 +13,7 @@ pub mod component;
 pub(crate) mod detectors;
 pub(crate) mod local;
 pub(crate) mod overlay;
+pub(crate) mod trajectory;
 
 #[cfg(test)]
 pub(crate) fn test_mutex() -> &'static Mutex<()> {

--- a/crates/pii-redaction/src/trajectory.rs
+++ b/crates/pii-redaction/src/trajectory.rs
@@ -1,0 +1,453 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structure-preserving removal of conversational trajectory content.
+
+use std::sync::Arc;
+
+use serde_json::Value as Json;
+
+use nemo_relay::api::event::{CategoryProfile, Event};
+use nemo_relay::codec::request::AnnotatedLlmRequest;
+use nemo_relay::codec::response::AnnotatedLlmResponse;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CustomMarkPayloadPolicy {
+    Preserve,
+    RedactAllLeaves,
+}
+
+impl CustomMarkPayloadPolicy {
+    pub(super) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "preserve" => Some(Self::Preserve),
+            "redact_all_leaves" => Some(Self::RedactAllLeaves),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct TrajectorySanitizer {
+    replacement: Arc<String>,
+    custom_mark_payload_policy: CustomMarkPayloadPolicy,
+}
+
+impl TrajectorySanitizer {
+    pub(super) fn new(replacement: String, policy: CustomMarkPayloadPolicy) -> Self {
+        Self {
+            replacement: Arc::new(replacement),
+            custom_mark_payload_policy: policy,
+        }
+    }
+
+    pub(super) fn sanitize_tool_payload(&self, value: Json) -> Json {
+        redact_all_leaves(value, &self.replacement)
+    }
+
+    pub(super) fn sanitize_provider_payload(&self, value: Json) -> Json {
+        redact_semantic_content(value, &self.replacement, None)
+    }
+
+    pub(super) fn sanitize_annotated_request(
+        &self,
+        request: AnnotatedLlmRequest,
+    ) -> Option<AnnotatedLlmRequest> {
+        let mut value = serde_json::to_value(request).ok()?;
+        let preserved = take_root_fields(
+            &value,
+            &[
+                "model",
+                "tool_choice",
+                "store",
+                "previous_response_id",
+                "truncation",
+                "include",
+                "service_tier",
+                "parallel_tool_calls",
+                "max_output_tokens",
+                "max_tool_calls",
+                "top_logprobs",
+                "stream",
+            ],
+        );
+        value = redact_semantic_content(value, &self.replacement, None);
+        restore_root_fields(&mut value, preserved);
+        serde_json::from_value(value).ok()
+    }
+
+    pub(super) fn sanitize_annotated_response(
+        &self,
+        response: AnnotatedLlmResponse,
+    ) -> Option<AnnotatedLlmResponse> {
+        let mut value = serde_json::to_value(response).ok()?;
+        let mut preserved = take_root_fields(
+            &value,
+            &[
+                "id",
+                "model",
+                "finish_reason",
+                "usage",
+                "optimization_summary",
+            ],
+        );
+        if let Some((_, summary)) = preserved
+            .iter_mut()
+            .find(|(field, _)| field == "optimization_summary")
+        {
+            sanitize_optimization_payloads(summary, &self.replacement);
+        }
+        value = redact_semantic_content(value, &self.replacement, None);
+        restore_root_fields(&mut value, preserved);
+        serde_json::from_value(value).ok()
+    }
+
+    pub(super) fn sanitize_event_fields(
+        &self,
+        event: &Event,
+        mut fields: nemo_relay::api::event::EventSanitizeFields,
+    ) -> nemo_relay::api::event::EventSanitizeFields {
+        let category = event.category().map(|category| category.as_str());
+        let specialized_scope =
+            matches!(event, Event::Scope(_)) && matches!(category, Some("llm" | "tool"));
+        let unknown_custom_mark = matches!(event, Event::Mark(_))
+            && category == Some("custom")
+            && !is_known_content_bearing_mark(event.name());
+
+        if unknown_custom_mark {
+            if self.custom_mark_payload_policy == CustomMarkPayloadPolicy::RedactAllLeaves {
+                fields.data = fields
+                    .data
+                    .map(|value| redact_all_leaves(value, &self.replacement));
+                fields.metadata = fields
+                    .metadata
+                    .map(|value| redact_all_leaves(value, &self.replacement));
+                fields.category_profile = fields
+                    .category_profile
+                    .and_then(|profile| redact_custom_category_profile(profile, self));
+            }
+            return fields;
+        }
+
+        if !specialized_scope {
+            fields.data = fields
+                .data
+                .map(|value| redact_semantic_content(value, &self.replacement, None));
+        }
+        fields.metadata = fields
+            .metadata
+            .map(|value| redact_semantic_content(value, &self.replacement, None));
+        fields.category_profile = fields
+            .category_profile
+            .and_then(|profile| sanitize_category_profile(profile, &self.replacement));
+        fields
+    }
+}
+
+fn is_known_content_bearing_mark(name: &str) -> bool {
+    matches!(
+        name,
+        "llm.chunk" | "nemo_relay.llm.optimization" | "skill.load"
+    )
+}
+
+fn sanitize_category_profile(
+    mut profile: CategoryProfile,
+    replacement: &str,
+) -> Option<CategoryProfile> {
+    profile.annotated_request = profile.annotated_request.as_ref().and_then(|request| {
+        TrajectorySanitizer::new(replacement.to_string(), CustomMarkPayloadPolicy::Preserve)
+            .sanitize_annotated_request((**request).clone())
+            .map(Arc::new)
+    });
+    profile.annotated_response = profile.annotated_response.as_ref().and_then(|response| {
+        TrajectorySanitizer::new(replacement.to_string(), CustomMarkPayloadPolicy::Preserve)
+            .sanitize_annotated_response((**response).clone())
+            .map(Arc::new)
+    });
+    profile.extra = profile
+        .extra
+        .into_iter()
+        .map(|(key, value)| {
+            let value = redact_semantic_content(value, replacement, Some(&key));
+            (key, value)
+        })
+        .collect();
+    Some(profile)
+}
+
+fn redact_custom_category_profile(
+    mut profile: CategoryProfile,
+    sanitizer: &TrajectorySanitizer,
+) -> Option<CategoryProfile> {
+    profile.annotated_request = profile.annotated_request.as_ref().and_then(|request| {
+        sanitizer
+            .sanitize_annotated_request((**request).clone())
+            .map(Arc::new)
+    });
+    profile.annotated_response = profile.annotated_response.as_ref().and_then(|response| {
+        sanitizer
+            .sanitize_annotated_response((**response).clone())
+            .map(Arc::new)
+    });
+    profile.extra = profile
+        .extra
+        .into_iter()
+        .map(|(key, value)| {
+            let value = redact_all_leaves(value, &sanitizer.replacement);
+            (key, value)
+        })
+        .collect();
+    Some(profile)
+}
+
+fn take_root_fields(value: &Json, fields: &[&str]) -> Vec<(String, Json)> {
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+    fields
+        .iter()
+        .filter_map(|field| {
+            object
+                .get(*field)
+                .cloned()
+                .map(|value| ((*field).to_string(), value))
+        })
+        .collect()
+}
+
+fn restore_root_fields(value: &mut Json, fields: Vec<(String, Json)>) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    object.extend(fields);
+}
+
+fn sanitize_optimization_payloads(value: &mut Json, replacement: &str) {
+    let Some(contributions) = value.get_mut("contributions").and_then(Json::as_array_mut) else {
+        return;
+    };
+    for contribution in contributions {
+        let Some(contribution) = contribution.as_object_mut() else {
+            continue;
+        };
+        if let Some(payload) = contribution.get_mut("payload") {
+            *payload = redact_all_leaves(payload.take(), replacement);
+        }
+        let known = [
+            "id",
+            "sequence",
+            "producer",
+            "kind",
+            "applied",
+            "model_transition",
+            "token_impact",
+            "payload_schema",
+            "payload",
+        ];
+        for (key, value) in contribution.iter_mut() {
+            if !known.contains(&key.as_str()) {
+                *value = redact_all_leaves(value.take(), replacement);
+            }
+        }
+    }
+}
+
+pub(super) fn redact_all_leaves(value: Json, replacement: &str) -> Json {
+    match value {
+        Json::Null => Json::Null,
+        Json::Bool(_) => Json::Bool(false),
+        Json::Number(_) => Json::from(0),
+        Json::String(_) => Json::String(replacement.to_string()),
+        Json::Array(values) => Json::Array(
+            values
+                .into_iter()
+                .map(|value| redact_all_leaves(value, replacement))
+                .collect(),
+        ),
+        Json::Object(values) => Json::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, redact_all_leaves(value, replacement)))
+                .collect(),
+        ),
+    }
+}
+
+fn redact_semantic_content(value: Json, replacement: &str, field: Option<&str>) -> Json {
+    match value {
+        Json::Null => Json::Null,
+        Json::Bool(value) => {
+            if field.is_some_and(preserve_analytical_bool) {
+                Json::Bool(value)
+            } else {
+                Json::Bool(false)
+            }
+        }
+        Json::Number(value) => {
+            if field.is_some_and(preserve_analytical_number) {
+                Json::Number(value)
+            } else {
+                Json::from(0)
+            }
+        }
+        Json::String(value) => {
+            if field.is_some_and(preserve_analytical_string) {
+                Json::String(value)
+            } else if field == Some("arguments") {
+                redact_stringified_json(value, replacement)
+            } else {
+                Json::String(replacement.to_string())
+            }
+        }
+        Json::Array(values) => Json::Array(
+            values
+                .into_iter()
+                .map(|value| redact_semantic_content(value, replacement, field))
+                .collect(),
+        ),
+        Json::Object(values) => {
+            let preserve_tool_name = preserves_tool_or_function_name(field, &values);
+            Json::Object(
+                values
+                    .into_iter()
+                    .map(|(key, value)| {
+                        let value = if key == "name" && preserve_tool_name && value.is_string() {
+                            value
+                        } else {
+                            redact_semantic_content(value, replacement, Some(&key))
+                        };
+                        (key, value)
+                    })
+                    .collect(),
+            )
+        }
+    }
+}
+
+fn redact_stringified_json(value: String, replacement: &str) -> Json {
+    let Ok(parsed) = serde_json::from_str::<Json>(&value) else {
+        return Json::String(replacement.to_string());
+    };
+    let scrubbed = redact_all_leaves(parsed, replacement);
+    Json::String(serde_json::to_string(&scrubbed).unwrap_or_else(|_| replacement.to_string()))
+}
+
+fn preserve_analytical_bool(key: &str) -> bool {
+    matches!(
+        key,
+        "applied"
+            | "enabled"
+            | "store"
+            | "stream"
+            | "parallel_tool_calls"
+            | "required"
+            | "additionalProperties"
+    )
+}
+
+fn preserve_analytical_number(key: &str) -> bool {
+    matches!(
+        key,
+        "chunk_index"
+            | "index"
+            | "attempt"
+            | "sequence"
+            | "priority"
+            | "version"
+            | "temperature"
+            | "top_p"
+            | "top_logprobs"
+            | "max_tokens"
+            | "max_output_tokens"
+            | "max_tool_calls"
+            | "total"
+            | "input"
+            | "output"
+            | "cache_read"
+            | "cache_write"
+            | "confidence"
+            | "logprob"
+    ) || key.ends_with("_tokens")
+        || key.ends_with("_count")
+        || key.ends_with("_index")
+        || key.ends_with("_indices")
+        || key.ends_with("_cost")
+        || key.ends_with("_latency")
+        || key.ends_with("_millis")
+        || key.ends_with("_ms")
+        || key.ends_with("_seconds")
+        || key.ends_with("_timestamp")
+}
+
+fn preserve_analytical_string(key: &str) -> bool {
+    if matches!(key, "token" | "token_id") {
+        return false;
+    }
+    matches!(
+        key,
+        "role"
+            | "type"
+            | "api"
+            | "kind"
+            | "producer"
+            | "subtype"
+            | "model"
+            | "model_name"
+            | "provider"
+            | "protocol"
+            | "backend"
+            | "tier"
+            | "status"
+            | "finish_reason"
+            | "stop_reason"
+            | "service_tier"
+            | "mode"
+            | "quality"
+            | "estimation_method"
+            | "currency"
+            | "pricing_source"
+            | "pricing_provider"
+            | "pricing_model"
+            | "pricing_as_of"
+            | "required"
+            | "version"
+            | "event_type"
+            | "object"
+            | "object_type"
+            | "system_fingerprint"
+            | "truncation"
+            | "include"
+            | "detail"
+            | "media_type"
+            | "selected_model"
+            | "selected_backend"
+            | "selected_tier"
+            | "selected_protocol"
+            | "selected_route"
+            | "selected_endpoint"
+            | "baseline_model"
+            | "baseline_backend"
+            | "baseline_tier"
+            | "baseline_protocol"
+            | "baseline_route"
+            | "effective_model"
+            | "effective_backend"
+            | "effective_tier"
+            | "effective_protocol"
+            | "effective_route"
+    ) || key == "id"
+        || key.ends_with("_id")
+        || key.ends_with("_uuid")
+}
+
+fn preserves_tool_or_function_name(
+    container: Option<&str>,
+    object: &serde_json::Map<String, Json>,
+) -> bool {
+    matches!(container, Some("function" | "tools"))
+        || object
+            .get("type")
+            .and_then(Json::as_str)
+            .is_some_and(|kind| matches!(kind, "function" | "function_call" | "tool_use"))
+}

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -10,11 +10,12 @@ use crate::api::event::{
     ScopeCategory, ScopeEvent,
 };
 use crate::api::llm::{
-    LlmCallExecuteParams, LlmCallParams, LlmRequest, llm_call, llm_call_execute,
+    LlmCallExecuteParams, LlmCallParams, LlmRequest, LlmStreamCallExecuteParams, llm_call,
+    llm_call_execute, llm_stream_call_execute,
 };
 use crate::api::runtime::{
-    LlmExecutionNextFn, NemoRelayContextState, create_scope_stack, global_context,
-    set_thread_scope_stack,
+    LlmExecutionNextFn, LlmJsonStream, LlmStreamExecutionNextFn, NemoRelayContextState,
+    create_scope_stack, global_context, set_thread_scope_stack,
 };
 use crate::api::scope::{
     EmitMarkEventParams, PopScopeParams, PushScopeParams, ScopeType, event, pop_scope, push_scope,
@@ -23,12 +24,13 @@ use crate::api::subscriber::{deregister_subscriber, register_subscriber};
 use crate::api::tool::{ToolCallEndParams, ToolCallParams, tool_call, tool_call_end};
 use crate::codec::openai_chat::OpenAIChatCodec;
 use crate::codec::openai_responses::OpenAIResponsesCodec;
-use crate::codec::traits::LlmResponseCodec;
+use crate::codec::traits::{LlmCodec, LlmResponseCodec};
 use crate::plugin::{
     PluginComponentSpec, PluginConfig, PluginError, PluginRegistrationContext,
     clear_plugin_configuration, ensure_builtin_plugins_registered, initialize_plugins,
     list_plugin_kinds, rollback_registrations, validate_plugin_config,
 };
+use futures::StreamExt;
 use nemo_relay::observability::atif::{AtifAgentInfo, AtifExporter};
 use nemo_relay::observability::atof::{AtofExporter, AtofExporterConfig};
 use nemo_relay::observability::openinference::OpenInferenceSubscriber;
@@ -128,10 +130,580 @@ fn builtin_registry_includes_pii_redaction_component() {
 fn builtin_backend_config_default_matches_documented_action_default() {
     let config = BuiltinBackendConfig::default();
 
+    assert!(config.preset.is_none());
     assert_eq!(config.action, "remove");
+    assert_eq!(config.custom_mark_payload_policy, "preserve");
     assert!(config.target_paths.is_empty());
     assert!(config.pattern.is_none());
     assert!(config.detector.is_none());
+}
+
+#[test]
+fn trajectory_preset_validates_without_an_action_and_rejects_matcher_fields() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+    let valid = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [{
+            "mode": "builtin",
+            "builtin": {
+                "preset": "trajectory_context",
+                "custom_mark_payload_policy": "redact_all_leaves"
+            }
+        }]
+    })));
+    assert!(!valid.has_errors(), "{:#?}", valid.diagnostics);
+
+    let invalid = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [{
+            "mode": "builtin",
+            "builtin": {
+                "preset": "trajectory_context",
+                "action": "redact",
+                "detector": "email"
+            }
+        }]
+    })));
+    assert!(invalid.has_errors());
+    assert!(
+        invalid.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref() == Some("profiles[0].builtin.action")
+        })
+    );
+    assert!(
+        invalid.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref() == Some("profiles[0].builtin.detector")
+        })
+    );
+
+    let policy_without_preset = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [{
+            "mode": "builtin",
+            "builtin": {"custom_mark_payload_policy": "preserve"}
+        }]
+    })));
+    assert!(policy_without_preset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.field.as_deref() == Some("profiles[0].builtin.custom_mark_payload_policy")
+    }));
+}
+
+fn trajectory_backend(codec: Option<&str>, policy: &str) -> crate::builtin::CompiledBuiltinBackend {
+    crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            preset: Some("trajectory_context".into()),
+            custom_mark_payload_policy: policy.into(),
+            ..BuiltinBackendConfig::default()
+        },
+        codec.map(str::to_string),
+    )
+    .unwrap()
+}
+
+#[test]
+fn trajectory_preset_redacts_chat_content_without_erasing_request_structure() {
+    let callback = crate::builtin::llm_sanitize_request_callback(trajectory_backend(
+        Some("openai_chat"),
+        "preserve",
+    ));
+    let request = callback(LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [
+                {"role": "system", "content": "private system prompt"},
+                {"role": "user", "content": [
+                    {"type": "text", "text": "private user prompt"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,secret", "detail": "high"}}
+                ]},
+                {"role": "assistant", "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{\"query\":\"private query\",\"limit\":5}"}
+                }]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "private result"}
+            ],
+            "tools": [{"type": "function", "function": {
+                "name": "search",
+                "description": "private description",
+                "parameters": {"type": "object", "properties": {
+                    "query": {"type": "string", "description": "private schema text", "default": "private default"}
+                }, "required": ["query"]}
+            }}],
+            "temperature": 0.2,
+            "stop": ["private stop sequence"],
+            "participant": {"name": "Alice Example", "username": "alice"},
+            "person_name": "Alice Example"
+        }),
+    });
+
+    assert_eq!(request.content["model"], "claude-sonnet-4-6");
+    assert_eq!(request.content["temperature"], 0.2);
+    assert_eq!(request.content["stop"][0], "[REDACTED]");
+    assert_eq!(request.content["participant"]["name"], "[REDACTED]");
+    assert_eq!(request.content["participant"]["username"], "[REDACTED]");
+    assert_eq!(request.content["person_name"], "[REDACTED]");
+    assert_eq!(request.content["messages"][0]["role"], "system");
+    assert_eq!(request.content["messages"][0]["content"], "[REDACTED]");
+    assert_eq!(request.content["messages"][1]["content"][0]["type"], "text");
+    assert_eq!(
+        request.content["messages"][1]["content"][0]["text"],
+        "[REDACTED]"
+    );
+    assert_eq!(
+        request.content["messages"][1]["content"][1]["image_url"]["url"],
+        "[REDACTED]"
+    );
+    assert_eq!(
+        request.content["messages"][2]["tool_calls"][0]["id"],
+        "call_1"
+    );
+    assert_eq!(
+        request.content["messages"][2]["tool_calls"][0]["function"]["name"],
+        "search"
+    );
+    let arguments: Json = serde_json::from_str(
+        request.content["messages"][2]["tool_calls"][0]["function"]["arguments"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(arguments, json!({"query": "[REDACTED]", "limit": 0}));
+    assert_eq!(request.content["messages"][3]["tool_call_id"], "call_1");
+    assert_eq!(request.content["messages"][3]["content"], "[REDACTED]");
+    assert_eq!(request.content["tools"][0]["function"]["name"], "search");
+    assert_eq!(
+        request.content["tools"][0]["function"]["description"],
+        "[REDACTED]"
+    );
+    assert_eq!(
+        request.content["tools"][0]["function"]["parameters"]["required"][0],
+        "query"
+    );
+}
+
+#[test]
+fn trajectory_preset_preserves_response_analytics_and_redacts_response_content() {
+    let callback = crate::builtin::llm_sanitize_response_callback(trajectory_backend(
+        Some("openai_chat"),
+        "preserve",
+    ));
+    let sanitized = callback(json!({
+        "id": "chatcmpl_1",
+        "model": "claude-opus-4-6",
+        "choices": [{"index": 0, "finish_reason": "tool_calls", "message": {
+            "role": "assistant",
+            "content": "private answer",
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {
+                "name": "terminal", "arguments": "{\"command\":\"cat secret.txt\"}"
+            }}]
+        }, "logprobs": {"content": [{"token": "secret", "logprob": -0.5}]}}],
+        "usage": {"prompt_tokens": 20, "completion_tokens": 5, "total_tokens": 25},
+        "cost": {"total": 1.25}
+    }));
+
+    assert_eq!(sanitized["id"], "chatcmpl_1");
+    assert_eq!(sanitized["model"], "claude-opus-4-6");
+    assert_eq!(sanitized["choices"][0]["finish_reason"], "tool_calls");
+    assert_eq!(sanitized["choices"][0]["message"]["role"], "assistant");
+    assert_eq!(sanitized["choices"][0]["message"]["content"], "[REDACTED]");
+    assert_eq!(
+        sanitized["choices"][0]["message"]["tool_calls"][0]["id"],
+        "call_1"
+    );
+    assert_eq!(
+        sanitized["choices"][0]["message"]["tool_calls"][0]["function"]["name"],
+        "terminal"
+    );
+    let arguments: Json = serde_json::from_str(
+        sanitized["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(arguments, json!({"command": "[REDACTED]"}));
+    assert_eq!(sanitized["usage"]["total_tokens"], 25);
+    assert_eq!(sanitized["cost"]["total"], 1.25);
+}
+
+#[test]
+fn trajectory_preset_covers_responses_and_anthropic_provider_shapes() {
+    let responses_request = crate::builtin::llm_sanitize_request_callback(trajectory_backend(
+        Some("openai_responses"),
+        "preserve",
+    ))(LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({
+            "model": "gpt-5",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "private input"}]}],
+            "reasoning": {"effort": "high", "summary": "private reasoning"},
+            "max_output_tokens": 100
+        }),
+    });
+    assert_eq!(responses_request.content["model"], "gpt-5");
+    assert_eq!(responses_request.content["input"][0]["role"], "user");
+    assert_eq!(
+        responses_request.content["input"][0]["content"][0]["text"],
+        "[REDACTED]"
+    );
+    assert_eq!(responses_request.content["max_output_tokens"], 100);
+
+    let responses_response = crate::builtin::llm_sanitize_response_callback(trajectory_backend(
+        Some("openai_responses"),
+        "preserve",
+    ))(json!({
+        "id": "resp_1",
+        "model": "gpt-5",
+        "status": "completed",
+        "output": [{"id": "msg_1", "type": "message", "role": "assistant", "content": [
+            {"type": "output_text", "text": "private output"}
+        ]}],
+        "usage": {"input_tokens": 10, "output_tokens": 4, "total_tokens": 14}
+    }));
+    assert_eq!(responses_response["id"], "resp_1");
+    assert_eq!(responses_response["status"], "completed");
+    assert_eq!(responses_response["output"][0]["id"], "msg_1");
+    assert_eq!(
+        responses_response["output"][0]["content"][0]["text"],
+        "[REDACTED]"
+    );
+    assert_eq!(responses_response["usage"]["total_tokens"], 14);
+
+    let anthropic_request = crate::builtin::llm_sanitize_request_callback(trajectory_backend(
+        Some("anthropic_messages"),
+        "preserve",
+    ))(LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({
+            "model": "claude-sonnet-4-6",
+            "system": "private system",
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "private user"},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "private-base64"}}
+            ]}],
+            "max_tokens": 128
+        }),
+    });
+    assert_eq!(anthropic_request.content["model"], "claude-sonnet-4-6");
+    assert_eq!(anthropic_request.content["system"], "[REDACTED]");
+    assert_eq!(
+        anthropic_request.content["messages"][0]["content"][0]["text"], "[REDACTED]",
+        "{}",
+        anthropic_request.content
+    );
+    assert_eq!(
+        anthropic_request.content["messages"][0]["content"][1]["source"]["data"],
+        "[REDACTED]"
+    );
+    assert_eq!(anthropic_request.content["max_tokens"], 128);
+
+    let anthropic_response = crate::builtin::llm_sanitize_response_callback(trajectory_backend(
+        Some("anthropic_messages"),
+        "preserve",
+    ))(json!({
+        "id": "msg_1",
+        "model": "claude-sonnet-4-6",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "private chain of thought", "signature": "private-signature"},
+            {"type": "text", "text": "private answer"}
+        ],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 12, "output_tokens": 6, "cache_read_input_tokens": 8}
+    }));
+    assert_eq!(anthropic_response["id"], "msg_1");
+    assert_eq!(anthropic_response["role"], "assistant");
+    assert_eq!(anthropic_response["content"][0]["type"], "thinking");
+    assert_eq!(anthropic_response["content"][0]["thinking"], "[REDACTED]");
+    assert_eq!(anthropic_response["content"][1]["text"], "[REDACTED]");
+    assert_eq!(anthropic_response["usage"]["input_tokens"], 12);
+    assert_eq!(anthropic_response["usage"]["cache_read_input_tokens"], 8);
+}
+
+#[test]
+fn trajectory_preset_redacts_known_marks_and_nested_scope_content() {
+    let callback = crate::builtin::event_sanitize_callback(trajectory_backend(None, "preserve"));
+    let chunk = Event::Mark(MarkEvent::new(
+        BaseEvent::builder().name("llm.chunk").build(),
+        Some(EventCategory::custom()),
+        Some(CategoryProfile::builder().subtype("llm.chunk").build()),
+    ));
+    let sanitized = callback(
+        &chunk,
+        EventSanitizeFields {
+            data: Some(json!({
+                "chunk_index": 2,
+                "event_type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "private delta"}
+            })),
+            category_profile: chunk.category_profile().cloned(),
+            metadata: None,
+        },
+    );
+    assert_eq!(sanitized.data.as_ref().unwrap()["chunk_index"], 2);
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["event_type"],
+        "content_block_delta"
+    );
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["delta"]["text"],
+        "[REDACTED]"
+    );
+
+    let optimization = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .name("nemo_relay.llm.optimization")
+            .build(),
+        Some(EventCategory::custom()),
+        Some(
+            CategoryProfile::builder()
+                .subtype("nemo_relay.llm.optimization")
+                .build(),
+        ),
+    ));
+    let sanitized = callback(
+        &optimization,
+        EventSanitizeFields {
+            data: Some(json!({
+                "producer": "neutral.router",
+                "kind": "model_routing",
+                "applied": true,
+                "model_transition": {
+                    "baseline": {"model": "claude-opus-4-6"},
+                    "effective": {"model": "claude-sonnet-4-6"}
+                },
+                "token_impact": {"saved": {"prompt_tokens": 40, "total_tokens": 40}},
+                "payload": {"private_excerpt": "private content"}
+            })),
+            category_profile: optimization.category_profile().cloned(),
+            metadata: None,
+        },
+    );
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["producer"],
+        "neutral.router"
+    );
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["model_transition"]["baseline"]["model"],
+        "claude-opus-4-6"
+    );
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["token_impact"]["saved"]["total_tokens"],
+        40
+    );
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["payload"]["private_excerpt"],
+        "[REDACTED]"
+    );
+
+    let nested_agent = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder().name("worker-agent").build(),
+        ScopeCategory::Start,
+        Vec::new(),
+        EventCategory::agent(),
+        None,
+    ));
+    let sanitized = callback(
+        &nested_agent,
+        EventSanitizeFields {
+            data: Some(json!({
+                "request_id": "request-1",
+                "instruction": "private delegated task",
+                "history": [{"role": "user", "content": "private history"}]
+            })),
+            category_profile: None,
+            metadata: Some(json!({"parent_scope_id": "scope-1", "note": "private note"})),
+        },
+    );
+    assert_eq!(sanitized.data.as_ref().unwrap()["request_id"], "request-1");
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["instruction"],
+        "[REDACTED]"
+    );
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["history"][0]["role"],
+        "user"
+    );
+    assert_eq!(
+        sanitized.data.as_ref().unwrap()["history"][0]["content"],
+        "[REDACTED]"
+    );
+    assert_eq!(
+        sanitized.metadata.as_ref().unwrap()["parent_scope_id"],
+        "scope-1"
+    );
+    assert_eq!(sanitized.metadata.as_ref().unwrap()["note"], "[REDACTED]");
+}
+
+#[test]
+fn trajectory_custom_mark_policy_is_explicit_and_shape_preserving() {
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder().name("neutral.plugin.evidence").build(),
+        Some(EventCategory::custom()),
+        Some(CategoryProfile {
+            subtype: Some("neutral.plugin".into()),
+            extra: BTreeMap::from([("opaque".into(), json!({"label": "private"}))]),
+            ..CategoryProfile::default()
+        }),
+    ));
+    let fields = EventSanitizeFields {
+        data: Some(json!({"text": "private", "score": 0.75, "nested": [true, null]})),
+        category_profile: event.category_profile().cloned(),
+        metadata: Some(json!({"owner": "private owner"})),
+    };
+
+    let preserve = crate::builtin::event_sanitize_callback(trajectory_backend(None, "preserve"));
+    assert_eq!(preserve(&event, fields.clone()), fields);
+
+    let redact =
+        crate::builtin::event_sanitize_callback(trajectory_backend(None, "redact_all_leaves"));
+    let sanitized = redact(&event, fields);
+    assert_eq!(
+        sanitized.data.unwrap(),
+        json!({
+            "text": "[REDACTED]", "score": 0, "nested": [false, null]
+        })
+    );
+    assert_eq!(sanitized.metadata.unwrap(), json!({"owner": "[REDACTED]"}));
+    let profile = sanitized.category_profile.unwrap();
+    assert_eq!(profile.subtype.as_deref(), Some("neutral.plugin"));
+    assert_eq!(profile.extra["opaque"]["label"], "[REDACTED]");
+}
+
+#[test]
+fn trajectory_profile_preserves_typed_llm_accounting_while_redacting_annotations() {
+    let callback = crate::builtin::event_sanitize_callback(trajectory_backend(None, "preserve"));
+    let annotated_response: nemo_relay::codec::response::AnnotatedLlmResponse =
+        serde_json::from_value(json!({
+            "model": "claude-sonnet-4-6",
+            "message": "private answer",
+            "finish_reason": "complete",
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "total_tokens": 120,
+                "cost": {
+                    "total": 0.42,
+                    "currency": "USD",
+                    "source": "provider_reported"
+                }
+            },
+            "optimization_summary": {
+                "schema_version": "1",
+                "calculation_version": "1",
+                "status": "complete",
+                "baseline_model": {"model": "claude-opus-4-6"},
+                "effective_model": {"model": "claude-sonnet-4-6"},
+                "effective_usage": {"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120},
+                "baseline_usage": {"prompt_tokens": 140, "completion_tokens": 20, "total_tokens": 160},
+                "tokens_saved": {"prompt_tokens": 40, "total_tokens": 40},
+                "estimated_cost_saved": 0.8,
+                "currency": "USD",
+                "contributions": [{
+                    "producer": "neutral.optimizer",
+                    "kind": "input_compression",
+                    "applied": true,
+                    "token_impact": {
+                        "saved": {"prompt_tokens": 40, "total_tokens": 40},
+                        "quality": "estimated",
+                        "estimation_method": "neutral_counter"
+                    },
+                    "payload_schema": {"name": "neutral.evidence", "version": "1"},
+                    "payload": {"private_excerpt": "private tool output", "strategy": "head_tail"}
+                }]
+            }
+        }))
+        .unwrap();
+    let event = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder().name("llm").build(),
+        ScopeCategory::End,
+        Vec::new(),
+        EventCategory::llm(),
+        None,
+    ));
+    let sanitized = callback(
+        &event,
+        EventSanitizeFields {
+            data: Some(json!({"already": "sanitized by the response callback"})),
+            category_profile: Some(
+                CategoryProfile::builder()
+                    .model_name("claude-sonnet-4-6")
+                    .annotated_response(Arc::new(annotated_response))
+                    .build(),
+            ),
+            metadata: None,
+        },
+    );
+
+    let profile = sanitized.category_profile.unwrap();
+    assert_eq!(profile.model_name.as_deref(), Some("claude-sonnet-4-6"));
+    let response = profile.annotated_response.unwrap();
+    assert_eq!(response.response_text(), Some("[REDACTED]"));
+    assert_eq!(response.usage.as_ref().unwrap().total_tokens, Some(120));
+    assert_eq!(
+        response
+            .usage
+            .as_ref()
+            .unwrap()
+            .cost
+            .as_ref()
+            .unwrap()
+            .total,
+        Some(0.42)
+    );
+    let summary = response.optimization_summary.as_ref().unwrap();
+    assert_eq!(summary.tokens_saved.prompt_tokens, Some(40));
+    assert_eq!(summary.estimated_cost_saved, Some(0.8));
+    assert_eq!(summary.contributions[0].producer, "neutral.optimizer");
+    assert_eq!(
+        summary.contributions[0].payload.as_ref().unwrap()["private_excerpt"],
+        "[REDACTED]"
+    );
+    assert_eq!(
+        summary.contributions[0].payload.as_ref().unwrap()["strategy"],
+        "[REDACTED]"
+    );
+    assert_eq!(
+        sanitized.data.unwrap()["already"],
+        "sanitized by the response callback",
+        "specialized LLM data must not be processed twice"
+    );
+}
+
+#[test]
+fn preserved_custom_marks_remain_eligible_for_a_later_email_profile() {
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder().name("neutral.plugin.evidence").build(),
+        Some(EventCategory::custom()),
+        Some(CategoryProfile::builder().subtype("neutral.plugin").build()),
+    ));
+    let fields = EventSanitizeFields {
+        data: Some(json!({"owner": "alice@example.com", "score": 0.9})),
+        category_profile: event.category_profile().cloned(),
+        metadata: Some(json!({"contact": "bob@example.com"})),
+    };
+    let trajectory = crate::builtin::event_sanitize_callback(trajectory_backend(None, "preserve"));
+    let email = crate::builtin::event_sanitize_callback(
+        crate::builtin::CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                action: "redact".into(),
+                detector: Some("email".into()),
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap(),
+    );
+
+    let sanitized = email(&event, trajectory(&event, fields));
+    assert_eq!(sanitized.data.as_ref().unwrap()["owner"], "[REDACTED]");
+    assert_eq!(sanitized.data.as_ref().unwrap()["score"], 0.9);
+    assert_eq!(
+        sanitized.metadata.as_ref().unwrap()["contact"],
+        "[REDACTED]"
+    );
 }
 
 #[test]
@@ -181,6 +753,18 @@ fn typed_profile_config_serializes_without_conflicting_legacy_defaults() {
 
     let report = validate_plugin_config(&plugin_config(serialized));
     assert!(!report.has_errors(), "{:?}", report.diagnostics);
+}
+
+#[test]
+fn typed_trajectory_preset_omits_the_legacy_default_action() {
+    let config = BuiltinBackendConfig {
+        preset: Some("trajectory_context".into()),
+        ..BuiltinBackendConfig::default()
+    };
+    let serialized = serde_json::to_value(config).unwrap();
+    assert_eq!(serialized["preset"], "trajectory_context");
+    assert!(serialized.get("action").is_none());
+    assert!(serialized.get("custom_mark_payload_policy").is_none());
 }
 
 #[test]
@@ -980,22 +1564,28 @@ fn mark_false_preserves_mark_fields() {
 }
 
 #[test]
-fn sanitized_pii_never_reaches_subscribers_or_exporters() {
+fn sanitized_trajectory_content_never_reaches_subscribers_or_exporters() {
     let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
     reset_runtime();
     setup_isolated_thread();
 
     futures::executor::block_on(initialize_plugins(plugin_config(json!({
-        "mode": "builtin",
         "codec": "openai_chat",
-        "input": true,
-        "output": true,
-        "tool_input": false,
-        "tool_output": false,
-        "builtin": {
-            "action": "redact",
-            "detector": "email"
-        }
+        "profiles": [
+            {
+                "mode": "builtin",
+                "priority": 80,
+                "builtin": {
+                    "preset": "trajectory_context",
+                    "custom_mark_payload_policy": "redact_all_leaves"
+                }
+            },
+            {
+                "mode": "builtin",
+                "priority": 90,
+                "builtin": {"action": "redact", "detector": "email"}
+            }
+        ]
     }))))
     .unwrap();
 
@@ -1038,11 +1628,12 @@ fn sanitized_pii_never_reaches_subscribers_or_exporters() {
         .unwrap();
 
     let raw_pii = "person@example.com";
+    let raw_context = "private trajectory context canary";
     let agent = push_scope(
         PushScopeParams::builder()
             .name("hermes-agent")
             .scope_type(ScopeType::Agent)
-            .input(json!({"prompt": raw_pii}))
+            .input(json!({"prompt": raw_context, "request_id": "request-1"}))
             .metadata(json!({"session_owner": raw_pii}))
             .build(),
     )
@@ -1050,7 +1641,7 @@ fn sanitized_pii_never_reaches_subscribers_or_exporters() {
     event(
         EmitMarkEventParams::builder()
             .name("hermes.checkpoint")
-            .data(json!({"email": raw_pii}))
+            .data(json!({"content": raw_context, "email": raw_pii, "score": 0.95}))
             .metadata(json!({"reviewer": raw_pii}))
             .build(),
     )
@@ -1058,7 +1649,7 @@ fn sanitized_pii_never_reaches_subscribers_or_exporters() {
     pop_scope(
         PopScopeParams::builder()
             .handle_uuid(&agent.uuid)
-            .output(json!({"answer": raw_pii}))
+            .output(json!({"answer": raw_context}))
             .metadata(json!({"approver": raw_pii}))
             .build(),
     )
@@ -1085,7 +1676,27 @@ fn sanitized_pii_never_reaches_subscribers_or_exporters() {
             !output.contains(raw_pii),
             "raw PII leaked through {surface}: {output}"
         );
+        assert!(
+            !output.contains(raw_context),
+            "trajectory context leaked through {surface}: {output}"
+        );
     }
+
+    let captured = captured_events_snapshot(&captured);
+    let agent_start = captured
+        .iter()
+        .find(|event| {
+            event.name() == "hermes-agent" && event.scope_category() == Some(ScopeCategory::Start)
+        })
+        .unwrap();
+    assert_eq!(agent_start.data().unwrap()["request_id"], "request-1");
+    assert_eq!(agent_start.data().unwrap()["prompt"], "[REDACTED]");
+    let custom_mark = captured
+        .iter()
+        .find(|event| event.name() == "hermes.checkpoint")
+        .unwrap();
+    assert_eq!(custom_mark.data().unwrap()["content"], "[REDACTED]");
+    assert_eq!(custom_mark.data().unwrap()["score"], 0);
 
     deregister_subscriber("pii-regression-subscriber").unwrap();
     atof.deregister("pii-regression-atof").unwrap();
@@ -1094,6 +1705,100 @@ fn sanitized_pii_never_reaches_subscribers_or_exporters() {
     openinference
         .deregister("pii-regression-openinference")
         .unwrap();
+    clear_plugin_configuration().unwrap();
+}
+
+#[tokio::test]
+async fn trajectory_preset_sanitizes_stream_finalization_without_changing_client_chunks() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+    setup_isolated_thread();
+
+    initialize_plugins(plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [{
+            "mode": "builtin",
+            "builtin": {"preset": "trajectory_context"}
+        }]
+    })))
+    .await
+    .unwrap();
+
+    let events = capture_events("pii-trajectory-stream");
+    let raw_delta = "private streaming delta";
+    let provider: LlmStreamExecutionNextFn = Arc::new(move |_request| {
+        Box::pin(async move {
+            Ok(LlmJsonStream::new(futures::stream::iter(vec![Ok(json!({
+                "id": "chatcmpl-stream",
+                "object": "chat.completion.chunk",
+                "model": "gpt-4o-mini",
+                "choices": [{"index": 0, "delta": {"content": raw_delta}, "finish_reason": null}]
+            }))])))
+        })
+    });
+    let request_codec: Arc<dyn LlmCodec> = Arc::new(OpenAIChatCodec);
+    let response_codec: Arc<dyn LlmResponseCodec> = Arc::new(OpenAIChatCodec);
+    let mut stream = llm_stream_call_execute(
+        LlmStreamCallExecuteParams::builder()
+            .name("openai")
+            .request(LlmRequest {
+                headers: serde_json::Map::new(),
+                content: json!({
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "private stream prompt"}]
+                }),
+            })
+            .func(provider)
+            .collector(Box::new(|_| Ok(())))
+            .finalizer(Box::new(|| {
+                json!({
+                    "id": "chatcmpl-stream",
+                    "model": "gpt-4o-mini",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "private final answer"},
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {"prompt_tokens": 8, "completion_tokens": 3, "total_tokens": 11}
+                })
+            }))
+            .codec(request_codec)
+            .response_codec(response_codec)
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    let chunk = stream.next().await.unwrap().unwrap();
+    assert_eq!(chunk["choices"][0]["delta"]["content"], raw_delta);
+    assert!(stream.next().await.is_none());
+
+    let captured = captured_events_snapshot(&events);
+    let start = captured
+        .iter()
+        .find(|event| event.scope_category() == Some(ScopeCategory::Start))
+        .unwrap();
+    assert_eq!(
+        start.input().unwrap()["content"]["messages"][0]["content"],
+        "[REDACTED]"
+    );
+    let chunk_mark = captured
+        .iter()
+        .find(|event| event.name() == "llm.chunk")
+        .unwrap();
+    assert_eq!(chunk_mark.data().unwrap()["chunk_index"], 0);
+    assert!(!chunk_mark.to_json_string().unwrap().contains(raw_delta));
+    let end = captured
+        .iter()
+        .find(|event| event.scope_category() == Some(ScopeCategory::End))
+        .unwrap();
+    assert_eq!(
+        end.output().unwrap()["choices"][0]["message"]["content"],
+        "[REDACTED]"
+    );
+    assert_eq!(end.output().unwrap()["usage"]["total_tokens"], 11);
+
+    deregister_subscriber("pii-trajectory-stream").unwrap();
     clear_plugin_configuration().unwrap();
 }
 


### PR DESCRIPTION
> [!WARNING]
> **BREAKING CHANGE — Rust built-in PII configuration API and serialized configuration:** `BuiltinBackendConfig` now includes the public `preset` and `custom_mark_payload_policy` fields, so downstream exhaustive struct literals must initialize them or use `..Default::default()`. The default `action = "remove"` value is now omitted during serialization, so consumers that depend on the previous exact serialized shape must update. Existing TOML and JSON configurations remain accepted, and existing runtime behavior is unchanged when `preset` is omitted; structure-preserving trajectory redaction is opt-in.

#### Overview

Adds a structure-preserving `trajectory_context` policy to the composable PII-redaction contract. Exported trajectories can retain conversation topology, tool-call relationships, agent hierarchy, routing, usage, cost, and optimization telemetry while removing request/response content.

This draft is intentionally stacked on [#512](https://github.com/NVIDIA/NeMo-Relay/pull/512). Review this PR relative to `bbednarski/pii-profile-composition`; its base can move to `release/0.6` after #512 merges.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds the built-in `trajectory_context` preset for OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages event shapes, including buffered and streaming flows.
- Redacts chat text, reasoning, multimodal references, tool inputs/outputs, nested-agent content, and stringified tool arguments while preserving structural identifiers and analytical fields.
- Sanitizes typed Relay marks semantically so lifecycle, model-routing, token, usage, cost, and optimization data remain useful.
- Adds `custom_mark_payload_policy`:
  - `preserve` (default) leaves opaque third-party mark payloads unchanged.
  - `redact_all_leaves` recursively replaces scalar payload leaves while retaining keys, arrays, objects, and typed category identity.
- Keeps email redaction composable as a later profile so addresses are also removed from retained metadata and custom marks.
- Sanitizes canonical event fields before subscriber fan-out. Exporter-owned resource attributes remain outside this plugin boundary.
- Updates the CLI editor, schema coverage, and crate documentation.

The policy changes only observability data; it does not rewrite the provider request or client-visible provider response.

#### Where should the reviewer start?

Start in `crates/pii-redaction/src/trajectory.rs` for the semantic redaction boundary, then review preset validation and wiring in `crates/pii-redaction/src/component.rs`. Provider-shape, streaming, mark-policy, and exporter-facing regression coverage is in `crates/pii-redaction/tests/unit/component_tests.rs`.

Validation performed on the complete stack:

```text
cargo fmt --all -- --check
cargo test -p nemo-relay-pii-redaction --features schema
cargo clippy -p nemo-relay-pii-redaction --all-targets --features schema -- -D warnings
cargo test -p nemo-relay-cli pii_redaction
```

The PII crate suite passes 83 tests, and the focused CLI suite passes 7 tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Depends on #512.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple ordered PII redaction profiles with profile-scoped backend registration and rollback-aware setup.
  * Added `trajectory_context` built-in preset for structure-preserving conversational sanitization.
  * Added `custom_mark_payload_policy` handling for unknown custom marks (preserve vs redact-all-leaves), including preset-specific constraints.
* **Documentation**
  * Updated plugin scope and configuration docs for profile-array mode, ordering/compatibility rules, and trajectory sanitization workflows.
* **Tests**
  * Expanded coverage for profile validation/registration, `trajectory_context` request/response/event sanitization, custom mark policies, and streaming finalization/export redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->