### PR TITLE
docs: resolve VDR documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ requiring changes to the existing agent stack. It gives coding agents,
 applications, framework integrations, middleware, and observability backends a
 shared runtime for scopes, policy, plugins, and lifecycle events.
 
+For how Relay complements OpenTelemetry GenAI conventions and observability or
+evaluation products, see [the Ecosystem guide](https://docs.nvidia.com/nemo/relay/about-nemo-relay/ecosystem).
+
 ## Where To Start
 
 | Goal | Start With |
@@ -30,7 +33,7 @@ shared runtime for scopes, policy, plugins, and lifecycle events.
 | Use LangChain, LangGraph, Deep Agents, or OpenClaw | [Supported Integrations](https://docs.nvidia.com/nemo/relay/supported-integrations/about) |
 | Build a framework or provider integration | [Integrate into Frameworks](https://docs.nvidia.com/nemo/relay/integrate-into-frameworks/about) |
 | Export ATOF, ATIF, OpenTelemetry, or OpenInference | [Observability Plugin](https://docs.nvidia.com/nemo/relay/configure-plugins/observability/about) |
-| Package reusable middleware or exporters | [Build Plugins](https://docs.nvidia.com/nemo/relay/v0.5.0/build-plugins/about) |
+| Package reusable middleware or exporters | [Build Plugins](https://docs.nvidia.com/nemo/relay/build-plugins/about) |
 | Develop or test this repository from source | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 
@@ -211,7 +214,7 @@ uv add nemo-relay
 
 # Node.js
 # Requires Node.js 24 or newer.
-npm install nemo-relay-node
+npm install nemo-relay-node@0.6.0
 
 # Rust
 cargo add nemo-relay

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -59,7 +59,7 @@ The Node.js package provides the following capabilities:
 Install the npm package in a Node.js 24 or newer project:
 
 ```bash
-npm install nemo-relay-node
+npm install nemo-relay-node@0.6.0
 ```
 
 ## Getting Started

--- a/docs/about-nemo-relay/ecosystem.mdx
+++ b/docs/about-nemo-relay/ecosystem.mdx
@@ -42,6 +42,22 @@ agent products. A framework asks, "What should the agent do next?" NeMo Relay
 asks, "When the agent does work, which scope owns it, which middleware applies,
 what events are emitted, and which subscribers can consume the result?"
 
+## How NeMo Relay Relates to Other Tooling
+
+NeMo Relay is an execution-time runtime contract. It captures work at the
+scope, tool, and LLM boundaries, and can apply middleware before or around that
+work. Telemetry conventions and observability or evaluation products serve
+different roles and can be used alongside Relay.
+
+| Tooling | Primary Role | Relationship to NeMo Relay |
+|---|---|---|
+| OpenTelemetry GenAI conventions | Define a common representation for AI telemetry. | Relay owns runtime capture and control, then can export its lifecycle events as generic OTLP spans for an existing OpenTelemetry tracing pipeline. |
+| Langfuse, LangSmith, and Arize Phoenix | Store, explore, and evaluate traces and agent runs. | These products are outside Relay's execution control loop. Use Relay to establish consistent execution boundaries and event data, then send data through the configured subscriber or export path that fits your backend. |
+
+Relay is not a replacement for a telemetry standard or an observability backend.
+Its role is to make the real execution path observable and controllable before
+the resulting lifecycle data is stored, visualized, or evaluated elsewhere.
+
 <MermaidStyles />
 
 ```mermaid

--- a/docs/about-nemo-relay/overview.mdx
+++ b/docs/about-nemo-relay/overview.mdx
@@ -31,6 +31,9 @@ observability backend, or guardrail authoring system. It gives those systems a
 common runtime boundary to meet at.
 </Note>
 
+For how Relay complements OpenTelemetry GenAI conventions and observability or
+evaluation products, see [How NeMo Relay Relates to Other Tooling](/about-nemo-relay/ecosystem#how-nemo-relay-relates-to-other-tooling).
+
 The first design question is simple: where can Relay observe or control the real
 work? The answer determines whether you should use a CLI sidecar, direct SDK
 instrumentation, a maintained integration, a framework wrapper, or a plugin.

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -194,7 +194,7 @@ Install the Node.js package when your application uses NeMo Relay through the
 JavaScript API and owns the tool or LLM call boundary.
 
 ```bash
-npm install nemo-relay-node
+npm install nemo-relay-node@0.6.0
 ```
 
 ## Rust

--- a/docs/getting-started/quick-start/nodejs.mdx
+++ b/docs/getting-started/quick-start/nodejs.mdx
@@ -19,7 +19,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-npm install nemo-relay-node
+npm install nemo-relay-node@0.6.0
 ```
 
 ### Install from the Repository


### PR DESCRIPTION
#### Overview

Resolve the NeMo Relay 0.6 documentation gaps identified in the VDR preparation report.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Pin published Node.js installation examples to `nemo-relay-node@0.6.0`.
- Replace the stale versioned Build Plugins README link.
- Add factual positioning for OpenTelemetry GenAI conventions and observability or evaluation products, with links from the Overview and README.

#### Where should the reviewer start?

Review `docs/about-nemo-relay/ecosystem.mdx` for the new comparison, then the Node.js installation examples and README entry points.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an ecosystem guide explaining how NeMo Relay complements telemetry, observability, and evaluation tooling.
  - Linked the new ecosystem guidance from relevant introductory documentation.
  - Updated Build Plugins documentation links.
  - Standardized Node.js installation instructions to use `nemo-relay-node@0.6.0` across the README and setup guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->