### PR TITLE
fix: emit OpenInference system prompts as input messages

### DIFF
--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -1038,7 +1038,13 @@ fn push_annotated_request_attributes(
     if let Some(params) = request.params.as_ref().and_then(to_json_string) {
         attributes.push(KeyValue::new(oi::llm::INVOCATION_PARAMETERS, params));
     }
-    push_annotated_input_messages(attributes, &request.messages);
+    let mut next_index = 0usize;
+    if let Some(instructions) = request.instructions.as_ref().and_then(message_content_text) {
+        push_message_role(attributes, "llm.input_messages", next_index, "system");
+        push_message_text_value(attributes, "llm.input_messages", next_index, instructions);
+        next_index += 1;
+    }
+    push_annotated_input_messages(attributes, &request.messages, next_index);
     if let Some(tools) = request.tools.as_deref() {
         push_annotated_tools(attributes, tools);
     }
@@ -1087,8 +1093,13 @@ fn push_optimization_attributes(
     crate::observability::push_common_optimization_attributes(attributes, summary);
 }
 
-fn push_annotated_input_messages(attributes: &mut Vec<KeyValue>, messages: &[Message]) {
-    for (index, message) in messages.iter().enumerate() {
+fn push_annotated_input_messages(
+    attributes: &mut Vec<KeyValue>,
+    messages: &[Message],
+    start_index: usize,
+) {
+    for (offset, message) in messages.iter().enumerate() {
+        let index = start_index + offset;
         let role = match message {
             Message::System { .. } => "system",
             Message::Developer { .. } => "developer",

--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -1253,12 +1253,15 @@ fn push_replay_input_messages(attributes: &mut Vec<KeyValue>, input: &Json) {
         next_index += 1;
     }
     if let Some(messages) = input.get("messages").and_then(Json::as_array) {
+        let first_message_index = next_index;
         for message in messages {
             if push_replay_input_message(attributes, next_index, message) {
                 next_index += 1;
             }
         }
-        return;
+        if next_index > first_message_index {
+            return;
+        }
     }
     if let Some(prompt) = input.get("prompt").and_then(display_text_from_json) {
         push_message_role(attributes, "llm.input_messages", next_index, "user");
@@ -1273,13 +1276,12 @@ fn push_replay_input_message(attributes: &mut Vec<KeyValue>, index: usize, messa
     let Some(object) = message.as_object() else {
         return false;
     };
-    if !object.contains_key("role") && !object.contains_key("content") {
+    let Some(role) = object.get("role").and_then(Json::as_str) else {
         return false;
-    }
+    };
     let Some(text) = object.get("content").and_then(display_text_from_json) else {
         return false;
     };
-    let role = object.get("role").and_then(Json::as_str).unwrap_or("user");
     push_message_role(attributes, "llm.input_messages", index, role);
     attributes.push(KeyValue::new(
         format!("llm.input_messages.{index}.message.content"),

--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -1000,9 +1000,6 @@ fn push_llm_request_attributes(attributes: &mut Vec<KeyValue>, event: &Event) {
         if let Some(provider) = input.get("provider").and_then(Json::as_str) {
             attributes.push(KeyValue::new(oi::llm::PROVIDER, provider.to_string()));
         }
-        if let Some(system) = input.get("systemPrompt").and_then(display_text_from_json) {
-            attributes.push(KeyValue::new(oi::llm::SYSTEM, system));
-        }
         push_replay_input_messages(attributes, input);
         return;
     }
@@ -1038,9 +1035,6 @@ fn push_annotated_request_attributes(
     attributes: &mut Vec<KeyValue>,
     request: &AnnotatedLlmRequest,
 ) {
-    if let Some(system) = request.system_prompt() {
-        attributes.push(KeyValue::new(oi::llm::SYSTEM, system.to_string()));
-    }
     if let Some(params) = request.params.as_ref().and_then(to_json_string) {
         attributes.push(KeyValue::new(oi::llm::INVOCATION_PARAMETERS, params));
     }
@@ -1229,27 +1223,38 @@ fn is_openclaw_replay_payload(content: &serde_json::Map<String, Json>) -> bool {
 }
 
 fn push_replay_input_messages(attributes: &mut Vec<KeyValue>, input: &Json) {
+    let mut next_index = 0usize;
+    if let Some(system_prompt) = input.get("systemPrompt").and_then(display_text_from_json) {
+        push_message_role(attributes, "llm.input_messages", next_index, "system");
+        attributes.push(KeyValue::new(
+            format!("llm.input_messages.{next_index}.message.content"),
+            system_prompt,
+        ));
+        next_index += 1;
+    }
     if let Some(messages) = input.get("messages").and_then(Json::as_array) {
-        for (index, message) in messages.iter().enumerate() {
-            push_replay_input_message(attributes, index, message);
+        for message in messages {
+            if push_replay_input_message(attributes, next_index, message) {
+                next_index += 1;
+            }
         }
         return;
     }
     if let Some(prompt) = input.get("prompt").and_then(display_text_from_json) {
-        push_message_role(attributes, "llm.input_messages", 0, "user");
+        push_message_role(attributes, "llm.input_messages", next_index, "user");
         attributes.push(KeyValue::new(
-            "llm.input_messages.0.message.content",
+            format!("llm.input_messages.{next_index}.message.content"),
             prompt,
         ));
     }
 }
 
-fn push_replay_input_message(attributes: &mut Vec<KeyValue>, index: usize, message: &Json) {
+fn push_replay_input_message(attributes: &mut Vec<KeyValue>, index: usize, message: &Json) -> bool {
     let Some(object) = message.as_object() else {
-        return;
+        return false;
     };
     if !object.contains_key("role") && !object.contains_key("content") {
-        return;
+        return false;
     }
     let role = object.get("role").and_then(Json::as_str).unwrap_or("user");
     push_message_role(attributes, "llm.input_messages", index, role);
@@ -1259,6 +1264,7 @@ fn push_replay_input_message(attributes: &mut Vec<KeyValue>, index: usize, messa
             text,
         ));
     }
+    true
 }
 
 fn push_replay_response_attributes(attributes: &mut Vec<KeyValue>, output: &Json) {

--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -1267,14 +1267,15 @@ fn push_replay_input_message(attributes: &mut Vec<KeyValue>, index: usize, messa
     if !object.contains_key("role") && !object.contains_key("content") {
         return false;
     }
+    let Some(text) = object.get("content").and_then(display_text_from_json) else {
+        return false;
+    };
     let role = object.get("role").and_then(Json::as_str).unwrap_or("user");
     push_message_role(attributes, "llm.input_messages", index, role);
-    if let Some(text) = object.get("content").and_then(display_text_from_json) {
-        attributes.push(KeyValue::new(
-            format!("llm.input_messages.{index}.message.content"),
-            text,
-        ));
-    }
+    attributes.push(KeyValue::new(
+        format!("llm.input_messages.{index}.message.content"),
+        text,
+    ));
     true
 }
 

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -1782,6 +1782,62 @@ fn openclaw_replay_payloads_emit_flattened_openinference_llm_attributes() {
 }
 
 #[test]
+fn openclaw_replay_payloads_skip_empty_replay_messages() {
+    let (provider, exporter) = make_provider();
+    let mut processor =
+        OpenInferenceEventProcessor::new(provider.clone(), "test-scope".to_string());
+    let uuid = Uuid::now_v7();
+
+    processor.process(&make_start_event(
+        uuid,
+        None,
+        "openclaw-model-call",
+        ScopeType::Llm,
+        Some(json!({
+            "headers": {"authorization": "Bearer secret-token"},
+            "content": {
+                "provider": "nvidia-inference",
+                "model": "claude-sonnet-4",
+                "systemPrompt": "Use reliable sources.",
+                "messages": [
+                    {"role": "user", "content": ""}
+                ],
+                "placeholderRequest": false,
+                "source": "openclaw.llm_output"
+            }
+        })),
+    ));
+    processor.process(&make_end_event(
+        uuid,
+        None,
+        "openclaw-model-call",
+        ScopeType::Llm,
+        Some(json!({
+            "role": "assistant",
+            "content": "I will search.",
+            "openclaw": {
+                "duration_ms": 42
+            }
+        })),
+    ));
+
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    let attributes = attr_map(&spans[0].attributes);
+    assert!(!attributes.contains_key("llm.system"));
+    assert_attr(&attributes, "llm.input_messages.0.message.role", "system");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.0.message.content",
+        "Use reliable sources.",
+    );
+    assert!(!attributes.contains_key("llm.input_messages.1.message.role"));
+    assert!(!attributes.contains_key("llm.input_messages.1.message.content"));
+}
+
+#[test]
 fn openclaw_replay_tool_call_alias_fields_emit_openinference_attributes() {
     let (provider, exporter) = make_provider();
     let mut processor =

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -4233,6 +4233,11 @@ fn annotated_llm_payloads_emit_flattened_openinference_message_and_tool_attribut
     let attributes = attr_map(&spans[0].attributes);
     assert!(!attributes.contains_key("llm.system"));
     assert_attr(&attributes, "llm.input_messages.0.message.role", "system");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.0.message.content",
+        "Use concise answers.",
+    );
     assert_attr(&attributes, "llm.input_messages.1.message.role", "user");
     assert_attr(
         &attributes,

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -405,6 +405,38 @@ fn sample_openinference_annotated_request() -> AnnotatedLlmRequest {
     }
 }
 
+fn sample_openinference_annotated_request_with_instructions() -> AnnotatedLlmRequest {
+    AnnotatedLlmRequest {
+        instructions: Some(MessageContent::Text("Use concise answers.".to_string())),
+        api_specific: None,
+        messages: vec![Message::User {
+            content: MessageContent::Text("Search docs.".to_string()),
+            name: None,
+        }],
+        model: Some("gpt-4o".to_string()),
+        params: Some(GenerationParams {
+            temperature: Some(0.2),
+            max_tokens: Some(128),
+            top_p: None,
+            stop: None,
+        }),
+        tools: Some(vec![ToolDefinition::Function {
+            function: FunctionDefinition {
+                name: "search_docs".to_string(),
+                description: Some("Search the docs corpus.".to_string()),
+                parameters: Some(json!({
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}}
+                })),
+                strict: None,
+                extra: serde_json::Map::new(),
+            },
+            extra: serde_json::Map::new(),
+        }]),
+        ..empty_annotated_request()
+    }
+}
+
 fn sample_openinference_annotated_response() -> AnnotatedLlmResponse {
     AnnotatedLlmResponse {
         message: Some(MessageContent::Text("I will search docs.".to_string())),
@@ -4281,7 +4313,7 @@ fn annotated_input_projection_covers_extended_roles_and_native_text() {
         },
     ];
     let mut attributes = Vec::new();
-    push_annotated_input_messages(&mut attributes, &messages);
+    push_annotated_input_messages(&mut attributes, &messages, 0);
     let attributes = attr_map(&attributes);
     assert_attr(
         &attributes,
@@ -4331,6 +4363,62 @@ fn annotated_input_projection_covers_extended_roles_and_native_text() {
     assert_eq!(
         message_content_text(&content).as_deref(),
         Some("portable refusal\nnative text\nnative refusal")
+    );
+}
+
+#[test]
+fn annotated_llm_instructions_emit_leading_system_input_message() {
+    let (provider, exporter) = make_provider();
+    let mut processor =
+        OpenInferenceEventProcessor::new(provider.clone(), "test-scope".to_string());
+    let uuid = Uuid::now_v7();
+
+    processor.process(&make_scope_event_with_profile(
+        ScopeCategory::Start,
+        uuid,
+        None,
+        "annotated-chat-with-instructions",
+        ScopeType::Llm,
+        None,
+        Some(
+            CategoryProfile::builder()
+                .annotated_request(Arc::new(
+                    sample_openinference_annotated_request_with_instructions(),
+                ))
+                .build(),
+        ),
+    ));
+    processor.process(&make_scope_event_with_profile(
+        ScopeCategory::End,
+        uuid,
+        None,
+        "annotated-chat-with-instructions",
+        ScopeType::Llm,
+        None,
+        Some(
+            CategoryProfile::builder()
+                .annotated_response(Arc::new(sample_openinference_annotated_response()))
+                .build(),
+        ),
+    ));
+
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    let attributes = attr_map(&spans[0].attributes);
+    assert!(!attributes.contains_key("llm.system"));
+    assert_attr(&attributes, "llm.input_messages.0.message.role", "system");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.0.message.content",
+        "Use concise answers.",
+    );
+    assert_attr(&attributes, "llm.input_messages.1.message.role", "user");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.1.message.content",
+        "Search docs.",
     );
 }
 

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -1782,7 +1782,7 @@ fn openclaw_replay_payloads_emit_flattened_openinference_llm_attributes() {
 }
 
 #[test]
-fn openclaw_replay_payloads_skip_empty_replay_messages() {
+fn openclaw_replay_payloads_fall_back_to_prompt_when_replay_messages_are_empty() {
     let (provider, exporter) = make_provider();
     let mut processor =
         OpenInferenceEventProcessor::new(provider.clone(), "test-scope".to_string());
@@ -1799,7 +1799,71 @@ fn openclaw_replay_payloads_skip_empty_replay_messages() {
                 "provider": "nvidia-inference",
                 "model": "claude-sonnet-4",
                 "systemPrompt": "Use reliable sources.",
+                "prompt": "Find the answer.",
+                "messages": [],
+                "placeholderRequest": false,
+                "source": "openclaw.llm_output"
+            }
+        })),
+    ));
+    processor.process(&make_end_event(
+        uuid,
+        None,
+        "openclaw-model-call",
+        ScopeType::Llm,
+        Some(json!({
+            "role": "assistant",
+            "content": "I will search.",
+            "openclaw": {
+                "duration_ms": 42
+            }
+        })),
+    ));
+
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    let attributes = attr_map(&spans[0].attributes);
+    assert!(!attributes.contains_key("llm.system"));
+    assert_attr(&attributes, "llm.input_messages.0.message.role", "system");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.0.message.content",
+        "Use reliable sources.",
+    );
+    assert_attr(&attributes, "llm.input_messages.1.message.role", "user");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.1.message.content",
+        "Find the answer.",
+    );
+    assert!(!attributes.contains_key("llm.input_messages.2.message.role"));
+    assert!(!attributes.contains_key("llm.input_messages.2.message.content"));
+}
+
+#[test]
+fn openclaw_replay_payloads_fall_back_to_prompt_when_replay_messages_are_incomplete() {
+    let (provider, exporter) = make_provider();
+    let mut processor =
+        OpenInferenceEventProcessor::new(provider.clone(), "test-scope".to_string());
+    let uuid = Uuid::now_v7();
+
+    processor.process(&make_start_event(
+        uuid,
+        None,
+        "openclaw-model-call",
+        ScopeType::Llm,
+        Some(json!({
+            "headers": {"authorization": "Bearer secret-token"},
+            "content": {
+                "provider": "nvidia-inference",
+                "model": "claude-sonnet-4",
+                "systemPrompt": "Use reliable sources.",
+                "prompt": "Find the answer.",
                 "messages": [
+                    {"content": "content without role"},
+                    {"role": "user"},
                     {"role": "user", "content": ""}
                 ],
                 "placeholderRequest": false,
@@ -1833,8 +1897,14 @@ fn openclaw_replay_payloads_skip_empty_replay_messages() {
         "llm.input_messages.0.message.content",
         "Use reliable sources.",
     );
-    assert!(!attributes.contains_key("llm.input_messages.1.message.role"));
-    assert!(!attributes.contains_key("llm.input_messages.1.message.content"));
+    assert_attr(&attributes, "llm.input_messages.1.message.role", "user");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.1.message.content",
+        "Find the answer.",
+    );
+    assert!(!attributes.contains_key("llm.input_messages.2.message.role"));
+    assert!(!attributes.contains_key("llm.input_messages.2.message.content"));
 }
 
 #[test]

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -1705,11 +1705,17 @@ fn openclaw_replay_payloads_emit_flattened_openinference_llm_attributes() {
     assert_eq!(spans.len(), 1);
     let attributes = attr_map(&spans[0].attributes);
     assert_attr(&attributes, "llm.provider", "nvidia-inference");
-    assert_attr(&attributes, "llm.system", "Use reliable sources.");
-    assert_attr(&attributes, "llm.input_messages.0.message.role", "user");
+    assert!(!attributes.contains_key("llm.system"));
+    assert_attr(&attributes, "llm.input_messages.0.message.role", "system");
     assert_attr(
         &attributes,
         "llm.input_messages.0.message.content",
+        "Use reliable sources.",
+    );
+    assert_attr(&attributes, "llm.input_messages.1.message.role", "user");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.1.message.content",
         "Find the answer.",
     );
     assert_attr(
@@ -4193,7 +4199,7 @@ fn annotated_llm_payloads_emit_flattened_openinference_message_and_tool_attribut
     let spans = exporter.get_finished_spans().unwrap();
     assert_eq!(spans.len(), 1);
     let attributes = attr_map(&spans[0].attributes);
-    assert_attr(&attributes, "llm.system", "Use concise answers.");
+    assert!(!attributes.contains_key("llm.system"));
     assert_attr(&attributes, "llm.input_messages.0.message.role", "system");
     assert_attr(&attributes, "llm.input_messages.1.message.role", "user");
     assert_attr(


### PR DESCRIPTION
#### Overview

Align OpenInference export behavior with the expected attribute contract by stopping Relay from writing prompt text into `llm.system`. System content is now exported as ordered `llm.input_messages` entries instead.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Remove `llm.system` emission from both replay-payload projection and annotated request projection in the OpenInference exporter.
- Preserve replay `systemPrompt` content by exporting it as the leading `llm.input_messages.<index>` entry with role `system`.
- Preserve `AnnotatedLlmRequest.instructions` as the leading system input message when present.
- Preserve annotated `Message::System` content in `llm.input_messages` instead of the legacy `llm.system` field.
- Harden replay input projection so `prompt` still falls back when replay `messages` is empty or every replay message is skipped, and skip incomplete replay message objects unless they provide both a string `role` and displayable `content`.
- Update unit coverage to assert that `llm.system` is absent, system and user messages are exported in the expected order, replay fallback remains contiguous, and migrated system-message content is preserved.

Validation:
- `cargo fmt --all`
- `just test-rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-python`
- `just test-go`
- `just test-node`
- `uv run pre-commit run --files crates/core/src/observability/openinference.rs crates/core/tests/unit/observability/openinference_tests.rs`

#### Where should the reviewer start?

Start in `crates/core/src/observability/openinference.rs`, especially the request projection path around `push_llm_request_attributes()` and `push_replay_input_messages()`. The most relevant regression coverage is in `crates/core/tests/unit/observability/openinference_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenInference tracing by representing the system prompt as the first `llm.input_messages` entry with `role: system`, instead of emitting a separate `llm.system` scalar.
  * Ensured consistent `llm.input_messages` indexing/ordering for both annotated requests (from instructions) and replay inputs, with correct shifting of subsequent messages.
  * Added more robust replay handling: only well-formed message entries (with required role/content) are projected, and fallback behavior works for empty or incomplete replay inputs.

* **Tests**
  * Updated and expanded OpenInference flattened-attribute tests to match the new system-message semantics and indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
