### PR TITLE
fix(node): make callback failures catchable

### DIFF
--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -1924,7 +1924,7 @@ pub fn tool_call_execute(
     env: Env,
     name: String,
     args: Json,
-    func: ThreadsafeFunction<Json, ErrorStrategy::Fatal>,
+    #[napi(ts_arg_type = "(arg: Json) => any")] func: JsFunction,
     handle: Option<&ScopeHandle>,
     attributes: Option<u32>,
     data: Option<Json>,
@@ -1934,7 +1934,8 @@ pub fn tool_call_execute(
     let parent = handle
         .map(|h| h.inner.clone())
         .unwrap_or_else(task_scope_top);
-    let exec_fn = callable::wrap_js_tool_exec_fn(func);
+    let callback = callable::safe_execution_callback(&env, &func)?;
+    let exec_fn = callable::wrap_js_tool_exec_fn(json_callback_tsfn(&env, &callback)?);
     let default_fn: ToolExecutionNextFn = std::sync::Arc::new(move |args| exec_fn(args));
     let scope_stack = current_scope_stack_handle();
 
@@ -2116,7 +2117,7 @@ pub fn llm_call_execute(
     env: Env,
     name: String,
     request: Json,
-    func: ThreadsafeFunction<Json, ErrorStrategy::Fatal>,
+    #[napi(ts_arg_type = "(arg: Json) => any")] func: JsFunction,
     handle: Option<&ScopeHandle>,
     attributes: Option<u32>,
     data: Option<Json>,
@@ -2132,7 +2133,8 @@ pub fn llm_call_execute(
         .unwrap_or_else(task_scope_top);
     let llm_request: LlmRequest = serde_json::from_value(request)
         .map_err(|e| napi::Error::from_reason(format!("invalid LlmRequest: {e}")))?;
-    let exec_fn = callable::wrap_js_llm_exec_fn(func);
+    let callback = callable::safe_execution_callback(&env, &func)?;
+    let exec_fn = callable::wrap_js_llm_exec_fn(json_callback_tsfn(&env, &callback)?);
     let default_fn: LlmExecutionNextFn = std::sync::Arc::new(move |req| exec_fn(req));
     let codec = match (codec_decode, codec_encode) {
         (Some(d), Some(e)) => Some(callable::wrap_js_codec(d, e)),

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -119,6 +119,68 @@ pub(crate) fn safe_middleware_callback(env: &Env, func: &JsFunction) -> napi::Re
     Ok(unsafe { wrapper_unknown.cast::<JsFunction>() })
 }
 
+/// Wrap a synchronous execution callback so failures cross the N-API boundary as data.
+///
+/// The return value is validated before NAPI-RS attempts to convert it to JSON. This
+/// prevents unsupported values such as `BigInt` from reaching conversion paths that
+/// abort the Node process.
+pub(crate) fn safe_execution_callback(env: &Env, func: &JsFunction) -> napi::Result<JsFunction> {
+    let factory: JsFunction = env.run_script(
+        r#"((fn) => {
+  function jsonValue(value, seen = new Set()) {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) {
+        throw new TypeError('JavaScript callback returned a non-finite number that cannot be converted to JSON');
+      }
+      return value;
+    }
+    if (typeof value !== 'object') {
+      throw new TypeError(`JavaScript callback returned an unsupported ${typeof value} value that cannot be converted to JSON`);
+    }
+    if (seen.has(value)) {
+      throw new TypeError('JavaScript callback returned a circular value that cannot be converted to JSON');
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+      const length = value.length;
+      const result = new Array(length);
+      for (let index = 0; index < length; index += 1) {
+        result[index] = jsonValue(value[index], seen);
+      }
+      seen.delete(value);
+      return result;
+    }
+
+    const result = Object.create(null);
+    for (const key of Object.keys(value)) {
+      result[key] = jsonValue(value[key], seen);
+    }
+    seen.delete(value);
+    return result;
+  }
+
+  return function __nemo_relay_execution_wrapper(...args) {
+    try {
+      const value = fn(...args);
+      return { ok: true, value: jsonValue(value === undefined ? null : value) };
+    } catch (error) {
+      let message = 'JavaScript callback failed';
+      try {
+        message = String(error?.message ?? error);
+      } catch {}
+      return { ok: false, error: message };
+    }
+  };
+})"#,
+    )?;
+    let func_unknown = unsafe { JsUnknown::from_raw_unchecked(env.raw(), func.raw()) };
+    let wrapper_unknown = factory.call(None, &[func_unknown])?;
+    Ok(unsafe { wrapper_unknown.cast::<JsFunction>() })
+}
+
 pub(crate) fn unwrap_middleware_result(value: Json, error_prefix: &str) -> Result<Json> {
     let result: MiddlewareCallbackResult = serde_json::from_value(value).map_err(|error| {
         FlowError::Internal(format!(
@@ -314,7 +376,8 @@ pub fn wrap_js_tool_exec_fn(
                     "failed to queue JS tool execution callback: {status:?}",
                 )));
             }
-            rx.await.map_err(|e| FlowError::Internal(e.to_string()))
+            let result = rx.await.map_err(|e| FlowError::Internal(e.to_string()))?;
+            unwrap_middleware_result(result, "JS tool execution callback failed")
         })
     })
 }
@@ -507,7 +570,8 @@ pub fn wrap_js_llm_exec_fn(
                     "failed to queue JS LLM execution callback: {status:?}",
                 )));
             }
-            rx.await.map_err(|e| FlowError::Internal(e.to_string()))
+            let result = rx.await.map_err(|e| FlowError::Internal(e.to_string()))?;
+            unwrap_middleware_result(result, "JS LLM execution callback failed")
         })
     })
 }

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -36,6 +36,7 @@ use nemo_relay::codec::response::AnnotatedLlmResponse;
 use nemo_relay::codec::traits::{LlmCodec, LlmResponseCodec};
 use nemo_relay::error::{FlowError, Result};
 
+use crate::callback_factory;
 use crate::convert::{callback_json, record_callback_error};
 use crate::promise_call::{JsonNextFn, JsonStreamNextFn, PromiseAwareFn};
 use crate::types::{EventSanitizeFields, JsEvent, event_sanitize_fields_from_json};
@@ -125,60 +126,7 @@ pub(crate) fn safe_middleware_callback(env: &Env, func: &JsFunction) -> napi::Re
 /// prevents unsupported values such as `BigInt` from reaching conversion paths that
 /// abort the Node process.
 pub(crate) fn safe_execution_callback(env: &Env, func: &JsFunction) -> napi::Result<JsFunction> {
-    let factory: JsFunction = env.run_script(
-        r#"((fn) => {
-  function jsonValue(value, seen = new Set()) {
-    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
-      return value;
-    }
-    if (typeof value === 'number') {
-      if (!Number.isFinite(value)) {
-        throw new TypeError('JavaScript callback returned a non-finite number that cannot be converted to JSON');
-      }
-      return value;
-    }
-    if (typeof value !== 'object') {
-      throw new TypeError(`JavaScript callback returned an unsupported ${typeof value} value that cannot be converted to JSON`);
-    }
-    if (seen.has(value)) {
-      throw new TypeError('JavaScript callback returned a circular value that cannot be converted to JSON');
-    }
-    seen.add(value);
-    if (Array.isArray(value)) {
-      const length = value.length;
-      const result = new Array(length);
-      for (let index = 0; index < length; index += 1) {
-        result[index] = jsonValue(value[index], seen);
-      }
-      seen.delete(value);
-      return result;
-    }
-
-    const result = Object.create(null);
-    for (const key of Object.keys(value)) {
-      result[key] = jsonValue(value[key], seen);
-    }
-    seen.delete(value);
-    return result;
-  }
-
-  return function __nemo_relay_execution_wrapper(...args) {
-    try {
-      const value = fn(...args);
-      return { ok: true, value: jsonValue(value === undefined ? null : value) };
-    } catch (error) {
-      let message = 'JavaScript callback failed';
-      try {
-        message = String(error?.message ?? error);
-      } catch {}
-      return { ok: false, error: message };
-    }
-  };
-})"#,
-    )?;
-    let func_unknown = unsafe { JsUnknown::from_raw_unchecked(env.raw(), func.raw()) };
-    let wrapper_unknown = factory.call(None, &[func_unknown])?;
-    Ok(unsafe { wrapper_unknown.cast::<JsFunction>() })
+    callback_factory::wrap_execution_callback(env, func)
 }
 
 pub(crate) fn unwrap_middleware_result(value: Json, error_prefix: &str) -> Result<Json> {

--- a/crates/node/src/callback_factory.rs
+++ b/crates/node/src/callback_factory.rs
@@ -35,6 +35,12 @@ const CALLBACK_FACTORIES_SOURCE: &str = r#"(() => {
       return result;
     }
 
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      seen.delete(value);
+      throw new TypeError('JavaScript callback returned an unsupported object value that cannot be converted to JSON');
+    }
+
     const result = Object.create(null);
     for (const key of Object.keys(value)) {
       result[key] = jsonValue(value[key], seen);

--- a/crates/node/src/callback_factory.rs
+++ b/crates/node/src/callback_factory.rs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cached JavaScript callback wrapper factories for the Node binding.
+
+use napi::{Env, JsFunction, JsObject, JsUnknown, NapiRaw, NapiValue};
+
+const CALLBACK_FACTORIES_PROPERTY: &str = "__nemo_relay_callback_factories_v1";
+
+const CALLBACK_FACTORIES_SOURCE: &str = r#"(() => {
+  function jsonValue(value, seen = new Set()) {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) {
+        throw new TypeError('JavaScript callback returned a non-finite number that cannot be converted to JSON');
+      }
+      return value;
+    }
+    if (typeof value !== 'object') {
+      throw new TypeError(`JavaScript callback returned an unsupported ${typeof value} value that cannot be converted to JSON`);
+    }
+    if (seen.has(value)) {
+      throw new TypeError('JavaScript callback returned a circular value that cannot be converted to JSON');
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+      const length = value.length;
+      const result = new Array(length);
+      for (let index = 0; index < length; index += 1) {
+        result[index] = jsonValue(value[index], seen);
+      }
+      seen.delete(value);
+      return result;
+    }
+
+    const result = Object.create(null);
+    for (const key of Object.keys(value)) {
+      result[key] = jsonValue(value[key], seen);
+    }
+    seen.delete(value);
+    return result;
+  }
+
+  return {
+    execution(fn) {
+      return function __nemo_relay_execution_wrapper(...args) {
+        try {
+          const value = fn(...args);
+          return { ok: true, value: jsonValue(value === undefined ? null : value) };
+        } catch (error) {
+          let message = 'JavaScript callback failed';
+          try {
+            message = String(error?.message ?? error);
+          } catch {}
+          return { ok: false, error: message };
+        }
+      };
+    },
+
+    promise(fn) {
+      return function __nemo_relay_promise_wrapper(error, arg0, next, resolve, reject) {
+        if (error != null) {
+          reject(error);
+          return;
+        }
+        Promise.resolve().then(() => (
+          next === undefined ? fn(arg0) : fn(arg0, next)
+        )).then((value) => jsonValue(value === undefined ? null : value)).then(resolve, reject);
+      };
+    },
+  };
+})()"#;
+
+fn as_unknown<T: NapiRaw>(env: &Env, value: &T) -> JsUnknown {
+    unsafe { JsUnknown::from_raw_unchecked(env.raw(), value.raw()) }
+}
+
+fn callback_factories(env: &Env) -> napi::Result<JsObject> {
+    let global = env.get_global()?;
+    if global.has_own_property(CALLBACK_FACTORIES_PROPERTY)? {
+        return global.get_named_property(CALLBACK_FACTORIES_PROPERTY);
+    }
+
+    let factories: JsObject = env.run_script(CALLBACK_FACTORIES_SOURCE)?;
+    let object: JsFunction = global.get_named_property("Object")?;
+    let object = unsafe { JsObject::from_raw_unchecked(env.raw(), object.raw()) };
+    let define_property: JsFunction = object.get_named_property("defineProperty")?;
+    let property = env.create_string(CALLBACK_FACTORIES_PROPERTY)?;
+    let mut descriptor = env.create_object()?;
+    descriptor.set_named_property("value", factories)?;
+    define_property.call(
+        None,
+        &[
+            as_unknown(env, &global),
+            as_unknown(env, &property),
+            as_unknown(env, &descriptor),
+        ],
+    )?;
+
+    global.get_named_property(CALLBACK_FACTORIES_PROPERTY)
+}
+
+fn wrap_callback(env: &Env, func: &JsFunction, factory_name: &str) -> napi::Result<JsFunction> {
+    let factories = callback_factories(env)?;
+    let factory: JsFunction = factories.get_named_property(factory_name)?;
+    let wrapper = factory.call(None, &[as_unknown(env, func)])?;
+    Ok(unsafe { wrapper.cast::<JsFunction>() })
+}
+
+pub(crate) fn wrap_execution_callback(env: &Env, func: &JsFunction) -> napi::Result<JsFunction> {
+    wrap_callback(env, func, "execution")
+}
+
+pub(crate) fn wrap_promise_callback(env: &Env, func: &JsFunction) -> napi::Result<JsFunction> {
+    wrap_callback(env, func, "promise")
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod api;
 mod callable;
+mod callback_factory;
 mod convert;
 mod promise_call;
 mod stream;

--- a/crates/node/src/promise_call.rs
+++ b/crates/node/src/promise_call.rs
@@ -156,8 +156,12 @@ fn build_completion_unknowns(
 ) -> napi::Result<(JsUnknown, JsUnknown)> {
     let resolve_completion = completion.clone();
     let resolve = env.create_function_from_closure("__nemo_relay_resolve", move |ctx| {
-        let value = ctx.get::<Json>(0).unwrap_or(Json::Null);
-        resolve_completion.send(Ok(value));
+        let value = ctx.get::<Json>(0).map_err(|error| {
+            FlowError::Internal(format!(
+                "JavaScript callback result could not be converted to JSON: {error}"
+            ))
+        });
+        resolve_completion.send(value);
         ctx.env.get_undefined()
     })?;
 
@@ -180,14 +184,51 @@ fn build_completion_unknowns(
 
 fn create_promise_wrapper(env: &Env, callable: &JsFunction) -> napi::Result<JsFunction> {
     let factory: JsFunction = env.run_script(
-        r#"((fn) => function __nemo_relay_promise_wrapper(error, arg0, next, resolve, reject) {
+        r#"((fn) => {
+  function jsonValue(value, seen = new Set()) {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) {
+        throw new TypeError('JavaScript callback returned a non-finite number that cannot be converted to JSON');
+      }
+      return value;
+    }
+    if (typeof value !== 'object') {
+      throw new TypeError(`JavaScript callback returned an unsupported ${typeof value} value that cannot be converted to JSON`);
+    }
+    if (seen.has(value)) {
+      throw new TypeError('JavaScript callback returned a circular value that cannot be converted to JSON');
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+      const length = value.length;
+      const result = new Array(length);
+      for (let index = 0; index < length; index += 1) {
+        result[index] = jsonValue(value[index], seen);
+      }
+      seen.delete(value);
+      return result;
+    }
+
+    const result = Object.create(null);
+    for (const key of Object.keys(value)) {
+      result[key] = jsonValue(value[key], seen);
+    }
+    seen.delete(value);
+    return result;
+  }
+
+  return function __nemo_relay_promise_wrapper(error, arg0, next, resolve, reject) {
   if (error != null) {
     reject(error);
     return;
   }
   Promise.resolve().then(() => (
     next === undefined ? fn(arg0) : fn(arg0, next)
-  )).then(resolve, reject);
+  )).then((value) => jsonValue(value === undefined ? null : value)).then(resolve, reject);
+  };
 })"#,
     )?;
     let wrapper_unknown: JsUnknown = factory.call(None, &[function_to_unknown(env, callable)])?;

--- a/crates/node/src/promise_call.rs
+++ b/crates/node/src/promise_call.rs
@@ -22,6 +22,8 @@ use serde_json::Value as Json;
 
 use nemo_relay::error::{FlowError, Result as FlowResult};
 
+use crate::callback_factory;
+
 pub type JsonNextFn =
     Arc<dyn Fn(Json) -> Pin<Box<dyn Future<Output = FlowResult<Json>> + Send>> + Send + Sync>;
 pub type JsonStreamNextFn =
@@ -182,59 +184,6 @@ fn build_completion_unknowns(
     ))
 }
 
-fn create_promise_wrapper(env: &Env, callable: &JsFunction) -> napi::Result<JsFunction> {
-    let factory: JsFunction = env.run_script(
-        r#"((fn) => {
-  function jsonValue(value, seen = new Set()) {
-    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
-      return value;
-    }
-    if (typeof value === 'number') {
-      if (!Number.isFinite(value)) {
-        throw new TypeError('JavaScript callback returned a non-finite number that cannot be converted to JSON');
-      }
-      return value;
-    }
-    if (typeof value !== 'object') {
-      throw new TypeError(`JavaScript callback returned an unsupported ${typeof value} value that cannot be converted to JSON`);
-    }
-    if (seen.has(value)) {
-      throw new TypeError('JavaScript callback returned a circular value that cannot be converted to JSON');
-    }
-    seen.add(value);
-    if (Array.isArray(value)) {
-      const length = value.length;
-      const result = new Array(length);
-      for (let index = 0; index < length; index += 1) {
-        result[index] = jsonValue(value[index], seen);
-      }
-      seen.delete(value);
-      return result;
-    }
-
-    const result = Object.create(null);
-    for (const key of Object.keys(value)) {
-      result[key] = jsonValue(value[key], seen);
-    }
-    seen.delete(value);
-    return result;
-  }
-
-  return function __nemo_relay_promise_wrapper(error, arg0, next, resolve, reject) {
-  if (error != null) {
-    reject(error);
-    return;
-  }
-  Promise.resolve().then(() => (
-    next === undefined ? fn(arg0) : fn(arg0, next)
-  )).then((value) => jsonValue(value === undefined ? null : value)).then(resolve, reject);
-  };
-})"#,
-    )?;
-    let wrapper_unknown: JsUnknown = factory.call(None, &[function_to_unknown(env, callable)])?;
-    Ok(unsafe { wrapper_unknown.cast::<JsFunction>() })
-}
-
 /// A wrapper around a JS function that can be called from any thread and
 /// transparently handles both synchronous and Promise return values.
 pub struct PromiseAwareFn {
@@ -246,7 +195,7 @@ impl PromiseAwareFn {
     ///
     /// Must be called on the JS main thread (i.e., in a sync `#[napi]` function).
     pub fn new(env: &Env, func: &JsFunction) -> napi::Result<Self> {
-        let wrapper = create_promise_wrapper(env, func)?;
+        let wrapper = callback_factory::wrap_promise_callback(env, func)?;
         let mut tsfn =
             env.create_threadsafe_function(&wrapper, 0, |ctx: ThreadSafeCallContext<CallArgs>| {
                 let next = match ctx.value.next {

--- a/crates/node/tests/llm_tests.mjs
+++ b/crates/node/tests/llm_tests.mjs
@@ -184,6 +184,42 @@ describe('LLM execute', () => {
     assert.equal(result, null);
   });
 
+  it('sync execute rejects thrown callbacks without terminating Node', async () => {
+    await assert.rejects(
+      () =>
+        llmCallExecute('exec_llm_throw', makeNative(), () => {
+          throw new Error('sync llm callback failed');
+        }),
+      /sync llm callback failed/,
+    );
+
+    const result = await llmCallExecute('exec_llm_after_throw', makeNative(), () => ({
+      ok: true,
+    }));
+    assert.deepEqual(result, {
+      ok: true,
+    });
+  });
+
+  it('sync and async execute reject invalid JSON results without terminating Node', async () => {
+    const cases = [
+      ['sync_bigint', () => llmCallExecute('exec_llm_bigint', makeNative(), () => ({ value: 1n }))],
+      ['async_bigint', () => llmCallExecuteAsync('exec_async_llm_bigint', makeNative(), async () => 1n)],
+      ['sync_sparse_array', () => llmCallExecute('exec_llm_sparse_array', makeNative(), () => [, 1])],
+      ['async_sparse_array', () => llmCallExecuteAsync('exec_async_llm_sparse_array', makeNative(), async () => [, 1])],
+    ];
+
+    for (const [kind, execute] of cases) {
+      await assert.rejects(execute, /bigint|undefined|json/i);
+      const result = await llmCallExecute(`exec_llm_after_${kind}`, makeNative(), () => ({
+        ok: true,
+      }));
+      assert.deepEqual(result, {
+        ok: true,
+      });
+    }
+  });
+
   it('execute records OTEL status metadata on end events', async () => {
     const events = [];
     registerSubscriber('node_llm_status_metadata_sub', (e) => events.push(e));

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -259,6 +259,8 @@ describe('Tool execute', () => {
     const cases = [
       ['sync_bigint', () => toolCallExecute('exec_tool_bigint', {}, () => 1n)],
       ['async_bigint', () => toolCallExecuteAsync('exec_async_tool_bigint', {}, async () => ({ value: 1n }))],
+      ['sync_date', () => toolCallExecute('exec_tool_date', {}, () => new Date())],
+      ['async_map', () => toolCallExecuteAsync('exec_async_tool_map', {}, async () => new Map([['value', 1]]))],
       ['sync_sparse_array', () => toolCallExecute('exec_tool_sparse_array', {}, () => [, 1])],
       ['async_sparse_array', () => toolCallExecuteAsync('exec_async_tool_sparse_array', {}, async () => [, 1])],
     ];

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -238,6 +238,83 @@ describe('Tool execute', () => {
     assert.equal(result, null);
   });
 
+  it('sync execute rejects thrown callbacks without terminating Node', async () => {
+    await assert.rejects(
+      () =>
+        toolCallExecute('exec_tool_throw', {}, () => {
+          throw new Error('sync tool callback failed');
+        }),
+      /sync tool callback failed/,
+    );
+
+    const result = await toolCallExecute('exec_tool_after_throw', {}, () => ({
+      ok: true,
+    }));
+    assert.deepEqual(result, {
+      ok: true,
+    });
+  });
+
+  it('sync and async execute reject invalid JSON results without terminating Node', async () => {
+    const cases = [
+      ['sync_bigint', () => toolCallExecute('exec_tool_bigint', {}, () => 1n)],
+      ['async_bigint', () => toolCallExecuteAsync('exec_async_tool_bigint', {}, async () => ({ value: 1n }))],
+      ['sync_sparse_array', () => toolCallExecute('exec_tool_sparse_array', {}, () => [, 1])],
+      ['async_sparse_array', () => toolCallExecuteAsync('exec_async_tool_sparse_array', {}, async () => [, 1])],
+    ];
+
+    for (const [kind, execute] of cases) {
+      await assert.rejects(execute, /bigint|undefined|json/i);
+      const result = await toolCallExecute(`exec_tool_after_${kind}`, {}, () => ({
+        ok: true,
+      }));
+      assert.deepEqual(result, {
+        ok: true,
+      });
+    }
+  });
+
+  it('sync and async execute read stateful getter results once', async () => {
+    const statefulResult = () => {
+      let reads = 0;
+      return {
+        get value() {
+          reads += 1;
+          return reads;
+        },
+      };
+    };
+    const cases = [
+      () => toolCallExecute('exec_tool_stateful_getter', {}, statefulResult),
+      () => toolCallExecuteAsync('exec_async_tool_stateful_getter', {}, async () => statefulResult()),
+    ];
+
+    for (const execute of cases) {
+      const result = await execute();
+      assert.deepEqual(result, {
+        value: 1,
+      });
+    }
+  });
+
+  it('sync and async execute serialize arrays by index instead of their iterator', async () => {
+    const statefulArray = () => {
+      const result = [1];
+      result[Symbol.iterator] = function* iterator() {
+        yield 99;
+      };
+      return result;
+    };
+    const cases = [
+      () => toolCallExecute('exec_tool_iterator', {}, statefulArray),
+      () => toolCallExecuteAsync('exec_async_tool_iterator', {}, async () => statefulArray()),
+    ];
+
+    for (const execute of cases) {
+      assert.deepEqual(await execute(), [1]);
+    }
+  });
+
   it('execute with attributes', async () => {
     const result = await toolCallExecute(
       'exec_attr_tool',


### PR DESCRIPTION
#### Overview

Make Node tool and LLM callback failures reject their returned promises instead of terminating the Node process.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Wrap synchronous tool and LLM execution callbacks on the JavaScript thread so thrown exceptions cross N-API as error envelopes.
- Normalize top-level undefined to null and copy callback results through recursive JSON validation before NAPI-RS conversion.
- Reject BigInt, sparse arrays, circular values, non-finite numbers, and other unsupported JSON values without aborting Node.
- Apply the same validation to promise-aware tool and LLM callbacks while preserving original rejection messages.
- Add regressions for sync throws, sync and async BigInt results, stateful getters, custom array iterators, process survival, and supported undefined behavior.
- Keep the public Node callback declarations and sync-only execution semantics unchanged.
- Breaking changes: none.

Validation:

- Focused Node callback, tool, and LLM tests: 94 passed.
- Full Node test suite: 283 passed.
- `just build-node`
- `just test-node`
- `cargo fmt --all`
- `just test-rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --all-files`
- Targeted pre-commit checks for the final staged files.

#### Where should the reviewer start?

Start with `safe_execution_callback` in `crates/node/src/callable.rs`, then compare the promise-aware validation in `crates/node/src/promise_call.rs` and the process-survival regressions in `crates/node/tests/tools_tests.mjs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool and LLM execution now accept regular JavaScript callback functions directly, with safer cross-boundary execution.

* **Bug Fixes**
  * More consistent rejection for invalid or unsupported callback results (e.g., circular references, non-finite numbers, BigInt/sparse arrays), avoiding runtime instability.
  * Completion argument validation is stricter: invalid inputs now fail explicitly instead of defaulting.

* **Tests**
  * Added/expanded tool and LLM execution cases covering thrown callbacks, invalid JSON-like outputs, getter/iterator edge cases, and continued operation after failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->