### PR TITLE
feat: package CLI for PyPI and npm

### DIFF
--- a/.github/ci-path-filters.yml
+++ b/.github/ci-path-filters.yml
@@ -86,6 +86,7 @@ node_package:
   - 'pyproject.toml'
   - 'rust-toolchain.toml'
   - 'scripts/package-cli-bin.py'
+  - 'scripts/package-node-bin.py'
   - 'uv.lock'
 
 python_package:

--- a/.github/ci-path-filters.yml
+++ b/.github/ci-path-filters.yml
@@ -59,7 +59,10 @@ rust_package:
   - 'crates/ffi/nemo_relay.h'
   - 'crates/ffi/src/**'
   - 'justfile'
+  - 'packages/cli-bin/**'
+  - 'python/cli-bin/**'
   - 'rust-toolchain.toml'
+  - 'scripts/package-cli-bin.py'
 
 node_package:
   - 'Cargo.lock'
@@ -79,8 +82,10 @@ node_package:
   - 'justfile'
   - 'package.json'
   - 'package-lock.json'
+  - 'packages/cli-bin/**'
   - 'pyproject.toml'
   - 'rust-toolchain.toml'
+  - 'scripts/package-cli-bin.py'
   - 'uv.lock'
 
 python_package:
@@ -96,8 +101,10 @@ python_package:
   - 'crates/python/src/**'
   - 'justfile'
   - 'pyproject.toml'
+  - 'python/cli-bin/**'
   - 'python/nemo_relay/**'
   - 'rust-toolchain.toml'
+  - 'scripts/package-cli-bin.py'
   - 'uv.lock'
 
 python_integration_langchain:
@@ -124,7 +131,9 @@ dependencies:
   - 'integrations/**/package.json'
   - 'package.json'
   - 'package-lock.json'
+  - 'packages/cli-bin/**'
   - 'pyproject.toml'
+  - 'python/cli-bin/**'
   - 'scripts/licensing/**'
   - 'uv.lock'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,6 +283,13 @@ jobs:
           merge-multiple: true
           path: release-assets/
 
+      - name: Download Python API wheel artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheel-*
+          merge-multiple: true
+          path: release-assets/
+
       - name: Generate distribution checksums
         run: |
           set -euo pipefail
@@ -302,10 +309,12 @@ jobs:
 
             cli_binaries=(nemo-relay-cli-*)
             cli_wheels=(nemo_relay_cli_bin-*.whl)
+            python_api_wheels=(nemo_relay-*.whl)
             cli_npm=(nemo-relay-bin-npm-*.tgz)
             node_npm=(nemo-relay-node-npm-*.tgz)
             expect_count 5 "CLI binary" "${cli_binaries[@]}"
             expect_count 5 "CLI wheel" "${cli_wheels[@]}"
+            expect_count 5 "Python API wheel" "${python_api_wheels[@]}"
             expect_count 6 "CLI npm" "${cli_npm[@]}"
             expect_count 6 "Node npm" "${node_npm[@]}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,7 +347,7 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           draft: true
-          prerelease: ${{ contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
+          prerelease: ${{ contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
           overwrite_files: true
           fail_on_unmatched_files: true
           files: release-assets/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,8 +257,8 @@ jobs:
             exit 1
           fi
 
-  release-cli-artifacts:
-    name: Release CLI Artifacts
+  release-distribution-artifacts:
+    name: Release Distribution Artifacts
     needs: [prepare, ci_required]
     if: ${{ needs.prepare.outputs.publish_packages == 'true' && needs.ci_required.result == 'success' }}
     runs-on: ubuntu-latest
@@ -269,28 +269,68 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Download CLI binary artifacts
+      - name: Download CLI distribution artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: cli-*
           merge-multiple: true
           path: release-assets/
 
-      - name: Generate CLI release checksums
+      - name: Download Node distribution artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: node-npm-package-*
+          merge-multiple: true
+          path: release-assets/
+
+      - name: Generate distribution checksums
         run: |
           set -euo pipefail
 
           (
             cd release-assets
-            cli_assets=(nemo-relay-cli-*)
-            sha256sum "${cli_assets[@]}" > SHA256SUMS
+            expect_count() {
+              local expected="$1"
+              local label="$2"
+              shift 2
+              local actual="$#"
+              if [ "$actual" -ne "$expected" ]; then
+                echo "Error: expected ${expected} ${label} artifacts, found ${actual}" >&2
+                exit 1
+              fi
+            }
+
+            cli_binaries=(nemo-relay-cli-*)
+            cli_wheels=(nemo_relay_cli_bin-*.whl)
+            cli_npm=(nemo-relay-bin-npm-*.tgz)
+            node_npm=(nemo-relay-node-npm-*.tgz)
+            expect_count 5 "CLI binary" "${cli_binaries[@]}"
+            expect_count 5 "CLI wheel" "${cli_wheels[@]}"
+            expect_count 6 "CLI npm" "${cli_npm[@]}"
+            expect_count 6 "Node npm" "${node_npm[@]}"
+
+            mapfile -t distribution_assets < <(
+              find . -maxdepth 1 -type f \
+                ! -name 'SHA256SUMS' \
+                ! -name '*.sha256' \
+                -printf '%f\n' |
+                sort
+            )
+            if [ "${#distribution_assets[@]}" -eq 0 ]; then
+              echo "Error: no distribution artifacts were collected" >&2
+              exit 1
+            fi
+            sha256sum "${distribution_assets[@]}" > SHA256SUMS
             sha256sum --check SHA256SUMS
 
-            while read -r digest filename; do
-              printf '%s  %s\n' "$digest" "$filename" > "${filename}.sha256"
-            done < SHA256SUMS
+            for filename in nemo-relay-cli-*; do
+              if [[ "$filename" == *.tgz || "$filename" == *.whl || "$filename" == *.sha256 ]]; then
+                continue
+              fi
+              sha256sum "$filename" > "${filename}.sha256"
+            done
 
-            printf 'CLI release assets:\n'
+            printf 'Distribution release assets:\n'
             printf '  release-assets/%s\n' *
           )
 
@@ -403,7 +443,7 @@ jobs:
       - name: Download CLI wheel artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: cli-wheel-*
+          pattern: cli-python-wheel-*
           merge-multiple: true
           path: dist/
 
@@ -435,11 +475,12 @@ jobs:
           node-version: ${{ steps.ci-config.outputs.node_version }}
           registry-url: "https://registry.npmjs.org"
 
-      - name: Download consolidated Node package artifact
+      - name: Download split Node package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: npm-consolidated
-          path: .
+          pattern: node-npm-package-*
+          merge-multiple: true
+          path: node-packages/
 
       - name: Download OpenClaw plugin artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -450,7 +491,7 @@ jobs:
       - name: Download CLI npm artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: cli-npm-*
+          pattern: cli-npm-package-*
           merge-multiple: true
           path: cli-packages/
 
@@ -467,20 +508,7 @@ jobs:
         run: |
           set -euo pipefail
           version="${{ github.ref_name }}"
-          if npm view "nemo-relay-node@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
-            echo "nemo-relay-node ${version} already exists on npm; skipping"
-            exit 0
-          fi
-          unzip -q ./consolidated.zip -d combined
-          echo "Platform binaries included:"
-          ls -la combined/package/*.node
-          npm publish ./combined/package --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
-
-      - name: Publish CLI packages to npm
-        run: |
-          set -euo pipefail
-          version="${{ github.ref_name }}"
-          for pkg in cli-packages/nemo-relay-cli-bin-{linux-x64,linux-arm64,darwin-arm64,win32-x64,win32-arm64}-${version}.tgz; do
+          for pkg in node-packages/nemo-relay-node-npm-{linux-x64,linux-arm64,darwin-arm64,win32-x64,win32-arm64}-${version}.tgz; do
             name="$(tar xOf "$pkg" package/package.json | node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).name')"
             if npm view "${name}@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
               echo "${name} ${version} already exists on npm; skipping"
@@ -488,7 +516,26 @@ jobs:
             fi
             npm publish "$pkg" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
           done
-          launcher="cli-packages/nemo-relay-cli-bin-${version}.tgz"
+          metapackage="node-packages/nemo-relay-node-npm-${version}.tgz"
+          if npm view "nemo-relay-node@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "nemo-relay-node ${version} already exists on npm; skipping"
+          else
+            npm publish "$metapackage" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+          fi
+
+      - name: Publish CLI packages to npm
+        run: |
+          set -euo pipefail
+          version="${{ github.ref_name }}"
+          for pkg in cli-packages/nemo-relay-bin-npm-{linux-x64,linux-arm64,darwin-arm64,win32-x64,win32-arm64}-${version}.tgz; do
+            name="$(tar xOf "$pkg" package/package.json | node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).name')"
+            if npm view "${name}@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+              echo "${name} ${version} already exists on npm; skipping"
+              continue
+            fi
+            npm publish "$pkg" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+          done
+          launcher="cli-packages/nemo-relay-bin-npm-${version}.tgz"
           if npm view "nemo-relay-cli-bin@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
             echo "nemo-relay-cli-bin ${version} already exists on npm; skipping"
           else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -400,6 +400,13 @@ jobs:
           name: plugin-wheel
           path: dist/
 
+      - name: Download CLI wheel artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: cli-wheel-*
+          merge-multiple: true
+          path: dist/
+
       - name: Publish to PyPI with trusted publishing
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
@@ -440,6 +447,13 @@ jobs:
           name: openclaw-npm
           path: openclaw-package/
 
+      - name: Download CLI npm artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: cli-npm-*
+          merge-multiple: true
+          path: cli-packages/
+
       - name: Select npm dist-tag
         run: |
           set -e
@@ -461,6 +475,25 @@ jobs:
           echo "Platform binaries included:"
           ls -la combined/package/*.node
           npm publish ./combined/package --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+
+      - name: Publish CLI packages to npm
+        run: |
+          set -euo pipefail
+          version="${{ github.ref_name }}"
+          for pkg in cli-packages/nemo-relay-cli-bin-{linux-x64,linux-arm64,darwin-arm64,win32-x64,win32-arm64}-${version}.tgz; do
+            name="$(tar xOf "$pkg" package/package.json | node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).name')"
+            if npm view "${name}@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+              echo "${name} ${version} already exists on npm; skipping"
+              continue
+            fi
+            npm publish "$pkg" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+          done
+          launcher="cli-packages/nemo-relay-cli-bin-${version}.tgz"
+          if npm view "nemo-relay-cli-bin@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "nemo-relay-cli-bin ${version} already exists on npm; skipping"
+          else
+            npm publish "$launcher" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+          fi
 
       - name: Publish OpenClaw plugin package to npm
         run: |

--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -220,3 +220,7 @@ jobs:
             fi
             pre-commit run --from-ref "$base_ref" --to-ref HEAD --show-diff-on-failure
           fi
+
+      - name: Test CLI package assembly
+        working-directory: ${{ env.NEMO_RELAY_CI_WORKSPACE }}
+        run: uv run --no-project python -m unittest scripts.tests.test_package_cli_bin

--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -221,6 +221,9 @@ jobs:
             pre-commit run --from-ref "$base_ref" --to-ref HEAD --show-diff-on-failure
           fi
 
-      - name: Test CLI package assembly
+      - name: Test binary package assembly
         working-directory: ${{ env.NEMO_RELAY_CI_WORKSPACE }}
-        run: uv run --no-project python -m unittest scripts.tests.test_package_cli_bin
+        run: >-
+          uv run --no-project python -m unittest
+          scripts.tests.test_package_cli_bin
+          scripts.tests.test_package_node_bin

--- a/.github/workflows/ci_node.yml
+++ b/.github/workflows/ci_node.yml
@@ -312,6 +312,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config

--- a/.github/workflows/ci_node.yml
+++ b/.github/workflows/ci_node.yml
@@ -172,6 +172,10 @@ jobs:
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
+      - uses: actions/setup-python@a309852fecd2e0c80e1b1b2ac6f4e6c2e1274d26 # v6.2.0
+        with:
+          python-version: ${{ steps.ci-config.outputs.default_python_version }}
+
       - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:
           tool: just@${{ steps.ci-config.outputs.just_version }}
@@ -204,14 +208,15 @@ jobs:
           just \
             --set ci true \
             --set output_dir "${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}" \
+            --set node_platform "${{ matrix.platform }}" \
             --set ref_name "${NEMO_RELAY_PACKAGE_VERSION}" \
             package-node
 
-      - name: Upload npm package artifact
+      - name: Upload split Node npm package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: ${{ inputs.run_package }}
         with:
-          name: npm-${{ matrix.platform }}
+          name: node-npm-package-${{ matrix.platform }}
           path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/npm/*.tgz
           if-no-files-found: error
 
@@ -282,79 +287,77 @@ jobs:
           path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/openclaw/*.tgz
           if-no-files-found: error
 
-  Consolidate:
-    name: Consolidate
+  PackageSmoke:
+    name: Package smoke (${{ matrix.platform }})
     needs: [Package]
     if: ${{ inputs.run_package && !cancelled() && needs.Package.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-amd64
+            runner: ubuntu-latest
+          - platform: linux-arm64
+            runner: ubuntu-24.04-arm
+          - platform: macos-arm64
+            runner: macos-15
+          - platform: windows-amd64
+            runner: windows-2022
+          - platform: windows-arm64
+            runner: windows-11-arm
     steps:
-      - name: Download npm linux-amd64 artifact
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Load CI tool versions
+        id: ci-config
+        uses: ./.github/actions/load-ci-tool-versions
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ steps.ci-config.outputs.node_version }}
+
+      - name: Download Node metapackage artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: npm-linux-amd64
-          path: npm-linux-amd64/
+          name: node-npm-package-linux-amd64
+          path: node-metapackage/
 
-      - name: Download npm linux-arm64 artifact
+      - name: Download matching Node native package artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: npm-linux-arm64
-          path: npm-linux-arm64/
+          name: node-npm-package-${{ matrix.platform }}
+          path: node-native/
 
-      - name: Download npm macos-arm64 artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: npm-macos-arm64
-          path: npm-macos-arm64/
-
-      - name: Download npm windows-amd64 artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: npm-windows-amd64
-          path: npm-windows-amd64/
-
-      - name: Download npm windows-arm64 artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: npm-windows-arm64
-          path: npm-windows-arm64/
-
-      - name: Consolidate Node package directory
+      - name: Install and load split Node package
         run: |
           set -euo pipefail
-          mkdir -p combined
-          first=true
-          for dir in npm-linux-amd64 npm-linux-arm64 npm-macos-arm64 npm-windows-amd64 npm-windows-arm64; do
-            shopt -s nullglob
-            tgzs=("${dir}"/*.tgz)
-            shopt -u nullglob
-            if [ "${#tgzs[@]}" -eq 0 ]; then
-              echo "Error: no npm package artifact found in ${dir}" >&2
-              exit 1
-            fi
-            for tgz in "${tgzs[@]}"; do
-              if [ "${first}" = true ]; then
-                tar xzf "${tgz}" -C combined
-                first=false
-              else
-                tar xzf "${tgz}" -C combined --wildcards '*.node'
-              fi
-            done
-          done
-          echo "Platform binaries included:"
-          ls -la combined/package/*.node
-
-      - name: Archive consolidated Node package
-        run: |
-          set -euo pipefail
-          cd combined
-          zip -rq "${{ github.workspace }}/consolidated.zip" package
-
-      - name: Upload consolidated Node package artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: npm-consolidated
-          path: ${{ github.workspace }}/consolidated.zip
-          if-no-files-found: error
+          mkdir package-smoke
+          cd package-smoke
+          npm init --yes >/dev/null
+          metapackage=(../node-metapackage/nemo-relay-node-npm-[0-9]*.tgz)
+          native=(../node-native/nemo-relay-node-npm-*-*-[0-9]*.tgz)
+          npm install --ignore-scripts "${native[0]}" "${metapackage[0]}"
+          node - <<'NODE'
+          const assert = require('node:assert/strict');
+          const { readdirSync } = require('node:fs');
+          const nativePackages = readdirSync('node_modules').filter(
+            (name) => name.startsWith('nemo-relay-node-') && name !== 'nemo-relay-node',
+          );
+          assert.equal(nativePackages.length, 1);
+          for (const entrypoint of [
+            'nemo-relay-node',
+            'nemo-relay-node/typed',
+            'nemo-relay-node/plugin',
+            'nemo-relay-node/adaptive',
+            'nemo-relay-node/observability',
+            'nemo-relay-node/pii_redaction',
+            'nemo-relay-node/model_pricing',
+          ]) {
+            require(entrypoint);
+          }
+          NODE

--- a/.github/workflows/ci_node.yml
+++ b/.github/workflows/ci_node.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
-      - uses: actions/setup-python@a309852fecd2e0c80e1b1b2ac6f4e6c2e1274d26 # v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ steps.ci-config.outputs.default_python_version }}
 

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -305,23 +305,31 @@ jobs:
           fi
           python scripts/package-cli-bin.py "${args[@]}"
 
+      - name: Install and run CLI wheel
+        working-directory: ${{ env.NEMO_RELAY_CI_WORKSPACE }}
+        run: |
+          set -euo pipefail
+          wheels=("${NEMO_RELAY_CI_WORKSPACE_TMP}"/cli-packages/*.whl)
+          python -m pip install --force-reinstall --no-deps "${wheels[0]}"
+          nemo-relay --version
+
       - name: Upload CLI binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: cli-${{ matrix.platform }}
+          name: cli-binary-${{ matrix.platform }}
           path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/cli/*
           if-no-files-found: error
 
       - name: Upload CLI wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: cli-wheel-${{ matrix.platform }}
+          name: cli-python-wheel-${{ matrix.platform }}
           path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/cli-packages/*.whl
           if-no-files-found: error
 
       - name: Upload CLI npm artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: cli-npm-${{ matrix.platform }}
+          name: cli-npm-package-${{ matrix.platform }}
           path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/cli-packages/*.tgz
           if-no-files-found: error

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -278,9 +278,50 @@ jobs:
           mkdir -p "${NEMO_RELAY_CI_WORKSPACE_TMP}/cli"
           cp "$source" "${NEMO_RELAY_CI_WORKSPACE_TMP}/cli/${asset}"
 
+      - name: Package CLI binary for PyPI and npm
+        working-directory: ${{ env.NEMO_RELAY_CI_WORKSPACE }}
+        run: |
+          set -euo pipefail
+          target="${{ matrix.target }}"
+          binary="nemo-relay"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            binary="${binary}.exe"
+          fi
+          source="${NEMO_RELAY_CI_WORKSPACE}/target/${target}/release/${binary}"
+          version="${{ github.ref_name }}"
+          if [ "${{ github.ref_type }}" != "tag" ]; then
+            version="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -n1)+${GIT_COMMIT::8}"
+          fi
+          rm -rf "${NEMO_RELAY_CI_WORKSPACE_TMP}/cli-packages"
+          mkdir -p "${NEMO_RELAY_CI_WORKSPACE_TMP}/cli-packages"
+          args=(
+            --binary "$source"
+            --target "$target"
+            --version "$version"
+            --output-dir "${NEMO_RELAY_CI_WORKSPACE_TMP}/cli-packages"
+          )
+          if [ "${{ matrix.platform }}" = "linux-amd64" ]; then
+            args+=(--npm-launcher)
+          fi
+          python scripts/package-cli-bin.py "${args[@]}"
+
       - name: Upload CLI binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cli-${{ matrix.platform }}
           path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/cli/*
+          if-no-files-found: error
+
+      - name: Upload CLI wheel artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cli-wheel-${{ matrix.platform }}
+          path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/cli-packages/*.whl
+          if-no-files-found: error
+
+      - name: Upload CLI npm artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cli-npm-${{ matrix.platform }}
+          path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/cli-packages/*.tgz
           if-no-files-found: error

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -310,8 +310,16 @@ jobs:
         run: |
           set -euo pipefail
           wheels=("${NEMO_RELAY_CI_WORKSPACE_TMP}"/cli-packages/*.whl)
-          python -m pip install --force-reinstall --no-deps "${wheels[0]}"
-          nemo-relay --version
+          python -m venv "${NEMO_RELAY_CI_WORKSPACE_TMP}/cli-wheel-venv"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            venv_python="${NEMO_RELAY_CI_WORKSPACE_TMP}/cli-wheel-venv/Scripts/python.exe"
+            venv_cli="${NEMO_RELAY_CI_WORKSPACE_TMP}/cli-wheel-venv/Scripts/nemo-relay.exe"
+          else
+            venv_python="${NEMO_RELAY_CI_WORKSPACE_TMP}/cli-wheel-venv/bin/python"
+            venv_cli="${NEMO_RELAY_CI_WORKSPACE_TMP}/cli-wheel-venv/bin/nemo-relay"
+          fi
+          "$venv_python" -m pip install --force-reinstall --no-deps "${wheels[0]}"
+          "$venv_cli" --version
 
       - name: Upload CLI binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,6 +150,10 @@ collect:github-artifacts:
         echo "Error: collected GitHub Node artifacts did not contain any .tgz files." >&2
         exit 1
       fi
+      if ! ls collected/cli-npm/*.tgz >/dev/null 2>&1; then
+        echo "Error: collected GitHub CLI npm artifacts did not contain any .tgz files." >&2
+        exit 1
+      fi
 
       {
         printf '{\n'
@@ -326,6 +330,8 @@ publish:artifactory:npm:
         npm publish --tag dev "$package"
       done
       npm publish --tag dev "collected/node/nemo-relay-node-npm-${CI_COMMIT_TAG}.tgz"
-      for package in collected/cli-npm/*.tgz; do
+      for platform in linux-x64 linux-arm64 darwin-arm64 win32-x64 win32-arm64; do
+        package="collected/cli-npm/nemo-relay-bin-npm-${platform}-${CI_COMMIT_TAG}.tgz"
         npm publish --tag dev "$package"
       done
+      npm publish --tag dev "collected/cli-npm/nemo-relay-bin-npm-${CI_COMMIT_TAG}.tgz"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,27 +132,22 @@ collect:github-artifacts:
       fi
 
       gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'wheel-*' --dir downloaded/wheels
-      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'cli-wheel-*' --dir downloaded/cli-wheels
-      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'cli-npm-*' --dir downloaded/cli-npm
+      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'cli-python-wheel-*' --dir downloaded/cli-wheels
+      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'cli-npm-package-*' --dir downloaded/cli-npm
       gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --name 'plugin-wheel' --dir downloaded/wheels
-      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --name npm-consolidated --dir downloaded/node
+      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'node-npm-package-*' --dir downloaded/node
 
       find downloaded/wheels -type f -name '*.whl' -exec cp {} collected/wheels/ \;
       find downloaded/cli-wheels -type f -name '*.whl' -exec cp {} collected/wheels/ \;
       find downloaded/cli-npm -type f -name '*.tgz' -exec cp {} collected/cli-npm/ \;
-      node_zip="$(find downloaded/node -type f -name consolidated.zip -print -quit)"
-      if [ -z "$node_zip" ]; then
-        echo "Error: collected GitHub npm-consolidated artifact did not contain consolidated.zip." >&2
-        exit 1
-      fi
-      cp "$node_zip" collected/node/consolidated.zip
+      find downloaded/node -type f -name '*.tgz' -exec cp {} collected/node/ \;
 
       if ! ls collected/wheels/*.whl >/dev/null 2>&1; then
         echo "Error: collected GitHub wheel artifacts did not contain any .whl files." >&2
         exit 1
       fi
-      if [ ! -f collected/node/consolidated.zip ]; then
-        echo "Error: collected GitHub npm-consolidated artifact did not contain consolidated.zip." >&2
+      if ! ls collected/node/*.tgz >/dev/null 2>&1; then
+        echo "Error: collected GitHub Node artifacts did not contain any .tgz files." >&2
         exit 1
       fi
 
@@ -170,7 +165,7 @@ collect:github-artifacts:
     expire_in: 7 days
     paths:
       - collected/wheels/*.whl
-      - collected/node/consolidated.zip
+      - collected/node/*.tgz
       - collected/cli-npm/*.tgz
       - collected/github-run.json
 
@@ -307,8 +302,6 @@ publish:artifactory:npm:
   needs:
     - job: collect:github-artifacts
       artifacts: true
-  before_script:
-    - apt-get update -qq && apt-get install -y --no-install-recommends unzip ca-certificates && rm -rf /var/lib/apt/lists/*
   script:
     - |
       set -eu
@@ -317,14 +310,8 @@ publish:artifactory:npm:
         echo "Error: uploading npm packages to Artifactory requires NEMO_RELAY_CI_ARTIFACTORY_USER, NEMO_RELAY_CI_ARTIFACTORY_KEY, and NEMO_RELAY_CI_ARTIFACTORY_NPM_URL." >&2
         exit 1
       fi
-      if [ ! -f collected/node/consolidated.zip ]; then
-        echo "Error: no collected consolidated Node package artifact found." >&2
-        exit 1
-      fi
-      mkdir -p collected/node/consolidated
-      unzip -q collected/node/consolidated.zip -d collected/node/consolidated
-      if [ ! -d collected/node/consolidated/package ]; then
-        echo "Error: consolidated Node artifact did not contain a package directory." >&2
+      if ! ls collected/node/*.tgz >/dev/null 2>&1; then
+        echo "Error: no collected split Node package artifacts found." >&2
         exit 1
       fi
 
@@ -334,7 +321,11 @@ publish:artifactory:npm:
       npm config set registry "$registry_url"
       npm config set "${registry_key}:_auth" "$npm_auth"
 
-      npm publish --tag dev collected/node/consolidated/package
+      for platform in linux-x64 linux-arm64 darwin-arm64 win32-x64 win32-arm64; do
+        package="collected/node/nemo-relay-node-npm-${platform}-${CI_COMMIT_TAG}.tgz"
+        npm publish --tag dev "$package"
+      done
+      npm publish --tag dev "collected/node/nemo-relay-node-npm-${CI_COMMIT_TAG}.tgz"
       for package in collected/cli-npm/*.tgz; do
         npm publish --tag dev "$package"
       done

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ collect:github-artifacts:
       fi
       export GH_TOKEN="${NEMO_RELAY_CI_GITHUB_TOKEN}"
 
-      mkdir -p collected/wheels collected/node downloaded
+      mkdir -p collected/wheels collected/node collected/cli-npm downloaded
 
       tag="${CI_COMMIT_TAG:-}"
       if [ -z "$tag" ]; then
@@ -132,10 +132,14 @@ collect:github-artifacts:
       fi
 
       gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'wheel-*' --dir downloaded/wheels
+      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'cli-wheel-*' --dir downloaded/cli-wheels
+      gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --pattern 'cli-npm-*' --dir downloaded/cli-npm
       gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --name 'plugin-wheel' --dir downloaded/wheels
       gh run download "$run_id" --repo "$NEMO_RELAY_CI_GITHUB_REPOSITORY" --name npm-consolidated --dir downloaded/node
 
       find downloaded/wheels -type f -name '*.whl' -exec cp {} collected/wheels/ \;
+      find downloaded/cli-wheels -type f -name '*.whl' -exec cp {} collected/wheels/ \;
+      find downloaded/cli-npm -type f -name '*.tgz' -exec cp {} collected/cli-npm/ \;
       node_zip="$(find downloaded/node -type f -name consolidated.zip -print -quit)"
       if [ -z "$node_zip" ]; then
         echo "Error: collected GitHub npm-consolidated artifact did not contain consolidated.zip." >&2
@@ -167,6 +171,7 @@ collect:github-artifacts:
     paths:
       - collected/wheels/*.whl
       - collected/node/consolidated.zip
+      - collected/cli-npm/*.tgz
       - collected/github-run.json
 
 publish:artifactory:wheels:
@@ -330,3 +335,6 @@ publish:artifactory:npm:
       npm config set "${registry_key}:_auth" "$npm_auth"
 
       npm publish --tag dev collected/node/consolidated/package
+      for package in collected/cli-npm/*.tgz; do
+        npm publish --tag dev "$package"
+      done

--- a/README.md
+++ b/README.md
@@ -45,18 +45,20 @@ trajectory file, you have concrete data to inspect, debug, and build on.
 ### Local Agent Trajectory
 
 This walkthrough shows an end-to-end quick success setup. Install the
-`nemo-relay-cli`, turn on local exporters, run Codex, Claude Code, or Hermes
+NeMo Relay CLI, turn on local exporters, run Codex, Claude Code, or Hermes
 through Relay, and check that Relay wrote both raw events and normalized
 trajectories.
 
 
 #### 1. Install the CLI
 
-Install the prebuilt CLI with Python or npm:
+Install the prebuilt CLI from PyPI:
 
 ```bash
 pip install nemo-relay-cli-bin
 ```
+
+Install the prebuilt CLI from npm:
 
 ```bash
 npm install --global nemo-relay-cli-bin

--- a/README.md
+++ b/README.md
@@ -52,7 +52,23 @@ trajectories.
 
 #### 1. Install the CLI
 
-Run the installer for your platform:
+Install the prebuilt CLI with Python or npm:
+
+```bash
+pip install nemo-relay-cli-bin
+```
+
+```bash
+npm install --global nemo-relay-cli-bin
+```
+
+Python API users can install the matching CLI through the optional extra:
+
+```bash
+pip install "nemo-relay[cli]"
+```
+
+Alternatively, run the installer for your platform:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,8 +62,8 @@ NeMo Relay versions are anchored on the workspace SemVer in the repository root
 - `integrations/openclaw/package.json` carries the base npm version for the
   OpenClaw plugin package and must stay aligned with the same release version.
 - `packages/cli-bin/package.json` and `python/cli-bin/pyproject.toml` carry the
-  base CLI package versions. The `nemo-relay[cli]` extra must pin the same
-  PEP 440 version.
+  base CLI package versions in their registry-specific SemVer and PEP 440
+  spellings. The `nemo-relay[cli]` extra must pin the exact PyPI version.
 - The Python package version is derived at packaging time. `pyproject.toml`
   stays `dynamic = ["version"]` in the repository, and the packaging recipe
   writes a concrete version into `pyproject.toml` and `crates/python/Cargo.toml`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,8 +32,8 @@ The release pipeline publishes these package surfaces from a tag push:
 |---|---|
 | crates.io | `nemo-relay-types`, `nemo-relay-plugin`, `nemo-relay-worker-proto`, `nemo-relay-worker`, `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-pii-redaction`, `nemo-relay-switchyard`, `nemo-relay-ffi`, `nemo-relay-cli` |
 | PyPI | `nemo-relay`, `nemo-relay-plugin`, `nemo-relay-cli-bin` |
-| npm | `nemo-relay-node`, `nemo-relay-openclaw`, `nemo-relay-cli-bin`, and its five platform packages |
-| GitHub Releases | CLI binaries and `SHA256SUMS` |
+| npm | `nemo-relay-node` and its five platform packages, `nemo-relay-openclaw`, `nemo-relay-cli-bin`, and its five platform packages |
+| GitHub Releases | CLI binaries, CLI wheels, CLI and Node npm tarballs, and checksums |
 | Fern | The documentation site |
 
 Go remains source-first. There is no separate Go package-manager publication
@@ -146,6 +146,10 @@ Before you create a release tag, confirm the following:
    - GitHub Actions `id-token: write` access for the top-level PyPI publish job
    - Pending or existing PyPI trusted publishing is configured for
      `nemo-relay-cli-bin`
+   - npm trusted publishers are configured for `nemo-relay-node`,
+     `nemo-relay-node-linux-x64-gnu`, `nemo-relay-node-linux-arm64-gnu`,
+     `nemo-relay-node-darwin-arm64`, `nemo-relay-node-win32-x64-msvc`, and
+     `nemo-relay-node-win32-arm64-msvc`
    - npm trusted publishers are configured for `nemo-relay-cli-bin` and
      `nemo-relay-cli-bin-linux-x64`, `nemo-relay-cli-bin-linux-arm64`,
      `nemo-relay-cli-bin-darwin-arm64`, `nemo-relay-cli-bin-win32-x64`, and
@@ -250,15 +254,22 @@ The release pipeline then:
    validation.
 3. Builds publishable package artifacts with the exact tag version:
    - `package-rust` packs the published Rust crates for local validation.
-   - `package-node` packs the npm Node.js package.
+   - `package-node` packs one native npm Node.js package per supported platform
+     and creates the JavaScript and TypeScript metapackage once.
    - `package-openclaw` packs the npm OpenClaw plugin package.
    - `package-python` builds platform `nemo-relay` wheels.
    - `package-python-plugin` builds the `nemo-relay-plugin` wheel.
    - The Rust CLI matrix packages each prebuilt binary as a
      `nemo-relay-cli-bin` wheel and npm platform package, and creates the npm
      launcher package once.
-   - The CLI release-asset job uploads each platform `nemo-relay` binary and
-     includes those binaries in `SHA256SUMS`.
+   - The distribution release-asset job uploads the CLI binaries, CLI wheels,
+     CLI npm packages, and split Node npm packages. `SHA256SUMS` covers every
+     attached distribution artifact, and raw CLI binaries also receive
+     individual `.sha256` files for installer compatibility.
+     GitHub-facing npm artifacts use
+     `nemo-relay-bin-npm[-<os>-<cpu>]-<version>.tgz` for the CLI and
+     `nemo-relay-node-npm[-<os>-<cpu>]-<version>.tgz` for Node.js; their
+     registry package names remain in the tarball manifests.
 4. Publishes packages from the top-level workflow after the reusable packaging
    jobs complete:
    - `publish-rust` stamps Cargo workspace versions from the release tag, then
@@ -271,8 +282,9 @@ The release pipeline then:
    - `publish-python` downloads the `nemo-relay`, `nemo-relay-plugin`, and
      `nemo-relay-cli-bin` wheel artifacts and uploads them to PyPI with trusted
      publishing from the top-level workflow
-   - `publish-npm` publishes the Node.js, OpenClaw, and CLI npm packages through
-     npm trusted publishing from the top-level workflow
+   - `publish-npm` publishes the Node.js and CLI native packages before their
+     metapackages, then publishes the OpenClaw package, through npm trusted
+     publishing from the top-level workflow
      - Stable tags publish to the npm `latest` dist-tag
      - Prerelease tags such as `0.1.0-rc.1` publish to the npm `next`
        dist-tag so they do not become the default upgrade target
@@ -305,9 +317,9 @@ NVIDIA Artifactory publication for the same tag:
 npm trusted publishing has its own registry-side constraints:
 
 - Each npm package can only have one trusted publisher configured at a time.
-- Configure trusted publishers for `nemo-relay-node`, `nemo-relay-openclaw`,
-  `nemo-relay-cli-bin`, and all five CLI platform packages before pushing a
-  release tag.
+- Configure trusted publishers for `nemo-relay-node`, all five Node platform
+  packages, `nemo-relay-openclaw`, `nemo-relay-cli-bin`, and all five CLI
+  platform packages before pushing a release tag.
 - npm trusted publishing currently supports GitHub-hosted runners, not
   self-hosted runners.
 
@@ -340,8 +352,8 @@ After the release is live, verify:
    are visible on crates.io.
 2. The `nemo-relay` and `nemo-relay-cli-bin` wheels are visible on PyPI, and
    `pip install "nemo-relay[cli]"` exposes `nemo-relay`.
-3. The `nemo-relay-node`, `nemo-relay-openclaw`, `nemo-relay-cli-bin`, and CLI
-   platform packages are visible on npm.
+3. The `nemo-relay-node`, its five platform packages, `nemo-relay-openclaw`,
+   `nemo-relay-cli-bin`, and its five platform packages are visible on npm.
 4. The Unix and Windows installers resolve the new stable tag and verify
    matching CLI release asset checksums on their supported platforms.
 5. The Fern documentation site shows the expected version and release notes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,7 @@ The release pipeline publishes these package surfaces from a tag push:
 | crates.io | `nemo-relay-types`, `nemo-relay-plugin`, `nemo-relay-worker-proto`, `nemo-relay-worker`, `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-pii-redaction`, `nemo-relay-switchyard`, `nemo-relay-ffi`, `nemo-relay-cli` |
 | PyPI | `nemo-relay`, `nemo-relay-plugin`, `nemo-relay-cli-bin` |
 | npm | `nemo-relay-node` and its five platform packages, `nemo-relay-openclaw`, `nemo-relay-cli-bin`, and its five platform packages |
-| GitHub Releases | CLI binaries, CLI wheels, CLI and Node npm tarballs, and checksums |
+| GitHub Releases | CLI binaries, `nemo-relay` and `nemo-relay-cli-bin` wheels, CLI and Node npm tarballs, and checksums |
 | Fern | The documentation site |
 
 Go remains source-first. There is no separate Go package-manager publication
@@ -262,10 +262,11 @@ The release pipeline then:
    - The Rust CLI matrix packages each prebuilt binary as a
      `nemo-relay-cli-bin` wheel and npm platform package, and creates the npm
      launcher package once.
-   - The distribution release-asset job uploads the CLI binaries, CLI wheels,
-     CLI npm packages, and split Node npm packages. `SHA256SUMS` covers every
-     attached distribution artifact, and raw CLI binaries also receive
-     individual `.sha256` files for installer compatibility.
+   - The distribution release-asset job uploads the CLI binaries, `nemo-relay`
+     API wheels, CLI wheels, CLI npm packages, and split Node npm packages.
+     `SHA256SUMS` covers every attached distribution artifact, and raw CLI
+     binaries also receive individual `.sha256` files for installer
+     compatibility.
      GitHub-facing npm artifacts use
      `nemo-relay-bin-npm[-<os>-<cpu>]-<version>.tgz` for the CLI and
      `nemo-relay-node-npm[-<os>-<cpu>]-<version>.tgz` for Node.js; their

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,8 +31,8 @@ The release pipeline publishes these package surfaces from a tag push:
 | Ecosystem | Published Surface |
 |---|---|
 | crates.io | `nemo-relay-types`, `nemo-relay-plugin`, `nemo-relay-worker-proto`, `nemo-relay-worker`, `nemo-relay`, `nemo-relay-adaptive`, `nemo-relay-pii-redaction`, `nemo-relay-switchyard`, `nemo-relay-ffi`, `nemo-relay-cli` |
-| PyPI | `nemo-relay`, `nemo-relay-plugin` |
-| npm | `nemo-relay-node`, `nemo-relay-openclaw` |
+| PyPI | `nemo-relay`, `nemo-relay-plugin`, `nemo-relay-cli-bin` |
+| npm | `nemo-relay-node`, `nemo-relay-openclaw`, `nemo-relay-cli-bin`, and its five platform packages |
 | GitHub Releases | CLI binaries and `SHA256SUMS` |
 | Fern | The documentation site |
 
@@ -61,6 +61,9 @@ NeMo Relay versions are anchored on the workspace SemVer in the repository root
   lock entries and must be updated with it.
 - `integrations/openclaw/package.json` carries the base npm version for the
   OpenClaw plugin package and must stay aligned with the same release version.
+- `packages/cli-bin/package.json` and `python/cli-bin/pyproject.toml` carry the
+  base CLI package versions. The `nemo-relay[cli]` extra must pin the same
+  PEP 440 version.
 - The Python package version is derived at packaging time. `pyproject.toml`
   stays `dynamic = ["version"]` in the repository, and the packaging recipe
   writes a concrete version into `pyproject.toml` and `crates/python/Cargo.toml`
@@ -141,6 +144,12 @@ Before you create a release tag, confirm the following:
      [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) workflow
    - GitHub Actions `id-token: write` access is available for the top-level npm publish job
    - GitHub Actions `id-token: write` access for the top-level PyPI publish job
+   - Pending or existing PyPI trusted publishing is configured for
+     `nemo-relay-cli-bin`
+   - npm trusted publishers are configured for `nemo-relay-cli-bin` and
+     `nemo-relay-cli-bin-linux-x64`, `nemo-relay-cli-bin-linux-arm64`,
+     `nemo-relay-cli-bin-darwin-arm64`, `nemo-relay-cli-bin-win32-x64`, and
+     `nemo-relay-cli-bin-win32-arm64`
 5. The GitHub Release entry is ready to become the only canonical release-notes
    surface.
 
@@ -167,6 +176,8 @@ The helper updates:
 4. [`integrations/openclaw/package.json`](integrations/openclaw/package.json)
    and the `integrations/openclaw` entry in the root
    [`package-lock.json`](package-lock.json) to the same release version.
+5. The Python and npm `nemo-relay-cli-bin` metadata, including the exact
+   `nemo-relay[cli]` dependency version.
 Review docs and snippets that mention explicit versions, including:
 
 - [`README.md`](README.md)
@@ -243,6 +254,9 @@ The release pipeline then:
    - `package-openclaw` packs the npm OpenClaw plugin package.
    - `package-python` builds platform `nemo-relay` wheels.
    - `package-python-plugin` builds the `nemo-relay-plugin` wheel.
+   - The Rust CLI matrix packages each prebuilt binary as a
+     `nemo-relay-cli-bin` wheel and npm platform package, and creates the npm
+     launcher package once.
    - The CLI release-asset job uploads each platform `nemo-relay` binary and
      includes those binaries in `SHA256SUMS`.
 4. Publishes packages from the top-level workflow after the reusable packaging
@@ -254,11 +268,11 @@ The release pipeline then:
      `nemo-relay-switchyard`, `nemo-relay-ffi`, and `nemo-relay-cli` through
      trusted publishing from
      the top-level workflow
-   - `publish-python` downloads both the `nemo-relay` and `nemo-relay-plugin`
-     wheel artifacts and uploads them to PyPI with trusted publishing from the
-     top-level workflow
-   - `publish-npm` publishes the Node.js and OpenClaw plugin npm packages
-     through npm trusted publishing from the top-level workflow
+   - `publish-python` downloads the `nemo-relay`, `nemo-relay-plugin`, and
+     `nemo-relay-cli-bin` wheel artifacts and uploads them to PyPI with trusted
+     publishing from the top-level workflow
+   - `publish-npm` publishes the Node.js, OpenClaw, and CLI npm packages through
+     npm trusted publishing from the top-level workflow
      - Stable tags publish to the npm `latest` dist-tag
      - Prerelease tags such as `0.1.0-rc.1` publish to the npm `next`
        dist-tag so they do not become the default upgrade target
@@ -291,9 +305,9 @@ NVIDIA Artifactory publication for the same tag:
 npm trusted publishing has its own registry-side constraints:
 
 - Each npm package can only have one trusted publisher configured at a time.
-- Because this repository publishes `nemo-relay-node` and `nemo-relay-openclaw`,
-  configure trusted publishers for both packages
-  before pushing a release tag.
+- Configure trusted publishers for `nemo-relay-node`, `nemo-relay-openclaw`,
+  `nemo-relay-cli-bin`, and all five CLI platform packages before pushing a
+  release tag.
 - npm trusted publishing currently supports GitHub-hosted runners, not
   self-hosted runners.
 
@@ -324,9 +338,10 @@ After the release is live, verify:
    `nemo-relay-pii-redaction`, `nemo-relay-switchyard`, `nemo-relay-ffi`, and
    `nemo-relay-cli` crates
    are visible on crates.io.
-2. The `nemo-relay` wheel is visible on PyPI.
-3. The `nemo-relay-node` and `nemo-relay-openclaw` packages
-   are visible on npm.
+2. The `nemo-relay` and `nemo-relay-cli-bin` wheels are visible on PyPI, and
+   `pip install "nemo-relay[cli]"` exposes `nemo-relay`.
+3. The `nemo-relay-node`, `nemo-relay-openclaw`, `nemo-relay-cli-bin`, and CLI
+   platform packages are visible on npm.
 4. The Unix and Windows installers resolve the new stable tag and verify
    matching CLI release asset checksums on their supported platforms.
 5. The Fern documentation site shows the expected version and release notes.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -62,6 +62,24 @@ The CLI provides these capabilities:
 
 ## Installation Options
 
+PyPI:
+
+```bash
+pip install nemo-relay-cli-bin
+```
+
+npm:
+
+```bash
+npm install --global nemo-relay-cli-bin
+```
+
+Python API package extra:
+
+```bash
+pip install "nemo-relay[cli]"
+```
+
 Cargo:
 
 ```bash

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -80,7 +80,7 @@ Install the Python API and matching CLI with the optional extra:
 pip install "nemo-relay[cli]"
 ```
 
-Cargo:
+Build and install the CLI from crates.io with Cargo:
 
 ```bash
 cargo install nemo-relay-cli

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -62,19 +62,19 @@ The CLI provides these capabilities:
 
 ## Installation Options
 
-PyPI:
+Install the prebuilt CLI from PyPI:
 
 ```bash
 pip install nemo-relay-cli-bin
 ```
 
-npm:
+Install the prebuilt CLI from npm:
 
 ```bash
 npm install --global nemo-relay-cli-bin
 ```
 
-Python API package extra:
+Install the Python API and matching CLI with the optional extra:
 
 ```bash
 pip install "nemo-relay[cli]"

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -33,6 +33,24 @@ coding-agent hook and LLM gateway observability.
 Install the latest stable release:
 
 <Tabs>
+<Tab title="Python">
+```bash
+pip install nemo-relay-cli-bin
+```
+
+To install the Python API and matching CLI together:
+
+```bash
+pip install "nemo-relay[cli]"
+```
+</Tab>
+
+<Tab title="npm">
+```bash
+npm install --global nemo-relay-cli-bin
+```
+</Tab>
+
 <Tab title="Unix shell">
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | sh
@@ -47,9 +65,10 @@ irm https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.ps1 | iex
 
 </Tabs>
 
-These commands intentionally download the installer from `main` and install the
-latest stable CLI release. The version of this documentation page does not
-select the CLI version; set `NEMO_RELAY_VERSION` to install a specific release.
+The shell installer commands intentionally download the installer from `main`
+and install the latest stable CLI release. The version of this documentation
+page does not select the CLI version; set `NEMO_RELAY_VERSION` to install a
+specific release.
 
 The Unix installer downloads the matching GitHub Release binary to
 `$HOME/.local/bin`. The PowerShell installer downloads `nemo-relay.exe` to
@@ -158,9 +177,9 @@ new download before replacing the binary in the selected installation directory.
 
 ### Alternative Installation Methods
 
-Use the installers on a supported platform when you want a prebuilt release
-asset. Use Cargo on unsupported platforms or when you prefer to build from
-source:
+The PyPI, npm, and installer methods all install the same release binary on
+supported platforms. Use Cargo on unsupported platforms or when you prefer to
+build from source:
 
 ```bash
 cargo install nemo-relay-cli

--- a/justfile
+++ b/justfile
@@ -13,6 +13,8 @@ output_dir := ""
 ref_name := ""
 # Linux package artifacts target this minimum glibc version for compatibility.
 linux_glibc_version := "2.17"
+# Supported Node package platform key. CI sets this from its package matrix.
+node_platform := ""
 
 bash_helpers := '''
 set -euo pipefail
@@ -1560,6 +1562,11 @@ package-node:
     # If `ref_name` is empty, append the current short HEAD SHA to the version.
     # If `ref_name` is set, write it as the exact package version before packing.
     linux_glibc_version="{{ linux_glibc_version }}"
+    node_platform="{{ node_platform }}"
+    python_executable="python"
+    if ! command -v "$python_executable" >/dev/null 2>&1; then
+        python_executable="python3"
+    fi
     output_dir="{{ output_dir }}"
     cd "$NEMO_RELAY_REPO_ROOT"
     package_dir="$(prepare_package_dir npm)"
@@ -1587,7 +1594,34 @@ package-node:
     fi
     npm install --workspace=nemo-relay-node --ignore-scripts
     npm run --workspace=nemo-relay-node "${build_args[@]}"
-    npm pack --workspace=nemo-relay-node --pack-destination "$package_dir"
+    if [[ -z "$node_platform" ]]; then
+        case "$(uname -s)-$(uname -m)" in
+            Linux-x86_64) node_platform="linux-amd64" ;;
+            Linux-aarch64|Linux-arm64) node_platform="linux-arm64" ;;
+            Darwin-arm64) node_platform="macos-arm64" ;;
+            MINGW*|MSYS*|CYGWIN*)
+                if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]]; then
+                    node_platform="windows-arm64"
+                else
+                    node_platform="windows-amd64"
+                fi
+                ;;
+            *)
+                echo "Error: unsupported Node package host $(uname -s)/$(uname -m)" >&2
+                exit 1
+                ;;
+        esac
+    fi
+    package_args=(
+        --node-dir crates/node
+        --platform "$node_platform"
+        --version "$package_version"
+        --output-dir "$package_dir"
+    )
+    if [[ "$node_platform" == "linux-amd64" ]]; then
+        package_args+=(--metapackage)
+    fi
+    "$python_executable" scripts/package-node-bin.py "${package_args[@]}"
     shopt -s nullglob
     packages=("$package_dir"/*.tgz)
     if ((${#packages[@]} == 0)); then

--- a/justfile
+++ b/justfile
@@ -562,6 +562,7 @@ set_node_package_versions() {
     local version="$1"
     set_npm_package_version crates/node/package.json package-lock.json "$version" crates/node
     set_npm_package_version integrations/openclaw/package.json package-lock.json "$version" integrations/openclaw
+    set_npm_package_version packages/cli-bin/package.json package-lock.json "$version" packages/cli-bin
     set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-relay-node "$version"
 }
 
@@ -689,6 +690,35 @@ else:
 if updated != text:
     path.write_text(updated)
 print("crates/python/Cargo.toml uses the workspace version")
+
+path = Path("python/cli-bin/pyproject.toml")
+text = path.read_text()
+updated, count = re.subn(
+    r'^version = "(.*)"$',
+    f'version = "{version}"',
+    text,
+    count=1,
+    flags=re.MULTILINE,
+)
+if count != 1:
+    raise SystemExit("Failed to update version in python/cli-bin/pyproject.toml")
+if updated != text:
+    path.write_text(updated)
+print(f"python/cli-bin/pyproject.toml version updated to {version}")
+
+path = Path("pyproject.toml")
+text = path.read_text()
+updated, count = re.subn(
+    r'("nemo-relay-cli-bin==)[^"]+(")',
+    rf'\g<1>{version}\g<2>',
+    text,
+    count=1,
+)
+if count != 1:
+    raise SystemExit("Failed to update the nemo-relay CLI extra version")
+if updated != text:
+    path.write_text(updated)
+print(f"nemo-relay CLI extra updated to {version}")
 PY
 }
 
@@ -1674,3 +1704,19 @@ package-python-plugin:
         echo "Error: No Python plugin wheels found in $package_dir"
         exit 1
     fi
+
+# Package a prebuilt CLI binary for PyPI and npm.
+package-cli-bin binary target version package_dir npm_launcher="false":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "$NEMO_RELAY_REPO_ROOT"
+    args=(
+        --binary "{{ binary }}"
+        --target "{{ target }}"
+        --version "{{ version }}"
+        --output-dir "{{ package_dir }}"
+    )
+    if [[ "{{ npm_launcher }}" == "true" ]]; then
+        args+=(--npm-launcher)
+    fi
+    uv run --no-project python scripts/package-cli-bin.py "${args[@]}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "nemo-relay-workspace",
       "workspaces": [
         "crates/node",
-        "integrations/openclaw"
+        "integrations/openclaw",
+        "packages/cli-bin"
       ],
       "devDependencies": {
         "fern-api": "5.57.0",
@@ -927,6 +928,10 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/nemo-relay-cli-bin": {
+      "resolved": "packages/cli-bin",
+      "link": true
     },
     "node_modules/nemo-relay-node": {
       "resolved": "crates/node",
@@ -5129,6 +5134,11 @@
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
       }
+    },
+    "packages/cli-bin": {
+      "name": "nemo-relay-cli-bin",
+      "version": "0.7.0",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "workspaces": [
     "crates/node",
-    "integrations/openclaw"
+    "integrations/openclaw",
+    "packages/cli-bin"
   ],
   "devDependencies": {
     "fern-api": "5.57.0",

--- a/packages/cli-bin/package.json
+++ b/packages/cli-bin/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nemo-relay-cli-bin",
+  "version": "0.7.0",
+  "description": "Prebuilt NeMo Relay command-line interface.",
+  "private": true,
+  "license": "Apache-2.0"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ test = [
 ]
 
 [project.optional-dependencies]
+cli = [
+    "nemo-relay-cli-bin==0.7.0",
+]
+
 langchain = [
     "langchain>=1.3.14,<2.0.0",
     "langchain-core",
@@ -106,6 +110,7 @@ default-groups = ["dev", "test"]
 package = true
 
 [tool.uv.sources]
+nemo-relay-cli-bin = { path = "python/cli-bin" }
 nemo-relay-plugin = { workspace = true }
 
 [tool.uv.workspace]

--- a/python/cli-bin/pyproject.toml
+++ b/python/cli-bin/pyproject.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["uv_build>=0.9,<0.12"]
+build-backend = "uv_build"
+
+[project]
+name = "nemo-relay-cli-bin"
+version = "0.7.0"
+description = "Prebuilt NeMo Relay command-line interface."
+requires-python = ">=3.11"
+license = "Apache-2.0"
+
+[tool.uv.build-backend]
+module-name = "nemo_relay_cli_bin"
+module-root = "src"

--- a/python/cli-bin/src/nemo_relay_cli_bin/__init__.py
+++ b/python/cli-bin/src/nemo_relay_cli_bin/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Development placeholder for the platform-specific CLI wheel distribution."""

--- a/scripts/package-cli-bin.py
+++ b/scripts/package-cli-bin.py
@@ -21,10 +21,13 @@ PACKAGE_NAME = "nemo-relay-cli-bin"
 SUMMARY = "Prebuilt NeMo Relay command-line interface."
 LICENSE = "Apache-2.0"
 REPOSITORY = "https://github.com/NVIDIA/NeMo-Relay"
+ROOT = Path(__file__).resolve().parent.parent
 
 
 @dataclass(frozen=True)
 class Platform:
+    """Describe one supported CLI distribution platform."""
+
     target: str
     npm_suffix: str
     npm_os: str
@@ -34,6 +37,7 @@ class Platform:
 
     @property
     def npm_package(self) -> str:
+        """Return the npm package name for this platform."""
         return f"{PACKAGE_NAME}-{self.npm_suffix}"
 
 
@@ -106,11 +110,13 @@ def wheel_version(version: str) -> str:
 
 
 def record_entry(path: str, content: bytes) -> str:
+    """Return one wheel RECORD entry for the provided file."""
     digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode()
     return f"{path},sha256={digest},{len(content)}"
 
 
 def add_zip_file(archive: zipfile.ZipFile, path: str, content: bytes, executable: bool = False) -> None:
+    """Add one regular file to a wheel archive."""
     info = zipfile.ZipInfo(path)
     info.compress_type = zipfile.ZIP_DEFLATED
     info.external_attr = ((0o755 if executable else 0o644) & 0xFFFF) << 16
@@ -118,6 +124,7 @@ def add_zip_file(archive: zipfile.ZipFile, path: str, content: bytes, executable
 
 
 def build_wheel(binary: Path, platform: Platform, version: str, output: Path) -> Path:
+    """Build a platform-tagged wheel containing the CLI binary."""
     pep440_version = wheel_version(version)
     normalized_name = PACKAGE_NAME.replace("-", "_")
     platform_tag = ".".join(platform.wheel_platforms)
@@ -142,7 +149,7 @@ def build_wheel(binary: Path, platform: Platform, version: str, output: Path) ->
         "Generator: NeMo Relay package-cli-bin.py\n"
         "Root-Is-Purelib: false\n" + "".join(f"Tag: py3-none-{tag}\n" for tag in platform.wheel_platforms) + "\n"
     ).encode()
-    license_text = Path("LICENSE").read_bytes()
+    license_text = (ROOT / "LICENSE").read_bytes()
     binary_content = binary.read_bytes()
     files = {
         script_path: binary_content,
@@ -161,6 +168,7 @@ def build_wheel(binary: Path, platform: Platform, version: str, output: Path) ->
 
 
 def add_tar_bytes(archive: tarfile.TarFile, path: str, content: bytes, mode: int = 0o644) -> None:
+    """Add one regular file to an npm tarball."""
     info = tarfile.TarInfo(path)
     info.size = len(content)
     info.mode = mode
@@ -168,6 +176,7 @@ def add_tar_bytes(archive: tarfile.TarFile, path: str, content: bytes, mode: int
 
 
 def build_npm_platform(binary: Path, platform: Platform, version: str, output: Path) -> Path:
+    """Build an OS- and CPU-constrained npm package containing the CLI binary."""
     filename = f"{platform.npm_package}-{version}.tgz"
     destination = output / filename
     manifest = {
@@ -188,11 +197,12 @@ def build_npm_platform(binary: Path, platform: Platform, version: str, output: P
             binary.read_bytes(),
             mode=0o755,
         )
-        add_tar_bytes(archive, "package/LICENSE", Path("LICENSE").read_bytes())
+        add_tar_bytes(archive, "package/LICENSE", (ROOT / "LICENSE").read_bytes())
     return destination
 
 
 def launcher_source() -> bytes:
+    """Return the Node.js launcher that selects the installed native package."""
     mapping = {
         f"{platform.npm_os}-{platform.npm_cpu}": {
             "package": platform.npm_package,
@@ -234,6 +244,7 @@ def launcher_source() -> bytes:
 
 
 def build_npm_launcher(version: str, output: Path) -> Path:
+    """Build the portable npm launcher package."""
     destination = output / f"{PACKAGE_NAME}-{version}.tgz"
     manifest = {
         "name": PACKAGE_NAME,
@@ -249,11 +260,12 @@ def build_npm_launcher(version: str, output: Path) -> Path:
     with tarfile.open(destination, "w:gz") as archive:
         add_tar_bytes(archive, "package/package.json", json.dumps(manifest, indent=2).encode() + b"\n")
         add_tar_bytes(archive, "package/bin/nemo-relay.js", launcher_source(), mode=0o755)
-        add_tar_bytes(archive, "package/LICENSE", Path("LICENSE").read_bytes())
+        add_tar_bytes(archive, "package/LICENSE", (ROOT / "LICENSE").read_bytes())
     return destination
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI package assembly arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--binary", type=Path, required=True)
     parser.add_argument("--target", choices=sorted(PLATFORMS), required=True)
@@ -264,6 +276,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    """Build the wheel and npm artifacts requested on the command line."""
     args = parse_args()
     if not args.binary.is_file():
         raise SystemExit(f"CLI binary does not exist: {args.binary}")

--- a/scripts/package-cli-bin.py
+++ b/scripts/package-cli-bin.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package a prebuilt NeMo Relay CLI binary for PyPI and npm."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+PACKAGE_NAME = "nemo-relay-cli-bin"
+SUMMARY = "Prebuilt NeMo Relay command-line interface."
+LICENSE = "Apache-2.0"
+REPOSITORY = "https://github.com/NVIDIA/NeMo-Relay"
+
+
+@dataclass(frozen=True)
+class Platform:
+    target: str
+    npm_suffix: str
+    npm_os: str
+    npm_cpu: str
+    wheel_platforms: tuple[str, ...]
+    executable: str
+
+    @property
+    def npm_package(self) -> str:
+        return f"{PACKAGE_NAME}-{self.npm_suffix}"
+
+
+PLATFORMS = {
+    platform.target: platform
+    for platform in (
+        Platform(
+            "x86_64-unknown-linux-musl",
+            "linux-x64",
+            "linux",
+            "x64",
+            ("manylinux_2_17_x86_64", "musllinux_1_2_x86_64"),
+            "nemo-relay",
+        ),
+        Platform(
+            "aarch64-unknown-linux-musl",
+            "linux-arm64",
+            "linux",
+            "arm64",
+            ("manylinux_2_17_aarch64", "musllinux_1_2_aarch64"),
+            "nemo-relay",
+        ),
+        Platform(
+            "aarch64-apple-darwin",
+            "darwin-arm64",
+            "darwin",
+            "arm64",
+            ("macosx_11_0_arm64",),
+            "nemo-relay",
+        ),
+        Platform(
+            "x86_64-pc-windows-msvc",
+            "win32-x64",
+            "win32",
+            "x64",
+            ("win_amd64",),
+            "nemo-relay.exe",
+        ),
+        Platform(
+            "aarch64-pc-windows-msvc",
+            "win32-arm64",
+            "win32",
+            "arm64",
+            ("win_arm64",),
+            "nemo-relay.exe",
+        ),
+    )
+}
+
+
+def wheel_version(version: str) -> str:
+    """Translate the repository SemVer spelling to PEP 440."""
+    import re
+
+    match = re.fullmatch(
+        r"(?P<release>\d+\.\d+\.\d+)"
+        r"(?:-(?P<label>alpha|beta|rc)\.(?P<number>\d+))?"
+        r"(?:\+(?P<local>[0-9A-Za-z._-]+))?",
+        version,
+    )
+    if match is None:
+        raise ValueError(f"unsupported package version: {version}")
+    translated = match.group("release")
+    if label := match.group("label"):
+        translated += {"alpha": "a", "beta": "b", "rc": "rc"}[label]
+        translated += match.group("number")
+    if local := match.group("local"):
+        translated += "+" + ".".join(part.lower() for part in re.split(r"[._-]+", local))
+    return translated
+
+
+def record_entry(path: str, content: bytes) -> str:
+    digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode()
+    return f"{path},sha256={digest},{len(content)}"
+
+
+def add_zip_file(archive: zipfile.ZipFile, path: str, content: bytes, executable: bool = False) -> None:
+    info = zipfile.ZipInfo(path)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = ((0o755 if executable else 0o644) & 0xFFFF) << 16
+    archive.writestr(info, content)
+
+
+def build_wheel(binary: Path, platform: Platform, version: str, output: Path) -> Path:
+    pep440_version = wheel_version(version)
+    normalized_name = PACKAGE_NAME.replace("-", "_")
+    platform_tag = ".".join(platform.wheel_platforms)
+    filename = f"{normalized_name}-{pep440_version}-py3-none-{platform_tag}.whl"
+    destination = output / filename
+    dist_info = f"{normalized_name}-{pep440_version}.dist-info"
+    script_path = f"{normalized_name}-{pep440_version}.data/scripts/{platform.executable}"
+    metadata = (
+        "Metadata-Version: 2.4\n"
+        f"Name: {PACKAGE_NAME}\n"
+        f"Version: {pep440_version}\n"
+        f"Summary: {SUMMARY}\n"
+        f"License-Expression: {LICENSE}\n"
+        "Requires-Python: >=3.11\n"
+        f"Project-URL: Repository, {REPOSITORY}\n"
+        "Description-Content-Type: text/markdown\n"
+        "\n"
+        "This platform wheel installs the prebuilt `nemo-relay` command-line interface.\n"
+    ).encode()
+    wheel = (
+        "Wheel-Version: 1.0\n"
+        "Generator: NeMo Relay package-cli-bin.py\n"
+        "Root-Is-Purelib: false\n" + "".join(f"Tag: py3-none-{tag}\n" for tag in platform.wheel_platforms) + "\n"
+    ).encode()
+    license_text = Path("LICENSE").read_bytes()
+    binary_content = binary.read_bytes()
+    files = {
+        script_path: binary_content,
+        f"{dist_info}/METADATA": metadata,
+        f"{dist_info}/WHEEL": wheel,
+        f"{dist_info}/licenses/LICENSE": license_text,
+    }
+    record_path = f"{dist_info}/RECORD"
+    record = "\n".join(record_entry(path, content) for path, content in files.items())
+    record += f"\n{record_path},,\n"
+    with zipfile.ZipFile(destination, "w") as archive:
+        for path, content in files.items():
+            add_zip_file(archive, path, content, executable=path == script_path)
+        add_zip_file(archive, record_path, record.encode())
+    return destination
+
+
+def add_tar_bytes(archive: tarfile.TarFile, path: str, content: bytes, mode: int = 0o644) -> None:
+    info = tarfile.TarInfo(path)
+    info.size = len(content)
+    info.mode = mode
+    archive.addfile(info, io.BytesIO(content))
+
+
+def build_npm_platform(binary: Path, platform: Platform, version: str, output: Path) -> Path:
+    filename = f"{platform.npm_package}-{version}.tgz"
+    destination = output / filename
+    manifest = {
+        "name": platform.npm_package,
+        "version": version,
+        "description": f"{SUMMARY} ({platform.npm_os} {platform.npm_cpu})",
+        "os": [platform.npm_os],
+        "cpu": [platform.npm_cpu],
+        "files": [f"bin/{platform.executable}"],
+        "license": LICENSE,
+        "repository": {"type": "git", "url": f"git+{REPOSITORY}.git"},
+    }
+    with tarfile.open(destination, "w:gz") as archive:
+        add_tar_bytes(archive, "package/package.json", json.dumps(manifest, indent=2).encode() + b"\n")
+        add_tar_bytes(
+            archive,
+            f"package/bin/{platform.executable}",
+            binary.read_bytes(),
+            mode=0o755,
+        )
+        add_tar_bytes(archive, "package/LICENSE", Path("LICENSE").read_bytes())
+    return destination
+
+
+def launcher_source() -> bytes:
+    mapping = {
+        f"{platform.npm_os}-{platform.npm_cpu}": {
+            "package": platform.npm_package,
+            "executable": platform.executable,
+        }
+        for platform in PLATFORMS.values()
+    }
+    return (
+        "#!/usr/bin/env node\n"
+        "// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
+        "// SPDX-License-Identifier: Apache-2.0\n\n"
+        "const { spawnSync } = require('node:child_process');\n"
+        "const path = require('node:path');\n\n"
+        f"const platforms = {json.dumps(mapping, indent=2)};\n"
+        "const key = `${process.platform}-${process.arch}`;\n"
+        "const selected = platforms[key];\n"
+        "if (!selected) {\n"
+        "  console.error(`nemo-relay-cli-bin does not support ${process.platform}/${process.arch}`);\n"
+        "  process.exit(1);\n"
+        "}\n"
+        "let manifest;\n"
+        "try {\n"
+        "  manifest = require.resolve(`${selected.package}/package.json`);\n"
+        "} catch (error) {\n"
+        "  console.error(\n"
+        "    `The native package ${selected.package} is missing. ` +\n"
+        "      'Reinstall nemo-relay-cli-bin without omitting optional dependencies.',\n"
+        "  );\n"
+        "  process.exit(1);\n"
+        "}\n"
+        "const executable = path.join(path.dirname(manifest), 'bin', selected.executable);\n"
+        "const result = spawnSync(executable, process.argv.slice(2), { stdio: 'inherit' });\n"
+        "if (result.error) {\n"
+        "  console.error(`Failed to start ${executable}: ${result.error.message}`);\n"
+        "  process.exit(1);\n"
+        "}\n"
+        "process.exit(result.status === null ? 1 : result.status);\n"
+    ).encode()
+
+
+def build_npm_launcher(version: str, output: Path) -> Path:
+    destination = output / f"{PACKAGE_NAME}-{version}.tgz"
+    manifest = {
+        "name": PACKAGE_NAME,
+        "version": version,
+        "description": SUMMARY,
+        "bin": {"nemo-relay": "bin/nemo-relay.js"},
+        "files": ["bin/nemo-relay.js"],
+        "engines": {"node": ">=24.0.0"},
+        "optionalDependencies": {platform.npm_package: version for platform in PLATFORMS.values()},
+        "license": LICENSE,
+        "repository": {"type": "git", "url": f"git+{REPOSITORY}.git"},
+    }
+    with tarfile.open(destination, "w:gz") as archive:
+        add_tar_bytes(archive, "package/package.json", json.dumps(manifest, indent=2).encode() + b"\n")
+        add_tar_bytes(archive, "package/bin/nemo-relay.js", launcher_source(), mode=0o755)
+        add_tar_bytes(archive, "package/LICENSE", Path("LICENSE").read_bytes())
+    return destination
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--target", choices=sorted(PLATFORMS), required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--npm-launcher", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.binary.is_file():
+        raise SystemExit(f"CLI binary does not exist: {args.binary}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    platform = PLATFORMS[args.target]
+    artifacts = [
+        build_wheel(args.binary, platform, args.version, args.output_dir),
+        build_npm_platform(args.binary, platform, args.version, args.output_dir),
+    ]
+    if args.npm_launcher:
+        artifacts.append(build_npm_launcher(args.version, args.output_dir))
+    for artifact in artifacts:
+        print(artifact)
+
+
+if __name__ == "__main__":
+    os.chdir(Path(__file__).resolve().parent.parent)
+    main()

--- a/scripts/package-cli-bin.py
+++ b/scripts/package-cli-bin.py
@@ -12,6 +12,7 @@ import hashlib
 import io
 import json
 import os
+import stat
 import tarfile
 import zipfile
 from dataclasses import dataclass
@@ -119,7 +120,8 @@ def add_zip_file(archive: zipfile.ZipFile, path: str, content: bytes, executable
     """Add one regular file to a wheel archive."""
     info = zipfile.ZipInfo(path)
     info.compress_type = zipfile.ZIP_DEFLATED
-    info.external_attr = ((0o755 if executable else 0o644) & 0xFFFF) << 16
+    info.create_system = 3
+    info.external_attr = (stat.S_IFREG | (0o755 if executable else 0o644)) << 16
     archive.writestr(info, content)
 
 
@@ -177,7 +179,7 @@ def add_tar_bytes(archive: tarfile.TarFile, path: str, content: bytes, mode: int
 
 def build_npm_platform(binary: Path, platform: Platform, version: str, output: Path) -> Path:
     """Build an OS- and CPU-constrained npm package containing the CLI binary."""
-    filename = f"{platform.npm_package}-{version}.tgz"
+    filename = f"nemo-relay-bin-npm-{platform.npm_os}-{platform.npm_cpu}-{version}.tgz"
     destination = output / filename
     manifest = {
         "name": platform.npm_package,
@@ -245,7 +247,7 @@ def launcher_source() -> bytes:
 
 def build_npm_launcher(version: str, output: Path) -> Path:
     """Build the portable npm launcher package."""
-    destination = output / f"{PACKAGE_NAME}-{version}.tgz"
+    destination = output / f"nemo-relay-bin-npm-{version}.tgz"
     manifest = {
         "name": PACKAGE_NAME,
         "version": version,

--- a/scripts/package-node-bin.py
+++ b/scripts/package-node-bin.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package the NeMo Relay Node.js binding as a metapackage and native package."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_NAME = "nemo-relay-node"
+
+
+@dataclass(frozen=True)
+class Platform:
+    """Describe one supported Node.js native package."""
+
+    key: str
+    package_suffix: str
+    npm_os: str
+    npm_cpu: str
+    binary: str
+    libc: str | None = None
+
+    @property
+    def package_name(self) -> str:
+        """Return the public npm package name."""
+        return f"{PACKAGE_NAME}-{self.package_suffix}"
+
+
+PLATFORMS = {
+    platform.key: platform
+    for platform in (
+        Platform("linux-amd64", "linux-x64-gnu", "linux", "x64", "nemo-relay.linux-x64-gnu.node", "glibc"),
+        Platform("linux-arm64", "linux-arm64-gnu", "linux", "arm64", "nemo-relay.linux-arm64-gnu.node", "glibc"),
+        Platform("macos-arm64", "darwin-arm64", "darwin", "arm64", "nemo-relay.darwin-arm64.node"),
+        Platform("windows-amd64", "win32-x64-msvc", "win32", "x64", "nemo-relay.win32-x64-msvc.node"),
+        Platform("windows-arm64", "win32-arm64-msvc", "win32", "arm64", "nemo-relay.win32-arm64-msvc.node"),
+    )
+}
+
+
+def add_tar_bytes(archive: tarfile.TarFile, path: str, content: bytes, mode: int = 0o644) -> None:
+    """Add one regular file to an npm tarball."""
+    info = tarfile.TarInfo(path)
+    info.size = len(content)
+    info.mode = mode
+    archive.addfile(info, io.BytesIO(content))
+
+
+def repository_metadata(source: dict[str, object]) -> dict[str, object]:
+    """Return metadata shared by the metapackage and native packages."""
+    fields = ("description", "keywords", "homepage", "bugs", "repository", "author", "engines", "license")
+    return {field: source[field] for field in fields if field in source}
+
+
+def metapackage_files(manifest: dict[str, object]) -> list[str]:
+    """Return the JavaScript and declaration files exported by the package."""
+    files = {str(manifest["main"]), str(manifest["types"]), "README.md"}
+    exports = manifest.get("exports")
+    if not isinstance(exports, dict):
+        raise ValueError("Node package manifest is missing exports")
+    for entry in exports.values():
+        if not isinstance(entry, dict):
+            raise ValueError("Node package export must contain types and default paths")
+        files.update(str(path).removeprefix("./") for path in entry.values())
+    return sorted(files)
+
+
+def build_native_package(node_dir: Path, platform: Platform, version: str, output: Path) -> Path:
+    """Build one OS- and CPU-constrained native npm package."""
+    source_manifest = json.loads((node_dir / "package.json").read_text())
+    manifest = {
+        "name": platform.package_name,
+        "version": version,
+        **repository_metadata(source_manifest),
+        "main": platform.binary,
+        "files": [platform.binary],
+        "os": [platform.npm_os],
+        "cpu": [platform.npm_cpu],
+    }
+    if platform.libc is not None:
+        manifest["libc"] = [platform.libc]
+    binary = node_dir / platform.binary
+    if not binary.is_file():
+        raise FileNotFoundError(f"Node native binary does not exist: {binary}")
+    destination = output / f"nemo-relay-node-npm-{platform.npm_os}-{platform.npm_cpu}-{version}.tgz"
+    with tarfile.open(destination, "w:gz") as archive:
+        add_tar_bytes(archive, "package/package.json", json.dumps(manifest, indent=2).encode() + b"\n")
+        add_tar_bytes(archive, f"package/{platform.binary}", binary.read_bytes(), mode=0o755)
+        add_tar_bytes(archive, "package/LICENSE", (ROOT / "LICENSE").read_bytes())
+    return destination
+
+
+def build_metapackage(node_dir: Path, version: str, output: Path) -> Path:
+    """Build the portable Node.js metapackage."""
+    source_manifest = json.loads((node_dir / "package.json").read_text())
+    manifest = {
+        "name": PACKAGE_NAME,
+        "version": version,
+        **repository_metadata(source_manifest),
+        "main": source_manifest["main"],
+        "types": source_manifest["types"],
+        "exports": source_manifest["exports"],
+        "files": metapackage_files(source_manifest),
+        "optionalDependencies": {platform.package_name: version for platform in PLATFORMS.values()},
+    }
+    destination = output / f"nemo-relay-node-npm-{version}.tgz"
+    with tarfile.open(destination, "w:gz") as archive:
+        add_tar_bytes(archive, "package/package.json", json.dumps(manifest, indent=2).encode() + b"\n")
+        for filename in manifest["files"]:
+            path = node_dir / filename
+            add_tar_bytes(archive, f"package/{filename}", path.read_bytes())
+        add_tar_bytes(archive, "package/LICENSE", (ROOT / "LICENSE").read_bytes())
+    return destination
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse Node package assembly arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--node-dir", type=Path, default=ROOT / "crates" / "node")
+    parser.add_argument("--platform", choices=sorted(PLATFORMS), required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--metapackage", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Build the requested native package and optional metapackage."""
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = [
+        build_native_package(args.node_dir, PLATFORMS[args.platform], args.version, args.output_dir),
+    ]
+    if args.metapackage:
+        artifacts.append(build_metapackage(args.node_dir, args.version, args.output_dir))
+    for artifact in artifacts:
+        print(artifact)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_package_cli_bin.py
+++ b/scripts/tests/test_package_cli_bin.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for CLI wheel and npm package assembly."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from typing import IO
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("package_cli_bin", ROOT / "scripts" / "package-cli-bin.py")
+assert SPEC is not None and SPEC.loader is not None
+PACKAGE_CLI_BIN = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = PACKAGE_CLI_BIN
+SPEC.loader.exec_module(PACKAGE_CLI_BIN)
+
+
+def required_member(archive: tarfile.TarFile, name: str) -> IO[bytes]:
+    member = archive.extractfile(name)
+    if member is None:
+        raise AssertionError(f"archive is missing {name}")
+    return member
+
+
+class PackageCliBinTests(unittest.TestCase):
+    def test_packages_linux_binary_for_python_and_npm(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            binary = output / "nemo-relay"
+            binary.write_bytes(b"test-binary")
+            platform = PACKAGE_CLI_BIN.PLATFORMS["x86_64-unknown-linux-musl"]
+
+            wheel = PACKAGE_CLI_BIN.build_wheel(binary, platform, "0.7.0-rc.1", output)
+            native = PACKAGE_CLI_BIN.build_npm_platform(binary, platform, "0.7.0-rc.1", output)
+            launcher = PACKAGE_CLI_BIN.build_npm_launcher("0.7.0-rc.1", output)
+
+            self.assertIn("0.7.0rc1-py3-none-manylinux_2_17_x86_64", wheel.name)
+            with zipfile.ZipFile(wheel) as archive:
+                names = archive.namelist()
+                self.assertTrue(any(name.endswith(".data/scripts/nemo-relay") for name in names))
+                wheel_metadata = archive.read(next(name for name in names if name.endswith("/WHEEL")))
+                self.assertIn(b"Tag: py3-none-musllinux_1_2_x86_64", wheel_metadata)
+
+            with tarfile.open(native) as archive:
+                manifest = json.load(required_member(archive, "package/package.json"))
+                self.assertEqual(manifest["os"], ["linux"])
+                self.assertEqual(manifest["cpu"], ["x64"])
+                self.assertEqual(
+                    required_member(archive, "package/bin/nemo-relay").read(),
+                    b"test-binary",
+                )
+
+            with tarfile.open(launcher) as archive:
+                manifest = json.load(required_member(archive, "package/package.json"))
+                self.assertEqual(manifest["bin"]["nemo-relay"], "bin/nemo-relay.js")
+                self.assertEqual(
+                    manifest["optionalDependencies"]["nemo-relay-cli-bin-linux-x64"],
+                    "0.7.0-rc.1",
+                )
+                launcher_path = output / "launcher/package/bin/nemo-relay.js"
+                launcher_path.parent.mkdir(parents=True)
+                launcher_path.write_bytes(required_member(archive, "package/bin/nemo-relay.js").read())
+
+            result = subprocess.run(
+                ["node", output / "launcher/package/bin/nemo-relay.js", "--version"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("The native package nemo-relay-cli-bin-", result.stderr)
+            self.assertIn("is missing", result.stderr)
+
+    def test_rejects_unsupported_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported package version"):
+            PACKAGE_CLI_BIN.wheel_version("dev-deadbeef")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_package_cli_bin.py
+++ b/scripts/tests/test_package_cli_bin.py
@@ -6,6 +6,7 @@
 import importlib.util
 import json
 import os
+import stat
 import subprocess
 import sys
 import tarfile
@@ -50,10 +51,14 @@ class PackageCliBinTests(unittest.TestCase):
             self.assertIn("0.7.0rc1-py3-none-manylinux_2_17_x86_64", wheel.name)
             with zipfile.ZipFile(wheel) as archive:
                 names = archive.namelist()
-                self.assertTrue(any(name.endswith(".data/scripts/nemo-relay") for name in names))
+                script = next(info for info in archive.infolist() if info.filename.endswith(".data/scripts/nemo-relay"))
+                script_mode = script.external_attr >> 16
+                self.assertTrue(stat.S_ISREG(script_mode))
+                self.assertEqual(stat.S_IMODE(script_mode), 0o755)
                 wheel_metadata = archive.read(next(name for name in names if name.endswith("/WHEEL")))
                 self.assertIn(b"Tag: py3-none-musllinux_1_2_x86_64", wheel_metadata)
 
+            self.assertEqual(native.name, "nemo-relay-bin-npm-linux-x64-0.7.0-rc.1.tgz")
             with tarfile.open(native) as archive:
                 manifest = json.load(required_member(archive, "package/package.json"))
                 self.assertEqual(manifest["os"], ["linux"])
@@ -63,6 +68,7 @@ class PackageCliBinTests(unittest.TestCase):
                     b"test-binary",
                 )
 
+            self.assertEqual(launcher.name, "nemo-relay-bin-npm-0.7.0-rc.1.tgz")
             with tarfile.open(launcher) as archive:
                 manifest = json.load(required_member(archive, "package/package.json"))
                 self.assertEqual(manifest["bin"]["nemo-relay"], "bin/nemo-relay.js")
@@ -87,6 +93,17 @@ class PackageCliBinTests(unittest.TestCase):
     def test_rejects_unsupported_version(self) -> None:
         with self.assertRaisesRegex(ValueError, "unsupported package version"):
             PACKAGE_CLI_BIN.wheel_version("dev-deadbeef")
+
+    def test_translates_release_versions_to_pep440(self) -> None:
+        versions = {
+            "0.7.0": "0.7.0",
+            "0.7.0-alpha.1": "0.7.0a1",
+            "0.7.0-rc.1": "0.7.0rc1",
+            "0.7.0+deadbeef": "0.7.0+deadbeef",
+        }
+        for version, expected in versions.items():
+            with self.subTest(version=version):
+                self.assertEqual(PACKAGE_CLI_BIN.wheel_version(version), expected)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_package_cli_bin.py
+++ b/scripts/tests/test_package_cli_bin.py
@@ -5,6 +5,7 @@
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tarfile
@@ -37,9 +38,14 @@ class PackageCliBinTests(unittest.TestCase):
             binary.write_bytes(b"test-binary")
             platform = PACKAGE_CLI_BIN.PLATFORMS["x86_64-unknown-linux-musl"]
 
-            wheel = PACKAGE_CLI_BIN.build_wheel(binary, platform, "0.7.0-rc.1", output)
-            native = PACKAGE_CLI_BIN.build_npm_platform(binary, platform, "0.7.0-rc.1", output)
-            launcher = PACKAGE_CLI_BIN.build_npm_launcher("0.7.0-rc.1", output)
+            previous_directory = Path.cwd()
+            try:
+                os.chdir(output)
+                wheel = PACKAGE_CLI_BIN.build_wheel(binary, platform, "0.7.0-rc.1", output)
+                native = PACKAGE_CLI_BIN.build_npm_platform(binary, platform, "0.7.0-rc.1", output)
+                launcher = PACKAGE_CLI_BIN.build_npm_launcher("0.7.0-rc.1", output)
+            finally:
+                os.chdir(previous_directory)
 
             self.assertIn("0.7.0rc1-py3-none-manylinux_2_17_x86_64", wheel.name)
             with zipfile.ZipFile(wheel) as archive:

--- a/scripts/tests/test_package_node_bin.py
+++ b/scripts/tests/test_package_node_bin.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for split Node.js package assembly."""
+
+import importlib.util
+import json
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from typing import IO
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("package_node_bin", ROOT / "scripts" / "package-node-bin.py")
+assert SPEC is not None and SPEC.loader is not None
+PACKAGE_NODE_BIN = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = PACKAGE_NODE_BIN
+SPEC.loader.exec_module(PACKAGE_NODE_BIN)
+
+
+def required_member(archive: tarfile.TarFile, name: str) -> IO[bytes]:
+    """Return a required regular file from a tar archive."""
+    member = archive.extractfile(name)
+    if member is None:
+        raise AssertionError(f"archive is missing {name}")
+    return member
+
+
+class PackageNodeBinTests(unittest.TestCase):
+    """Verify Node metapackage and native package assembly."""
+
+    def test_builds_metapackage_and_linux_native_package(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            node_dir = output / "node"
+            node_dir.mkdir()
+            source_manifest = {
+                "name": "nemo-relay-node",
+                "version": "0.7.0",
+                "description": "Node bindings.",
+                "main": "index.js",
+                "types": "index.d.ts",
+                "exports": {
+                    ".": {"types": "./index.d.ts", "default": "./index.js"},
+                    "./typed": {"types": "./typed.d.ts", "default": "./typed.js"},
+                },
+                "engines": {"node": ">=24.0.0"},
+                "license": "Apache-2.0",
+            }
+            (node_dir / "package.json").write_text(json.dumps(source_manifest))
+            for filename in ("index.js", "index.d.ts", "typed.js", "typed.d.ts", "README.md"):
+                (node_dir / filename).write_text(filename)
+            binary_name = "nemo-relay.linux-x64-gnu.node"
+            (node_dir / binary_name).write_bytes(b"native")
+
+            platform = PACKAGE_NODE_BIN.PLATFORMS["linux-amd64"]
+            native = PACKAGE_NODE_BIN.build_native_package(node_dir, platform, "0.7.0-rc.1", output)
+            metapackage = PACKAGE_NODE_BIN.build_metapackage(node_dir, "0.7.0-rc.1", output)
+
+            self.assertEqual(native.name, "nemo-relay-node-npm-linux-x64-0.7.0-rc.1.tgz")
+            with tarfile.open(native) as archive:
+                manifest = json.load(required_member(archive, "package/package.json"))
+                self.assertEqual(manifest["name"], "nemo-relay-node-linux-x64-gnu")
+                self.assertEqual(manifest["os"], ["linux"])
+                self.assertEqual(manifest["cpu"], ["x64"])
+                self.assertEqual(manifest["libc"], ["glibc"])
+                self.assertEqual(manifest["main"], binary_name)
+                self.assertEqual(required_member(archive, f"package/{binary_name}").read(), b"native")
+                self.assertNotIn("package/index.js", archive.getnames())
+
+            self.assertEqual(metapackage.name, "nemo-relay-node-npm-0.7.0-rc.1.tgz")
+            with tarfile.open(metapackage) as archive:
+                manifest = json.load(required_member(archive, "package/package.json"))
+                self.assertEqual(
+                    manifest["optionalDependencies"]["nemo-relay-node-linux-x64-gnu"],
+                    "0.7.0-rc.1",
+                )
+                self.assertIn("package/index.js", archive.getnames())
+                self.assertFalse(any(name.endswith(".node") for name in archive.getnames()))
+
+            development = PACKAGE_NODE_BIN.build_metapackage(node_dir, "0.7.0+deadbeef", output)
+            with tarfile.open(development) as archive:
+                manifest = json.load(required_member(archive, "package/package.json"))
+                self.assertEqual(manifest["version"], "0.7.0+deadbeef")
+                self.assertTrue(
+                    all(version == "0.7.0+deadbeef" for version in manifest["optionalDependencies"].values())
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1274,7 +1274,7 @@ wheels = [
 
 [package.optional-dependencies]
 zig = [
-    { name = "ziglang", marker = "sys_platform == 'linux'" },
+    { name = "ziglang" },
 ]
 
 [[package]]
@@ -1399,6 +1399,9 @@ name = "nemo-relay"
 source = { editable = "." }
 
 [package.optional-dependencies]
+cli = [
+    { name = "nemo-relay-cli-bin" },
+]
 deepagents = [
     { name = "deepagents" },
     { name = "langchain" },
@@ -1469,8 +1472,9 @@ requires-dist = [
     { name = "nemo-relay", extras = ["langchain"], marker = "extra == 'langchain-nvidia'" },
     { name = "nemo-relay", extras = ["langchain"], marker = "extra == 'langgraph'" },
     { name = "nemo-relay", extras = ["langgraph"], marker = "extra == 'deepagents'" },
+    { name = "nemo-relay-cli-bin", marker = "extra == 'cli'", directory = "python/cli-bin" },
 ]
-provides-extras = ["deepagents", "langchain", "langchain-nvidia", "langgraph"]
+provides-extras = ["cli", "deepagents", "langchain", "langchain-nvidia", "langgraph"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1493,6 +1497,11 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.26" },
     { name = "pytest-cov", specifier = "~=7.0" },
 ]
+
+[[package]]
+name = "nemo-relay-cli-bin"
+version = "0.7.0"
+source = { directory = "python/cli-bin" }
 
 [[package]]
 name = "nemo-relay-plugin"

--- a/uv.lock
+++ b/uv.lock
@@ -1274,7 +1274,7 @@ wheels = [
 
 [package.optional-dependencies]
 zig = [
-    { name = "ziglang" },
+    { name = "ziglang", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]


### PR DESCRIPTION
#### Overview

Publish the NeMo Relay CLI as `nemo-relay-cli-bin` on PyPI and npm, add the exact-version `nemo-relay[cli]` extra, and split `nemo-relay-node` into a portable metapackage plus platform-specific native npm packages. Keep Cargo installation and direct GitHub Release binaries supported while attaching the main Python API wheels and clearly named package-manager artifacts to each GitHub Release.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Package every supported CLI binary as a platform-tagged, Python-ABI-independent wheel and an OS/CPU-specific npm package.
- Install the wheel CLI as a regular executable file and smoke-test `nemo-relay --version` on every supported packaging runner.
- Add an npm CLI launcher that selects its exact-version native package and reports unsupported or missing platforms clearly.
- Add `nemo-relay[cli]` with an exact dependency on the matching `nemo-relay-cli-bin` release.

#### Additional Publishing Changes
- Keep `nemo-relay-node` as the JavaScript/TypeScript metapackage and publish five exact-version native packages for Linux x64/ARM64 GNU, macOS ARM64, and Windows x64/ARM64.
- Publish Node and CLI native npm packages before their metapackages while preserving the existing npm `latest` and `next` dist-tag policy.
- Attach five main `nemo-relay` API wheels alongside the raw CLI binaries, five `nemo-relay-cli-bin` wheels, six CLI npm tarballs, and six split Node npm tarballs on GitHub Releases. Include every attached distribution in `SHA256SUMS`, while retaining individual checksums for raw CLI binaries used by installers.
- Name GitHub-facing npm artifacts `nemo-relay-bin-npm[-<os>-<cpu>]-<version>.tgz` and `nemo-relay-node-npm[-<os>-<cpu>]-<version>.tgz` without changing their registry package names.
- Extend GitHub and GitLab packaging, collection, publication, versioning, tests, installation docs, and trusted-publisher guidance for the new distributions.

Validation:

- `just test-python` — 562 passed
- `just test-node` — 293 passed
- `uv run --no-project python -m unittest -v scripts.tests.test_package_cli_bin scripts.tests.test_package_node_bin` — 4 passed
- Installed a generated macOS CLI wheel and verified `nemo-relay --version`
- Installed stable and development-version split Node tarballs and loaded the main package and every exported subpath
- `just --set output_dir <temp> --set node_platform macos-arm64 --set ref_name 0.7.0 package-node`
- `bash scripts/test-install-mocks.sh` — 8 scenarios passed
- Targeted pre-commit checks passed, including actionlint, Ruff, formatting, type checking, and documentation link checks
- The repository-wide pre-commit pass completed all checks; the Rust attribution hook rewrote unchanged lockfile-derived content, and that unrelated generated diff was restored

#### Where should the reviewer start?

Start with `scripts/package-cli-bin.py` for the wheel permission fix and CLI release filenames, then `scripts/package-node-bin.py` for the Node metapackage/native split. Review `.github/workflows/ci_node.yml` and `.github/workflows/ci.yaml` for per-platform smoke tests, publication order, release attachment naming, and checksums.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes RELAY-532



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prebuilt `nemo-relay-cli-bin` distribution packages for PyPI and npm, including platform variants and npm launcher support.
  * Expanded release artifact collection/publishing to include CLI wheels and CLI/Node npm tarballs with verification.
  * Updated release packaging to produce split Node/CLI tarballs and publish them per platform.
* **Documentation**
  * Updated CLI install docs and getting-started instructions to lead with PyPI/npm/extra install commands.
  * Expanded release contract and published-surface guidance to include `nemo-relay-cli-bin`.
* **Tests**
  * Added automated packaging tests and CI smoke checks that install/validate produced CLI and Node artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->