### PR TITLE
docs: describe trajectory-context trusted metadata

### DIFF
--- a/docs/about-nemo-relay/release-notes/known-issues.mdx
+++ b/docs/about-nemo-relay/release-notes/known-issues.mdx
@@ -56,6 +56,15 @@ The following limitations and migration steps apply to NVIDIA NeMo Relay 0.6.
   3.11 or newer and `nemoguardrails==0.22.0`.
 - The PII redaction plugin currently supports its deterministic local backend.
   Local-model backend configuration is reserved for future work.
+- The `trajectory_context` PII preset can replace string-valued classification
+  fields in generic scope metadata when those fields are not part of its
+  analytical allowlist. Affected fields include `nemo_relay_scope_role`,
+  `hook_event_name`, and harness-provided `agent_kind`. This can make explicit
+  agent-role or harness classification unavailable even though the event keys
+  and scope topology remain. `custom_mark_payload_policy` does not control
+  scope metadata, and profile-array mode cannot exclude generic scopes while
+  retaining both LLM and tool sanitization. Track the correction in
+  [GitHub issue #528](https://github.com/NVIDIA/NeMo-Relay/issues/528).
 - Pricing and optimization estimates are only as complete as the model name,
   token data, pricing source, and freshness evidence that Relay receives. When
   evidence is missing or inconsistent, cost fields remain partial or absent

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -173,6 +173,19 @@ surface flags. Profile-array configurations intentionally do not expose those
 flags: every enabled profile owns the complete pre-subscriber sanitization
 boundary.
 
+<Warning>
+The `trajectory_context` preset currently applies its analytical-field
+allowlist to generic scope metadata. String-valued classification fields that
+are not on that allowlist, including `nemo_relay_scope_role`,
+`hook_event_name`, and harness-provided `agent_kind`, can be replaced with the
+configured redaction token. `custom_mark_payload_policy` affects unknown
+custom Mark payloads, not Scope metadata.
+
+Profile-array mode does not currently provide a way to preserve generic scope
+metadata while retaining both LLM and tool sanitization. Track this limitation
+in [GitHub issue #528](https://github.com/NVIDIA/NeMo-Relay/issues/528).
+</Warning>
+
 ### CLI Editor Support
 
 The NeMo Relay CLI plugin editor now exposes `pii_redaction` directly through


### PR DESCRIPTION
#### Overview

Documents the `trajectory_context` trusted Scope-metadata contract implemented by #531 for NeMo Relay 0.6. Merge this documentation PR after #531 so the public guidance and release branch stay aligned.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Removes the obsolete known-issue claim that `trajectory_context` redacts Relay's structural classification metadata.
- Lists the direct string and boolean Scope metadata fields retained by the preset and explains that unexpected types, nested values, and unlisted fields remain subject to semantic redaction.
- Clarifies that `custom_mark_payload_policy` controls unknown custom Mark payloads, not Scope metadata.
- Documents `nemo_relay.agent.kind` as the canonical OpenTelemetry and OpenInference root-span attribute for harness classification.
- Adds matching release-migration guidance and warns against placing PII or conversational content in retained classification fields.
- Makes no runtime, configuration-schema, or breaking behavior changes.

Validation:

- Generated the Python, Node.js, and Rust API-reference pages used by the Fern checks.
- Fern configuration validation passed with zero errors and one expected unauthenticated-redirect warning.
- Fern strict broken-link validation passed.
- Focused pre-commit checks passed for both changed files.
- `just docs` could not run because `just` is not installed in the environment; the equivalent generators and Fern validation commands completed successfully.

#### Where should the reviewer start?

Start with the new trusted-metadata contract in `docs/configure-plugins/pii-redaction/configuration.mdx`, then confirm the matching release-migration note in `docs/about-nemo-relay/release-notes/known-issues.mdx`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #528
- Relates to #531 (merge after #531)
