### PR TITLE
fix: align ATIF model fallback with OpenTelemetry and OpenInference

### DIFF
--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -2553,6 +2553,8 @@ impl StepConversionState {
             .llm_start_model_names
             .get(&event.uuid())
             .map(String::as_str);
+        let step_model_name =
+            effective_response_model_name(event).or_else(|| paired_start_model.map(str::to_owned));
         let ancestry = build_ancestry(event, &lookups.name_map);
         let invocation = build_invocation_info(
             start_ts,
@@ -2582,7 +2584,7 @@ impl StepConversionState {
                 .and_then(|response| atif_message_from_annotated_response(response))
                 .unwrap_or_else(|| extract_llm_response_message(output)),
             timestamp: Some(event.timestamp().to_rfc3339()),
-            model_name: effective_response_model_name(event),
+            model_name: step_model_name,
             reasoning_effort,
             reasoning_content,
             tool_calls,

--- a/crates/core/tests/unit/observability/exporter_parity_tests.rs
+++ b/crates/core/tests/unit/observability/exporter_parity_tests.rs
@@ -568,6 +568,10 @@ fn test_exporters_fall_back_to_requested_model_when_response_model_is_missing() 
     );
 
     assert_eq!(
+        exports.agent_step().model_name.as_deref(),
+        Some("requested-model")
+    );
+    assert_eq!(
         exports
             .otel_attrs("model-call")
             .get("nemo_relay.model_name"),


### PR DESCRIPTION
#### Overview

Keep ATIF model attribution aligned with OpenTelemetry and OpenInference when an LLM end event does not provide response-side model attribution.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update the ATIF agent-step end path to preserve the paired start or request model when the end event has no response-side model attribution.
- Keep existing response-first behavior unchanged when a normalized or manual response model is present.
- Extend the exporter parity regression to assert that ATIF now matches the existing OpenTelemetry and OpenInference fallback behavior for this case.

Validation:

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p nemo-relay test_exporters_fall_back_to_requested_model_when_response_model_is_missing --lib`
- `cargo test -p nemo-relay test_exporters_prefer_response_model_name_over_requested_model --lib`
- `cargo test -p nemo-relay test_exporters_prefer_manual_response_model_name_over_requested_model --lib`
- `just test-rust`
- `just test-python`
- `just test-go`
- `just test-node`
- `PATH="$HOME/.local/nemo-relay-tools/bin:$PATH" uv run pre-commit run --files crates/core/src/observability/atif.rs crates/core/tests/unit/observability/exporter_parity_tests.rs`

#### Where should the reviewer start?

Start in `crates/core/src/observability/atif.rs` in `handle_llm_end()`, where the emitted ATIF agent step now falls back to the paired start model only when the end event cannot provide response-side model attribution. The key regression coverage is in `crates/core/tests/unit/observability/exporter_parity_tests.rs`, especially `test_exporters_fall_back_to_requested_model_when_response_model_is_missing`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observability exports so agent steps retain the requested model name when response metadata is unavailable.
  * Ensured model names remain consistent across ATIF, OpenTelemetry, and OpenInference exports.

* **Tests**
  * Added coverage verifying the requested model name is preserved in ATIF fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->