### PR TITLE
fix(python): reject cyclic tool callback results

### DIFF
--- a/crates/node/tests/codec_tests.mjs
+++ b/crates/node/tests/codec_tests.mjs
@@ -92,7 +92,7 @@ describe('Codec pipeline integration', () => {
       await execWithCodec(
         'test-llm',
         makeRequest(),
-        async (req) => ({
+        (req) => ({
           choices: [
             {
               message: {
@@ -135,7 +135,7 @@ describe('Codec pipeline integration', () => {
       await execWithCodec(
         'test-llm',
         makeRequest(),
-        async (req) => {
+        (req) => {
           executedContent = req.content;
           return {
             choices: [],
@@ -222,7 +222,7 @@ describe('Codec pipeline integration', () => {
       await execWithCodec(
         'test-llm',
         makeRequest(),
-        async (req) => ({
+        (req) => ({
           choices: [],
         }),
         decodeB,

--- a/crates/node/tests/event_sanitizers_tests.mjs
+++ b/crates/node/tests/event_sanitizers_tests.mjs
@@ -135,7 +135,7 @@ describe('event sanitizer registries', () => {
       metadata: { background: true },
     }));
     try {
-      await lib.toolCallExecute('background-tool', { raw: true }, async (args) => args);
+      await lib.toolCallExecute('background-tool', { raw: true }, (args) => args);
       lib.flushSubscribers();
       await waitFor(events, 2);
     } finally {
@@ -168,7 +168,7 @@ describe('event sanitizer registries', () => {
         }));
         lib.registerScopeSanitizeStartGuardrail(name, 0, sanitizer);
         try {
-          await lib.toolCallExecute(name, { kept: kind }, async (args) => args);
+          await lib.toolCallExecute(name, { kept: kind }, (args) => args);
           lib.flushSubscribers();
           await waitFor(events, (Object.keys(invalidResults).indexOf(kind) + 1) * 2);
         } finally {
@@ -199,7 +199,7 @@ describe('event sanitizer registries', () => {
       throw new Error('background sanitizer boom');
     });
     try {
-      await lib.toolCallExecute('background-throw-tool', { kept: true }, async (args) => args);
+      await lib.toolCallExecute('background-throw-tool', { kept: true }, (args) => args);
       lib.flushSubscribers();
       await waitFor(events, 2);
       const start = events.find(

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -276,6 +276,28 @@ describe('Tool execute', () => {
     }
   });
 
+  it('sync and async execute reject circular results without terminating Node', async () => {
+    const circularResult = () => {
+      const result = {};
+      result.self = result;
+      return result;
+    };
+
+    const cases = [
+      ['sync', () => toolCallExecute('exec_tool_circular', {}, circularResult)],
+      ['async', () => toolCallExecuteAsync('exec_async_tool_circular', {}, async () => circularResult())],
+    ];
+
+    for (const [kind, execute] of cases) {
+      await assert.rejects(execute, /circular|json/i);
+
+      const result = await toolCallExecute(`exec_tool_after_circular_${kind}`, {}, () => ({
+        ok: true,
+      }));
+      assert.deepEqual(result, { ok: true });
+    }
+  });
+
   it('sync and async execute read stateful getter results once', async () => {
     const statefulResult = () => {
       let reads = 0;

--- a/crates/python/src/convert.rs
+++ b/crates/python/src/convert.rs
@@ -10,17 +10,32 @@
 use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
-use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyTuple};
+use pyo3::types::{
+    PyByteArray, PyBytes, PyDict, PyFrozenSet, PyMapping, PySequence, PySet, PyString,
+};
+use pyo3::{intern, prelude::*};
 use serde_json::Value as Json;
 
 fn validate_acyclic(
     value: &Bound<'_, PyAny>,
     active_containers: &mut HashSet<usize>,
 ) -> PyResult<()> {
-    let is_container = value.cast::<PyDict>().is_ok()
-        || value.cast::<PyList>().is_ok()
-        || value.cast::<PyTuple>().is_ok();
+    if value.is_instance_of::<PyString>()
+        || value.is_instance_of::<PyBytes>()
+        || value.is_instance_of::<PyByteArray>()
+    {
+        return Ok(());
+    }
+
+    let dataclass_fields = value
+        .getattr_opt(intern!(value.py(), "__dataclass_fields__"))
+        .ok()
+        .flatten();
+    let is_container = value.cast::<PySet>().is_ok()
+        || value.cast::<PyFrozenSet>().is_ok()
+        || value.cast::<PySequence>().is_ok()
+        || value.cast::<PyMapping>().is_ok()
+        || dataclass_fields.is_some();
     if !is_container {
         return Ok(());
     }
@@ -32,18 +47,36 @@ fn validate_acyclic(
         ));
     }
 
-    let result = if let Ok(dictionary) = value.cast::<PyDict>() {
-        dictionary
-            .iter()
-            .try_for_each(|(_, child)| validate_acyclic(&child, active_containers))
-    } else if let Ok(list) = value.cast::<PyList>() {
-        list.iter()
+    let result = if let Ok(set) = value.cast::<PySet>() {
+        set.iter()
             .try_for_each(|child| validate_acyclic(&child, active_containers))
+    } else if let Ok(set) = value.cast::<PyFrozenSet>() {
+        set.iter()
+            .try_for_each(|child| validate_acyclic(&child, active_containers))
+    } else if let Ok(sequence) = value.cast::<PySequence>() {
+        (0..sequence.len()?).try_for_each(|index| {
+            let child = sequence.get_item(index)?;
+            validate_acyclic(&child, active_containers)
+        })
+    } else if let Ok(mapping) = value.cast::<PyMapping>() {
+        let keys = mapping.keys()?;
+        let values = mapping.values()?;
+        keys.iter()
+            .chain(values.iter())
+            .try_for_each(|child| validate_acyclic(&child, active_containers))
+    } else if let Some(fields) = dataclass_fields {
+        let fields = fields.cast::<PyDict>()?.keys();
+        let attributes = value
+            .getattr(intern!(value.py(), "__dict__"))?
+            .cast_into::<PyDict>()?;
+        fields.iter().try_for_each(|field| {
+            if let Some(child) = attributes.get_item(&field)? {
+                validate_acyclic(&child, active_containers)?;
+            }
+            Ok(())
+        })
     } else {
-        value
-            .cast::<PyTuple>()?
-            .iter()
-            .try_for_each(|child| validate_acyclic(&child, active_containers))
+        Ok(())
     };
 
     active_containers.remove(&identity);

--- a/crates/python/src/convert.rs
+++ b/crates/python/src/convert.rs
@@ -7,12 +7,52 @@
 //! the required/optional × to-json/from-json matrix used throughout the PyO3
 //! binding layer.
 
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyTuple};
 use serde_json::Value as Json;
+
+fn validate_acyclic(
+    value: &Bound<'_, PyAny>,
+    active_containers: &mut HashSet<usize>,
+) -> PyResult<()> {
+    let is_container = value.cast::<PyDict>().is_ok()
+        || value.cast::<PyList>().is_ok()
+        || value.cast::<PyTuple>().is_ok();
+    if !is_container {
+        return Ok(());
+    }
+
+    let identity = value.as_ptr() as usize;
+    if !active_containers.insert(identity) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Failed to convert to JSON: circular reference detected",
+        ));
+    }
+
+    let result = if let Ok(dictionary) = value.cast::<PyDict>() {
+        dictionary
+            .iter()
+            .try_for_each(|(_, child)| validate_acyclic(&child, active_containers))
+    } else if let Ok(list) = value.cast::<PyList>() {
+        list.iter()
+            .try_for_each(|child| validate_acyclic(&child, active_containers))
+    } else {
+        value
+            .cast::<PyTuple>()?
+            .iter()
+            .try_for_each(|child| validate_acyclic(&child, active_containers))
+    };
+
+    active_containers.remove(&identity);
+    result
+}
 
 /// Convert a Python object to serde_json::Value via pythonize.
 pub fn py_to_json(obj: &Bound<'_, PyAny>) -> PyResult<Json> {
+    validate_acyclic(obj, &mut HashSet::new())?;
     pythonize::depythonize(obj).map_err(|e| {
         PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Failed to convert to JSON: {e}"))
     })

--- a/python/tests/test_tools.py
+++ b/python/tests/test_tools.py
@@ -3,6 +3,8 @@
 
 """Tests for NeMo Relay tool lifecycle, guardrails, and intercepts."""
 
+from collections import UserDict, UserList
+from dataclasses import dataclass
 from typing import cast
 
 import pytest
@@ -99,6 +101,31 @@ class TestToolsAsync:
 
         with pytest.raises(RuntimeError, match="circular reference detected"):
             await tools.execute("cyclic_result", {}, cyclic_result)
+
+        async def async_cyclic_result(_args):
+            return cyclic_result(_args)
+
+        with pytest.raises(RuntimeError, match="circular reference detected"):
+            await tools.execute("async_cyclic_result", {}, async_cyclic_result)
+
+        cyclic_mapping = UserDict()
+        cyclic_mapping["self"] = cyclic_mapping
+        with pytest.raises(RuntimeError, match="circular reference detected"):
+            await tools.execute("cyclic_mapping", {}, lambda _args: cyclic_mapping)
+
+        cyclic_sequence = UserList()
+        cyclic_sequence.append(cyclic_sequence)
+        with pytest.raises(RuntimeError, match="circular reference detected"):
+            await tools.execute("cyclic_sequence", {}, lambda _args: cyclic_sequence)
+
+        @dataclass
+        class CyclicDataclass:
+            child: object | None = None
+
+        cyclic_dataclass = CyclicDataclass()
+        cyclic_dataclass.child = cyclic_dataclass
+        with pytest.raises(RuntimeError, match="circular reference detected"):
+            await tools.execute("cyclic_dataclass", {}, lambda _args: cyclic_dataclass)
 
         result = await tools.execute(
             "post_cycle_result",

--- a/python/tests/test_tools.py
+++ b/python/tests/test_tools.py
@@ -91,6 +91,36 @@ class TestToolsAsync:
         result = await tools.execute("double", {"x": 5}, my_func)
         assert result == {"result": 10}
 
+    async def test_execute_rejects_cyclic_results_and_remains_usable(self):
+        def cyclic_result(_args):
+            result = {}
+            result["self"] = result
+            return result
+
+        with pytest.raises(RuntimeError, match="circular reference detected"):
+            await tools.execute("cyclic_result", {}, cyclic_result)
+
+        result = await tools.execute(
+            "post_cycle_result",
+            {},
+            lambda _args: {"status": "ok"},
+        )
+        assert result == {"status": "ok"}
+
+    async def test_execute_allows_shared_non_cyclic_results(self):
+        shared = {"value": True}
+
+        result = await tools.execute(
+            "shared_result",
+            {},
+            lambda _args: {"first": shared, "second": shared},
+        )
+
+        assert result == {
+            "first": {"value": True},
+            "second": {"value": True},
+        }
+
     async def test_execute_returns_string(self):
         def func(args):
             return "hello"


### PR DESCRIPTION
#### Overview

Prevent cyclic Python tool callback results from overflowing native JSON conversion and terminating the process. Cyclic results now produce a catchable exception while shared non-cyclic values remain supported.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Validate Python dictionaries, lists, and tuples for active-path cycles before converting callback results to JSON.
- Preserve ordinary shared references by removing container identities after each recursive branch completes.
- Add Python regressions for cycle rejection, process recovery, and shared non-cyclic values.
- Add Node regression coverage confirming synchronous and asynchronous circular results reject without terminating the process.
- Breaking changes: none.

Validation:

- Focused Python cyclic/shared-reference tests: 2 passed.
- Focused Node circular-result test: 1 passed.
- Python and Node native binding builds passed.
- Repository-wide pre-commit validation passed.

#### Where should the reviewer start?

Start with `validate_acyclic` in `crates/python/src/convert.rs`, then review the Python behavioral tests in `python/tests/test_tools.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-543


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tool executions now detect and reject circular result data with a clear “circular reference detected” error, instead of risking a process crash.
  - After a circular-result rejection, the tool system remains usable for subsequent executions.
  - Shared references in non-cyclic result graphs are preserved correctly.

- **Tests**
  - Added regression coverage for rejecting cyclic tool results across sync/async and multiple data shapes, plus verification of continued operation.
  - Updated several codec/sanitizer tests to use synchronous callbacks consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->