### PR TITLE
fix: extend worker startup timeout

### DIFF
--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -79,7 +79,7 @@ use super::{
 const JSON_SCHEMA: &str = "nemo.relay.Json@1";
 const EVENT_SCHEMA: &str = "nemo.relay.Event@1";
 const LLM_REQUEST_SCHEMA: &str = "nemo.relay.LlmRequest@1";
-const WORKER_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+const WORKER_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKER_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKER_CONNECT_RETRY: Duration = Duration::from_millis(25);
 const MANAGED_ENVIRONMENTS_DIR: &str = ".dynamic-plugin-environments";

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -28,6 +28,11 @@ use super::*;
 const ACTIVATION_ID: &str = "activation-test";
 const AUTH_TOKEN: &str = "auth-test";
 
+#[test]
+fn worker_startup_timeout_allows_slow_environment_initialization() {
+    assert!(WORKER_STARTUP_TIMEOUT >= std::time::Duration::from_secs(30));
+}
+
 fn enable_operational_logs() {
     let _ = spdlog::init_log_crate_proxy();
     log::set_max_level(log::LevelFilter::Info);


### PR DESCRIPTION
#### Overview

Increase the worker startup deadline from 10 to 30 seconds so cold Python workers can initialize on loaded hosts.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Extend only the worker startup deadline; RPC timeouts and retry cadence are unchanged.
- Add a focused unit assertion that preserves the 30-second minimum.
- No public API, worker protocol, SDK, packaging, or documentation changes.

Validation:
- `cargo test -p nemo-relay --features worker-grpc worker_startup_timeout_allows_slow_environment_initialization`
- Dynamic plugin crate and native/worker integration tests
- `just test-python-plugin`
- `just test-python`
- `just test-go`
- `just test-node`
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just docs`
- `uv run pre-commit run --all-files`

`just test-rust` reached 898 passing tests, then failed in existing built-in plugin registration tests because `pii_redaction` was not registered. The same failure reproduces in an isolated unrelated test; the worker timeout test and all dynamic-plugin integration tests pass.

#### Where should the reviewer start?

`crates/core/src/plugin/dynamic/worker.rs` contains the one-line runtime change.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic worker startup reliability by allowing up to 30 seconds for initialization before timing out.

* **Tests**
  * Added coverage to verify the extended startup window remains configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->