### PR TITLE
docs: update 0.6 PII release notes

### DIFF
--- a/docs/about-nemo-relay/release-notes/highlights.mdx
+++ b/docs/about-nemo-relay/release-notes/highlights.mdx
@@ -45,6 +45,16 @@ dynamic plugins.
 - The built-in PII redaction plugin now cleans mark data, category profiles,
   metadata, and generic scope inputs and outputs before subscribers or
   exporters receive them.
+- The PII redaction plugin now supports ordered, composable profiles. A single
+  component can apply multiple privacy policies to marks, LLM and tool
+  inputs/outputs, and scope metadata. Relay runs profiles by priority and uses
+  array order to break ties.
+- The opt-in `trajectory_context` preset removes request and response content
+  from buffered and streaming events for OpenAI Chat Completions, OpenAI
+  Responses, and Anthropic Messages. It preserves conversation topology,
+  tool-call relationships, agent hierarchy, routing, usage, cost, and
+  optimization telemetry. You can preserve custom mark payloads or redact them
+  recursively.
 - Relay now tracks LLM event-history freshness per agent. A new agent and the
   first LLM start after a `compaction` mark retain the complete sanitized
   history. Later starts keep the system instructions, latest user turn, and

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -59,9 +59,10 @@ Here's what changed across the main product surfaces:
   and Hermes can share that gateway, coordinate a single recovery attempt, and
   let it shut down after it becomes idle.
 - **Events and security:** Mark, scope-start, and scope-end sanitizers now work
-  at global, scope-local, and plugin levels. The PII plugin sanitizes those
-  surfaces, later LLM events can omit stale history, and Relay records
-  skill-load attempts with `skill.load` marks.
+  at global, scope-local, and plugin levels. The PII plugin sanitizes these
+  surfaces and supports ordered, composable profiles plus an opt-in
+  `trajectory_context` preset. Later LLM events can omit stale history, and
+  Relay records skill-load attempts with `skill.load` marks.
 - **Observability and optimization:** ATOF can send every event to multiple
   file and stream sinks. OTLP exporters use typed attributes, trace exporters
   can show marks as tool spans, session identifiers correlate across formats,

--- a/docs/about-nemo-relay/release-notes/known-issues.mdx
+++ b/docs/about-nemo-relay/release-notes/known-issues.mdx
@@ -81,6 +81,56 @@ The following limitations and migration steps apply to NVIDIA NeMo Relay 0.6.
 
 ### Compatibility and Migration Notes
 
+#### Migrate Composable PII Redaction Configuration
+
+<Warning>
+If your Rust code constructs `PiiRedactionConfig` with a struct literal,
+initialize the new `profiles` field or use `..Default::default()`. Serialization
+now omits the default-valued legacy fields (`mode`, `input`, `output`, `mark`,
+`tool_input`, `tool_output`, and `priority`). Update any code that depends on
+the previous exact serialized shape.
+
+Existing TOML and JSON files still work. You can continue to use the legacy
+single-policy form, but don't combine its fields with `profiles`. Relay runs
+profiles in ascending priority and uses array order to break ties. Profiles can
+apply to marks, LLM input/output, tool input/output, and scope metadata.
+Existing PII redaction configurations now also sanitize LLM and tool scope
+metadata, so downstream telemetry can change even when its schema does not.
+
+For profile examples and migration guidance, refer to the
+[PII Redaction Configuration](/configure-plugins/pii-redaction/configuration)
+guide. PR
+[#512](https://github.com/NVIDIA/NeMo-Relay/pull/512) introduced the composable
+configuration API.
+</Warning>
+
+#### Configure Structure-Preserving Trajectory Redaction
+
+<Warning>
+If your Rust code constructs `BuiltinBackendConfig` with a struct literal,
+initialize the new `preset` and `custom_mark_payload_policy` fields or use
+`..Default::default()`. Serialization now omits the default `action = "remove"`
+value. Update any code that depends on the previous exact serialized shape.
+
+The `trajectory_context` preset is opt-in. If you leave `preset` unset, existing
+runtime behavior stays the same. With the preset enabled, Relay removes request
+and response content from buffered and streaming events for OpenAI Chat
+Completions, OpenAI Responses, and Anthropic Messages. It preserves conversation
+topology, tool-call relationships, agent hierarchy, routing, usage, cost, and
+optimization fields. Relay preserves opaque custom marks by default; set
+`custom_mark_payload_policy = "redact_all_leaves"` to redact their scalar
+values recursively. If retained metadata or custom marks can contain email
+addresses, apply an email-redaction profile later in the profile list.
+
+The policy affects observability data only. It doesn't change the provider
+request or the client-visible provider response. For the full configuration
+options, refer to the
+[PII Redaction Configuration](/configure-plugins/pii-redaction/configuration)
+guide. PR
+[#513](https://github.com/NVIDIA/NeMo-Relay/pull/513) added trajectory-context
+redaction on top of [PR #512](https://github.com/NVIDIA/NeMo-Relay/pull/512).
+</Warning>
+
 #### Update Plugins and Workers That Consume Request Annotations
 
 <Warning>


### PR DESCRIPTION
#### Overview

Update the NeMo Relay 0.6 release notes for the PII redaction changes in PRs #512 and #513. The release notes now explain the new composable profiles and structure-preserving trajectory redaction in plain language, with migration warnings for the breaking Rust configuration and serialization changes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update the 0.6 release summary and highlights with the new PII redaction capabilities.
- Add migration warnings for `PiiRedactionConfig.profiles`, `BuiltinBackendConfig.preset`, `custom_mark_payload_policy`, and the changed serialized defaults.
- Document that `trajectory_context` is opt-in and changes observability data without changing provider requests or client-visible responses.
- Keep the change limited to `docs/about-nemo-relay/release-notes/`.

Validation:

- `git diff --check`
- `just docs`
- `just docs-linkcheck`
- `uv run pre-commit run --files docs/about-nemo-relay/release-notes/index.mdx docs/about-nemo-relay/release-notes/highlights.mdx docs/about-nemo-relay/release-notes/known-issues.mdx`

#### Where should the reviewer start?

Start with `docs/about-nemo-relay/release-notes/known-issues.mdx` to review the migration warnings, then review the user-facing summaries in `index.mdx` and `highlights.mdx`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #512
- Relates to #513


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented composable, priority-based PII redaction profiles.
  * Added details about the opt-in `trajectory_context` preset, which removes sensitive request and response content while preserving conversation structure and telemetry.
  * Added migration guidance for configuration changes, serialization behavior, and custom mark redaction policies.
  * Updated release scope and known-issues documentation for Relay 0.6 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->