### PR TITLE
fix: honor top-level built-in plugin policy

### DIFF
--- a/crates/adaptive/src/plugin_component.rs
+++ b/crates/adaptive/src/plugin_component.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 
 use nemo_relay::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
-    PluginRegistration, PluginRegistrationContext, Result, UnsupportedBehavior, deregister_plugin,
-    lookup_plugin, register_plugin,
+    PluginRegistration, PluginRegistrationContext, Result, UnsupportedBehavior,
+    apply_global_config_policy, deregister_plugin, lookup_plugin, register_plugin,
 };
 use serde_json::{Map, Value as Json};
 
@@ -69,6 +69,14 @@ impl Plugin for AdaptivePlugin {
 
     fn validate(&self, plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
         validate_adaptive_plugin_config(plugin_config)
+    }
+
+    fn validate_with_policy(
+        &self,
+        plugin_config: &Map<String, Json>,
+        policy: &ConfigPolicy,
+    ) -> Vec<ConfigDiagnostic> {
+        validate_adaptive_plugin_config_with_policy(plugin_config, Some(policy))
     }
 
     fn register<'a>(
@@ -155,7 +163,14 @@ fn parse_adaptive_config(plugin_config: &Map<String, Json>) -> Result<AdaptiveCo
 }
 
 fn validate_adaptive_plugin_config(plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
-    let config = match parse_adaptive_config(plugin_config) {
+    validate_adaptive_plugin_config_with_policy(plugin_config, None)
+}
+
+fn validate_adaptive_plugin_config_with_policy(
+    plugin_config: &Map<String, Json>,
+    policy: Option<&ConfigPolicy>,
+) -> Vec<ConfigDiagnostic> {
+    let mut config = match parse_adaptive_config(plugin_config) {
         Ok(config) => config,
         Err(err) => {
             return vec![ConfigDiagnostic {
@@ -167,6 +182,9 @@ fn validate_adaptive_plugin_config(plugin_config: &Map<String, Json>) -> Vec<Con
             }];
         }
     };
+    if let Some(policy) = policy {
+        config.policy = apply_global_config_policy(config.policy, policy);
+    }
 
     let mut diagnostics = vec![];
     validate_unknown_fields(

--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -62,7 +62,7 @@ use crate::observability::{
 use crate::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
     PluginRegistration, PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior,
-    deregister_plugin, register_builtin_plugin,
+    apply_global_config_policy, deregister_plugin, register_builtin_plugin,
 };
 
 /// The plugin kind registered by the core crate.
@@ -632,6 +632,14 @@ impl Plugin for ObservabilityPlugin {
 
     fn validate(&self, plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
         validate_observability_plugin_config(plugin_config)
+    }
+
+    fn validate_with_policy(
+        &self,
+        plugin_config: &Map<String, Json>,
+        policy: &ConfigPolicy,
+    ) -> Vec<ConfigDiagnostic> {
+        validate_observability_plugin_config_with_policy(plugin_config, Some(policy))
     }
 
     fn register<'a>(
@@ -1704,7 +1712,14 @@ fn parse_observability_config(
 fn validate_observability_plugin_config(
     plugin_config: &Map<String, Json>,
 ) -> Vec<ConfigDiagnostic> {
-    let config = match parse_observability_config(plugin_config) {
+    validate_observability_plugin_config_with_policy(plugin_config, None)
+}
+
+fn validate_observability_plugin_config_with_policy(
+    plugin_config: &Map<String, Json>,
+    policy: Option<&ConfigPolicy>,
+) -> Vec<ConfigDiagnostic> {
+    let mut config = match parse_observability_config(plugin_config) {
         Ok(config) => config,
         Err(err) => {
             return vec![ConfigDiagnostic {
@@ -1716,6 +1731,9 @@ fn validate_observability_plugin_config(
             }];
         }
     };
+    if let Some(policy) = policy {
+        config.policy = apply_global_config_policy(config.policy, policy);
+    }
 
     let mut diagnostics = vec![];
     validate_top_level_observability_fields(&mut diagnostics, &config.policy, plugin_config);

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -135,6 +135,8 @@ pub struct PluginConfig {
     #[serde(default)]
     pub components: Vec<PluginComponentSpec>,
     /// Plugin-level policy for unsupported plugin kinds, fields, and values.
+    ///
+    /// Non-default field values override the corresponding component policy.
     #[serde(default)]
     pub policy: ConfigPolicy,
 }
@@ -196,7 +198,7 @@ impl ConfigReport {
 }
 
 /// Policy for how unsupported plugin/runtime config is handled.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ConfigPolicy {
     /// Policy applied when a component kind is unknown to the plugin registry.
@@ -217,6 +219,34 @@ impl Default for ConfigPolicy {
             unknown_field: default_warn(),
             unsupported_value: default_error(),
         }
+    }
+}
+
+/// Applies non-default global policy fields to a component policy.
+///
+/// Component-specific policy remains in effect when the corresponding global
+/// setting is left at its default value.
+pub fn apply_global_config_policy(
+    component_policy: ConfigPolicy,
+    global_policy: &ConfigPolicy,
+) -> ConfigPolicy {
+    let default_policy = ConfigPolicy::default();
+    ConfigPolicy {
+        unknown_component: if global_policy.unknown_component != default_policy.unknown_component {
+            global_policy.unknown_component
+        } else {
+            component_policy.unknown_component
+        },
+        unknown_field: if global_policy.unknown_field != default_policy.unknown_field {
+            global_policy.unknown_field
+        } else {
+            component_policy.unknown_field
+        },
+        unsupported_value: if global_policy.unsupported_value != default_policy.unsupported_value {
+            global_policy.unsupported_value
+        } else {
+            component_policy.unsupported_value
+        },
     }
 }
 
@@ -815,6 +845,20 @@ pub trait Plugin: Send + Sync + 'static {
     /// from activating the configuration.
     fn validate(&self, plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic>;
 
+    /// Validates one plugin component config using the host's global policy.
+    ///
+    /// The default preserves the validation behavior of existing custom
+    /// plugins. Plugins that emit policy-controlled diagnostics should
+    /// override this method so host validation honors non-default fields in
+    /// [`PluginConfig::policy`].
+    fn validate_with_policy(
+        &self,
+        plugin_config: &Map<String, Json>,
+        _policy: &ConfigPolicy,
+    ) -> Vec<ConfigDiagnostic> {
+        self.validate(plugin_config)
+    }
+
     /// Registers runtime middleware/subscribers for one plugin component.
     ///
     /// The provided [`PluginRegistrationContext`] is component-scoped. Any
@@ -1119,7 +1163,7 @@ pub fn validate_plugin_config(config: &PluginConfig) -> ConfigReport {
         };
         report
             .diagnostics
-            .extend(plugin.validate(&component.config));
+            .extend(plugin.validate_with_policy(&component.config, &config.policy));
     }
 
     report

--- a/crates/core/src/plugins/nemo_guardrails/component.rs
+++ b/crates/core/src/plugins/nemo_guardrails/component.rs
@@ -14,8 +14,8 @@ use serde_json::{Map, Value as Json};
 use crate::codec::resolve::supported_codec_names;
 use crate::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
-    PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior, deregister_plugin,
-    register_builtin_plugin,
+    PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior,
+    apply_global_config_policy, deregister_plugin, register_builtin_plugin,
 };
 
 #[path = "local.rs"]
@@ -383,6 +383,14 @@ impl Plugin for NeMoGuardrailsPlugin {
         validate_nemo_guardrails_plugin_config(plugin_config)
     }
 
+    fn validate_with_policy(
+        &self,
+        plugin_config: &Map<String, Json>,
+        policy: &ConfigPolicy,
+    ) -> Vec<ConfigDiagnostic> {
+        validate_nemo_guardrails_plugin_config_with_policy(plugin_config, Some(policy))
+    }
+
     fn register<'a>(
         &'a self,
         plugin_config: &Map<String, Json>,
@@ -471,7 +479,14 @@ fn parse_nemo_guardrails_config(
 fn validate_nemo_guardrails_plugin_config(
     plugin_config: &Map<String, Json>,
 ) -> Vec<ConfigDiagnostic> {
-    let config = match parse_nemo_guardrails_config(plugin_config) {
+    validate_nemo_guardrails_plugin_config_with_policy(plugin_config, None)
+}
+
+fn validate_nemo_guardrails_plugin_config_with_policy(
+    plugin_config: &Map<String, Json>,
+    policy: Option<&ConfigPolicy>,
+) -> Vec<ConfigDiagnostic> {
+    let mut config = match parse_nemo_guardrails_config(plugin_config) {
         Ok(config) => config,
         Err(err) => {
             return vec![ConfigDiagnostic {
@@ -483,6 +498,9 @@ fn validate_nemo_guardrails_plugin_config(
             }];
         }
     };
+    if let Some(policy) = policy {
+        config.policy = apply_global_config_policy(config.policy, policy);
+    }
 
     let mut diagnostics = vec![];
 

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -19,6 +19,7 @@ use crate::api::tool::tool_conditional_execution;
 use crate::error::FlowError;
 
 struct TestPlugin;
+struct PolicyAwarePlugin;
 
 struct SingletonPlugin;
 struct RecordingPlugin;
@@ -119,6 +120,48 @@ impl Plugin for TestPlugin {
                 }),
             )
         })
+    }
+}
+
+impl Plugin for PolicyAwarePlugin {
+    fn plugin_kind(&self) -> &str {
+        "policy-aware.plugin"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        vec![]
+    }
+
+    fn validate_with_policy(
+        &self,
+        _plugin_config: &Map<String, Json>,
+        policy: &ConfigPolicy,
+    ) -> Vec<ConfigDiagnostic> {
+        match policy.unsupported_value {
+            UnsupportedBehavior::Ignore => vec![],
+            UnsupportedBehavior::Warn => vec![ConfigDiagnostic {
+                level: DiagnosticLevel::Warning,
+                code: "policy-aware.unsupported_value".into(),
+                component: Some(self.plugin_kind().into()),
+                field: None,
+                message: "unsupported value".into(),
+            }],
+            UnsupportedBehavior::Error => vec![ConfigDiagnostic {
+                level: DiagnosticLevel::Error,
+                code: "policy-aware.unsupported_value".into(),
+                component: Some(self.plugin_kind().into()),
+                field: None,
+                message: "unsupported value".into(),
+            }],
+        }
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        _ctx: &'a mut PluginRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
     }
 }
 
@@ -707,6 +750,38 @@ fn test_validate_plugin_config_honors_policy_and_duplicate_singletons() {
         policy: ConfigPolicy {
             unknown_component: UnsupportedBehavior::Ignore,
             ..PluginConfig::default().policy
+        },
+        ..PluginConfig::default()
+    });
+    assert!(ignored.diagnostics.is_empty());
+
+    reset_global();
+}
+
+#[test]
+fn test_validate_plugin_config_passes_top_level_policy_to_plugins() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    register_plugin(Arc::new(PolicyAwarePlugin)).unwrap();
+
+    let warning = validate_plugin_config(&PluginConfig {
+        components: vec![PluginComponentSpec::new("policy-aware.plugin")],
+        policy: ConfigPolicy {
+            unsupported_value: UnsupportedBehavior::Warn,
+            ..ConfigPolicy::default()
+        },
+        ..PluginConfig::default()
+    });
+    assert!(warning.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "policy-aware.unsupported_value"
+            && diagnostic.level == DiagnosticLevel::Warning
+    }));
+
+    let ignored = validate_plugin_config(&PluginConfig {
+        components: vec![PluginComponentSpec::new("policy-aware.plugin")],
+        policy: ConfigPolicy {
+            unsupported_value: UnsupportedBehavior::Ignore,
+            ..ConfigPolicy::default()
         },
         ..PluginConfig::default()
     });

--- a/crates/pii-redaction/src/component.rs
+++ b/crates/pii-redaction/src/component.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use nemo_relay::codec::resolve::supported_codec_names;
 use nemo_relay::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
-    PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior, deregister_plugin,
-    register_plugin,
+    PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior,
+    apply_global_config_policy, deregister_plugin, register_plugin,
 };
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -417,6 +417,14 @@ impl Plugin for PiiRedactionPlugin {
         validate_pii_redaction_plugin_config(plugin_config)
     }
 
+    fn validate_with_policy(
+        &self,
+        plugin_config: &Map<String, Json>,
+        policy: &ConfigPolicy,
+    ) -> Vec<ConfigDiagnostic> {
+        validate_pii_redaction_plugin_config_with_policy(plugin_config, Some(policy))
+    }
+
     fn register<'a>(
         &'a self,
         plugin_config: &Map<String, Json>,
@@ -582,7 +590,14 @@ fn parse_pii_redaction_config(
 fn validate_pii_redaction_plugin_config(
     plugin_config: &Map<String, Json>,
 ) -> Vec<ConfigDiagnostic> {
-    let config = match parse_pii_redaction_config(plugin_config) {
+    validate_pii_redaction_plugin_config_with_policy(plugin_config, None)
+}
+
+fn validate_pii_redaction_plugin_config_with_policy(
+    plugin_config: &Map<String, Json>,
+    policy: Option<&ConfigPolicy>,
+) -> Vec<ConfigDiagnostic> {
+    let mut config = match parse_pii_redaction_config(plugin_config) {
         Ok(config) => config,
         Err(err) => {
             return vec![ConfigDiagnostic {
@@ -594,6 +609,9 @@ fn validate_pii_redaction_plugin_config(
             }];
         }
     };
+    if let Some(policy) = policy {
+        config.policy = apply_global_config_policy(config.policy, policy);
+    }
 
     let mut diagnostics = vec![];
 

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -26,9 +26,10 @@ use crate::codec::openai_chat::OpenAIChatCodec;
 use crate::codec::openai_responses::OpenAIResponsesCodec;
 use crate::codec::traits::{LlmCodec, LlmResponseCodec};
 use crate::plugin::{
-    PluginComponentSpec, PluginConfig, PluginError, PluginRegistrationContext,
-    clear_plugin_configuration, ensure_builtin_plugins_registered, initialize_plugins,
-    list_plugin_kinds, rollback_registrations, validate_plugin_config,
+    ConfigPolicy, DiagnosticLevel, PluginComponentSpec, PluginConfig, PluginError,
+    PluginRegistrationContext, UnsupportedBehavior, clear_plugin_configuration,
+    ensure_builtin_plugins_registered, initialize_plugins, list_plugin_kinds,
+    rollback_registrations, validate_plugin_config,
 };
 use futures::StreamExt;
 use nemo_relay::observability::atif::{AtifAgentInfo, AtifExporter};
@@ -71,6 +72,67 @@ fn plugin_config(config: Json) -> PluginConfig {
         components: vec![component(config)],
         policy: Default::default(),
     }
+}
+
+#[test]
+fn top_level_policy_controls_component_diagnostics() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+
+    let component_config = json!({
+        "mode": "builtin",
+        "input": false,
+        "output": false,
+        "tool_output": true,
+        "builtin": {
+            "action": "INVALID_ACTION",
+            "target_paths": ["/secret"]
+        }
+    });
+
+    let mut warn_config = plugin_config(component_config.clone());
+    warn_config.policy = ConfigPolicy {
+        unsupported_value: UnsupportedBehavior::Warn,
+        ..ConfigPolicy::default()
+    };
+    let warn_report = validate_plugin_config(&warn_config);
+    assert!(warn_report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "pii_redaction.unsupported_value"
+            && diagnostic.field.as_deref() == Some("builtin.action")
+            && diagnostic.level == DiagnosticLevel::Warning
+    }));
+
+    let mut ignored_config = plugin_config(component_config);
+    ignored_config.policy = ConfigPolicy {
+        unsupported_value: UnsupportedBehavior::Ignore,
+        ..ConfigPolicy::default()
+    };
+    let ignored_report = validate_plugin_config(&ignored_config);
+    assert!(
+        !ignored_report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "pii_redaction.unsupported_value")
+    );
+
+    let mut unknown_field_config = plugin_config(json!({
+        "mode": "builtin",
+        "input": false,
+        "output": false,
+        "tool_output": true,
+        "builtin": {"action": "remove"},
+        "unexpected": true
+    }));
+    unknown_field_config.policy = ConfigPolicy {
+        unknown_field: UnsupportedBehavior::Error,
+        ..ConfigPolicy::default()
+    };
+    let unknown_field_report = validate_plugin_config(&unknown_field_config);
+    assert!(unknown_field_report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "pii_redaction.unknown_field"
+            && diagnostic.field.as_deref() == Some("unexpected")
+            && diagnostic.level == DiagnosticLevel::Error
+    }));
 }
 
 fn reset_runtime() {

--- a/docs/build-plugins/language-binding/validate-configuration.mdx
+++ b/docs/build-plugins/language-binding/validate-configuration.mdx
@@ -29,9 +29,15 @@ Relay validates disabled components. This lets operators detect configuration
 problems before enabling a component in a later rollout.
 
 The top-level `policy` controls validation that Relay handles, including unknown
-plugin kinds and unsupported document versions. A custom plugin's `validate()`
-method controls how its own `config` fields handle unknown fields and
-unsupported values.
+plugin kinds and unsupported document versions. For built-in components,
+non-default `unknown_field` and `unsupported_value` settings also override the
+matching component policy during host validation. When a top-level setting uses
+its default value, an explicitly configured component policy remains in effect.
+
+A custom plugin's `validate()` method controls how its own `config` fields
+handle unknown fields and unsupported values. This includes in-process Python
+and Node.js plugins, native plugins, and gRPC worker plugins; their validation
+callbacks receive only component configuration.
 
 The following examples create the same configuration in each supported binding:
 

--- a/docs/configure-plugins/plugin-configuration-files.mdx
+++ b/docs/configure-plugins/plugin-configuration-files.mdx
@@ -123,7 +123,7 @@ The top-level fields are:
 |---|---|---|
 | `version` | `1` | Plugin configuration format version. Non-`1` versions fail validation by default. |
 | `components` | `[]` | Ordered plugin components to validate and activate. |
-| `policy` | warn unknown components and fields, error on unsupported values | Global validation policy. |
+| `policy` | warn unknown components and fields, error on unsupported values | Global host validation policy. Non-default field/value settings override the matching policy for built-in components. |
 
 Each built-in component has:
 


### PR DESCRIPTION
#### Overview

Fix RELAY-557 so top-level plugin policy settings control validation diagnostics for built-in components.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Forward the host policy through an opt-in validation hook.
- Apply non-default top-level field/value policy settings to PII Redaction, Adaptive, Observability, and NeMo Guardrails, while preserving explicit component policy when the top-level setting remains at its default.
- Add focused host-level and PII regression tests, and document the built-in versus custom/dynamic plugin boundary.

#### Where should the reviewer start?

Start with `crates/core/src/plugin.rs`, which defines the policy merge and host validation dispatch. The PII regression in `crates/pii-redaction/tests/unit/component_tests.rs` reproduces the reported behavior.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [RELAY-557](https://linear.app/nvidia/issue/RELAY-557/nemo-relay060-rc4-pluginconfigpolicyunsupported-valueunknown-field)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Global configuration policies now consistently influence plugin validation, including adaptive, observability, guardrails, and PII redaction components.
  - Custom plugins can receive the active global policy during configuration validation.
  - Policy settings can control warnings and errors for unsupported values and unknown fields.

- **Documentation**
  - Clarified how global and component-level policies interact during validation.
  - Expanded guidance for built-in and custom plugin validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->