### PR TITLE
docs: clarify subscriber delivery and shutdown

### DIFF
--- a/crates/core/src/api/subscriber.rs
+++ b/crates/core/src/api/subscriber.rs
@@ -72,6 +72,10 @@ pub fn deregister_subscriber(name: &str) -> Result<bool> {
 
 /// Wait for all subscriber callbacks queued before this call to finish.
 ///
+/// Call this helper outside native subscriber callbacks. A re-entrant call returns without
+/// waiting to avoid blocking the dispatcher, so callbacks later in the same dispatch snapshot can
+/// still run.
+///
 /// Native targets deliver subscriber callbacks on a background dispatcher so
 /// event-producing APIs do not wait for observer work. Call this helper from
 /// tests, shutdown paths, or exporter lifecycle code when callers need a

--- a/crates/core/src/observability/atof.rs
+++ b/crates/core/src/observability/atof.rs
@@ -477,8 +477,11 @@ impl AtofExporter {
         Ok(removed)
     }
 
-    /// Wait for queued subscriber delivery, then flush the configured file sink or drain the
-    /// configured stream sink.
+    /// Outside a native subscriber callback, wait for queued subscriber delivery, then flush the
+    /// configured file sink or ask the configured stream sink to drain for up to its timeout.
+    ///
+    /// A re-entrant call does not establish the delivery barrier. A stream timeout is logged and
+    /// does not by itself return an error.
     pub fn force_flush(&self) -> Result<()> {
         flush_subscribers()?;
         let mut state = self
@@ -516,7 +519,11 @@ impl AtofExporter {
         )
     }
 
-    /// Wait for queued subscriber delivery, then flush buffered data and close the exporter.
+    /// Outside a native subscriber callback, wait for queued subscriber delivery, then flush the
+    /// configured file sink or ask the configured stream sink to drain and close up to its timeout.
+    ///
+    /// A re-entrant call does not establish the delivery barrier. A stream timeout is logged and
+    /// does not by itself return an error.
     pub fn shutdown(&self) -> Result<()> {
         flush_subscribers()?;
         let mut state = self

--- a/crates/core/src/observability/atof.rs
+++ b/crates/core/src/observability/atof.rs
@@ -477,7 +477,8 @@ impl AtofExporter {
         Ok(removed)
     }
 
-    /// Flush the underlying file and drain queued endpoint events.
+    /// Wait for queued subscriber delivery, then flush the configured file sink or drain the
+    /// configured stream sink.
     pub fn force_flush(&self) -> Result<()> {
         flush_subscribers()?;
         let mut state = self
@@ -515,7 +516,7 @@ impl AtofExporter {
         )
     }
 
-    /// Shut down the exporter by flushing buffered data and closing endpoints.
+    /// Wait for queued subscriber delivery, then flush buffered data and close the exporter.
     pub fn shutdown(&self) -> Result<()> {
         flush_subscribers()?;
         let mut state = self

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -1301,7 +1301,11 @@ NemoRelayStatus nemo_relay_atof_exporter_register(const struct FfiAtofExporter *
 NemoRelayStatus nemo_relay_atof_exporter_deregister(const char *name);
 
 /**
- * Flushes the ATOF exporter output file.
+ * Outside a native subscriber callback, waits for queued subscriber delivery, then flushes the
+ * configured file sink or asks the configured stream sink to drain for up to its timeout.
+ *
+ * A re-entrant call does not establish the delivery barrier. A stream timeout is logged and does
+ * not by itself return an error.
  *
  * # Safety
  * `exporter` must be a valid, non-null pointer.
@@ -1309,7 +1313,11 @@ NemoRelayStatus nemo_relay_atof_exporter_deregister(const char *name);
 NemoRelayStatus nemo_relay_atof_exporter_force_flush(const struct FfiAtofExporter *exporter);
 
 /**
- * Shuts down the ATOF exporter by flushing output.
+ * Outside a native subscriber callback, waits for queued subscriber delivery, then flushes the
+ * configured file sink or asks the configured stream sink to drain and close up to its timeout.
+ *
+ * A re-entrant call does not establish the delivery barrier. A stream timeout is logged and does
+ * not by itself return an error.
  *
  * # Safety
  * `exporter` must be a valid, non-null pointer.

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -1150,6 +1150,10 @@ NemoRelayStatus nemo_relay_deregister_subscriber(const char *name);
 
 /**
  * Wait for subscriber callbacks queued before this call to finish.
+ *
+ * Call this function outside native subscriber callbacks. A re-entrant call returns without
+ * waiting to avoid blocking the dispatcher, so callbacks later in the same dispatch snapshot can
+ * still run.
  */
 NemoRelayStatus nemo_relay_flush_subscribers(void);
 

--- a/crates/ffi/src/api/llm_registry.rs
+++ b/crates/ffi/src/api/llm_registry.rs
@@ -390,6 +390,10 @@ pub unsafe extern "C" fn nemo_relay_deregister_subscriber(name: *const c_char) -
 }
 
 /// Wait for subscriber callbacks queued before this call to finish.
+///
+/// Call this function outside native subscriber callbacks. A re-entrant call returns without
+/// waiting to avoid blocking the dispatcher, so callbacks later in the same dispatch snapshot can
+/// still run.
 #[unsafe(no_mangle)]
 pub extern "C" fn nemo_relay_flush_subscribers() -> NemoRelayStatus {
     clear_last_error();

--- a/crates/ffi/src/api/observability.rs
+++ b/crates/ffi/src/api/observability.rs
@@ -431,7 +431,11 @@ pub unsafe extern "C" fn nemo_relay_atof_exporter_deregister(
     }
 }
 
-/// Flushes the ATOF exporter output file.
+/// Outside a native subscriber callback, waits for queued subscriber delivery, then flushes the
+/// configured file sink or asks the configured stream sink to drain for up to its timeout.
+///
+/// A re-entrant call does not establish the delivery barrier. A stream timeout is logged and does
+/// not by itself return an error.
 ///
 /// # Safety
 /// `exporter` must be a valid, non-null pointer.
@@ -450,7 +454,11 @@ pub unsafe extern "C" fn nemo_relay_atof_exporter_force_flush(
     }
 }
 
-/// Shuts down the ATOF exporter by flushing output.
+/// Outside a native subscriber callback, waits for queued subscriber delivery, then flushes the
+/// configured file sink or asks the configured stream sink to drain and close up to its timeout.
+///
+/// A re-entrant call does not establish the delivery barrier. A stream timeout is logged and does
+/// not by itself return an error.
 ///
 /// # Safety
 /// `exporter` must be a valid, non-null pointer.

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -87,6 +87,7 @@ async function main() {
   });
 
   flushSubscribers();
+  await new Promise((resolve) => setImmediate(resolve));
   deregisterSubscriber("printer");
 }
 
@@ -95,6 +96,10 @@ main().catch((error) => {
   process.exitCode = 1;
 });
 ```
+
+Native subscriber delivery is asynchronous. `flushSubscribers()` drains the
+native dispatcher. The extra event-loop turn lets queued JavaScript callback
+side effects complete before deregistration or exit.
 
 The main runtime API is exported from `nemo-relay-node`. Additional entry points
 are available at `nemo-relay-node/typed`, `nemo-relay-node/plugin`,

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -3676,7 +3676,7 @@ impl AtofExporter {
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
-    /// Flush the output file.
+    /// Wait for queued subscriber delivery, then flush the file sink or drain the stream sink.
     #[napi]
     pub fn force_flush(&self) -> napi::Result<()> {
         self.inner
@@ -3684,7 +3684,7 @@ impl AtofExporter {
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
-    /// Shut down the exporter by flushing output.
+    /// Wait for queued subscriber delivery, then flush and shut down the exporter.
     #[napi]
     pub fn shutdown(&self) -> napi::Result<()> {
         self.inner

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -3680,7 +3680,10 @@ impl AtofExporter {
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
-    /// Wait for queued subscriber delivery, then flush the file sink or drain the stream sink.
+    /// Outside a native subscriber callback, wait for queued subscriber delivery, then flush the
+    /// file sink or ask the stream sink to drain for up to its timeout. A re-entrant call does not
+    /// establish the delivery barrier. A stream timeout is logged and does not by itself return an
+    /// error.
     #[napi]
     pub fn force_flush(&self) -> napi::Result<()> {
         self.inner
@@ -3688,7 +3691,10 @@ impl AtofExporter {
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
-    /// Wait for queued subscriber delivery, then flush and shut down the exporter.
+    /// Outside a native subscriber callback, wait for queued subscriber delivery, then flush the
+    /// file sink or ask the stream sink to drain and close up to its timeout. A re-entrant call
+    /// does not establish the delivery barrier. A stream timeout is logged and does not by itself
+    /// return an error.
     #[napi]
     pub fn shutdown(&self) -> napi::Result<()> {
         self.inner

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -2849,6 +2849,10 @@ pub fn deregister_subscriber(name: String) -> Result<bool> {
 
 /// Wait for native subscriber callbacks queued before this call to finish.
 ///
+/// Call this function outside native subscriber callbacks. A re-entrant call returns without
+/// waiting to avoid blocking the dispatcher, so callbacks later in the same dispatch snapshot can
+/// still run.
+///
 /// JavaScript subscribers are queued through Node's `ThreadsafeFunction`; callers that
 /// need JS callback side effects should await an event-loop tick after this returns.
 #[napi]

--- a/crates/python/src/py_api/mod.rs
+++ b/crates/python/src/py_api/mod.rs
@@ -1328,6 +1328,10 @@ fn deregister_subscriber(name: &str) -> PyResult<bool> {
 }
 
 /// Wait for subscriber callbacks queued before this call to finish.
+///
+/// Call this function outside native subscriber callbacks. A re-entrant call returns without
+/// waiting to avoid blocking the dispatcher, so callbacks later in the same dispatch snapshot can
+/// still run.
 #[pyfunction]
 fn flush_subscribers(py: Python<'_>) -> PyResult<()> {
     py.detach(core_subscriber_api::flush_subscribers)

--- a/crates/python/src/py_types/observability.rs
+++ b/crates/python/src/py_types/observability.rs
@@ -391,13 +391,13 @@ impl PyAtofExporter {
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 
-    /// Flush the output file.
+    /// Wait for queued subscriber delivery, then flush the file sink or drain the stream sink.
     pub(crate) fn force_flush(&self, py: Python<'_>) -> PyResult<()> {
         py.detach(|| self.inner.force_flush())
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 
-    /// Shut down the exporter by flushing output.
+    /// Wait for queued subscriber delivery, then flush and shut down the exporter.
     pub(crate) fn shutdown(&self, py: Python<'_>) -> PyResult<()> {
         py.detach(|| self.inner.shutdown())
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))

--- a/crates/python/src/py_types/observability.rs
+++ b/crates/python/src/py_types/observability.rs
@@ -391,13 +391,19 @@ impl PyAtofExporter {
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 
-    /// Wait for queued subscriber delivery, then flush the file sink or drain the stream sink.
+    /// Outside a native subscriber callback, wait for queued subscriber delivery, then flush the
+    /// file sink or ask the stream sink to drain for up to its timeout. A re-entrant call does not
+    /// establish the delivery barrier. A stream timeout is logged and does not by itself return an
+    /// error.
     pub(crate) fn force_flush(&self, py: Python<'_>) -> PyResult<()> {
         py.detach(|| self.inner.force_flush())
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 
-    /// Wait for queued subscriber delivery, then flush and shut down the exporter.
+    /// Outside a native subscriber callback, wait for queued subscriber delivery, then flush the
+    /// file sink or ask the stream sink to drain and close up to its timeout. A re-entrant call
+    /// does not establish the delivery barrier. A stream timeout is logged and does not by itself
+    /// return an error.
     pub(crate) fn shutdown(&self, py: Python<'_>) -> PyResult<()> {
         py.detach(|| self.inner.shutdown())
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))

--- a/docs/about-nemo-relay/concepts/subscribers.mdx
+++ b/docs/about-nemo-relay/concepts/subscribers.mdx
@@ -24,6 +24,11 @@ waiting for subscriber callbacks or exporter work.
 Events describe what happened. Subscribers are the components that watch those
 events.
 
+In this documentation, an event is **emitted** when the runtime submits it for
+subscriber dispatch. An event is **delivered** to a subscriber when its callback
+runs. An event is **exported** when an exporter completes the downstream work
+defined by its API. On native targets, these are separate milestones.
+
 That separation matters:
 
 - The runtime can emit one canonical event stream
@@ -127,14 +132,37 @@ order and subscriber snapshot order.
 
 ## Waiting for Delivery
 
-Use the flush API when application shutdown, tests, or examples must observe
-side effects from subscriber callbacks that have already been queued:
+An event-producing call returning is not a delivery barrier. Use the following
+milestones to choose the barrier that matches the output you need to observe:
+
+| Milestone | What It Establishes | What It Does Not Establish |
+|---|---|---|
+| Event-producing call returns | The runtime call completed. On native targets, the runtime normally queues subscriber work for background dispatch. | Subscriber callbacks ran, exporter work completed, or output is visible or durable. |
+| Subscriber flush returns | All native subscriber callbacks queued before the flush call have completed. | Exporter-owned workers drained or a remote backend accepted the data. |
+| Exporter barrier returns | The runtime drained the shared subscriber queue, and the exporter completed its documented `force_flush()`, `export()`, or equivalent operation. | Exactly-once delivery, machine-crash durability, or success beyond the exporter's documented error and timeout behavior. |
+| Plugin clear or exporter shutdown returns | NeMo Relay completed graceful terminal draining and cleanup, or reported an error. | Retention if the process terminates before teardown completes. |
+| Process terminates before a barrier | You can observe only callback side effects and exporter work that completed before termination. | Retention of queued subscriber callbacks or pending exporter work. |
+
+Use the subscriber flush API when application shutdown, tests, or examples must
+observe side effects from callbacks that were already queued before the barrier:
 
 - Rust: `nemo_relay::api::subscriber::flush_subscribers()?`
 - Python: `nemo_relay.subscribers.flush()`
 - Node.js: `flushSubscribers()`, then await an event-loop tick for JavaScript
   callback side effects
 - FFI: `nemo_relay_flush_subscribers()`
+
+Events emitted concurrently after the flush barrier are not covered by that
+call. Exporters with their own workers or batch processors require the
+exporter-specific flush, export, or shutdown operation described in
+[Observability](/configure-plugins/observability/about).
+
+<Warning>
+If the process terminates before subscriber delivery and exporter teardown
+complete, queued telemetry can be lost. Returning from the event-producing API
+does not make that telemetry crash-safe.
+
+</Warning>
 
 ### Forwarding and Export
 
@@ -190,8 +218,10 @@ plugin component.
 Use these practices when applying the concept in application or integration code.
 
 - Use a plain subscriber when you want in-process custom behavior.
-- Flush subscribers before asserting on printed output, captured lists, or files
-  written by subscriber callbacks.
+- Flush subscribers before inspecting printed output, captured lists, or other
+  custom callback side effects.
+- Use the exporter's documented barrier before inspecting exporter output.
+- Clear plugin-managed exporters during graceful shutdown.
 - Use `event.to_dict()` or `event.to_json()` when a host runtime or exporter
   needs the canonical event JSON shape in-process.
 - Use a scope-local subscriber when the observation should disappear with the

--- a/docs/about-nemo-relay/concepts/subscribers.mdx
+++ b/docs/about-nemo-relay/concepts/subscribers.mdx
@@ -141,8 +141,8 @@ observe:
 |---|---|---|
 | Event-producing call returns | The runtime call completed. On native targets, the runtime normally queues subscriber work for background dispatch. | Subscriber callbacks ran, exporter work completed, or output is visible or durable. |
 | Subscriber flush returns | All native subscriber callbacks queued before the flush call have completed. | Exporter-owned workers drained or a remote backend accepted the data. |
-| Exporter barrier returns | The runtime drained the shared subscriber queue, and the exporter completed its documented `force_flush()`, `export()`, or equivalent operation. | Exactly-once delivery, machine-crash durability, or success beyond the exporter's documented error and timeout behavior. |
-| Plugin clear or exporter shutdown returns | NeMo Relay completed graceful terminal draining and cleanup, or reported an error. | Retention if the process terminates before teardown completes. |
+| Exporter barrier returns | The runtime drained the shared subscriber queue, and the exporter completed its documented `force_flush()`, `export()`, or equivalent operation. For a worker-backed exporter, that operation can stop after its configured timeout. | Exactly-once delivery, machine-crash durability, confirmed completion by a worker that timed out, or success beyond the exporter's documented error and timeout behavior. |
+| Plugin clear or exporter shutdown returns | NeMo Relay completed the component's documented graceful teardown steps, or reported an error. | Retention if the process terminates before teardown completes or completion by a worker that timed out during teardown. |
 | Process terminates before a barrier | You can observe only callback side effects and exporter work that completed before termination. | Retention of queued subscriber callbacks or pending exporter work. |
 
 Use the subscriber flush API when application shutdown, tests, or examples must

--- a/docs/about-nemo-relay/concepts/subscribers.mdx
+++ b/docs/about-nemo-relay/concepts/subscribers.mdx
@@ -132,8 +132,10 @@ order and subscriber snapshot order.
 
 ## Waiting for Delivery
 
-An event-producing call returning is not a delivery barrier. Use the following
-milestones to choose the barrier that matches the output you need to observe:
+An event-producing call returning is not a delivery barrier. These guarantees
+apply when you call a barrier outside a native subscriber callback. Use the
+following milestones to choose the barrier that matches the output you need to
+observe:
 
 | Milestone | What It Establishes | What It Does Not Establish |
 |---|---|---|
@@ -158,6 +160,12 @@ exporter-specific flush, export, or shutdown operation described in
 [Observability](/configure-plugins/observability/about).
 
 <Warning>
+Do not invoke a subscriber flush, an exporter barrier, or plugin clear from a
+native subscriber callback. To avoid blocking its worker, the native dispatcher
+returns a re-entrant subscriber flush without waiting. Callbacks later in the
+active dispatch snapshot can still run after the barrier returns. Run those
+operations after the callback returns.
+
 If the process terminates before subscriber delivery and exporter teardown
 complete, queued telemetry can be lost. Returning from the event-producing API
 does not make that telemetry crash-safe.

--- a/docs/configure-plugins/observability/about.mdx
+++ b/docs/configure-plugins/observability/about.mdx
@@ -19,7 +19,8 @@ manual subscribers. A common first path is:
 1. Instrument one scope, tool call, or LLM call in your application.
 2. Enable the Observability plugin with only one exporter, such as ATOF JSONL.
 3. Run one request through the instrumented path.
-4. Confirm the emitted output before adding more exporters or sanitization rules.
+4. Clear the plugin, or call the manual exporter's documented barrier.
+5. Confirm the output before adding more exporters or sanitization rules.
 
 Observability in NeMo Relay starts with events. Scopes, marks, managed tool
 calls, managed LLM calls, middleware, and manual lifecycle APIs emit the
@@ -69,6 +70,28 @@ Both paths consume the same runtime event contract. Choose plugin-managed export
 for reusable process configuration, and choose manual APIs only when the caller
 needs direct control over registration or lifetime.
 
+## Delivery and Shutdown
+
+All built-in exporters begin with the same asynchronous native subscriber
+dispatcher. An event-producing API can return before the exporter subscriber
+runs. The subscriber flush API waits for callbacks queued before that barrier,
+but some exporters then hand work to their own stream worker, trajectory
+builder, batch processor, or remote backend.
+
+Use the barrier that matches how you manage the exporter lifecycle:
+
+- For a custom subscriber, call the subscriber flush API before inspecting
+  callback side effects.
+- For a manual exporter, call its documented `force_flush()`, `export()`, or
+  `shutdown()` operation.
+- For plugin-managed export, call `plugin.clear()` or
+  `clear_plugin_configuration()` during graceful shutdown.
+
+If the process terminates before those operations complete, the output can omit
+queued telemetry even when the instrumented application work completed
+successfully. Refer to [Subscribers](/about-nemo-relay/concepts/subscribers#waiting-for-delivery)
+for the complete delivery-barrier contract.
+
 ## Use Observability When
 
 Start here when you need to:
@@ -101,9 +124,13 @@ guardrails before exporters receive sensitive payloads.
 Your first exporter path works correctly when:
 
 - The instrumented request still completes successfully.
-- The chosen exporter receives scope data for that request, plus tool or LLM
-  lifecycle data when the request exercises those paths.
+- After the appropriate exporter or plugin barrier returns, the output contains
+  scope data for that request, plus tool or LLM lifecycle data when the request
+  exercises those paths.
 - The exported output shows the same NeMo Relay scope hierarchy you expect from that request.
+
+Application success alone does not prove telemetry delivery because exporter
+work is downstream from runtime execution.
 
 If that basic check fails, use the
 [Trace Incident Runbook](/resources/troubleshooting/trace-incident-runbook)

--- a/docs/configure-plugins/observability/atif.mdx
+++ b/docs/configure-plugins/observability/atif.mdx
@@ -378,11 +378,12 @@ Ok(())
 ## Manual API
 
 Use the manual `AtifExporter` API when you need explicit collection boundaries
-or one exporter object per run. `export()` and `export_json()` wait for queued
-subscriber callbacks before taking a snapshot of the collected event history,
-so a separate subscriber flush immediately before export is unnecessary. The
-returned trajectory includes events that the exporter observed before the
-barrier completed. It does not include events emitted concurrently afterward.
+or one exporter object per run. `export()` and `export_json()` first wait for
+subscriber callbacks queued before the call, then take a snapshot of the
+collected event history. A separate subscriber flush immediately before export
+is unnecessary. The snapshot can also include events delivered after the
+internal flush returns but before the snapshot is taken. Events delivered after
+the snapshot are not included.
 
 <Tabs>
 <Tab title="Python" language="python">

--- a/docs/configure-plugins/observability/atif.mdx
+++ b/docs/configure-plugins/observability/atif.mdx
@@ -217,7 +217,10 @@ single-file ATIF v1.7 artifact.
 
 The plugin writes each trajectory when its top-level Agent scope or supported
 coding-agent turn scope closes. If the plugin is cleared while that root scope
-is still open, teardown flushes the partial trajectory.
+is still open, teardown first drains queued subscriber callbacks and then
+writes the partial trajectory. Terminating the process before root-scope
+closure or plugin teardown completes can leave the trajectory absent or
+incomplete.
 
 To correlate ATIF with OpenTelemetry or OpenInference traces from the same run,
 join on NeMo Relay UUIDs. The plugin-managed ATIF `session_id` is the
@@ -375,7 +378,11 @@ Ok(())
 ## Manual API
 
 Use the manual `AtifExporter` API when you need explicit collection boundaries
-or one exporter object per run.
+or one exporter object per run. `export()` and `export_json()` wait for queued
+subscriber callbacks before taking a snapshot of the collected event history,
+so a separate subscriber flush immediately before export is unnecessary. The
+returned trajectory includes events that the exporter observed before the
+barrier completed. It does not include events emitted concurrently afterward.
 
 <Tabs>
 <Tab title="Python" language="python">
@@ -416,7 +423,7 @@ try {
 
 <Tab title="Rust" language="rust">
 ```rust
-use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
+use nemo_relay::api::subscriber::{deregister_subscriber, register_subscriber};
 use nemo_relay::observability::atif::{AtifAgentInfo, AtifExporter};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -434,7 +441,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Run instrumented application work here.
 
-    flush_subscribers()?;
     let trajectory = exporter.export()?;
     let trajectory_json = serde_json::to_string_pretty(&trajectory)?;
     println!("{trajectory_json}");
@@ -456,6 +462,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - Tool definitions or `extra` metadata are not JSON-compatible.
 - The application never opens a top-level Agent scope or a supported
   coding-agent turn scope, so no trajectory file is created.
+- The application expects manual trajectory output without calling `export()`
+  or `export_json()`.
+- The process terminates before manual `export()`, supported root-scope closure,
+  or plugin teardown establishes the export boundary.
 - `storage[i].type` is unknown or `storage[i].bucket` is empty for some entry.
 - `storage` is non-empty in a build that was compiled without the
   `atif-storage` feature.

--- a/docs/configure-plugins/observability/atof.mdx
+++ b/docs/configure-plugins/observability/atof.mdx
@@ -112,7 +112,7 @@ The following table describes each stream sink:
 | `transport` | `http_post` | `http_post`, `websocket`, or `ndjson`. |
 | `headers` | `{}` | String-to-string headers for requests or handshakes. |
 | `header_env` | `{}` | Maps each header name to an environment variable that contains the full header value. Each variable must be set and nonblank, and the same header cannot also appear in `headers`. |
-| `timeout_millis` | `3000` | Per-sink timeout. Must be greater than `0`. |
+| `timeout_millis` | `3000` | Per-sink timeout for stream I/O and flush or close acknowledgement. Must be greater than `0`. |
 | `field_name_policy` | `preserve` | Field-name handling before Relay sends stream events. Accepted values are `preserve` and `replace_dots`. |
 
 Use `header_env` for secrets so the configuration stores the environment
@@ -137,13 +137,20 @@ The following transports are supported:
 For a file sink, the shared subscriber flush completes the synchronous file
 callback. For a stream sink, it only confirms that the ATOF callback queued the
 stream work. A manual exporter's `force_flush()` first waits for queued
-subscriber callbacks, then flushes file output or drains queued stream events
-while keeping the exporter open. `shutdown()` performs the terminal form of
-that operation, closes stream connections, and ignores events delivered after
-the exporter closes.
+subscriber callbacks, then flushes file output or asks each stream worker to
+drain its queued events while keeping the exporter open. It waits for each
+stream worker up to that sink's `timeout_millis` value. If a worker does not
+acknowledge in time, NeMo Relay logs a warning and `force_flush()` can still
+return successfully; the worker can still have queued work.
+
+`shutdown()` follows the same delivery barrier, flushes file output, and asks
+each stream worker to drain and close within the configured timeout. It ignores
+events delivered after the exporter closes. A timeout is logged and does not by
+itself cause `shutdown()` to return an error.
 
 During graceful shutdown, `plugin.clear()` or `clear_plugin_configuration()`
-drains and closes plugin-managed stream sinks.
+uses that same terminal stream-sink operation. It does not guarantee that a
+worker which timed out drained or closed.
 
 ## Migrate From Version 1
 

--- a/docs/configure-plugins/observability/atof.mdx
+++ b/docs/configure-plugins/observability/atof.mdx
@@ -66,7 +66,7 @@ The following table describes the top-level ATOF settings:
 | Field | Default | Notes |
 |---|---|---|
 | `enabled` | `false` | Must be `true` to export events. |
-| `sinks` | `[]` | File and stream destinations. An enabled ATOF section requires at least one sink, and every sink receives each event. |
+| `sinks` | `[]` | File and stream destinations. An enabled ATOF section requires at least one sink. Each event delivered to the ATOF subscriber is sent to every configured sink. |
 
 ## File Sinks
 
@@ -79,6 +79,20 @@ table describes each file sink:
 | `output_directory` | Current working directory | Directory containing the JSONL file. |
 | `filename` | Timestamped `nemo-relay-events-*.jsonl` | Output filename. |
 | `mode` | `append` | `append` or `overwrite`. |
+
+<Note>
+Native event-producing APIs return before the ATOF subscriber necessarily
+runs. After it receives an event, a file sink writes one complete JSONL record
+and flushes the process writer. A subscriber flush waits for the file callback
+to complete its write attempt for every event queued before the barrier. A
+manual exporter reports any stored file errors during `force_flush()` or
+`shutdown()`. Plugin teardown also reports stored file errors.
+
+Flushing the process writer does not call `fsync` or guarantee durability after
+a machine crash. If the process terminates before the subscriber receives an
+event, the corresponding record can still be lost.
+
+</Note>
 
 ## Stream Sinks
 
@@ -120,9 +134,16 @@ The following transports are supported:
 - `ndjson` opens one long-lived HTTP upload and writes each event as one
   newline-delimited JSON record.
 
-`force_flush()` flushes file output and drains queued stream events while
-keeping stream connections open. `shutdown()` is terminal: it flushes pending
-work, closes the connections, and ignores events that arrive later.
+For a file sink, the shared subscriber flush completes the synchronous file
+callback. For a stream sink, it only confirms that the ATOF callback queued the
+stream work. A manual exporter's `force_flush()` first waits for queued
+subscriber callbacks, then flushes file output or drains queued stream events
+while keeping the exporter open. `shutdown()` performs the terminal form of
+that operation, closes stream connections, and ignores events delivered after
+the exporter closes.
+
+During graceful shutdown, `plugin.clear()` or `clear_plugin_configuration()`
+drains and closes plugin-managed stream sinks.
 
 ## Migrate From Version 1
 
@@ -138,15 +159,16 @@ Make the following changes when you migrate a plugin configuration:
 - Keep static request headers in `headers`, or use `header_env` to read complete
   header values from environment variables at activation time.
 
-The plugin sends every event to every configured sink. The manual
-`AtofExporter` API is different: each exporter owns one file or stream sink.
+The plugin fans out each event delivered to its ATOF subscriber to every
+configured sink. The manual `AtofExporter` API is different: each exporter owns
+one file or stream sink.
 
 ## Expected Output
 
-Each file sink writes an emitted scope, tool, LLM, middleware, or mark event as
-one ATOF JSON object per line. Stream sinks encode the event as described in
-[Stream Sinks](#stream-sinks). For event field semantics, refer to
-[Events](/about-nemo-relay/concepts/events).
+Each file sink writes a scope, tool, LLM, middleware, or mark event delivered to
+the exporter as one ATOF JSON object per line. Stream sinks encode the delivered
+event as described in [Stream Sinks](#stream-sinks). For event field semantics,
+refer to [Events](/about-nemo-relay/concepts/events).
 
 Coding-agent sessions emit a `session.start` mark with the logical
 `metadata.session_id`, a Relay-owned UUIDv7 `metadata.session_instance_id`, and
@@ -167,6 +189,8 @@ annotation. The request used for provider execution remains unchanged. Refer to
 
 Register the plugin before instrumented work starts. Clear it during shutdown
 so every sink flushes pending events and stream connections close cleanly.
+Terminating the process before subscriber delivery or plugin teardown completes
+can leave the final records missing.
 
 ## Plugin Configuration
 
@@ -426,3 +450,5 @@ Common configuration and runtime issues include:
   configured stream sink.
 - A file sink is configured in a target that cannot access the native
   filesystem.
+- The process terminates before a subscriber or exporter barrier, so the file
+  or stream destination is missing queued tail records.

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -161,6 +161,7 @@ The following table describes how each failure affects application work:
 | ATIF dispatcher serialization or subscriber-management failure | The ATIF dispatcher records a fatal exporter error and stops observing later ATIF events. Other observability sections continue to run. |
 | OpenTelemetry or OpenInference construction failure | Plugin initialization fails before the subscriber is registered. |
 | OpenTelemetry or OpenInference export failure after registration | Application work continues. The OTLP exporter reports failures through its runtime logging and flush or shutdown path. |
+| Process termination before plugin teardown completes | The output can omit events that were still in the subscriber queue or an exporter-owned worker. NeMo Relay does not backfill those events after restart, and the process can end before an exporter reports an error. |
 
 Missing or delayed telemetry is represented as absence of exporter output, not
 as synthetic success or failure events. NeMo Relay does not backfill events for
@@ -438,9 +439,17 @@ filename templates, unknown fields according to policy, and enabled exporters
 that are unavailable in the current build or target.
 
 Call `plugin.clear()` or `clear_plugin_configuration()` during teardown.
-Clearing the plugin configuration deregisters inferred subscribers, flushes file
-exporters, drains and closes ATOF stream sinks, and shuts down owned OTLP
+Clearing the plugin configuration waits for previously queued subscriber
+callbacks, runs exporter-specific shutdown work, and removes plugin-owned
+registrations. That work flushes file exporters, drains and closes ATOF stream
+sinks, writes any eligible partial ATIF trajectories, and shuts down owned OTLP
 subscribers.
+
+This is a graceful teardown barrier, not a crash-durability guarantee. If the
+process terminates before clearing begins or finishes, the output can omit
+telemetry for application work that completed successfully. Telemetry delivery
+failures remain fail-open and do not retroactively change the application
+result.
 
 Use manual subscriber/exporter APIs instead of the plugin when you need custom
 subscriber names, explicit per-run exporter objects, or direct control over the

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -441,9 +441,12 @@ that are unavailable in the current build or target.
 Call `plugin.clear()` or `clear_plugin_configuration()` during teardown.
 Clearing the plugin configuration waits for previously queued subscriber
 callbacks, runs exporter-specific shutdown work, and removes plugin-owned
-registrations. That work flushes file exporters, drains and closes ATOF stream
-sinks, writes any eligible partial ATIF trajectories, and shuts down owned OTLP
-subscribers.
+registrations. That work flushes file exporters, asks ATOF stream sink workers
+to drain and close within their configured timeout, writes any eligible partial
+ATIF trajectories, and shuts down owned OTLP subscribers. If an ATOF stream
+worker times out, NeMo Relay logs a warning and continues teardown; clearing
+the plugin can still return successfully without confirming that worker drained
+or closed.
 
 This is a graceful teardown barrier, not a crash-durability guarantee. If the
 process terminates before clearing begins or finishes, the output can omit

--- a/docs/configure-plugins/observability/openinference.mdx
+++ b/docs/configure-plugins/observability/openinference.mdx
@@ -158,6 +158,11 @@ the alias.
 Redact sensitive event payloads with sanitize guardrails before production
 export.
 
+Register the plugin before the first instrumented request and clear it during
+graceful shutdown. Calling subscriber flush delivers queued events to the
+tracing subscriber, but it does not necessarily drain the tracer provider's
+export processor.
+
 ## Plugin Configuration
 
 Use plugin configuration when the application should let NeMo Relay own the
@@ -309,7 +314,11 @@ Ok(())
 ## Manual API
 
 Use the manual subscriber API when you need an explicit subscriber name or
-direct `force_flush` control.
+direct control over when spans are exported. `force_flush()` first waits for
+shared subscriber delivery and then asks the tracer provider to export finished
+spans. `shutdown()` waits for shared subscriber work and then shuts down the
+provider. During plugin teardown, `plugin.clear()` or
+`clear_plugin_configuration()` invokes the owned subscriber shutdown path.
 
 <Tabs>
 <Tab title="Python" language="python">
@@ -394,3 +403,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - The OpenInference feature is unavailable in the current build or target.
 - Tool and LLM calls do not use managed helpers, so spans contain only scope
   lifecycle data.
+- Abrupt termination can discard events that are still in the shared dispatcher
+  or spans that are still in the provider queue. Backend visibility also
+  depends on transport success, timeouts, and backend processing.

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -149,8 +149,10 @@ discrete attributes. Refer to
 for the full mapping.
 
 Register the plugin before the first instrumented request, use stable service
-identity fields, keep credentials outside source code, and flush during
-graceful shutdown.
+identity fields, keep credentials outside source code, and clear the plugin
+during graceful shutdown. Calling subscriber flush delivers queued events to
+the tracing subscriber, but it does not necessarily drain the tracer provider's
+export processor.
 
 ## Plugin Configuration
 
@@ -303,7 +305,11 @@ Ok(())
 ## Manual API
 
 Use the manual subscriber API when you need an explicit subscriber name or
-direct `force_flush` control.
+direct control over when spans are exported. `force_flush()` first waits for
+shared subscriber delivery and then asks the tracer provider to export finished
+spans. `shutdown()` waits for shared subscriber work and then shuts down the
+provider. During plugin teardown, `plugin.clear()` or
+`clear_plugin_configuration()` invokes the owned subscriber shutdown path.
 
 <Tabs>
 <Tab title="Python" language="python">
@@ -384,3 +390,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - Headers or resource attributes are not string-to-string maps.
 - The exporter feature is unavailable in the current build or target.
 - The endpoint is unreachable at runtime.
+- Abrupt termination can discard events that are still in the shared dispatcher
+  or spans that are still in the provider queue. Backend visibility also
+  depends on transport success, timeouts, and backend processing.

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -1549,7 +1549,10 @@ func DeregisterSubscriber(name string) error {
 
 // FlushSubscribers waits for subscriber callbacks queued before this call to
 // finish. Native event-producing APIs enqueue subscriber work and return
-// without waiting for observer callbacks.
+// without waiting for observer callbacks. Call this function outside native
+// subscriber callbacks. A re-entrant call returns without waiting to avoid
+// blocking the dispatcher, so callbacks later in the same dispatch snapshot
+// can still run.
 func FlushSubscribers() error {
 	return checkStatus(C.nemo_relay_flush_subscribers())
 }

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -1830,13 +1830,19 @@ func (e *AtofExporter) Deregister(name string) error {
 	return checkStatus(status)
 }
 
-// ForceFlush flushes the output file.
+// ForceFlush, outside a native subscriber callback, waits for queued subscriber delivery and then
+// flushes the configured file sink or asks the configured stream sink to drain up to its timeout.
+// A re-entrant call does not establish the delivery barrier. A stream timeout is logged and does
+// not by itself return an error.
 func (e *AtofExporter) ForceFlush() error {
 	status := C.nemo_relay_atof_exporter_force_flush(e.ptr)
 	return checkStatus(status)
 }
 
-// Shutdown flushes the output file.
+// Shutdown, outside a native subscriber callback, waits for queued subscriber delivery and then
+// flushes the configured file sink or asks the configured stream sink to drain and close up to its
+// timeout. A re-entrant call does not establish the delivery barrier. A stream timeout is logged
+// and does not by itself return an error.
 func (e *AtofExporter) Shutdown() error {
 	status := C.nemo_relay_atof_exporter_shutdown(e.ptr)
 	return checkStatus(status)

--- a/go/nemo_relay/subscribers/subscribers.go
+++ b/go/nemo_relay/subscribers/subscribers.go
@@ -42,8 +42,8 @@ func Deregister(name string) error {
 	return nemo_relay.DeregisterSubscriber(name)
 }
 
-// Flush waits for subscriber callbacks queued before this call to finish. This
-// is a shorthand for [nemo_relay.FlushSubscribers].
+// Flush has the same completion semantics and re-entrant limitation as
+// [nemo_relay.FlushSubscribers].
 func Flush() error {
 	return nemo_relay.FlushSubscribers()
 }

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -912,10 +912,10 @@ class AtofExporter:
         """Deregister ``name`` and return whether it existed."""
         ...
     def force_flush(self) -> None:
-        """Flush the output file."""
+        """Wait for queued subscriber delivery, then flush the file sink or drain the stream sink."""
         ...
     def shutdown(self) -> None:
-        """Flush the output file before shutdown."""
+        """Wait for queued subscriber delivery, then flush and shut down the exporter."""
         ...
 
 class ScopeStack:

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -1968,7 +1968,11 @@ def deregister_subscriber(name: str) -> bool:
     ...
 
 def flush_subscribers() -> None:
-    """Wait for subscriber callbacks already queued by native event emission."""
+    """Wait for subscriber callbacks queued by native event emission.
+
+    Call this function outside subscriber callbacks. A re-entrant call returns
+    without waiting, so callbacks later in the same dispatch snapshot can run.
+    """
     ...
 
 def scope_register_tool_sanitize_request_guardrail(

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -912,10 +912,24 @@ class AtofExporter:
         """Deregister ``name`` and return whether it existed."""
         ...
     def force_flush(self) -> None:
-        """Wait for queued subscriber delivery, then flush the file sink or drain the stream sink."""
+        """Flush the exporter.
+
+        Outside a native subscriber callback, wait for queued subscriber
+        delivery, then flush the file sink or ask the stream sink to drain up
+        to its timeout. A re-entrant call does not establish the delivery
+        barrier. A stream timeout is logged and does not by itself return an
+        error.
+        """
         ...
     def shutdown(self) -> None:
-        """Wait for queued subscriber delivery, then flush and shut down the exporter."""
+        """Flush the exporter and shut it down.
+
+        Outside a native subscriber callback, wait for queued subscriber
+        delivery, then flush the file sink or ask the stream sink to drain and
+        close up to its timeout. A re-entrant call does not establish the
+        delivery barrier. A stream timeout is logged and does not by itself
+        return an error.
+        """
         ...
 
 class ScopeStack:

--- a/python/nemo_relay/subscribers.py
+++ b/python/nemo_relay/subscribers.py
@@ -93,6 +93,10 @@ def flush() -> None:
     Native NeMo Relay event APIs enqueue subscriber callbacks and return without
     waiting for observer work. Use this barrier in tests and shutdown paths when
     captured subscriber output must be complete before continuing.
+
+    Call this function outside subscriber callbacks. A re-entrant call returns
+    without waiting to avoid blocking the dispatcher, so callbacks later in the
+    same dispatch snapshot can still run.
     """
     return _native_flush()
 


### PR DESCRIPTION
#### Overview

Clarify when NeMo Relay subscribers and observability exporters finish processing events, including the behavior during graceful and abrupt shutdown.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Define emitted, delivered, and exported events in the subscriber concept documentation.
- Document the shared subscriber flush barrier and the downstream barriers for ATOF, ATIF, OpenTelemetry, and OpenInference.
- Explain the file and stream differences for ATOF, including the limits of process-writer flushing and abrupt termination.
- Clarify ATIF export timing and remove the redundant subscriber flush from the Rust example.
- Update the Node.js custom subscriber example to allow an event-loop turn after native dispatch.
- Update public ATOF method comments in the Rust, Python, and Node.js bindings without changing behavior or signatures.
- Preserve the existing fail-open telemetry behavior. This change has no runtime, configuration, compatibility, or breaking change.

Validation:

- `uv run pre-commit run --all-files`
- `just docs-linkcheck`
- `just docs`
- `git diff --check`
- Runtime test suites were not run because the change is limited to documentation, examples, and public doc comments.

#### Where should the reviewer start?

Start with `docs/about-nemo-relay/concepts/subscribers.mdx`, which defines the canonical delivery contract and the boundary between subscriber flush and exporter-specific completion.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified telemetry lifecycle milestones (emitted vs delivered vs exported) and the correct barrier semantics for queued delivery, file sink flushing, and stream sink draining/closing (including stream timeouts being logged without failing).
  - Updated `force_flush()`/`shutdown()` and `flush_subscribers()` guidance across Rust, Python, native typings, and FFI, including re-entrant behavior and ordering.
  - Expanded observability plugin teardown and configuration guidance (including plugin teardown steps and warnings about telemetry loss/truncated outputs on abrupt termination).
  - Refreshed ATIF/ATOF, OpenTelemetry/OpenInference, and Node “Getting Started” (extra event-loop turn after scope creation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->