### PR TITLE
fix: handle streaming provider errors before SSE parsing

### DIFF
--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -534,7 +534,10 @@ fn build_streaming_func(
             };
             let status = response.status();
             let response_headers = response_headers(response.headers());
-            if retry_aware && !status.is_success() {
+            // A provider error is not an SSE stream. Drain it before returning so the shared
+            // HTTP client can safely reuse the connection, and keep it out of the managed stream
+            // pipeline so a later request cannot inherit an unfinished provider stream.
+            if !status.is_success() {
                 let bytes = response
                     .bytes()
                     .await

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -998,6 +998,81 @@ async fn sse_json_stream_yields_valid_event_before_later_batch_error() {
 }
 
 #[tokio::test]
+async fn streaming_provider_error_does_not_poison_the_next_request() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let sse_body = "data: {\"type\":\"message_stop\"}\n\n";
+    let success_response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        sse_body.len(),
+        sse_body
+    );
+    let server = tokio::spawn(async move {
+        for response in [
+            "HTTP/1.1 429 Too Many Requests\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            success_response.as_str(),
+        ] {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            socket.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+
+    let state = AppState::new(GatewayConfig::default());
+    let prepared = PreparedGatewayRequest {
+        method: Method::POST,
+        headers: HeaderMap::new(),
+        path: "/v1/messages".into(),
+        provider: ProviderRoute::AnthropicMessages,
+        upstream_url: format!("http://{address}/v1/messages"),
+        body_bytes: Bytes::from_static(b"{}"),
+        request_json: json!({}),
+        streaming: true,
+        authorization: crate::provider_auth::ProviderRequestAuthorization {
+            source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
+            allow_environment_provider_auth: false,
+        },
+    };
+    let upstream_info = Arc::new(Mutex::new(None));
+    let upstream_error = Arc::new(Mutex::new(None));
+    let func = build_streaming_func(
+        state,
+        &prepared,
+        upstream_info.clone(),
+        upstream_error.clone(),
+    );
+    let request = LlmRequest {
+        headers: Map::new(),
+        content: json!({}),
+    };
+
+    let error = match func(request.clone()).await {
+        Ok(_) => panic!("expected the provider error to terminate managed streaming"),
+        Err(error) => error,
+    };
+    let FlowError::Upstream(failure) = error else {
+        panic!("expected structured upstream failure, got {error:?}");
+    };
+    assert_eq!(failure.status, Some(429));
+    assert_eq!(failure.class, UpstreamFailureClass::RetryableStatus);
+    assert!(upstream_info.lock().unwrap().is_none());
+    assert!(upstream_error.lock().unwrap().is_none());
+
+    let mut stream = func(request).await.unwrap();
+    assert_eq!(
+        stream.next().await.unwrap().unwrap(),
+        json!({"type": "message_stop"})
+    );
+    assert!(stream.next().await.is_none());
+    assert_eq!(
+        upstream_info.lock().unwrap().as_ref().unwrap().0,
+        StatusCode::OK
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
 async fn retry_aware_buffered_body_read_failure_stays_structured() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();


### PR DESCRIPTION
#### Overview

Prevent streaming provider errors such as HTTP 429 responses from entering the SSE pipeline and leaving later Claude requests stuck waiting for the relay timeout.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Streaming requests previously converted non-success responses into structured upstream failures only when retry-aware mode was enabled. Normal Claude traffic therefore treated a provider 429 response as an SSE stream. The response could remain unfinished in the managed stream pipeline, causing a subsequent model request to wait until the HTTP client timeout.

This change handles every non-2xx streaming response before SSE parsing, drains its body so the shared HTTP client can safely reuse the connection, and returns the existing structured upstream failure. It also adds a regression test covering a 429 followed by a successful streaming request through the same callback and state.

Validation:

- `cargo test -p nemo-relay-cli streaming_provider_error_does_not_poison_the_next_request`
- `cargo test -p nemo-relay-cli --lib` (1,118 passed)
- `cargo clippy -p nemo-relay-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

#### Where should the reviewer start?

Start with `build_streaming_func` in `crates/cli/src/gateway/mod.rs`; the regression test is `streaming_provider_error_does_not_poison_the_next_request` in `crates/cli/tests/coverage/shared/gateway_tests.rs`.

#### Related Issues

No linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming requests now correctly fail when upstream services return any unsuccessful HTTP status.
  * Prevented failed streaming responses from being misinterpreted as valid event streams.
  * Ensured a failed streaming request does not affect subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->