### PR TITLE
fix: bound transparent gateway shutdown

### DIFF
--- a/crates/cli/src/process/launcher.rs
+++ b/crates/cli/src/process/launcher.rs
@@ -26,6 +26,8 @@ use crate::server::GatewayOverrides;
 
 use super::{PreparedAgentLaunch, RunOverrides};
 
+const TRANSPARENT_GATEWAY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// Runs a child coding-agent command behind an ephemeral local gateway.
 ///
 /// The gateway binds to an OS-assigned loopback port, prepares agent-specific hook/gateway wiring,
@@ -378,13 +380,29 @@ impl RunningGateway {
             .map_err(|error| CliError::Launch(format!("gateway task failed: {error}")))?
     }
 
-    // Requests shutdown and joins the server task. The send can fail only if the task already exited;
-    // the join result still captures whether serving ended cleanly.
+    // Requests shutdown and joins the server task, aborting it if an in-flight request prevents
+    // graceful shutdown from completing. The send can fail only if the task already exited.
     async fn stop(self) -> Result<(), CliError> {
-        let _ = self.shutdown_tx.send(());
-        self.task
+        self.stop_with_timeout(TRANSPARENT_GATEWAY_SHUTDOWN_TIMEOUT)
             .await
-            .map_err(|error| CliError::Launch(format!("gateway task failed: {error}")))?
+    }
+
+    async fn stop_with_timeout(mut self, timeout: Duration) -> Result<(), CliError> {
+        let _ = self.shutdown_tx.send(());
+        match tokio::time::timeout(timeout, &mut self.task).await {
+            Ok(result) => {
+                result.map_err(|error| CliError::Launch(format!("gateway task failed: {error}")))?
+            }
+            Err(_) => {
+                self.task.abort();
+                match self.task.await {
+                    Err(error) if error.is_cancelled() => Ok(()),
+                    result => result.map_err(|error| {
+                        CliError::Launch(format!("gateway task failed: {error}"))
+                    })?,
+                }
+            }
+        }
     }
 }
 

--- a/crates/cli/src/process/launcher.rs
+++ b/crates/cli/src/process/launcher.rs
@@ -394,6 +394,12 @@ impl RunningGateway {
                 result.map_err(|error| CliError::Launch(format!("gateway task failed: {error}")))?
             }
             Err(_) => {
+                log::info!(
+                    target: "nemo_relay.server",
+                    event = "transparent_gateway_shutdown_timed_out",
+                    timeout_ms = timeout.as_millis();
+                    "Transparent gateway shutdown timed out; aborting task"
+                );
                 self.task.abort();
                 match self.task.await {
                     Err(error) if error.is_cancelled() => Ok(()),

--- a/crates/cli/tests/coverage/agents/launcher_tests.rs
+++ b/crates/cli/tests/coverage/agents/launcher_tests.rs
@@ -62,6 +62,16 @@ impl Drop for EnvScope {
     }
 }
 
+struct DropSignal(Option<oneshot::Sender<()>>);
+
+impl Drop for DropSignal {
+    fn drop(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
+}
+
 #[test]
 fn infers_agent_from_command_or_uses_override() {
     let command = RunOverrides {
@@ -2009,6 +2019,32 @@ async fn gateway_failure_terminates_the_agent_and_restores_private_state() {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
     }
+}
+
+#[tokio::test]
+async fn gateway_stop_aborts_a_task_that_exceeds_the_grace_period() {
+    let (shutdown_tx, _shutdown_rx) = oneshot::channel();
+    let (started_tx, started_rx) = oneshot::channel();
+    let (dropped_tx, dropped_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let _drop_signal = DropSignal(Some(dropped_tx));
+        let _ = started_tx.send(());
+        std::future::pending::<Result<(), CliError>>().await
+    });
+    started_rx.await.unwrap();
+    let gateway = RunningGateway { shutdown_tx, task };
+
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        gateway.stop_with_timeout(Duration::from_millis(10)),
+    )
+    .await
+    .expect("forced gateway shutdown did not finish")
+    .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), dropped_rx)
+        .await
+        .expect("aborted gateway task was not dropped")
+        .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Overview

Prevent `nemo-relay codex` and other transparent agent runs from waiting indefinitely during gateway shutdown when an in-flight streaming request never completes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

The transparent launcher currently sends the gateway shutdown signal and awaits the Axum server task without a deadline. Axum graceful shutdown waits for every in-flight request, so a provider stream stuck inside managed execution can keep the Relay wrapper—and therefore the terminal job—alive indefinitely after the coding agent exits.

This change gives transparent gateway shutdown a three-second grace period. If the server task remains active, Relay aborts and joins it so cleanup can finish and the wrapper can exit. Standalone and managed shared gateways are unchanged.

Validation:

- `cargo test -p nemo-relay-cli gateway_stop_aborts_a_task_that_exceeds_the_grace_period`
- `cargo test -p nemo-relay-cli --lib` (1,121 passed)
- `cargo clippy -p nemo-relay-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

#### Where should the reviewer start?

Start with `RunningGateway::stop_with_timeout` in `crates/cli/src/process/launcher.rs`. The regression test uses a permanently pending gateway task and verifies that the timeout aborts and drops it.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #577.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transparent gateway shutdown reliability with a bounded 3-second grace period to prevent CLI hangs.
  * Ensures shutdown succeeds when the gateway is cancelled due to interrupt/timeout, while surfacing other unexpected failures consistently.
  * Logs when the gateway shutdown grace period is exceeded.
* **Tests**
  * Added coverage verifying gateway stop aborts tasks that remain unresponsive past the grace period, and updated existing shutdown tests accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->