### PR TITLE
chore: clear release notes and migration guide for 0.7

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,4 +3,3 @@
 
 branches:
   - main
-  - release/0.6

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -40,10 +40,8 @@ supported platforms and architectures, worker runtimes, coding agents, and
 integrations. It also records current limitations, including platform-specific
 worker requirements.
 
-This release requires migration work for persistent coding-agent installations,
-ATOF configuration, typed observability attributes, annotated-request plugin
-consumers, and managed LLM streams. Refer to the [Migration
-Guides](/reference/migration-guides) for upgrade actions from 0.6 to 0.7.
+Migration guidance for upgrading from 0.6 to 0.7 will be added to the
+[Migration Guides](/reference/migration-guides) before the release.
 
 ### Fixed Known Issues in 0.7
 

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Release Notes for NVIDIA NeMo Relay"
 sidebar-title: "Release Notes"
-description: "Review highlights, compatibility updates, fixed known issues, and current known issues for NVIDIA NeMo Relay 0.6."
+description: "Review highlights, compatibility updates, fixed known issues, and current known issues for NVIDIA NeMo Relay 0.7."
 template-library-version: "1.0.0"
 position: 6
 ---
@@ -25,32 +25,13 @@ This is the Release Notes template. Document one release version per page and us
 This page contains the release notes for [NVIDIA NeMo
 Relay](/about-nemo-relay/overview).
 
-## Release 0.6
+## Release 0.7
 
-NVIDIA NeMo Relay 0.6 strengthens local coding-agent observability, event
-sanitization, observability exports, and dynamic plugin lifecycle management.
+NVIDIA NeMo Relay 0.7 release notes are in preparation.
 
 ### Highlights
 
-- Coding agents now connect through `nemo-relay mcp`, which starts or adopts a
-  shared authenticated gateway before hooks or routed provider traffic arrive.
-  Codex, Claude Code, and Hermes clients can share the gateway and coordinate
-  recovery before idle shutdown.
-- Relay adds global, scope-local, and plugin-installed sanitizers for mark,
-  scope-start, and scope-end events. The PII redaction plugin now supports
-  ordered, composable profiles and the opt-in `trajectory_context` preset.
-- ATOF configuration version 2 supports multiple independently configured file
-  and stream sinks. OpenTelemetry and OpenInference now use typed attributes,
-  and trace exporters can project selected marks as tool spans.
-- Rust, Python, and Node.js embedding hosts can own native and worker dynamic
-  plugin lifecycles. Experimental Go and C entry points expose the same
-  source-first lifecycle.
-- The coding-agent gateway supports lossless request annotations for Anthropic
-  Messages, OpenAI Chat Completions, and OpenAI Responses generation routes.
-- The CLI adds recursive plugin configuration editing and configurable
-  human-readable or JSONL operational logging.
-- The opt-in Switchyard integration can validate and route buffered or
-  streaming provider requests through a separately managed Decision API.
+- _Highlights will be added for the 0.7 release._
 
 ### Support Matrix and Compatibility Updates
 
@@ -62,29 +43,13 @@ worker requirements.
 This release requires migration work for persistent coding-agent installations,
 ATOF configuration, typed observability attributes, annotated-request plugin
 consumers, and managed LLM streams. Refer to the [Migration
-Guides](/reference/migration-guides) for upgrade actions from 0.5 to 0.6.
+Guides](/reference/migration-guides) for upgrade actions from 0.6 to 0.7.
 
-### Fixed Known Issues in 0.6
+### Fixed Known Issues in 0.7
 
-- Coding-agent gateway generation routes now decode request annotations for
-  Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses while
-  preserving unchanged nested fields, explicit nulls, and provider
-  representations.
-- Installed coding-agent sessions now acquire the shared gateway through MCP
-  before hooks or routed provider traffic, preventing cold-start loss and
-  coordinating concurrent startup and recovery.
-- Transparent Codex routing now recognizes `at-...` access tokens and sends
-  them to the ChatGPT Codex backend without rewriting unrelated bearer tokens
-  or provider API keys.
-- Relay now asks Codex to prefer the readable legacy multi-agent path during
-  managed runs and restores the user's prior setting during uninstall.
-- ATIF now reports the normalized provider response model when a routed or
-  translated call runs on a model that differs from the request.
-- The NeMo Flow migration skill now skips credential-bearing dotenv files and
-  symbolic links, requires exact project-root confirmation, and refuses write
-  mode for filesystem roots and home directories.
+- _Fixed issues will be added for the 0.7 release._
 
-## Known Issues in 0.6
+## Known Issues in 0.7
 
 - Go and the raw C FFI remain experimental and source-first. Generated API
   pages focus on Rust, Python, and Node.js.

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -6,100 +6,14 @@ position: 6
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-Use this page to plan an upgrade from NeMo Relay 0.5 to 0.6. It groups the
+Use this page to plan an upgrade from NeMo Relay 0.6 to 0.7. It will group the
 actions from the release notes by the surface you operate. If you skip one or
 more releases, review the migration guides and release notes for every
 intervening release in sequence.
 
-## Upgrade to NeMo Relay 0.6
+## Upgrade to NeMo Relay 0.7
 
-### Coding-Agent Integrations
-
-Reinstall every persistent Codex, Claude Code, and Hermes Agent integration:
-
-```bash
-nemo-relay install <agent> --force
-```
-
-Or refresh all detected supported hosts:
-
-```bash
-nemo-relay install all --force
-```
-
-Version 0.5 installations do not use the 0.6 MCP-owned gateway lifecycle,
-agent-owned hooks, generation fencing, or user-scoped configuration. Confirm
-that the host satisfies the current minimum version before reinstalling:
-Claude Code 2.1.121, Codex CLI 0.143.0, or Hermes Agent 0.18.2. Then run
-`nemo-relay doctor --plugin <agent>` to verify the refreshed installation.
-
-### Dynamic Plugins and Workers
-
-Rebuild Rust native plugins and Rust `grpc-v1` workers that consume annotated
-LLM requests against NeMo Relay 0.6. Update Python workers to the 0.6 worker
-SDK and declare:
-
-```toml
-[compat]
-relay = ">=0.6,<1.0"
-```
-
-The annotation and LLM request-intercept outcome envelopes gained fields and
-variants. A plugin that registers an LLM request intercept cannot claim a
-compatibility range that admits Relay 0.5. Node.js, Go, and raw C FFI callbacks
-continue to receive JSON, but their consumers must not exhaustively match role
-or component discriminator strings. Go and raw C FFI remain experimental and
-source-first.
-
-### Streaming Consumers
-
-Close a managed LLM stream when you stop consuming it early so Relay can stop
-the producer and emit the interrupted end event. Replace direct Rust
-`LlmJsonStream` construction with its constructors, handle the result from Go
-`LlmStream.Close`, use Python `await stream.aclose()`, Node.js
-`await stream.close()`, or call `nemo_relay_stream_close` before freeing a C
-stream.
-
-### Exporters and Observability Queries
-
-Update ATOF configuration to version 2 and replace the legacy output fields
-with the tagged `atof.sinks` list. Direct ATOF exporter construction now takes
-one typed file or stream sink.
-
-Update OpenTelemetry and OpenInference queries, dashboards, and processors to
-the typed attribute paths. The former raw `*_json` payload attributes are no
-longer emitted. Use `attribute_mappings` only when an older key must continue
-to be available.
-
-ATIF no longer models marks as synthetic system steps. Use ATOF for canonical
-mark data or enable the OpenTelemetry or OpenInference `mark_projection =
-"tool"` visualization when a trace viewer needs visible mark nodes. Review
-any consumers that assume `step.model_name` always identifies the requested
-model; it now uses the effective response model where available.
-
-### Middleware, Sanitizers, and Runtime APIs
-
-Update PII redaction configuration to the composable `profiles` form when you
-need ordered policies. Existing single-policy configuration continues to work,
-but it cannot be combined with `profiles`. The optional
-`trajectory_context` preset changes observability payloads only; it does not
-change provider requests or client-visible responses.
-
-Sanitizer failures now drop the affected event. If your policy requires
-fail-open behavior, handle the failure inside the sanitizer and return only the
-safe fields.
-
-For Rust consumers, update exhaustive matches and direct struct literals for
-the expanded public enums and types. Prefer the current builders and typed sink
-constructors over direct literals where available.
-
-### Skills and Automation
-
-Replace retired 0.5 skill directories with the task-oriented public entry
-points, including `nemo-relay-install`, `nemo-relay-get-started`, the
-`nemo-relay-instrument-*` skills, and `nemo-relay-plugin-*` skills. The
-[NeMo Relay User Skills](https://github.com/NVIDIA/NeMo-Relay/blob/main/skills/README.md)
-catalog lists the current paths.
+Migration guidance will be added before the 0.7 release.
 
 ## Related Release Information
 


### PR DESCRIPTION
#### Overview

Prepare the repository for the upcoming 0.7 release.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Stop nightly alpha tag creation for `release/0.6`.
- Replace 0.6-specific release-note highlights and fixed issues with 0.7 placeholders.
- Carry forward known issues and update the migration reference to 0.6 to 0.7.

#### Where should the reviewer start?

Review `.github/nightly-alpha-branches.yaml` for the nightly-tag change, then `docs/about-nemo-relay/release-notes/index.mdx` for the 0.7 release-note structure.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NVIDIA NeMo Relay release notes to document version **0.7** (including placeholders for **Highlights** and **Fixed Known Issues**).
  * Updated migration guidance to reference upgrading **0.6 → 0.7**, replacing detailed **0.6** content with a **0.7** placeholder.
* **Chores**
  * Adjusted nightly alpha branch configuration to remove the **release/0.6** branch, leaving **main** only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->