### PR TITLE
chore: update CODEOWNERS teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default ownership for repository files.
-* @nvidia/nat-developers
+* @nvidia/nemo-relay-developers
+
+# CODEOWNERS changes require repository administrator review.
+/.github/CODEOWNERS @nvidia/nemo-relay-admins
 
 # Attribution files require dependency approver review due to change in version(s)
-ATTRIBUTIONS-*.md @nvidia/nat-dep-approvers
+ATTRIBUTIONS-*.md @nvidia/nemo-relay-dep-approvers
 
-# Documentation changes must go to technical writers and NAT developers.
-docs/ @lvojtku @nvidia/NAT-developers
-fern/ @lvojtku @nvidia/NAT-developers
+# Documentation changes must go to technical writers and NeMo Relay developers.
+docs/ @nvidia/nemo-relay-docs-reviewers @nvidia/nemo-relay-developers
+fern/ @nvidia/nemo-relay-docs-reviewers @nvidia/nemo-relay-developers


### PR DESCRIPTION
#### Overview

Update CODEOWNERS to use the NeMo Relay developer, dependency approver, documentation reviewer, and administrator teams.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace NAT ownership teams with NeMo Relay ownership teams.
- Assign `/.github/CODEOWNERS` to `@nvidia/nemo-relay-admins`.
- Assign documentation paths to the NeMo Relay documentation reviewers and developers.

#### Where should the reviewer start?

Review `.github/CODEOWNERS`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership and review assignments.
  * Added dedicated administrative review for ownership configuration.
  * Updated documentation and attribution review assignments to the appropriate teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->