### PR TITLE
fix: preserve streaming provider error responses

### DIFF
--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -90,6 +90,9 @@ type UpstreamResponseInfo = Arc<Mutex<Option<(StatusCode, HeaderMap)>>>;
 // `FlowError::Internal`, which would otherwise map to a generic 400.
 type UpstreamErrorSlot = Arc<Mutex<Option<reqwest::Error>>>;
 
+// Captures a non-SSE provider error response so ordinary dispatch can preserve proxy semantics.
+type UpstreamPassthroughSlot = Arc<Mutex<Option<(StatusCode, HeaderMap, Bytes)>>>;
+
 // Runs the managed pipeline for a prepared gateway request. Streaming and non-streaming branches
 // share the same prep + codec dispatch but diverge in how the runtime drives the upstream call.
 async fn run_managed_gateway(
@@ -390,11 +393,13 @@ async fn run_managed_streaming(
 ) -> Result<Response<Body>, CliError> {
     let upstream_info: UpstreamResponseInfo = Arc::new(Mutex::new(None));
     let upstream_error: UpstreamErrorSlot = Arc::new(Mutex::new(None));
+    let upstream_passthrough: UpstreamPassthroughSlot = Arc::new(Mutex::new(None));
     let func = build_streaming_func(
         state.clone(),
         &prepared,
         upstream_info.clone(),
         upstream_error.clone(),
+        upstream_passthrough.clone(),
     );
     let provider_route = prepared.provider;
 
@@ -456,10 +461,17 @@ async fn run_managed_streaming(
     let json_stream = match json_stream_result {
         Ok(json_stream) => json_stream,
         Err(error) => {
+            let passthrough = upstream_passthrough
+                .lock()
+                .expect("upstream passthrough lock poisoned")
+                .take();
             state
                 .sessions
                 .finish_gateway_call(&session_id, session_finish)
                 .await;
+            if let Some((status, headers, body)) = passthrough {
+                return build_response(status, headers, Body::from(body));
+            }
             return Err(translate_runtime_error(error, &upstream_error));
         }
     };
@@ -492,6 +504,7 @@ fn build_streaming_func(
     prepared: &PreparedGatewayRequest,
     upstream_info: UpstreamResponseInfo,
     upstream_error: UpstreamErrorSlot,
+    upstream_passthrough: UpstreamPassthroughSlot,
 ) -> LlmStreamExecutionNextFn {
     let http = state.http.clone();
     let method = prepared.method.clone();
@@ -509,6 +522,7 @@ fn build_streaming_func(
         let headers = headers.clone();
         let upstream_info = upstream_info.clone();
         let upstream_error = upstream_error.clone();
+        let upstream_passthrough = upstream_passthrough.clone();
         Box::pin(async move {
             let retry_aware = retry_aware_dispatch(&request);
             let response = match forward_upstream_request(
@@ -534,15 +548,31 @@ fn build_streaming_func(
             };
             let status = response.status();
             let response_headers = response_headers(response.headers());
-            if retry_aware && !status.is_success() {
-                let bytes = response
-                    .bytes()
-                    .await
-                    .map_err(|error| FlowError::Upstream(transport_failure(&error)))?;
-                return Err(FlowError::Upstream(http_failure(
-                    status,
-                    &response_headers,
-                    &bytes,
+            if !status.is_success() {
+                let bytes = match response.bytes().await {
+                    Ok(bytes) => bytes,
+                    Err(error) if retry_aware => {
+                        return Err(FlowError::Upstream(transport_failure(&error)));
+                    }
+                    Err(error) => {
+                        let message = error.to_string();
+                        *upstream_error.lock().expect("upstream error lock poisoned") = Some(error);
+                        return Err(FlowError::Internal(message));
+                    }
+                };
+                if retry_aware {
+                    return Err(FlowError::Upstream(http_failure(
+                        status,
+                        &response_headers,
+                        &bytes,
+                    )));
+                }
+                *upstream_passthrough
+                    .lock()
+                    .expect("upstream passthrough lock poisoned") =
+                    Some((status, response_headers, bytes));
+                return Err(FlowError::Internal(format!(
+                    "upstream provider returned HTTP {status}"
                 )));
             }
             *upstream_info.lock().expect("upstream info lock poisoned") =

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -998,6 +998,147 @@ async fn sse_json_stream_yields_valid_event_before_later_batch_error() {
 }
 
 #[tokio::test]
+async fn streaming_provider_error_does_not_poison_the_next_request() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let error_body = r#"{"error":{"type":"rate_limit_error"}}"#;
+    let error_response = format!(
+        "HTTP/1.1 429 Too Many Requests\r\ncontent-type: application/json\r\nretry-after: 7\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        error_body.len(),
+        error_body
+    );
+    let sse_body = "data: {\"type\":\"message_stop\"}\n\n";
+    let success_response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        sse_body.len(),
+        sse_body
+    );
+    let server = tokio::spawn(async move {
+        for response in [error_response.as_str(), success_response.as_str()] {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            socket.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+
+    let state = AppState::new(GatewayConfig::default());
+    let prepared = PreparedGatewayRequest {
+        method: Method::POST,
+        headers: HeaderMap::new(),
+        path: "/v1/messages".into(),
+        provider: ProviderRoute::AnthropicMessages,
+        upstream_url: format!("http://{address}/v1/messages"),
+        body_bytes: Bytes::from_static(b"{}"),
+        request_json: json!({}),
+        streaming: true,
+        authorization: crate::provider_auth::ProviderRequestAuthorization {
+            source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
+            allow_environment_provider_auth: false,
+        },
+    };
+    let upstream_info = Arc::new(Mutex::new(None));
+    let upstream_error = Arc::new(Mutex::new(None));
+    let upstream_passthrough = Arc::new(Mutex::new(None));
+    let func = build_streaming_func(
+        state,
+        &prepared,
+        upstream_info.clone(),
+        upstream_error.clone(),
+        upstream_passthrough.clone(),
+    );
+    let request = LlmRequest {
+        headers: Map::new(),
+        content: json!({}),
+    };
+
+    let error = match func(request.clone()).await {
+        Ok(_) => panic!("expected the provider error to terminate managed streaming"),
+        Err(error) => error,
+    };
+    assert!(matches!(error, FlowError::Internal(_)));
+    assert!(upstream_info.lock().unwrap().is_none());
+    assert!(upstream_error.lock().unwrap().is_none());
+    let (status, headers, body) = upstream_passthrough.lock().unwrap().take().unwrap();
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        headers.get(header::CONTENT_TYPE).unwrap(),
+        "application/json"
+    );
+    assert_eq!(headers.get(header::RETRY_AFTER).unwrap(), "7");
+    assert_eq!(body, error_body);
+
+    let mut stream = func(request).await.unwrap();
+    assert_eq!(
+        stream.next().await.unwrap().unwrap(),
+        json!({"type": "message_stop"})
+    );
+    assert!(stream.next().await.is_none());
+    assert_eq!(
+        upstream_info.lock().unwrap().as_ref().unwrap().0,
+        StatusCode::OK
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn retry_aware_streaming_provider_error_stays_structured() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0_u8; 1024];
+        let _ = socket.read(&mut request).await.unwrap();
+        socket
+            .write_all(
+                b"HTTP/1.1 429 Too Many Requests\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            )
+            .await
+            .unwrap();
+    });
+
+    let state = AppState::new(GatewayConfig::default());
+    let prepared = PreparedGatewayRequest {
+        method: Method::POST,
+        headers: HeaderMap::new(),
+        path: "/v1/messages".into(),
+        provider: ProviderRoute::AnthropicMessages,
+        upstream_url: format!("http://{address}/v1/messages"),
+        body_bytes: Bytes::from_static(b"{}"),
+        request_json: json!({}),
+        streaming: true,
+        authorization: crate::provider_auth::ProviderRequestAuthorization {
+            source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
+            allow_environment_provider_auth: false,
+        },
+    };
+    let upstream_passthrough = Arc::new(Mutex::new(None));
+    let func = build_streaming_func(
+        state,
+        &prepared,
+        Arc::new(Mutex::new(None)),
+        Arc::new(Mutex::new(None)),
+        upstream_passthrough.clone(),
+    );
+    let request = LlmRequest {
+        headers: Map::from_iter([(INTERNAL_RETRY_AWARE_HEADER.to_string(), json!("true"))]),
+        content: json!({}),
+    };
+
+    let error = match func(request).await {
+        Ok(_) => panic!("expected a structured provider failure"),
+        Err(error) => error,
+    };
+    let FlowError::Upstream(failure) = error else {
+        panic!("expected structured upstream failure, got {error:?}");
+    };
+    assert_eq!(failure.status, Some(429));
+    assert_eq!(failure.class, UpstreamFailureClass::RetryableStatus);
+    assert!(upstream_passthrough.lock().unwrap().is_none());
+    server.await.unwrap();
+}
+
+#[tokio::test]
 async fn retry_aware_buffered_body_read_failure_stays_structured() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -2911,6 +2911,64 @@ async fn gateway_preserves_streaming_body() {
 }
 
 #[tokio::test]
+async fn gateway_preserves_streaming_provider_error_response() {
+    async fn rate_limited() -> impl IntoResponse {
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            [
+                (header::CONTENT_TYPE, "application/json"),
+                (header::RETRY_AFTER, "7"),
+            ],
+            r#"{"error":{"type":"rate_limit_error"}}"#,
+        )
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            Router::new().route("/v1/responses", post(rate_limited)),
+        )
+        .await
+        .unwrap();
+    });
+    let mut config = test_config();
+    config.openai_base_url = format!("http://{address}");
+
+    let response = router(config)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "gpt-test",
+                        "input": "hello",
+                        "stream": true
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/json"
+    );
+    assert_eq!(response.headers().get(header::RETRY_AFTER).unwrap(), "7");
+    assert_eq!(
+        response.into_body().collect().await.unwrap().to_bytes(),
+        r#"{"error":{"type":"rate_limit_error"}}"#
+    );
+    handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_surfaces_streaming_upstream_errors() {
     let upstream = spawn_failing_stream_upstream().await;
     let mut config = test_config();


### PR DESCRIPTION
#### Overview

Prevent non-2xx provider responses from entering the managed SSE pipeline while preserving Relay's existing transparent-proxy behavior for ordinary dispatches. This is the proxy-preserving alternative to #576.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests. This intentionally presents an alternative implementation to #576 for reviewer comparison.

#### Details

Normal streaming dispatch previously passed provider 429 responses into the SSE decoder. Provider error bodies are ordinary JSON rather than successful SSE streams, so an unfinished response could leave a later Claude request waiting for the shared HTTP client timeout.

This change drains every non-2xx streaming response before SSE parsing. Retry-aware dispatches retain the existing `FlowError::Upstream` behavior used by Switchyard. Ordinary dispatches capture the original status, filtered response headers, and body, then return that provider response directly from the outer gateway.

Compared with #576, this option adds a small response side channel but preserves the original provider error body and headers instead of wrapping normal failures as Relay gateway errors.

Validation:

- `cargo test -p nemo-relay-cli --lib` (1,120 passed)
- `cargo clippy -p nemo-relay-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Regression coverage verifies ordinary 429 passthrough, retry-aware structured failures, and a successful request after the failed stream.

#### Where should the reviewer start?

Start with `run_managed_streaming` and `build_streaming_func` in `crates/cli/src/gateway/mod.rs`. The full HTTP passthrough regression is `gateway_preserves_streaming_provider_error_response` in `crates/cli/tests/coverage/shared/server_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #576.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved upstream HTTP error responses for non-retry-aware streaming requests, including status codes, headers, and response bodies.
  * Streaming rate-limit errors now retain details such as `Retry-After` headers instead of being rewritten as generic runtime errors.
  * Retry-aware requests continue to return structured errors for retry handling.
  * Ensured provider errors do not affect subsequent streaming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->