### PR TITLE
refactor: address Sonar findings

### DIFF
--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -832,57 +832,13 @@ fn effective_dispatch_request(
     let mut headers = headers.clone();
     strip_internal_dispatch_headers(&mut headers);
     let Some(request) = effective_request else {
-        return EffectiveUpstreamRequest {
-            body_bytes: body_bytes.clone(),
-            headers,
-            url: url.to_string(),
-            target_route: route,
-            credential_policy: TargetCredentialPolicy::SourceOrEnvironment,
-        };
+        return source_request(body_bytes, headers, url, route);
     };
-
-    let mut body_reencoded = false;
-    let body_bytes = if request.content.is_null() {
-        body_bytes.clone()
-    } else {
-        match serde_json::to_vec(&request.content) {
-            Ok(serialized) => {
-                body_reencoded = true;
-                Bytes::from(serialized)
-            }
-            Err(_) => {
-                log::warn!(
-                    target: "nemo_relay.gateway",
-                    event = "request_rewrite_fallback",
-                    reason = "serialization_failed";
-                    "The original upstream request was retained after rewrite serialization failed"
-                );
-                return EffectiveUpstreamRequest {
-                    body_bytes: body_bytes.clone(),
-                    headers,
-                    url: url.to_string(),
-                    target_route: route,
-                    credential_policy: TargetCredentialPolicy::SourceOrEnvironment,
-                };
-            }
-        }
+    let Some((body_bytes, body_reencoded)) = reencode_request_body(request, body_bytes) else {
+        return source_request(body_bytes, headers, url, route);
     };
-    let mut override_url = None;
-    let mut override_route = None;
-    let mut dispatch_route_header_seen = false;
-    for (name, value) in &request.headers {
-        if name.eq_ignore_ascii_case(INTERNAL_DISPATCH_URL_HEADER) {
-            override_url = json_header_string(value);
-            continue;
-        }
-        if name.eq_ignore_ascii_case(INTERNAL_DISPATCH_ROUTE_HEADER) {
-            dispatch_route_header_seen = true;
-            override_route = json_header_string(value)
-                .and_then(|value| ProviderRoute::from_dispatch_override(&value));
-            continue;
-        }
-    }
-    let credential_policy = if override_url.is_some() || dispatch_route_header_seen {
+    let overrides = dispatch_overrides(&request.headers);
+    let credential_policy = if overrides.is_explicit_target() {
         crate::provider_auth::remove_provider_credentials(&mut headers);
         TargetCredentialPolicy::ExplicitTarget
     } else {
@@ -891,7 +847,97 @@ fn effective_dispatch_request(
     // Observable source headers exclude credentials. Applying the rewritten map only after source
     // credentials are removed lets an explicit target binding add its own authorization without
     // inheriting credentials intended for the original provider.
-    for (name, value) in &request.headers {
+    apply_rewritten_headers(&mut headers, &request.headers);
+    if body_reencoded {
+        headers.remove(header::CONTENT_ENCODING);
+    }
+    EffectiveUpstreamRequest {
+        body_bytes,
+        headers,
+        url: overrides.resolve_url(url),
+        target_route: overrides.route.unwrap_or(route),
+        credential_policy,
+    }
+}
+
+fn source_request(
+    body_bytes: &Bytes,
+    headers: HeaderMap,
+    url: &str,
+    route: ProviderRoute,
+) -> EffectiveUpstreamRequest {
+    EffectiveUpstreamRequest {
+        body_bytes: body_bytes.clone(),
+        headers,
+        url: url.to_string(),
+        target_route: route,
+        credential_policy: TargetCredentialPolicy::SourceOrEnvironment,
+    }
+}
+
+fn reencode_request_body(request: &LlmRequest, body_bytes: &Bytes) -> Option<(Bytes, bool)> {
+    if request.content.is_null() {
+        return Some((body_bytes.clone(), false));
+    }
+    match serde_json::to_vec(&request.content) {
+        Ok(serialized) => Some((Bytes::from(serialized), true)),
+        Err(_) => {
+            log::warn!(
+                target: "nemo_relay.gateway",
+                event = "request_rewrite_fallback",
+                reason = "serialization_failed";
+                "The original upstream request was retained after rewrite serialization failed"
+            );
+            None
+        }
+    }
+}
+
+struct DispatchOverrides {
+    url: Option<String>,
+    route: Option<ProviderRoute>,
+    route_header_seen: bool,
+}
+
+impl DispatchOverrides {
+    fn is_explicit_target(&self) -> bool {
+        self.url.is_some() || self.route_header_seen
+    }
+
+    fn resolve_url(&self, fallback: &str) -> String {
+        if self.route_header_seen && self.route.is_none() {
+            fallback.to_string()
+        } else {
+            self.url.clone().unwrap_or_else(|| fallback.to_string())
+        }
+    }
+}
+
+fn dispatch_overrides(headers: &serde_json::Map<String, Value>) -> DispatchOverrides {
+    let mut url = None;
+    let mut route = None;
+    let mut route_header_seen = false;
+    for (name, value) in headers {
+        if name.eq_ignore_ascii_case(INTERNAL_DISPATCH_URL_HEADER) {
+            url = json_header_string(value);
+        } else if name.eq_ignore_ascii_case(INTERNAL_DISPATCH_ROUTE_HEADER) {
+            route_header_seen = true;
+            route = json_header_string(value)
+                .and_then(|value| ProviderRoute::from_dispatch_override(&value));
+        }
+    }
+    DispatchOverrides {
+        url,
+        route,
+        route_header_seen,
+    }
+}
+
+fn apply_rewritten_headers(
+    headers: &mut HeaderMap,
+    request_headers: &serde_json::Map<String, Value>,
+) {
+    for (name, value) in request_headers {
         let Ok(name) = HeaderName::from_bytes(name.as_bytes()) else {
             continue;
         };
@@ -902,20 +948,6 @@ fn effective_dispatch_request(
             continue;
         };
         headers.insert(name, value);
-    }
-    if body_reencoded {
-        headers.remove(header::CONTENT_ENCODING);
-    }
-    EffectiveUpstreamRequest {
-        body_bytes,
-        headers,
-        url: if dispatch_route_header_seen && override_route.is_none() {
-            url.to_string()
-        } else {
-            override_url.unwrap_or_else(|| url.to_string())
-        },
-        target_route: override_route.unwrap_or(route),
-        credential_policy,
     }
 }
 

--- a/crates/core/src/codec/anthropic.rs
+++ b/crates/core/src/codec/anthropic.rs
@@ -584,6 +584,270 @@ fn set_or_remove_json(obj: &mut serde_json::Map<String, Json>, key: &str, value:
     }
 }
 
+fn patch_anthropic_messages_and_model(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    if annotated.messages != baseline.messages {
+        let original_messages = obj.get("messages").and_then(Json::as_array);
+        let messages = super::encode_changed_items(
+            &annotated.messages,
+            &baseline.messages,
+            original_messages.map(Vec::as_slice),
+            encode_anthropic_message,
+        )?;
+        obj.insert("messages".into(), Json::Array(messages));
+    }
+    if annotated.instructions != baseline.instructions {
+        set_or_remove_json(
+            obj,
+            "system",
+            annotated
+                .instructions
+                .as_ref()
+                .map(encode_anthropic_content)
+                .transpose()?,
+        );
+    }
+    if annotated.model != baseline.model {
+        set_or_remove_json(obj, "model", annotated.model.clone().map(Json::String));
+    }
+    Ok(())
+}
+
+fn patch_anthropic_params(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) {
+    if annotated.params == baseline.params {
+        return;
+    }
+    let edited = annotated.params.as_ref();
+    let before = baseline.params.as_ref();
+    for (key, value, old_value) in [
+        (
+            "temperature",
+            edited.and_then(|params| params.temperature),
+            before.and_then(|params| params.temperature),
+        ),
+        (
+            "top_p",
+            edited.and_then(|params| params.top_p),
+            before.and_then(|params| params.top_p),
+        ),
+    ] {
+        if value != old_value {
+            set_or_remove_json(obj, key, value.map(json_f64));
+        }
+    }
+    let max_tokens = edited.and_then(|params| params.max_tokens);
+    if max_tokens != before.and_then(|params| params.max_tokens) {
+        set_or_remove_json(obj, "max_tokens", max_tokens.map(Json::from));
+    }
+    let stop = edited.and_then(|params| params.stop.as_ref());
+    if stop != before.and_then(|params| params.stop.as_ref()) {
+        set_or_remove_json(
+            obj,
+            "stop_sequences",
+            stop.map(|values| serde_json::json!(values)),
+        );
+    }
+}
+
+fn patch_anthropic_tools(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    if annotated.tools != baseline.tools {
+        let tools = annotated
+            .tools
+            .as_deref()
+            .map(|tools| {
+                super::encode_changed_items(
+                    tools,
+                    baseline.tools.as_deref().unwrap_or(&[]),
+                    obj.get("tools").and_then(Json::as_array).map(Vec::as_slice),
+                    encode_anthropic_tool,
+                )
+            })
+            .transpose()?
+            .map(Json::Array);
+        set_or_remove_json(obj, "tools", tools);
+    }
+    if annotated.tool_choice != baseline.tool_choice
+        || annotated.parallel_tool_calls != baseline.parallel_tool_calls
+    {
+        let tool_choice = match (&annotated.tool_choice, &baseline.tool_choice) {
+            (Some(edited), Some(before)) => {
+                let edited =
+                    encode_tool_choice_with_parallel_hint(edited, annotated.parallel_tool_calls)?;
+                let before =
+                    encode_tool_choice_with_parallel_hint(before, baseline.parallel_tool_calls)?;
+                Some(match obj.get("tool_choice") {
+                    Some(original) => super::patch_changed_json(original, &before, &edited)?,
+                    None => edited,
+                })
+            }
+            (Some(edited), None) => Some(encode_tool_choice_with_parallel_hint(
+                edited,
+                annotated.parallel_tool_calls,
+            )?),
+            (None, _) => annotated
+                .parallel_tool_calls
+                .map(|parallel| {
+                    encode_tool_choice_with_parallel_hint(&ToolChoice::Auto, Some(parallel))
+                })
+                .transpose()?,
+        };
+        set_or_remove_json(obj, "tool_choice", tool_choice);
+    }
+    Ok(())
+}
+
+fn patch_anthropic_common_fields(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) {
+    if annotated.metadata != baseline.metadata {
+        set_or_remove_json(obj, "metadata", annotated.metadata.clone());
+    }
+    if annotated.service_tier != baseline.service_tier {
+        set_or_remove_json(
+            obj,
+            "service_tier",
+            annotated.service_tier.clone().map(Json::String),
+        );
+    }
+    if annotated.stream != baseline.stream {
+        set_or_remove_json(obj, "stream", annotated.stream.map(Json::Bool));
+    }
+}
+
+fn validate_anthropic_supported_fields(
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    let unsupported = [
+        annotated.store != baseline.store,
+        annotated.previous_response_id != baseline.previous_response_id,
+        annotated.truncation != baseline.truncation,
+        annotated.reasoning != baseline.reasoning,
+        annotated.include != baseline.include,
+        annotated.user != baseline.user,
+        annotated.max_output_tokens != baseline.max_output_tokens,
+        annotated.max_tool_calls != baseline.max_tool_calls,
+        annotated.top_logprobs != baseline.top_logprobs,
+    ]
+    .into_iter()
+    .any(|changed| changed);
+    if unsupported {
+        return Err(FlowError::InvalidArgument(
+            "request contains fields that cannot be encoded for Anthropic Messages".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn patch_anthropic_api_specific(
+    obj: &mut serde_json::Map<String, Json>,
+    edited: &Option<ApiSpecificRequest>,
+    baseline: &Option<ApiSpecificRequest>,
+) -> Result<()> {
+    match (edited, baseline) {
+        (
+            Some(ApiSpecificRequest::AnthropicMessages {
+                cache_control,
+                container,
+                inference_geo,
+                output_config,
+                thinking,
+                top_k,
+                user_profile_id,
+            }),
+            Some(ApiSpecificRequest::AnthropicMessages {
+                cache_control: old_cache_control,
+                container: old_container,
+                inference_geo: old_inference_geo,
+                output_config: old_output_config,
+                thinking: old_thinking,
+                top_k: old_top_k,
+                user_profile_id: old_user_profile_id,
+            }),
+        ) => {
+            if cache_control != old_cache_control {
+                set_or_remove_json(obj, "cache_control", cache_control.clone());
+            }
+            patch_anthropic_api_strings(
+                obj,
+                &[
+                    ("container", container, old_container),
+                    ("inference_geo", inference_geo, old_inference_geo),
+                    (
+                        "anthropic-user-profile-id",
+                        user_profile_id,
+                        old_user_profile_id,
+                    ),
+                ],
+            );
+            patch_anthropic_api_json(
+                obj,
+                &[
+                    ("output_config", output_config, old_output_config),
+                    ("thinking", thinking, old_thinking),
+                ],
+            );
+            if top_k != old_top_k {
+                set_or_remove_json(obj, "top_k", top_k.map(Json::from));
+            }
+            Ok(())
+        }
+        (None, Some(ApiSpecificRequest::AnthropicMessages { .. })) => {
+            for key in [
+                "cache_control",
+                "container",
+                "inference_geo",
+                "output_config",
+                "thinking",
+                "top_k",
+                "anthropic-user-profile-id",
+            ] {
+                obj.remove(key);
+            }
+            Ok(())
+        }
+        (Some(_), _) | (None, Some(_)) => Err(FlowError::InvalidArgument(
+            "api_specific provider does not match Anthropic Messages".into(),
+        )),
+        (None, None) => Ok(()),
+    }
+}
+
+fn patch_anthropic_api_strings(
+    obj: &mut serde_json::Map<String, Json>,
+    fields: &[(&str, &Option<String>, &Option<String>)],
+) {
+    for (key, edited, before) in fields {
+        if edited != before {
+            set_or_remove_json(obj, key, (*edited).clone().map(Json::String));
+        }
+    }
+}
+
+fn patch_anthropic_api_json(
+    obj: &mut serde_json::Map<String, Json>,
+    fields: &[(&str, &Option<Json>, &Option<Json>)],
+) {
+    for (key, edited, before) in fields {
+        if edited != before {
+            set_or_remove_json(obj, key, (*edited).clone());
+        }
+    }
+}
+
 fn anthropic_text_message(content_blocks: Option<&[Json]>) -> Option<MessageContent> {
     let text_parts: Vec<&str> = content_blocks
         .map(|blocks| blocks.iter().filter_map(anthropic_text_block).collect())
@@ -830,212 +1094,12 @@ impl LlmCodec for AnthropicMessagesCodec {
         let obj = content
             .as_object_mut()
             .ok_or_else(|| FlowError::Internal("original content is not an object".into()))?;
-        if annotated.messages != baseline.messages {
-            let original_messages = obj.get("messages").and_then(Json::as_array);
-            let messages = super::encode_changed_items(
-                &annotated.messages,
-                &baseline.messages,
-                original_messages.map(Vec::as_slice),
-                encode_anthropic_message,
-            )?;
-            obj.insert("messages".into(), Json::Array(messages));
-        }
-        if annotated.instructions != baseline.instructions {
-            set_or_remove_json(
-                obj,
-                "system",
-                annotated
-                    .instructions
-                    .as_ref()
-                    .map(encode_anthropic_content)
-                    .transpose()?,
-            );
-        }
-        if annotated.model != baseline.model {
-            set_or_remove_json(obj, "model", annotated.model.clone().map(Json::String));
-        }
-        if annotated.params != baseline.params {
-            let edited = annotated.params.as_ref();
-            let before = baseline.params.as_ref();
-            if edited.and_then(|p| p.temperature) != before.and_then(|p| p.temperature) {
-                set_or_remove_json(
-                    obj,
-                    "temperature",
-                    edited.and_then(|p| p.temperature).map(json_f64),
-                );
-            }
-            if edited.and_then(|p| p.top_p) != before.and_then(|p| p.top_p) {
-                set_or_remove_json(obj, "top_p", edited.and_then(|p| p.top_p).map(json_f64));
-            }
-            if edited.and_then(|p| p.max_tokens) != before.and_then(|p| p.max_tokens) {
-                set_or_remove_json(
-                    obj,
-                    "max_tokens",
-                    edited.and_then(|p| p.max_tokens).map(Json::from),
-                );
-            }
-            if edited.and_then(|p| p.stop.as_ref()) != before.and_then(|p| p.stop.as_ref()) {
-                set_or_remove_json(
-                    obj,
-                    "stop_sequences",
-                    edited
-                        .and_then(|p| p.stop.as_ref())
-                        .map(|stop| serde_json::json!(stop)),
-                );
-            }
-        }
-        if annotated.tools != baseline.tools {
-            let tools = annotated
-                .tools
-                .as_deref()
-                .map(|tools| {
-                    super::encode_changed_items(
-                        tools,
-                        baseline.tools.as_deref().unwrap_or(&[]),
-                        obj.get("tools").and_then(Json::as_array).map(Vec::as_slice),
-                        encode_anthropic_tool,
-                    )
-                })
-                .transpose()?
-                .map(Json::Array);
-            set_or_remove_json(obj, "tools", tools);
-        }
-        if annotated.tool_choice != baseline.tool_choice
-            || annotated.parallel_tool_calls != baseline.parallel_tool_calls
-        {
-            let tool_choice = match (&annotated.tool_choice, &baseline.tool_choice) {
-                (Some(edited), Some(before)) => {
-                    let edited = encode_tool_choice_with_parallel_hint(
-                        edited,
-                        annotated.parallel_tool_calls,
-                    )?;
-                    let before = encode_tool_choice_with_parallel_hint(
-                        before,
-                        baseline.parallel_tool_calls,
-                    )?;
-                    Some(match obj.get("tool_choice") {
-                        Some(original) => super::patch_changed_json(original, &before, &edited)?,
-                        None => edited,
-                    })
-                }
-                (Some(edited), None) => Some(encode_tool_choice_with_parallel_hint(
-                    edited,
-                    annotated.parallel_tool_calls,
-                )?),
-                (None, _) => annotated
-                    .parallel_tool_calls
-                    .map(|parallel| {
-                        encode_tool_choice_with_parallel_hint(&ToolChoice::Auto, Some(parallel))
-                    })
-                    .transpose()?,
-            };
-            set_or_remove_json(obj, "tool_choice", tool_choice);
-        }
-        for (key, edited, before) in [("metadata", &annotated.metadata, &baseline.metadata)] {
-            if edited != before {
-                set_or_remove_json(obj, key, edited.clone());
-            }
-        }
-        if annotated.service_tier != baseline.service_tier {
-            set_or_remove_json(
-                obj,
-                "service_tier",
-                annotated.service_tier.clone().map(Json::String),
-            );
-        }
-        if annotated.stream != baseline.stream {
-            set_or_remove_json(obj, "stream", annotated.stream.map(Json::Bool));
-        }
-
-        if annotated.store != baseline.store
-            || annotated.previous_response_id != baseline.previous_response_id
-            || annotated.truncation != baseline.truncation
-            || annotated.reasoning != baseline.reasoning
-            || annotated.include != baseline.include
-            || annotated.user != baseline.user
-            || annotated.max_output_tokens != baseline.max_output_tokens
-            || annotated.max_tool_calls != baseline.max_tool_calls
-            || annotated.top_logprobs != baseline.top_logprobs
-        {
-            return Err(FlowError::InvalidArgument(
-                "request contains fields that cannot be encoded for Anthropic Messages".into(),
-            ));
-        }
-
-        match (&annotated.api_specific, &baseline.api_specific) {
-            (
-                Some(ApiSpecificRequest::AnthropicMessages {
-                    cache_control,
-                    container,
-                    inference_geo,
-                    output_config,
-                    thinking,
-                    top_k,
-                    user_profile_id,
-                }),
-                Some(ApiSpecificRequest::AnthropicMessages {
-                    cache_control: old_cache_control,
-                    container: old_container,
-                    inference_geo: old_inference_geo,
-                    output_config: old_output_config,
-                    thinking: old_thinking,
-                    top_k: old_top_k,
-                    user_profile_id: old_user_profile_id,
-                }),
-            ) => {
-                if cache_control != old_cache_control {
-                    set_or_remove_json(obj, "cache_control", cache_control.clone());
-                }
-                for (key, edited, before) in [
-                    ("container", container, old_container),
-                    ("inference_geo", inference_geo, old_inference_geo),
-                    (
-                        "anthropic-user-profile-id",
-                        user_profile_id,
-                        old_user_profile_id,
-                    ),
-                ] {
-                    if edited != before {
-                        set_or_remove_json(obj, key, edited.clone().map(Json::String));
-                    }
-                }
-                for (key, edited, before) in [
-                    ("output_config", output_config, old_output_config),
-                    ("thinking", thinking, old_thinking),
-                ] {
-                    if edited != before {
-                        set_or_remove_json(obj, key, edited.clone());
-                    }
-                }
-                if top_k != old_top_k {
-                    set_or_remove_json(obj, "top_k", top_k.map(Json::from));
-                }
-            }
-            (None, Some(ApiSpecificRequest::AnthropicMessages { .. })) => {
-                for key in [
-                    "cache_control",
-                    "container",
-                    "inference_geo",
-                    "output_config",
-                    "thinking",
-                    "top_k",
-                    "anthropic-user-profile-id",
-                ] {
-                    obj.remove(key);
-                }
-            }
-            (Some(_), _) => {
-                return Err(FlowError::InvalidArgument(
-                    "api_specific provider does not match Anthropic Messages".into(),
-                ));
-            }
-            (None, Some(_)) => {
-                return Err(FlowError::InvalidArgument(
-                    "api_specific provider does not match Anthropic Messages".into(),
-                ));
-            }
-            (None, None) => {}
-        }
+        patch_anthropic_messages_and_model(obj, annotated, &baseline)?;
+        patch_anthropic_params(obj, annotated, &baseline);
+        patch_anthropic_tools(obj, annotated, &baseline)?;
+        patch_anthropic_common_fields(obj, annotated, &baseline);
+        validate_anthropic_supported_fields(annotated, &baseline)?;
+        patch_anthropic_api_specific(obj, &annotated.api_specific, &baseline.api_specific)?;
         patch_extra_fields(obj, &baseline.extra, &annotated.extra);
 
         Ok(LlmRequest {

--- a/crates/core/src/codec/openai_chat.rs
+++ b/crates/core/src/codec/openai_chat.rs
@@ -706,6 +706,411 @@ fn set_or_remove_json(obj: &mut serde_json::Map<String, Json>, key: &str, value:
     }
 }
 
+fn patch_chat_messages_and_validate(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    if annotated.messages != baseline.messages {
+        let original_messages = obj.get("messages").and_then(Json::as_array);
+        obj.insert(
+            "messages".into(),
+            Json::Array(super::encode_changed_items(
+                &annotated.messages,
+                &baseline.messages,
+                original_messages.map(Vec::as_slice),
+                encode_chat_message,
+            )?),
+        );
+    }
+    let unsupported = [
+        annotated.instructions != baseline.instructions,
+        annotated.previous_response_id != baseline.previous_response_id,
+        annotated.truncation != baseline.truncation,
+        annotated.reasoning != baseline.reasoning,
+        annotated.include != baseline.include,
+        annotated.max_output_tokens != baseline.max_output_tokens,
+        annotated.max_tool_calls != baseline.max_tool_calls,
+    ]
+    .into_iter()
+    .any(|changed| changed);
+    if unsupported {
+        return Err(FlowError::InvalidArgument(
+            "request contains fields that cannot be encoded for OpenAI Chat".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn patch_chat_model_and_params(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) {
+    if annotated.model != baseline.model {
+        set_or_remove_json(obj, "model", annotated.model.clone().map(Json::String));
+    }
+    if annotated.params == baseline.params {
+        return;
+    }
+    let edited = annotated.params.as_ref();
+    let before = baseline.params.as_ref();
+    patch_chat_optional_params(obj, edited, before);
+    patch_chat_max_tokens(obj, edited, before);
+    patch_chat_stop_sequences(obj, edited, before);
+}
+
+fn patch_chat_optional_params(
+    obj: &mut serde_json::Map<String, Json>,
+    edited: Option<&GenerationParams>,
+    before: Option<&GenerationParams>,
+) {
+    for (key, value, old_value) in [
+        (
+            "temperature",
+            edited.and_then(|params| params.temperature),
+            before.and_then(|params| params.temperature),
+        ),
+        (
+            "top_p",
+            edited.and_then(|params| params.top_p),
+            before.and_then(|params| params.top_p),
+        ),
+    ] {
+        if value != old_value {
+            set_or_remove_json(obj, key, value.map(json_f64));
+        }
+    }
+}
+
+fn patch_chat_max_tokens(
+    obj: &mut serde_json::Map<String, Json>,
+    edited: Option<&GenerationParams>,
+    before: Option<&GenerationParams>,
+) {
+    let max_tokens = edited.and_then(|params| params.max_tokens);
+    if max_tokens == before.and_then(|params| params.max_tokens) {
+        return;
+    }
+    let max_tokens = max_tokens.map(Json::from);
+    if max_tokens.is_none() {
+        obj.remove("max_completion_tokens");
+        obj.remove("max_tokens");
+        return;
+    }
+    let key = if obj.contains_key("max_completion_tokens") || !obj.contains_key("max_tokens") {
+        "max_completion_tokens"
+    } else {
+        "max_tokens"
+    };
+    set_or_remove_json(obj, key, max_tokens);
+}
+
+fn patch_chat_stop_sequences(
+    obj: &mut serde_json::Map<String, Json>,
+    edited: Option<&GenerationParams>,
+    before: Option<&GenerationParams>,
+) {
+    let stop = edited.and_then(|params| params.stop.as_ref());
+    if stop == before.and_then(|params| params.stop.as_ref()) {
+        return;
+    }
+    let stop = stop.map(|values| {
+        if obj.get("stop").is_some_and(Json::is_string) && values.len() == 1 {
+            Json::String(values[0].clone())
+        } else {
+            serde_json::json!(values)
+        }
+    });
+    set_or_remove_json(obj, "stop", stop);
+}
+
+fn patch_chat_tools(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    if annotated.tools != baseline.tools {
+        let tools = annotated
+            .tools
+            .as_deref()
+            .map(|tools| {
+                super::encode_changed_items(
+                    tools,
+                    baseline.tools.as_deref().unwrap_or(&[]),
+                    obj.get("tools").and_then(Json::as_array).map(Vec::as_slice),
+                    encode_chat_tool,
+                )
+            })
+            .transpose()?
+            .map(Json::Array);
+        set_or_remove_json(obj, "tools", tools);
+    }
+    if annotated.tool_choice != baseline.tool_choice {
+        let tool_choice = match (&annotated.tool_choice, &baseline.tool_choice) {
+            (Some(edited), Some(before)) => {
+                let edited = encode_chat_tool_choice(edited)?;
+                let before = encode_chat_tool_choice(before)?;
+                Some(match obj.get("tool_choice") {
+                    Some(original) => super::patch_changed_json(original, &before, &edited)?,
+                    None => edited,
+                })
+            }
+            (Some(edited), None) => Some(encode_chat_tool_choice(edited)?),
+            (None, _) => None,
+        };
+        set_or_remove_json(obj, "tool_choice", tool_choice);
+    }
+    Ok(())
+}
+
+fn patch_chat_common_fields(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) {
+    if annotated.metadata != baseline.metadata {
+        set_or_remove_json(obj, "metadata", annotated.metadata.clone());
+    }
+    for (key, edited, before) in [
+        ("store", annotated.store, baseline.store),
+        (
+            "parallel_tool_calls",
+            annotated.parallel_tool_calls,
+            baseline.parallel_tool_calls,
+        ),
+        ("stream", annotated.stream, baseline.stream),
+    ] {
+        if edited != before {
+            set_or_remove_json(obj, key, edited.map(Json::Bool));
+        }
+    }
+    for (key, edited, before) in [
+        ("user", &annotated.user, &baseline.user),
+        (
+            "service_tier",
+            &annotated.service_tier,
+            &baseline.service_tier,
+        ),
+    ] {
+        if edited != before {
+            set_or_remove_json(obj, key, edited.clone().map(Json::String));
+        }
+    }
+    if annotated.top_logprobs != baseline.top_logprobs {
+        set_or_remove_json(obj, "top_logprobs", annotated.top_logprobs.map(Json::from));
+    }
+}
+
+fn patch_optional_json_fields(
+    obj: &mut serde_json::Map<String, Json>,
+    fields: &[(&str, &Option<Json>, &Option<Json>)],
+) {
+    for (key, edited, before) in fields {
+        if edited != before {
+            set_or_remove_json(obj, key, (*edited).clone());
+        }
+    }
+}
+
+fn patch_optional_string_fields(
+    obj: &mut serde_json::Map<String, Json>,
+    fields: &[(&str, &Option<String>, &Option<String>)],
+) {
+    for (key, edited, before) in fields {
+        if edited != before {
+            set_or_remove_json(obj, key, (*edited).clone().map(Json::String));
+        }
+    }
+}
+
+fn patch_optional_f64_fields(
+    obj: &mut serde_json::Map<String, Json>,
+    fields: &[(&str, &Option<f64>, &Option<f64>)],
+) {
+    for (key, edited, before) in fields {
+        if edited != before {
+            set_or_remove_json(obj, key, (*edited).map(json_f64));
+        }
+    }
+}
+
+fn patch_chat_api_specific(
+    obj: &mut serde_json::Map<String, Json>,
+    edited: &Option<ApiSpecificRequest>,
+    baseline: &Option<ApiSpecificRequest>,
+) -> Result<()> {
+    match (edited, baseline) {
+        (
+            Some(edited @ ApiSpecificRequest::OpenAIChat { .. }),
+            Some(baseline @ ApiSpecificRequest::OpenAIChat { .. }),
+        ) => {
+            patch_chat_api_fields(obj, edited, baseline);
+            Ok(())
+        }
+        (None, Some(ApiSpecificRequest::OpenAIChat { .. })) => {
+            for key in [
+                "audio",
+                "frequency_penalty",
+                "function_call",
+                "functions",
+                "logit_bias",
+                "logprobs",
+                "modalities",
+                "moderation",
+                "n",
+                "prediction",
+                "presence_penalty",
+                "prompt_cache_key",
+                "prompt_cache_options",
+                "prompt_cache_retention",
+                "reasoning_effort",
+                "response_format",
+                "safety_identifier",
+                "seed",
+                "stream_options",
+                "verbosity",
+                "web_search_options",
+            ] {
+                obj.remove(key);
+            }
+            Ok(())
+        }
+        (Some(_), _) | (None, Some(_)) => Err(FlowError::InvalidArgument(
+            "api_specific provider does not match OpenAI Chat".into(),
+        )),
+        (None, None) => Ok(()),
+    }
+}
+
+fn patch_chat_api_fields(
+    obj: &mut serde_json::Map<String, Json>,
+    edited: &ApiSpecificRequest,
+    baseline: &ApiSpecificRequest,
+) {
+    let (
+        ApiSpecificRequest::OpenAIChat {
+            audio,
+            frequency_penalty,
+            function_call,
+            functions,
+            logit_bias,
+            logprobs,
+            modalities,
+            moderation,
+            n,
+            prediction,
+            presence_penalty,
+            prompt_cache_key,
+            prompt_cache_options,
+            prompt_cache_retention,
+            reasoning_effort,
+            response_format,
+            safety_identifier,
+            seed,
+            stream_options,
+            verbosity,
+            web_search_options,
+        },
+        ApiSpecificRequest::OpenAIChat {
+            audio: old_audio,
+            frequency_penalty: old_frequency_penalty,
+            function_call: old_function_call,
+            functions: old_functions,
+            logit_bias: old_logit_bias,
+            logprobs: old_logprobs,
+            modalities: old_modalities,
+            moderation: old_moderation,
+            n: old_n,
+            prediction: old_prediction,
+            presence_penalty: old_presence_penalty,
+            prompt_cache_key: old_prompt_cache_key,
+            prompt_cache_options: old_prompt_cache_options,
+            prompt_cache_retention: old_prompt_cache_retention,
+            reasoning_effort: old_reasoning_effort,
+            response_format: old_response_format,
+            safety_identifier: old_safety_identifier,
+            seed: old_seed,
+            stream_options: old_stream_options,
+            verbosity: old_verbosity,
+            web_search_options: old_web_search_options,
+        },
+    ) = (edited, baseline)
+    else {
+        unreachable!("OpenAI Chat variants checked by caller");
+    };
+    patch_optional_json_fields(
+        obj,
+        &[
+            ("audio", audio, old_audio),
+            ("function_call", function_call, old_function_call),
+            ("logit_bias", logit_bias, old_logit_bias),
+            ("moderation", moderation, old_moderation),
+            ("prediction", prediction, old_prediction),
+            (
+                "prompt_cache_options",
+                prompt_cache_options,
+                old_prompt_cache_options,
+            ),
+            ("response_format", response_format, old_response_format),
+            ("stream_options", stream_options, old_stream_options),
+            (
+                "web_search_options",
+                web_search_options,
+                old_web_search_options,
+            ),
+        ],
+    );
+    patch_optional_f64_fields(
+        obj,
+        &[
+            (
+                "frequency_penalty",
+                frequency_penalty,
+                old_frequency_penalty,
+            ),
+            ("presence_penalty", presence_penalty, old_presence_penalty),
+        ],
+    );
+    patch_optional_string_fields(
+        obj,
+        &[
+            ("prompt_cache_key", prompt_cache_key, old_prompt_cache_key),
+            (
+                "prompt_cache_retention",
+                prompt_cache_retention,
+                old_prompt_cache_retention,
+            ),
+            ("reasoning_effort", reasoning_effort, old_reasoning_effort),
+            (
+                "safety_identifier",
+                safety_identifier,
+                old_safety_identifier,
+            ),
+            ("verbosity", verbosity, old_verbosity),
+        ],
+    );
+    if functions != old_functions {
+        set_or_remove_json(obj, "functions", functions.clone().map(Json::Array));
+    }
+    if modalities != old_modalities {
+        set_or_remove_json(
+            obj,
+            "modalities",
+            modalities.as_ref().map(|value| serde_json::json!(value)),
+        );
+    }
+    if logprobs != old_logprobs {
+        set_or_remove_json(obj, "logprobs", logprobs.map(Json::Bool));
+    }
+    if n != old_n {
+        set_or_remove_json(obj, "n", n.map(Json::from));
+    }
+    if seed != old_seed {
+        set_or_remove_json(obj, "seed", seed.map(Json::from));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // LlmResponseCodec implementation
 // ---------------------------------------------------------------------------
@@ -962,299 +1367,11 @@ impl LlmCodec for OpenAIChatCodec {
         let obj = content
             .as_object_mut()
             .ok_or_else(|| FlowError::Internal("original content is not an object".into()))?;
-        if annotated.messages != baseline.messages {
-            let original_messages = obj.get("messages").and_then(Json::as_array);
-            obj.insert(
-                "messages".into(),
-                Json::Array(super::encode_changed_items(
-                    &annotated.messages,
-                    &baseline.messages,
-                    original_messages.map(Vec::as_slice),
-                    encode_chat_message,
-                )?),
-            );
-        }
-        if annotated.instructions != baseline.instructions
-            || annotated.previous_response_id != baseline.previous_response_id
-            || annotated.truncation != baseline.truncation
-            || annotated.reasoning != baseline.reasoning
-            || annotated.include != baseline.include
-            || annotated.max_output_tokens != baseline.max_output_tokens
-            || annotated.max_tool_calls != baseline.max_tool_calls
-        {
-            return Err(FlowError::InvalidArgument(
-                "request contains fields that cannot be encoded for OpenAI Chat".into(),
-            ));
-        }
-        if annotated.model != baseline.model {
-            set_or_remove_json(obj, "model", annotated.model.clone().map(Json::String));
-        }
-        if annotated.params != baseline.params {
-            let edited = annotated.params.as_ref();
-            let before = baseline.params.as_ref();
-            if edited.and_then(|p| p.temperature) != before.and_then(|p| p.temperature) {
-                set_or_remove_json(
-                    obj,
-                    "temperature",
-                    edited.and_then(|p| p.temperature).map(json_f64),
-                );
-            }
-            if edited.and_then(|p| p.top_p) != before.and_then(|p| p.top_p) {
-                set_or_remove_json(obj, "top_p", edited.and_then(|p| p.top_p).map(json_f64));
-            }
-            if edited.and_then(|p| p.max_tokens) != before.and_then(|p| p.max_tokens) {
-                let max_tokens = edited.and_then(|p| p.max_tokens).map(Json::from);
-                if max_tokens.is_none() {
-                    obj.remove("max_completion_tokens");
-                    obj.remove("max_tokens");
-                } else {
-                    let key = if obj.contains_key("max_completion_tokens")
-                        || !obj.contains_key("max_tokens")
-                    {
-                        "max_completion_tokens"
-                    } else {
-                        "max_tokens"
-                    };
-                    set_or_remove_json(obj, key, max_tokens);
-                }
-            }
-            if edited.and_then(|p| p.stop.as_ref()) != before.and_then(|p| p.stop.as_ref()) {
-                let stop = edited.and_then(|p| p.stop.as_ref()).map(|values| {
-                    if obj.get("stop").is_some_and(Json::is_string) && values.len() == 1 {
-                        Json::String(values[0].clone())
-                    } else {
-                        serde_json::json!(values)
-                    }
-                });
-                set_or_remove_json(obj, "stop", stop);
-            }
-        }
-        if annotated.tools != baseline.tools {
-            let tools = annotated
-                .tools
-                .as_deref()
-                .map(|tools| {
-                    super::encode_changed_items(
-                        tools,
-                        baseline.tools.as_deref().unwrap_or(&[]),
-                        obj.get("tools").and_then(Json::as_array).map(Vec::as_slice),
-                        encode_chat_tool,
-                    )
-                })
-                .transpose()?
-                .map(Json::Array);
-            set_or_remove_json(obj, "tools", tools);
-        }
-        if annotated.tool_choice != baseline.tool_choice {
-            let tool_choice = match (&annotated.tool_choice, &baseline.tool_choice) {
-                (Some(edited), Some(before)) => {
-                    let edited = encode_chat_tool_choice(edited)?;
-                    let before = encode_chat_tool_choice(before)?;
-                    Some(match obj.get("tool_choice") {
-                        Some(original) => super::patch_changed_json(original, &before, &edited)?,
-                        None => edited,
-                    })
-                }
-                (Some(edited), None) => Some(encode_chat_tool_choice(edited)?),
-                (None, _) => None,
-            };
-            set_or_remove_json(obj, "tool_choice", tool_choice);
-        }
-        for (key, edited, before) in [("metadata", &annotated.metadata, &baseline.metadata)] {
-            if edited != before {
-                set_or_remove_json(obj, key, edited.clone());
-            }
-        }
-        for (key, edited, before) in [
-            ("store", annotated.store, baseline.store),
-            (
-                "parallel_tool_calls",
-                annotated.parallel_tool_calls,
-                baseline.parallel_tool_calls,
-            ),
-            ("stream", annotated.stream, baseline.stream),
-        ] {
-            if edited != before {
-                set_or_remove_json(obj, key, edited.map(Json::Bool));
-            }
-        }
-        for (key, edited, before) in [
-            ("user", &annotated.user, &baseline.user),
-            (
-                "service_tier",
-                &annotated.service_tier,
-                &baseline.service_tier,
-            ),
-        ] {
-            if edited != before {
-                set_or_remove_json(obj, key, edited.clone().map(Json::String));
-            }
-        }
-        if annotated.top_logprobs != baseline.top_logprobs {
-            set_or_remove_json(obj, "top_logprobs", annotated.top_logprobs.map(Json::from));
-        }
-        match (&annotated.api_specific, &baseline.api_specific) {
-            (
-                Some(ApiSpecificRequest::OpenAIChat {
-                    audio,
-                    frequency_penalty,
-                    function_call,
-                    functions,
-                    logit_bias,
-                    logprobs,
-                    modalities,
-                    moderation,
-                    n,
-                    prediction,
-                    presence_penalty,
-                    prompt_cache_key,
-                    prompt_cache_options,
-                    prompt_cache_retention,
-                    reasoning_effort,
-                    response_format,
-                    safety_identifier,
-                    seed,
-                    stream_options,
-                    verbosity,
-                    web_search_options,
-                }),
-                Some(ApiSpecificRequest::OpenAIChat {
-                    audio: old_audio,
-                    frequency_penalty: old_frequency_penalty,
-                    function_call: old_function_call,
-                    functions: old_functions,
-                    logit_bias: old_logit_bias,
-                    logprobs: old_logprobs,
-                    modalities: old_modalities,
-                    moderation: old_moderation,
-                    n: old_n,
-                    prediction: old_prediction,
-                    presence_penalty: old_presence_penalty,
-                    prompt_cache_key: old_prompt_cache_key,
-                    prompt_cache_options: old_prompt_cache_options,
-                    prompt_cache_retention: old_prompt_cache_retention,
-                    reasoning_effort: old_reasoning_effort,
-                    response_format: old_response_format,
-                    safety_identifier: old_safety_identifier,
-                    seed: old_seed,
-                    stream_options: old_stream_options,
-                    verbosity: old_verbosity,
-                    web_search_options: old_web_search_options,
-                }),
-            ) => {
-                for (key, edited, before) in [
-                    ("audio", audio, old_audio),
-                    ("function_call", function_call, old_function_call),
-                    ("logit_bias", logit_bias, old_logit_bias),
-                    ("moderation", moderation, old_moderation),
-                    ("prediction", prediction, old_prediction),
-                    (
-                        "prompt_cache_options",
-                        prompt_cache_options,
-                        old_prompt_cache_options,
-                    ),
-                    ("response_format", response_format, old_response_format),
-                    ("stream_options", stream_options, old_stream_options),
-                    (
-                        "web_search_options",
-                        web_search_options,
-                        old_web_search_options,
-                    ),
-                ] {
-                    if edited != before {
-                        set_or_remove_json(obj, key, edited.clone());
-                    }
-                }
-                for (key, edited, before) in [
-                    (
-                        "frequency_penalty",
-                        frequency_penalty,
-                        old_frequency_penalty,
-                    ),
-                    ("presence_penalty", presence_penalty, old_presence_penalty),
-                ] {
-                    if edited != before {
-                        set_or_remove_json(obj, key, edited.map(json_f64));
-                    }
-                }
-                if functions != old_functions {
-                    set_or_remove_json(obj, "functions", functions.clone().map(Json::Array));
-                }
-                if modalities != old_modalities {
-                    set_or_remove_json(
-                        obj,
-                        "modalities",
-                        modalities.as_ref().map(|v| serde_json::json!(v)),
-                    );
-                }
-                if logprobs != old_logprobs {
-                    set_or_remove_json(obj, "logprobs", logprobs.map(Json::Bool));
-                }
-                if n != old_n {
-                    set_or_remove_json(obj, "n", n.map(Json::from));
-                }
-                for (key, edited, before) in [
-                    ("prompt_cache_key", prompt_cache_key, old_prompt_cache_key),
-                    (
-                        "prompt_cache_retention",
-                        prompt_cache_retention,
-                        old_prompt_cache_retention,
-                    ),
-                    ("reasoning_effort", reasoning_effort, old_reasoning_effort),
-                    (
-                        "safety_identifier",
-                        safety_identifier,
-                        old_safety_identifier,
-                    ),
-                    ("verbosity", verbosity, old_verbosity),
-                ] {
-                    if edited != before {
-                        set_or_remove_json(obj, key, edited.clone().map(Json::String));
-                    }
-                }
-                if seed != old_seed {
-                    set_or_remove_json(obj, "seed", seed.map(Json::from));
-                }
-            }
-            (None, Some(ApiSpecificRequest::OpenAIChat { .. })) => {
-                for key in [
-                    "audio",
-                    "frequency_penalty",
-                    "function_call",
-                    "functions",
-                    "logit_bias",
-                    "logprobs",
-                    "modalities",
-                    "moderation",
-                    "n",
-                    "prediction",
-                    "presence_penalty",
-                    "prompt_cache_key",
-                    "prompt_cache_options",
-                    "prompt_cache_retention",
-                    "reasoning_effort",
-                    "response_format",
-                    "safety_identifier",
-                    "seed",
-                    "stream_options",
-                    "verbosity",
-                    "web_search_options",
-                ] {
-                    obj.remove(key);
-                }
-            }
-            (Some(_), _) => {
-                return Err(FlowError::InvalidArgument(
-                    "api_specific provider does not match OpenAI Chat".into(),
-                ));
-            }
-            (None, Some(_)) => {
-                return Err(FlowError::InvalidArgument(
-                    "api_specific provider does not match OpenAI Chat".into(),
-                ));
-            }
-            (None, None) => {}
-        }
+        patch_chat_messages_and_validate(obj, annotated, &baseline)?;
+        patch_chat_model_and_params(obj, annotated, &baseline);
+        patch_chat_tools(obj, annotated, &baseline)?;
+        patch_chat_common_fields(obj, annotated, &baseline);
+        patch_chat_api_specific(obj, &annotated.api_specific, &baseline.api_specific)?;
         patch_extra_fields(obj, &baseline.extra, &annotated.extra);
 
         Ok(LlmRequest {

--- a/crates/core/src/codec/openai_responses.rs
+++ b/crates/core/src/codec/openai_responses.rs
@@ -989,6 +989,206 @@ fn decode_openai_or_anthropic_parallel_tool_calls(
     .map(|disabled| !disabled))
 }
 
+fn patch_responses_messages(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+    original: &LlmRequest,
+) -> Result<()> {
+    if annotated.messages != baseline.messages {
+        let input = if original.content.get("input").is_some_and(Json::is_string)
+            && matches!(
+                annotated.messages.as_slice(),
+                [Message::User {
+                    content: MessageContent::Text(_),
+                    name: None
+                }]
+            ) {
+            match &annotated.messages[0] {
+                Message::User {
+                    content: MessageContent::Text(text),
+                    ..
+                } => Json::String(text.clone()),
+                _ => unreachable!(),
+            }
+        } else {
+            Json::Array(super::encode_changed_items(
+                &annotated.messages,
+                &baseline.messages,
+                original
+                    .content
+                    .get("input")
+                    .and_then(Json::as_array)
+                    .map(Vec::as_slice),
+                encode_responses_input_item,
+            )?)
+        };
+        obj.insert("input".into(), input);
+    }
+    if annotated.instructions != baseline.instructions {
+        let instructions = match &annotated.instructions {
+            Some(MessageContent::Text(text)) => Some(Json::String(text.clone())),
+            Some(MessageContent::Parts(_)) => {
+                return Err(FlowError::InvalidArgument(
+                    "OpenAI Responses instructions cannot contain content parts".into(),
+                ));
+            }
+            None => None,
+        };
+        set_or_remove_json(obj, "instructions", instructions);
+    }
+    Ok(())
+}
+
+fn patch_responses_model_and_params(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    if annotated.model != baseline.model {
+        set_or_remove_json(obj, "model", annotated.model.clone().map(Json::String));
+    }
+    if annotated.params != baseline.params {
+        let edited = annotated.params.as_ref();
+        let before = baseline.params.as_ref();
+        let stop = edited.and_then(|params| params.stop.as_ref());
+        if stop != before.and_then(|params| params.stop.as_ref()) && stop.is_some() {
+            return Err(FlowError::InvalidArgument(
+                "OpenAI Responses does not support stop sequences".into(),
+            ));
+        }
+        for (key, value, old_value) in [
+            (
+                "temperature",
+                edited.and_then(|params| params.temperature),
+                before.and_then(|params| params.temperature),
+            ),
+            (
+                "top_p",
+                edited.and_then(|params| params.top_p),
+                before.and_then(|params| params.top_p),
+            ),
+        ] {
+            if value != old_value {
+                set_or_remove_json(obj, key, value.map(json_f64));
+            }
+        }
+        let max_tokens = edited.and_then(|params| params.max_tokens);
+        if max_tokens != before.and_then(|params| params.max_tokens) {
+            set_or_remove_json(obj, "max_output_tokens", max_tokens.map(Json::from));
+        }
+    }
+    Ok(())
+}
+
+fn patch_responses_tools(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    if annotated.tools != baseline.tools {
+        let tools = annotated
+            .tools
+            .as_deref()
+            .map(|tools| {
+                super::encode_changed_items_with_patch(
+                    tools,
+                    baseline.tools.as_deref().unwrap_or(&[]),
+                    obj.get("tools").and_then(Json::as_array).map(Vec::as_slice),
+                    encode_responses_tool,
+                    patch_responses_tool,
+                )
+            })
+            .transpose()?
+            .map(Json::Array);
+        set_or_remove_json(obj, "tools", tools);
+    }
+    if annotated.tool_choice != baseline.tool_choice {
+        let tool_choice = match (&annotated.tool_choice, &baseline.tool_choice) {
+            (Some(edited), Some(before)) => {
+                let edited = encode_responses_tool_choice(edited)?;
+                let before = encode_responses_tool_choice(before)?;
+                Some(match obj.get("tool_choice") {
+                    Some(original) => super::patch_changed_json(original, &before, &edited)?,
+                    None => edited,
+                })
+            }
+            (Some(edited), None) => Some(encode_responses_tool_choice(edited)?),
+            (None, _) => None,
+        };
+        set_or_remove_json(obj, "tool_choice", tool_choice);
+    }
+    Ok(())
+}
+
+fn patch_responses_common_fields(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) {
+    for (key, value, old_value) in [
+        ("truncation", &annotated.truncation, &baseline.truncation),
+        ("reasoning", &annotated.reasoning, &baseline.reasoning),
+        ("include", &annotated.include, &baseline.include),
+        ("metadata", &annotated.metadata, &baseline.metadata),
+    ] {
+        if value != old_value {
+            set_or_remove_json(obj, key, value.clone());
+        }
+    }
+    for (key, value, old_value) in [
+        (
+            "previous_response_id",
+            &annotated.previous_response_id,
+            &baseline.previous_response_id,
+        ),
+        ("user", &annotated.user, &baseline.user),
+        (
+            "service_tier",
+            &annotated.service_tier,
+            &baseline.service_tier,
+        ),
+    ] {
+        if value != old_value {
+            set_or_remove_json(obj, key, value.clone().map(Json::String));
+        }
+    }
+    for (key, value, old_value) in [
+        ("store", annotated.store, baseline.store),
+        (
+            "parallel_tool_calls",
+            annotated.parallel_tool_calls,
+            baseline.parallel_tool_calls,
+        ),
+        ("stream", annotated.stream, baseline.stream),
+    ] {
+        if value != old_value {
+            set_or_remove_json(obj, key, value.map(Json::Bool));
+        }
+    }
+    for (key, value, old_value) in [
+        (
+            "max_output_tokens",
+            annotated.max_output_tokens,
+            baseline.max_output_tokens,
+        ),
+        (
+            "max_tool_calls",
+            annotated.max_tool_calls,
+            baseline.max_tool_calls,
+        ),
+        (
+            "top_logprobs",
+            annotated.top_logprobs,
+            baseline.top_logprobs,
+        ),
+    ] {
+        if value != old_value {
+            set_or_remove_json(obj, key, value.map(Json::from));
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // LlmResponseCodec implementation
 // ---------------------------------------------------------------------------
@@ -1213,177 +1413,10 @@ impl LlmCodec for OpenAIResponsesCodec {
         let obj = content
             .as_object_mut()
             .ok_or_else(|| FlowError::Internal("original content is not an object".into()))?;
-        if annotated.messages != baseline.messages {
-            let input = if original.content.get("input").is_some_and(Json::is_string)
-                && matches!(
-                    annotated.messages.as_slice(),
-                    [Message::User {
-                        content: MessageContent::Text(_),
-                        name: None
-                    }]
-                ) {
-                match &annotated.messages[0] {
-                    Message::User {
-                        content: MessageContent::Text(text),
-                        ..
-                    } => Json::String(text.clone()),
-                    _ => unreachable!(),
-                }
-            } else {
-                Json::Array(super::encode_changed_items(
-                    &annotated.messages,
-                    &baseline.messages,
-                    original
-                        .content
-                        .get("input")
-                        .and_then(Json::as_array)
-                        .map(Vec::as_slice),
-                    encode_responses_input_item,
-                )?)
-            };
-            obj.insert("input".into(), input);
-        }
-        if annotated.instructions != baseline.instructions {
-            let instructions = match &annotated.instructions {
-                Some(MessageContent::Text(text)) => Some(Json::String(text.clone())),
-                Some(MessageContent::Parts(_)) => {
-                    return Err(FlowError::InvalidArgument(
-                        "OpenAI Responses instructions cannot contain content parts".into(),
-                    ));
-                }
-                None => None,
-            };
-            set_or_remove_json(obj, "instructions", instructions);
-        }
-        if annotated.model != baseline.model {
-            set_or_remove_json(obj, "model", annotated.model.clone().map(Json::String));
-        }
-        if annotated.params != baseline.params {
-            let edited = annotated.params.as_ref();
-            let before = baseline.params.as_ref();
-            if edited.and_then(|params| params.stop.as_ref())
-                != before.and_then(|params| params.stop.as_ref())
-                && edited.and_then(|params| params.stop.as_ref()).is_some()
-            {
-                return Err(FlowError::InvalidArgument(
-                    "OpenAI Responses does not support stop sequences".into(),
-                ));
-            }
-            for (key, value, old_value) in [
-                (
-                    "temperature",
-                    edited.and_then(|params| params.temperature),
-                    before.and_then(|params| params.temperature),
-                ),
-                (
-                    "top_p",
-                    edited.and_then(|params| params.top_p),
-                    before.and_then(|params| params.top_p),
-                ),
-            ] {
-                if value != old_value {
-                    set_or_remove_json(obj, key, value.map(json_f64));
-                }
-            }
-            let max_tokens = edited.and_then(|params| params.max_tokens);
-            let old_max_tokens = before.and_then(|params| params.max_tokens);
-            if max_tokens != old_max_tokens {
-                set_or_remove_json(obj, "max_output_tokens", max_tokens.map(Json::from));
-            }
-        }
-        if annotated.tools != baseline.tools {
-            let tools = annotated
-                .tools
-                .as_deref()
-                .map(|tools| {
-                    super::encode_changed_items_with_patch(
-                        tools,
-                        baseline.tools.as_deref().unwrap_or(&[]),
-                        obj.get("tools").and_then(Json::as_array).map(Vec::as_slice),
-                        encode_responses_tool,
-                        patch_responses_tool,
-                    )
-                })
-                .transpose()?
-                .map(Json::Array);
-            set_or_remove_json(obj, "tools", tools);
-        }
-        if annotated.tool_choice != baseline.tool_choice {
-            let tool_choice = match (&annotated.tool_choice, &baseline.tool_choice) {
-                (Some(edited), Some(before)) => {
-                    let edited = encode_responses_tool_choice(edited)?;
-                    let before = encode_responses_tool_choice(before)?;
-                    Some(match obj.get("tool_choice") {
-                        Some(original) => super::patch_changed_json(original, &before, &edited)?,
-                        None => edited,
-                    })
-                }
-                (Some(edited), None) => Some(encode_responses_tool_choice(edited)?),
-                (None, _) => None,
-            };
-            set_or_remove_json(obj, "tool_choice", tool_choice);
-        }
-        for (key, value, old_value) in [
-            ("truncation", &annotated.truncation, &baseline.truncation),
-            ("reasoning", &annotated.reasoning, &baseline.reasoning),
-            ("include", &annotated.include, &baseline.include),
-            ("metadata", &annotated.metadata, &baseline.metadata),
-        ] {
-            if value != old_value {
-                set_or_remove_json(obj, key, value.clone());
-            }
-        }
-        for (key, value, old_value) in [
-            (
-                "previous_response_id",
-                &annotated.previous_response_id,
-                &baseline.previous_response_id,
-            ),
-            ("user", &annotated.user, &baseline.user),
-            (
-                "service_tier",
-                &annotated.service_tier,
-                &baseline.service_tier,
-            ),
-        ] {
-            if value != old_value {
-                set_or_remove_json(obj, key, value.clone().map(Json::String));
-            }
-        }
-        for (key, value, old_value) in [
-            ("store", annotated.store, baseline.store),
-            (
-                "parallel_tool_calls",
-                annotated.parallel_tool_calls,
-                baseline.parallel_tool_calls,
-            ),
-            ("stream", annotated.stream, baseline.stream),
-        ] {
-            if value != old_value {
-                set_or_remove_json(obj, key, value.map(Json::Bool));
-            }
-        }
-        for (key, value, old_value) in [
-            (
-                "max_output_tokens",
-                annotated.max_output_tokens,
-                baseline.max_output_tokens,
-            ),
-            (
-                "max_tool_calls",
-                annotated.max_tool_calls,
-                baseline.max_tool_calls,
-            ),
-            (
-                "top_logprobs",
-                annotated.top_logprobs,
-                baseline.top_logprobs,
-            ),
-        ] {
-            if value != old_value {
-                set_or_remove_json(obj, key, value.map(Json::from));
-            }
-        }
+        patch_responses_messages(obj, annotated, &baseline, original)?;
+        patch_responses_model_and_params(obj, annotated, &baseline)?;
+        patch_responses_tools(obj, annotated, &baseline)?;
+        patch_responses_common_fields(obj, annotated, &baseline);
         patch_responses_api_specific(obj, &annotated.api_specific, &baseline.api_specific)?;
         patch_extra_fields(obj, &baseline.extra, &annotated.extra);
 

--- a/crates/node/tests/llm_tests.mjs
+++ b/crates/node/tests/llm_tests.mjs
@@ -63,6 +63,29 @@ function makeNative() {
   };
 }
 
+function sparseArray() {
+  const values = new Array(2);
+  values[1] = 1;
+  return values;
+}
+
+function unprintableError() {
+  const error = new Error('sanitize request guardrail failed');
+  Object.defineProperties(error, {
+    message: {
+      get() {
+        throw new Error('message getter boom');
+      },
+    },
+    toString: {
+      value() {
+        throw new Error('string conversion boom');
+      },
+    },
+  });
+  return error;
+}
+
 // ===========================================================================
 // LLM lifecycle
 // ===========================================================================
@@ -205,8 +228,11 @@ describe('LLM execute', () => {
     const cases = [
       ['sync_bigint', () => llmCallExecute('exec_llm_bigint', makeNative(), () => ({ value: 1n }))],
       ['async_bigint', () => llmCallExecuteAsync('exec_async_llm_bigint', makeNative(), async () => 1n)],
-      ['sync_sparse_array', () => llmCallExecute('exec_llm_sparse_array', makeNative(), () => [, 1])],
-      ['async_sparse_array', () => llmCallExecuteAsync('exec_async_llm_sparse_array', makeNative(), async () => [, 1])],
+      ['sync_sparse_array', () => llmCallExecute('exec_llm_sparse_array', makeNative(), sparseArray)],
+      [
+        'async_sparse_array',
+        () => llmCallExecuteAsync('exec_async_llm_sparse_array', makeNative(), async () => sparseArray()),
+      ],
     ];
 
     for (const [kind, execute] of cases) {
@@ -424,14 +450,7 @@ describe('LLM guardrails', () => {
     clearLastCallbackError();
     registerSubscriber('node_llm_san_req_throw_sub', (event) => events.push(event));
     registerLlmSanitizeRequestGuardrail('node_llm_san_req_throw', 10, () => {
-      throw {
-        get message() {
-          throw new Error('message getter boom');
-        },
-        toString() {
-          throw new Error('string conversion boom');
-        },
-      };
+      throw unprintableError();
     });
     try {
       const request = makeNative();

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -41,6 +41,12 @@ function rejectWithPrimitive(value) {
   return Promise.reject(value);
 }
 
+function sparseArray() {
+  const values = new Array(2);
+  values[1] = 1;
+  return values;
+}
+
 async function waitForSubscriberCallbacks(predicate, timeoutMs = 15000) {
   flushSubscribers();
   // flushSubscribers() waits for Relay's Rust subscriber dispatcher, but JS
@@ -261,8 +267,8 @@ describe('Tool execute', () => {
       ['async_bigint', () => toolCallExecuteAsync('exec_async_tool_bigint', {}, async () => ({ value: 1n }))],
       ['sync_date', () => toolCallExecute('exec_tool_date', {}, () => new Date())],
       ['async_map', () => toolCallExecuteAsync('exec_async_tool_map', {}, async () => new Map([['value', 1]]))],
-      ['sync_sparse_array', () => toolCallExecute('exec_tool_sparse_array', {}, () => [, 1])],
-      ['async_sparse_array', () => toolCallExecuteAsync('exec_async_tool_sparse_array', {}, async () => [, 1])],
+      ['sync_sparse_array', () => toolCallExecute('exec_tool_sparse_array', {}, sparseArray)],
+      ['async_sparse_array', () => toolCallExecuteAsync('exec_async_tool_sparse_array', {}, async () => sparseArray())],
     ];
 
     for (const [kind, execute] of cases) {

--- a/crates/pii-redaction/src/component.rs
+++ b/crates/pii-redaction/src/component.rs
@@ -908,52 +908,8 @@ fn validate_builtin_action_requirements(
         return;
     };
 
-    if let Some(preset) = builtin.preset.as_deref() {
-        if preset != "trajectory_context" {
-            push_policy_diag(
-                diagnostics,
-                policy.unsupported_value,
-                "pii_redaction.unsupported_value",
-                Some(PII_REDACTION_PLUGIN_KIND.to_string()),
-                Some("builtin.preset".to_string()),
-                "builtin.preset must be 'trajectory_context'".to_string(),
-            );
-        }
-        if !matches!(
-            builtin.custom_mark_payload_policy.as_str(),
-            "preserve" | "redact_all_leaves"
-        ) {
-            push_policy_diag(
-                diagnostics,
-                policy.unsupported_value,
-                "pii_redaction.unsupported_value",
-                Some(PII_REDACTION_PLUGIN_KIND.to_string()),
-                Some("builtin.custom_mark_payload_policy".to_string()),
-                "builtin.custom_mark_payload_policy must be 'preserve' or 'redact_all_leaves'"
-                    .to_string(),
-            );
-        }
-        let raw_builtin = plugin_config.get("builtin").and_then(Json::as_object);
-        for field in [
-            "action",
-            "detector",
-            "pattern",
-            "target_paths",
-            "mask_char",
-            "unmasked_prefix",
-            "unmasked_suffix",
-        ] {
-            if raw_builtin.is_some_and(|raw| raw.contains_key(field)) {
-                push_policy_diag(
-                    diagnostics,
-                    policy.unsupported_value,
-                    "pii_redaction.unsupported_value",
-                    Some(PII_REDACTION_PLUGIN_KIND.to_string()),
-                    Some(format!("builtin.{field}")),
-                    format!("builtin.{field} cannot be combined with builtin.preset"),
-                );
-            }
-        }
+    if builtin.preset.is_some() {
+        validate_builtin_preset_requirements(diagnostics, policy, plugin_config, builtin);
         return;
     }
 
@@ -1059,6 +1015,59 @@ fn validate_builtin_action_requirements(
             Some("builtin.mask_char".to_string()),
             "builtin.mask_char must not be empty when builtin.action = 'mask'".to_string(),
         );
+    }
+}
+
+fn validate_builtin_preset_requirements(
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    policy: &ConfigPolicy,
+    plugin_config: &Map<String, Json>,
+    builtin: &BuiltinBackendConfig,
+) {
+    if builtin.preset.as_deref() != Some("trajectory_context") {
+        push_policy_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "pii_redaction.unsupported_value",
+            Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+            Some("builtin.preset".to_string()),
+            "builtin.preset must be 'trajectory_context'".to_string(),
+        );
+    }
+    if !matches!(
+        builtin.custom_mark_payload_policy.as_str(),
+        "preserve" | "redact_all_leaves"
+    ) {
+        push_policy_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "pii_redaction.unsupported_value",
+            Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+            Some("builtin.custom_mark_payload_policy".to_string()),
+            "builtin.custom_mark_payload_policy must be 'preserve' or 'redact_all_leaves'"
+                .to_string(),
+        );
+    }
+    let raw_builtin = plugin_config.get("builtin").and_then(Json::as_object);
+    for field in [
+        "action",
+        "detector",
+        "pattern",
+        "target_paths",
+        "mask_char",
+        "unmasked_prefix",
+        "unmasked_suffix",
+    ] {
+        if raw_builtin.is_some_and(|raw| raw.contains_key(field)) {
+            push_policy_diag(
+                diagnostics,
+                policy.unsupported_value,
+                "pii_redaction.unsupported_value",
+                Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+                Some(format!("builtin.{field}")),
+                format!("builtin.{field} cannot be combined with builtin.preset"),
+            );
+        }
     }
 }
 

--- a/crates/pii-redaction/src/trajectory.rs
+++ b/crates/pii-redaction/src/trajectory.rs
@@ -277,28 +277,8 @@ pub(super) fn redact_all_leaves(value: Json, replacement: &str) -> Json {
 fn redact_semantic_content(value: Json, replacement: &str, field: Option<&str>) -> Json {
     match value {
         Json::Null => Json::Null,
-        Json::Bool(value) => {
-            if field.is_some_and(preserve_analytical_bool) {
-                Json::Bool(value)
-            } else {
-                Json::Bool(false)
-            }
-        }
-        Json::Number(value) => {
-            if field.is_some_and(preserve_analytical_number) {
-                Json::Number(value)
-            } else {
-                Json::from(0)
-            }
-        }
-        Json::String(value) => {
-            if field.is_some_and(preserve_analytical_string) {
-                Json::String(value)
-            } else if field == Some("arguments") {
-                redact_stringified_json(value, replacement)
-            } else {
-                Json::String(replacement.to_string())
-            }
+        value @ (Json::Bool(_) | Json::Number(_) | Json::String(_)) => {
+            redact_semantic_scalar(value, replacement, field)
         }
         Json::Array(values) => Json::Array(
             values
@@ -306,23 +286,44 @@ fn redact_semantic_content(value: Json, replacement: &str, field: Option<&str>) 
                 .map(|value| redact_semantic_content(value, replacement, field))
                 .collect(),
         ),
-        Json::Object(values) => {
-            let preserve_tool_name = preserves_tool_or_function_name(field, &values);
-            Json::Object(
-                values
-                    .into_iter()
-                    .map(|(key, value)| {
-                        let value = if key == "name" && preserve_tool_name && value.is_string() {
-                            value
-                        } else {
-                            redact_semantic_content(value, replacement, Some(&key))
-                        };
-                        (key, value)
-                    })
-                    .collect(),
-            )
-        }
+        Json::Object(values) => redact_semantic_object(values, replacement, field),
     }
+}
+
+fn redact_semantic_scalar(value: Json, replacement: &str, field: Option<&str>) -> Json {
+    match value {
+        Json::Bool(value) if field.is_some_and(preserve_analytical_bool) => Json::Bool(value),
+        Json::Bool(_) => Json::Bool(false),
+        Json::Number(value) if field.is_some_and(preserve_analytical_number) => Json::Number(value),
+        Json::Number(_) => Json::from(0),
+        Json::String(value) if field.is_some_and(preserve_analytical_string) => Json::String(value),
+        Json::String(value) if field == Some("arguments") => {
+            redact_stringified_json(value, replacement)
+        }
+        Json::String(_) => Json::String(replacement.to_string()),
+        _ => unreachable!("only scalar JSON values are passed to redact_semantic_scalar"),
+    }
+}
+
+fn redact_semantic_object(
+    values: serde_json::Map<String, Json>,
+    replacement: &str,
+    field: Option<&str>,
+) -> Json {
+    let preserve_tool_name = preserves_tool_or_function_name(field, &values);
+    Json::Object(
+        values
+            .into_iter()
+            .map(|(key, value)| {
+                let value = if key == "name" && preserve_tool_name && value.is_string() {
+                    value
+                } else {
+                    redact_semantic_content(value, replacement, Some(&key))
+                };
+                (key, value)
+            })
+            .collect(),
+    )
 }
 
 fn redact_stringified_json(value: String, replacement: &str) -> Json {

--- a/crates/python/src/py_callable.rs
+++ b/crates/python/src/py_callable.rs
@@ -226,6 +226,54 @@ async fn close_async_iter(async_iter: &Arc<Py<PyAny>>) -> FlowResult<()> {
     Ok(())
 }
 
+async fn send_async_iter_value(
+    tx: &tokio::sync::mpsc::Sender<FlowResult<Json>>,
+    value: FlowResult<Json>,
+    cancel: &mut tokio::sync::watch::Receiver<bool>,
+    async_iter: &Arc<Py<PyAny>>,
+) -> FlowResult<bool> {
+    let sent = tokio::select! {
+        _ = cancel.changed() => {
+            close_async_iter(async_iter).await?;
+            return Ok(false);
+        }
+        sent = tx.send(value) => sent,
+    };
+    if sent.is_err() {
+        close_async_iter(async_iter).await?;
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+async fn forward_async_iter_result(
+    next_value: FlowResult<AsyncIterTaskResult>,
+    tx: &tokio::sync::mpsc::Sender<FlowResult<Json>>,
+    cancel: &mut tokio::sync::watch::Receiver<bool>,
+    async_iter: &Arc<Py<PyAny>>,
+) -> Option<FlowResult<()>> {
+    match next_value {
+        Ok(AsyncIterTaskResult::Item(value)) => {
+            match send_async_iter_value(tx, Ok(value), cancel, async_iter).await {
+                Ok(true) => None,
+                Ok(false) => Some(Ok(())),
+                Err(error) => Some(Err(error)),
+            }
+        }
+        Ok(AsyncIterTaskResult::End) => Some(Ok(())),
+        Ok(AsyncIterTaskResult::Cancelled) => Some(close_async_iter(async_iter).await.and(Err(
+            FlowError::Internal("async iterator task was cancelled".into()),
+        ))),
+        Err(error) => Some(
+            match send_async_iter_value(tx, Err(error), cancel, async_iter).await {
+                Ok(true) => close_async_iter(async_iter).await,
+                Ok(false) => Ok(()),
+                Err(error) => Err(error),
+            },
+        ),
+    }
+}
+
 async fn forward_async_iter(
     async_iter: Arc<Py<PyAny>>,
     tx: tokio::sync::mpsc::Sender<FlowResult<Json>>,
@@ -260,35 +308,10 @@ async fn forward_async_iter(
             Err(error) => Err(error),
         };
 
-        match next_value {
-            Ok(AsyncIterTaskResult::Item(value)) => {
-                let sent = tokio::select! {
-                    _ = cancel.changed() => {
-                        break close_async_iter(&async_iter).await;
-                    }
-                    sent = tx.send(Ok(value)) => sent,
-                };
-                if sent.is_err() {
-                    break close_async_iter(&async_iter).await;
-                }
-            }
-            Ok(AsyncIterTaskResult::End) => break Ok(()),
-            Ok(AsyncIterTaskResult::Cancelled) => {
-                let close_result = close_async_iter(&async_iter).await;
-                break close_result.and(Err(FlowError::Internal(
-                    "async iterator task was cancelled".into(),
-                )));
-            }
-            Err(error) => {
-                let sent = tokio::select! {
-                    _ = cancel.changed() => break close_async_iter(&async_iter).await,
-                    sent = tx.send(Err(error)) => sent,
-                };
-                if sent.is_err() {
-                    break close_async_iter(&async_iter).await;
-                }
-                break close_async_iter(&async_iter).await;
-            }
+        if let Some(result) =
+            forward_async_iter_result(next_value, &tx, &mut cancel, &async_iter).await
+        {
+            break result;
         }
     };
     closed.send_replace(Some(result));

--- a/go/nemo_relay/coverage_gap_test.go
+++ b/go/nemo_relay/coverage_gap_test.go
@@ -13,59 +13,44 @@ import (
 func TestEventBaseNilPointerFallbacks(t *testing.T) {
 	event := eventBase{}
 
-	if got := event.UUID(); got != "" {
-		t.Fatalf("expected empty UUID, got %q", got)
+	assertEmptyEventString(t, "UUID", event.UUID())
+	assertEmptyEventString(t, "Name", event.Name())
+	assertEmptyEventString(t, "Kind", event.Kind())
+	assertEmptyEventString(t, "ATOFVersion", event.ATOFVersion())
+	assertEmptyEventString(t, "ScopeType", event.ScopeType())
+	assertZeroEventAttributes(t, event.Attributes())
+	assertNilEventJSON(t, "AttributesJSON", event.AttributesJSON())
+	assertNilEventJSON(t, "Data", event.Data())
+	assertNilEventJSON(t, "DataSchema", event.DataSchema())
+	assertNilEventJSON(t, "Metadata", event.Metadata())
+	assertEmptyEventString(t, "Timestamp", event.Timestamp())
+	assertNilEventJSON(t, "Input", event.Input())
+	assertNilEventJSON(t, "Output", event.Output())
+	assertEmptyEventString(t, "ModelName", event.ModelName())
+	assertEmptyEventString(t, "ToolCallID", event.ToolCallID())
+	assertEmptyEventString(t, "ParentUUID", event.ParentUUID())
+	assertNilEventJSON(t, "AnnotatedRequest", event.AnnotatedRequest())
+	assertNilEventJSON(t, "AnnotatedResponse", event.AnnotatedResponse())
+}
+
+func assertEmptyEventString(t *testing.T, name string, got string) {
+	t.Helper()
+	if got != "" {
+		t.Fatalf("expected empty %s, got %q", name, got)
 	}
-	if got := event.Name(); got != "" {
-		t.Fatalf("expected empty Name, got %q", got)
-	}
-	if got := event.Kind(); got != "" {
-		t.Fatalf("expected empty Kind, got %q", got)
-	}
-	if got := event.ATOFVersion(); got != "" {
-		t.Fatalf("expected empty ATOFVersion, got %q", got)
-	}
-	if got := event.ScopeType(); got != "" {
-		t.Fatalf("expected empty ScopeType, got %q", got)
-	}
-	if got := event.Attributes(); got != 0 {
+}
+
+func assertZeroEventAttributes(t *testing.T, got uint32) {
+	t.Helper()
+	if got != 0 {
 		t.Fatalf("expected zero Attributes, got %d", got)
 	}
-	if got := event.AttributesJSON(); got != nil {
-		t.Fatalf("expected nil AttributesJSON, got %s", got)
-	}
-	if got := event.Data(); got != nil {
-		t.Fatalf("expected nil Data, got %s", got)
-	}
-	if got := event.DataSchema(); got != nil {
-		t.Fatalf("expected nil DataSchema, got %s", got)
-	}
-	if got := event.Metadata(); got != nil {
-		t.Fatalf("expected nil Metadata, got %s", got)
-	}
-	if got := event.Timestamp(); got != "" {
-		t.Fatalf("expected empty Timestamp, got %q", got)
-	}
-	if got := event.Input(); got != nil {
-		t.Fatalf("expected nil Input, got %s", got)
-	}
-	if got := event.Output(); got != nil {
-		t.Fatalf("expected nil Output, got %s", got)
-	}
-	if got := event.ModelName(); got != "" {
-		t.Fatalf("expected empty ModelName, got %q", got)
-	}
-	if got := event.ToolCallID(); got != "" {
-		t.Fatalf("expected empty ToolCallID, got %q", got)
-	}
-	if got := event.ParentUUID(); got != "" {
-		t.Fatalf("expected empty ParentUUID, got %q", got)
-	}
-	if got := event.AnnotatedRequest(); got != nil {
-		t.Fatalf("expected nil AnnotatedRequest, got %s", got)
-	}
-	if got := event.AnnotatedResponse(); got != nil {
-		t.Fatalf("expected nil AnnotatedResponse, got %s", got)
+}
+
+func assertNilEventJSON(t *testing.T, name string, got []byte) {
+	t.Helper()
+	if got != nil {
+		t.Fatalf("expected nil %s, got %s", name, got)
 	}
 }
 

--- a/python/plugin/build_backend.py
+++ b/python/plugin/build_backend.py
@@ -14,10 +14,19 @@ from pathlib import Path
 from typing import Any
 
 _PROJECT_ROOT = Path(__file__).resolve().parent
+
+
+def _project_file(relative_path: str) -> Path:
+    candidate = (_PROJECT_ROOT / relative_path).resolve()
+    if candidate.parent != _PROJECT_ROOT:
+        raise ValueError(f"path must be a direct child of {_PROJECT_ROOT}")
+    return candidate
+
+
 _REPOSITORY_PROTO = _PROJECT_ROOT.parents[1] / "crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto"
 _SDIST_PROTO = _PROJECT_ROOT / "proto/plugin_worker.proto"
 _GENERATED_DIR = _PROJECT_ROOT / "src/nemo_relay_plugin/_proto"
-_MANIFEST = _PROJECT_ROOT / "MANIFEST.in"
+_MANIFEST = _project_file("MANIFEST.in")
 
 
 def generate_worker_proto(output_dir: Path = _GENERATED_DIR) -> None:


### PR DESCRIPTION
#### Overview

Address the open Sonar findings on `release/0.6` with behavior-preserving refactors and concrete test/security fixes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Split the gateway, codec, redaction, and Python iterator paths into focused helpers to reduce cognitive complexity.
- Replace sparse-array and non-`Error` test cases with equivalent explicit fixtures.
- Confine the Python build manifest path to the project root.

#### Where should the reviewer start?

Start with the codec encoder decompositions in `crates/core/src/codec/`, then review the focused test and path-validation changes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request handling across Anthropic and OpenAI integrations, including safer field updates, removals, and validation of unsupported changes.
  - Improved dispatch behavior when request rewriting or encoding fails, preserving the original request where needed.
  - Improved semantic redaction while preserving permitted analytical and tool-related values.
  - Improved async iterator cancellation and error handling.

- **Tests**
  - Expanded coverage for invalid JSON results, unusual error objects, sparse arrays, and event fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->