### PR TITLE
fix: prefer response model in observability exporters

### DIFF
--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -2705,6 +2705,7 @@ fn normalized_response_model_name(event: &Event) -> Option<String> {
 
 fn effective_model_for_pair(start: &Event, end: &Event) -> Option<String> {
     normalized_response_model_name(end)
+        .or_else(|| manual::model_name_from_manual_llm_output(end.output()).map(ToOwned::to_owned))
         .or_else(|| {
             start
                 .model_name()

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -523,15 +523,13 @@ pub(crate) fn merge_usage(
 }
 
 pub(crate) fn model_name_for_llm_event(event: &crate::api::event::Event) -> Option<String> {
-    if let Some(model_name) = event.model_name() {
-        return Some(model_name.to_string());
-    }
     if event.category().map(|category| category.as_str()) != Some("llm") {
         return None;
     }
     event
         .normalized_llm_response()
         .and_then(|response| response.as_ref().model.clone())
+        .or_else(|| event.model_name().map(ToOwned::to_owned))
         .or_else(|| {
             event
                 .normalized_llm_request()

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -526,22 +526,21 @@ pub(crate) fn model_name_for_llm_event(event: &crate::api::event::Event) -> Opti
     if event.category().map(|category| category.as_str()) != Some("llm") {
         return None;
     }
+    let manual_response_model =
+        manual::model_name_from_manual_llm_output(event.output()).map(ToOwned::to_owned);
+    let manual_request_model =
+        manual::model_name_from_manual_llm_output(event.input()).map(ToOwned::to_owned);
     event
         .normalized_llm_response()
         .and_then(|response| response.as_ref().model.clone())
+        .or(manual_response_model)
         .or_else(|| event.model_name().map(ToOwned::to_owned))
         .or_else(|| {
             event
                 .normalized_llm_request()
                 .and_then(|request| request.as_ref().model.clone())
         })
-        .or_else(|| {
-            event
-                .output()
-                .or_else(|| event.input())
-                .and_then(|payload| manual::model_name_from_manual_llm_output(Some(payload)))
-                .map(ToOwned::to_owned)
-        })
+        .or(manual_request_model)
 }
 
 #[cfg(any(feature = "otel", feature = "openinference"))]

--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -562,6 +562,7 @@ fn build_grpc_metadata(headers: &HashMap<String, String>) -> Result<MetadataMap>
 struct ActiveSpan {
     span: Span,
     span_context: SpanContext,
+    start_model_name: Option<String>,
     projected_attributes: Vec<KeyValue>,
 }
 
@@ -656,6 +657,7 @@ impl OpenInferenceEventProcessor {
         self.remove_completed_span_context(event.uuid());
         let parent_context = self.parent_context(event);
         let is_trace_root = !parent_context.span().span_context().is_valid();
+        let start_model_name = model_name_for_llm_event(event);
         let mut span = self
             .tracer
             .span_builder(span_name(event))
@@ -665,6 +667,9 @@ impl OpenInferenceEventProcessor {
             .with_span_id(relay_span_id(event.uuid()))
             .start_with_context(&self.tracer, &parent_context);
         let mut attributes = start_attributes(event);
+        if start_model_name.is_some() {
+            attributes.retain(|attribute| attribute.key.as_str() != oi::llm::MODEL_NAME.as_str());
+        }
         if is_trace_root {
             push_session_identity_attributes(&mut attributes, event);
         }
@@ -676,6 +681,7 @@ impl OpenInferenceEventProcessor {
             ActiveSpan {
                 span,
                 span_context,
+                start_model_name,
                 projected_attributes,
             },
         );
@@ -688,6 +694,9 @@ impl OpenInferenceEventProcessor {
         self.record_completed_span_context(event.uuid(), active_span.span_context.clone());
         super::set_span_status_from_event_metadata(&mut active_span.span, event);
         let mut attributes = end_attributes(event);
+        if let Some(model_name) = model_name_for_llm_event(event).or(active_span.start_model_name) {
+            attributes.push(KeyValue::new(oi::llm::MODEL_NAME, model_name));
+        }
         if !self.attribute_mappings.is_empty() {
             let mut projected_attributes = active_span.projected_attributes;
             projected_attributes.extend(attributes.iter().cloned());

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -555,6 +555,7 @@ fn build_grpc_metadata(headers: &HashMap<String, String>) -> Result<MetadataMap>
 struct ActiveSpan {
     span: Span,
     span_context: SpanContext,
+    start_model_name: Option<String>,
     projected_attributes: Vec<KeyValue>,
 }
 
@@ -649,6 +650,7 @@ impl OtelEventProcessor {
         self.remove_completed_span_context(event.uuid());
         let parent_context = self.parent_context(event);
         let is_trace_root = !parent_context.span().span_context().is_valid();
+        let start_model_name = model_name_for_llm_event(event);
         let mut span = self
             .tracer
             .span_builder(span_name(event))
@@ -658,6 +660,9 @@ impl OtelEventProcessor {
             .with_span_id(relay_span_id(event.uuid()))
             .start_with_context(&self.tracer, &parent_context);
         let mut attributes = start_attributes(event);
+        if start_model_name.is_some() {
+            attributes.retain(|attribute| attribute.key.as_str() != "nemo_relay.model_name");
+        }
         if is_trace_root {
             push_session_identity_attributes(&mut attributes, event);
         }
@@ -669,6 +674,7 @@ impl OtelEventProcessor {
             ActiveSpan {
                 span,
                 span_context,
+                start_model_name,
                 projected_attributes,
             },
         );
@@ -682,6 +688,9 @@ impl OtelEventProcessor {
 
         super::set_span_status_from_event_metadata(&mut active_span.span, event);
         let mut attributes = end_attributes(event);
+        if let Some(model_name) = model_name_for_llm_event(event).or(active_span.start_model_name) {
+            attributes.push(KeyValue::new("nemo_relay.model_name", model_name));
+        }
         if !self.attribute_mappings.is_empty() {
             let mut projected_attributes = active_span.projected_attributes;
             projected_attributes.extend(attributes.iter().cloned());

--- a/crates/core/tests/unit/observability/exporter_parity_tests.rs
+++ b/crates/core/tests/unit/observability/exporter_parity_tests.rs
@@ -527,6 +527,31 @@ fn test_exporters_agree_on_model_name() {
     );
 }
 
+#[test]
+fn test_exporters_prefer_response_model_name_over_requested_model() {
+    let exports = run_llm_scenario(
+        chat_request_content("requested-model"),
+        chat_response_output("response-model"),
+    );
+
+    assert_eq!(
+        exports.agent_step().model_name.as_deref(),
+        Some("response-model")
+    );
+    assert_eq!(
+        exports
+            .otel_attrs("model-call")
+            .get("nemo_relay.model_name"),
+        Some(&"response-model".to_string())
+    );
+    assert_eq!(
+        exports
+            .openinference_attrs("model-call")
+            .get("llm.model_name"),
+        Some(&"response-model".to_string())
+    );
+}
+
 // ===================================================================
 // Tool-call parity
 // ===================================================================

--- a/crates/core/tests/unit/observability/exporter_parity_tests.rs
+++ b/crates/core/tests/unit/observability/exporter_parity_tests.rs
@@ -552,6 +552,35 @@ fn test_exporters_prefer_response_model_name_over_requested_model() {
     );
 }
 
+#[test]
+fn test_exporters_fall_back_to_requested_model_when_response_model_is_missing() {
+    let exports = run_llm_scenario(
+        chat_request_content("requested-model"),
+        json!({
+            "id": "chatcmpl-no-model",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop"
+            }]
+        }),
+    );
+
+    assert_eq!(
+        exports
+            .otel_attrs("model-call")
+            .get("nemo_relay.model_name"),
+        Some(&"requested-model".to_string())
+    );
+    assert_eq!(
+        exports
+            .openinference_attrs("model-call")
+            .get("llm.model_name"),
+        Some(&"requested-model".to_string())
+    );
+}
+
 // ===================================================================
 // Tool-call parity
 // ===================================================================

--- a/crates/core/tests/unit/observability/exporter_parity_tests.rs
+++ b/crates/core/tests/unit/observability/exporter_parity_tests.rs
@@ -581,6 +581,47 @@ fn test_exporters_fall_back_to_requested_model_when_response_model_is_missing() 
     );
 }
 
+#[test]
+fn test_exporters_prefer_manual_response_model_name_over_requested_model() {
+    let uuid = Uuid::now_v7();
+    let start = llm_event_with_model(
+        ScopeCategory::Start,
+        uuid,
+        "model-call",
+        json!({"prompt": "manual prompt"}),
+        "requested-model",
+    );
+    let end = llm_event_with_model(
+        ScopeCategory::End,
+        uuid,
+        "model-call",
+        json!({
+            "content": "manual answer",
+            "model": "response-model"
+        }),
+        "requested-model",
+    );
+    assert!(
+        end.normalized_llm_response().is_none(),
+        "payload must exercise the manual response-model fallback, not a codec",
+    );
+
+    let exports = export_through_all_exporters(&[start, end]);
+
+    assert_eq!(
+        exports
+            .otel_attrs("model-call")
+            .get("nemo_relay.model_name"),
+        Some(&"response-model".to_string())
+    );
+    assert_eq!(
+        exports
+            .openinference_attrs("model-call")
+            .get("llm.model_name"),
+        Some(&"response-model".to_string())
+    );
+}
+
 // ===================================================================
 // Tool-call parity
 // ===================================================================

--- a/crates/core/tests/unit/observability/exporter_parity_tests.rs
+++ b/crates/core/tests/unit/observability/exporter_parity_tests.rs
@@ -609,6 +609,10 @@ fn test_exporters_prefer_manual_response_model_name_over_requested_model() {
     let exports = export_through_all_exporters(&[start, end]);
 
     assert_eq!(
+        exports.agent_step().model_name.as_deref(),
+        Some("response-model")
+    );
+    assert_eq!(
         exports
             .otel_attrs("model-call")
             .get("nemo_relay.model_name"),

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -3343,6 +3343,32 @@ fn helper_functions_cover_additional_openinference_branches() {
         raw_model_attributes.get(oi::llm::MODEL_NAME.as_str()),
         Some(&"raw-model".to_string())
     );
+    let response_model_end = Event::Scope(ScopeEvent::new(
+        BaseEvent::builder()
+            .name("chat")
+            .data(json!({
+                "id": "chatcmpl-response-model",
+                "model": "response-model",
+                "choices": [{
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }]
+            }))
+            .build(),
+        ScopeCategory::End,
+        Vec::new(),
+        EventCategory::llm(),
+        Some(
+            CategoryProfile::builder()
+                .model_name("requested-model")
+                .build(),
+        ),
+    ));
+    let response_model_attributes = attr_map(&common_attributes(&response_model_end));
+    assert_eq!(
+        response_model_attributes.get(oi::llm::MODEL_NAME.as_str()),
+        Some(&"response-model".to_string())
+    );
     assert_eq!(
         llm_attributes.get("openinference.metadata.phase"),
         Some(&"done".to_string())

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -1778,6 +1778,31 @@ fn helper_functions_cover_additional_otel_branches() {
         raw_model_attributes.get("nemo_relay.model_name"),
         Some(&"raw-model".to_string())
     );
+    let response_model_event = make_scope_event_with_profile(
+        ScopeCategory::End,
+        Uuid::now_v7(),
+        None,
+        "chat",
+        ScopeType::Llm,
+        Some(json!({
+            "id": "chatcmpl-response-model",
+            "model": "response-model",
+            "choices": [{
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop"
+            }]
+        })),
+        Some(
+            CategoryProfile::builder()
+                .model_name("requested-model")
+                .build(),
+        ),
+    );
+    let response_model_attributes = attr_map(&common_attributes(&response_model_event));
+    assert_eq!(
+        response_model_attributes.get("nemo_relay.model_name"),
+        Some(&"response-model".to_string())
+    );
 
     let tool_event = Event::Scope(ScopeEvent::new(
         BaseEvent::builder()


### PR DESCRIPTION
#### Overview

Prefer response-derived LLM model names over requested model names when Relay exports observability data. This keeps ATIF, OpenTelemetry, and OpenInference aligned when a router, alias, or versioned endpoint returns a different model than the request asked for.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

This change fixes model-name precedence for LLM observability exports.

- Updates `model_name_for_llm_event()` to prefer, in order, the normalized response model, manual response model, requested or profile model, normalized request model, and manual request fallback.
- Updates the OpenTelemetry and OpenInference exporters to preserve one final end-time model-name attribute, preferring response-derived model data and keeping the start or request model only as fallback.
- Updates ATIF pair resolution to prefer manual response models when normalized response data is unavailable.
- Adds regression coverage for:
  - normalized response model overriding requested model
  - requested model remaining the fallback when no response model exists
  - manual response model overriding requested model across ATIF, OpenTelemetry, and OpenInference

Validation run:

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p nemo-relay helper_functions_cover_additional_openinference_branches --lib`
- `cargo test -p nemo-relay helper_functions_cover_additional_otel_branches --lib`
- `cargo test -p nemo-relay test_exporters_agree_on_model_name --lib`
- `cargo test -p nemo-relay test_exporters_prefer_response_model_name_over_requested_model --lib`
- `cargo test -p nemo-relay test_exporters_prefer_manual_response_model_name_over_requested_model --lib`
- `just test-rust`
- `just test-python`
- `just test-go`
- `just test-node`
- `PATH="$HOME/.local/nemo-relay-tools/bin:$PATH" uv run pre-commit run --files crates/core/src/observability/atif.rs crates/core/src/observability/mod.rs crates/core/src/observability/openinference.rs crates/core/src/observability/otel.rs crates/core/tests/unit/observability/exporter_parity_tests.rs crates/core/tests/unit/observability/openinference_tests.rs crates/core/tests/unit/observability/otel_tests.rs`

#### Where should the reviewer start?

Start in `crates/core/src/observability/mod.rs` at `model_name_for_llm_event()`, then review how that precedence is applied in:

- `crates/core/src/observability/atif.rs`
- `crates/core/src/observability/otel.rs`
- `crates/core/src/observability/openinference.rs`

The most useful regression coverage is in:

- `crates/core/tests/unit/observability/exporter_parity_tests.rs`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none
