### PR TITLE
test: stabilize flaky CI cancellation tests

### DIFF
--- a/crates/cli/tests/coverage/agents/launcher_tests.rs
+++ b/crates/cli/tests/coverage/agents/launcher_tests.rs
@@ -2072,9 +2072,15 @@ async fn execute_live_run_reports_gateway_startup_error_when_health_check_fails(
 async fn execute_live_run_removes_hermes_overlay_when_health_check_fails() {
     let _guard = crate::test_support::PLUGIN_CONFIG_TEST_LOCK.lock().await;
     let _cwd = crate::test_support::CwdTestScope::locked();
-    let _env = EnvScope::without_managed_bootstrap();
-    let _ = nemo_relay::plugin::clear_plugin_configuration();
     let temp = tempfile::tempdir().unwrap();
+    let _env = EnvScope::set(&[
+        (crate::bootstrap::state::BOOTSTRAP_STATE_DIR_ENV, None),
+        ("NEMO_RELAY_BOOTSTRAP_SHUTDOWN_TOKEN", None),
+        (crate::configuration::BOOTSTRAP_FINGERPRINT_ENV, None),
+        ("HOME", Some(temp.path().as_os_str())),
+        ("XDG_CONFIG_HOME", Some(temp.path().join("xdg").as_os_str())),
+    ]);
+    let _ = nemo_relay::plugin::clear_plugin_configuration();
     let hooks_path = temp.path().join("hermes-home/config.yaml");
     std::fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
     let original = "hooks:\n  PreToolUse: []\n";

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -406,6 +406,9 @@ async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
     .expect("cancelled stream should terminate");
     assert!(stream_ack.accepted);
     assert_eq!(stream_error.code, "worker.cancelled");
+    tokio::time::timeout(timeout, plugin.stream_cancelled_notified.notified())
+        .await
+        .expect("cancelled stream should be dropped");
     assert!(plugin.stream_cancelled.load(Ordering::SeqCst));
 
     handle.abort();
@@ -1498,6 +1501,7 @@ struct CancellationPlugin {
     unary_cancelled: Arc<AtomicBool>,
     stream_started: Arc<tokio::sync::Notify>,
     stream_cancelled: Arc<AtomicBool>,
+    stream_cancelled_notified: Arc<tokio::sync::Notify>,
     stream_setup_started: Arc<tokio::sync::Notify>,
     stream_setup_cancelled: Arc<AtomicBool>,
 }
@@ -1530,13 +1534,16 @@ impl WorkerPlugin for CancellationPlugin {
 
         let stream_started = self.stream_started.clone();
         let stream_cancelled = self.stream_cancelled.clone();
+        let stream_cancelled_notified = self.stream_cancelled_notified.clone();
         ctx.register_llm_stream_execution_intercept("cancel-stream", 0, move |_, _, _| {
             let stream_started = stream_started.clone();
             let stream_cancelled = stream_cancelled.clone();
+            let stream_cancelled_notified = stream_cancelled_notified.clone();
             async move {
                 Ok(Box::pin(FillThenPendingStream {
                     started: stream_started,
                     cancelled: stream_cancelled,
+                    cancelled_notified: stream_cancelled_notified,
                     yielded: 0,
                 }) as JsonStream)
             }
@@ -1560,6 +1567,7 @@ impl WorkerPlugin for CancellationPlugin {
 struct FillThenPendingStream {
     started: Arc<tokio::sync::Notify>,
     cancelled: Arc<AtomicBool>,
+    cancelled_notified: Arc<tokio::sync::Notify>,
     yielded: usize,
 }
 
@@ -1584,6 +1592,7 @@ impl Stream for FillThenPendingStream {
 impl Drop for FillThenPendingStream {
     fn drop(&mut self) {
         self.cancelled.store(true, Ordering::SeqCst);
+        self.cancelled_notified.notify_one();
     }
 }
 


### PR DESCRIPTION
#### Overview

Stabilize two independent Rust CI tests that relied on ambient state or asynchronous cleanup timing.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Give the Hermes launcher health-check test its own `HOME` and `XDG_CONFIG_HOME`, preventing concurrent tests from sharing `hook-tls-identity.json`.
- Make the worker stream-cancellation test wait for the stream's actual drop before asserting the cancellation callback ran.

#### Where should the reviewer start?

Review the environment scope in `crates/cli/tests/coverage/agents/launcher_tests.rs` and the explicit stream-drop notification in `crates/worker/tests/worker_sdk_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment isolation for live-run health-check scenarios by using a fresh temporary home/config directory and clearing relevant plugin configuration.
  * Strengthened cancellation end-to-end tests to deterministically verify stream termination: tests now wait for a “stream cancelled” notification and assert the stream is dropped, rather than relying only on a boolean flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->