### PR TITLE
fix: allow interrupting transparent gateway shutdown

### DIFF
--- a/crates/cli/src/process/launcher.rs
+++ b/crates/cli/src/process/launcher.rs
@@ -378,13 +378,33 @@ impl RunningGateway {
             .map_err(|error| CliError::Launch(format!("gateway task failed: {error}")))?
     }
 
-    // Requests shutdown and joins the server task. The send can fail only if the task already exited;
-    // the join result still captures whether serving ended cleanly.
+    // Requests shutdown and joins the server task. A second Ctrl-C while cleanup is in progress
+    // aborts the task so a stuck in-flight request cannot make the terminal unresponsive.
     async fn stop(self) -> Result<(), CliError> {
+        self.stop_with_interrupt(tokio::signal::ctrl_c()).await
+    }
+
+    async fn stop_with_interrupt<F>(mut self, interrupt: F) -> Result<(), CliError>
+    where
+        F: std::future::Future<Output = std::io::Result<()>>,
+    {
         let _ = self.shutdown_tx.send(());
-        self.task
-            .await
-            .map_err(|error| CliError::Launch(format!("gateway task failed: {error}")))?
+        tokio::pin!(interrupt);
+        tokio::select! {
+            result = &mut self.task => {
+                result.map_err(|error| CliError::Launch(format!("gateway task failed: {error}")))?
+            }
+            interrupt_result = &mut interrupt => {
+                interrupt_result?;
+                self.task.abort();
+                match self.task.await {
+                    Err(error) if error.is_cancelled() => Ok(()),
+                    result => result.map_err(|error| {
+                        CliError::Launch(format!("gateway task failed: {error}"))
+                    })?,
+                }
+            }
+        }
     }
 }
 

--- a/crates/cli/tests/coverage/agents/launcher_tests.rs
+++ b/crates/cli/tests/coverage/agents/launcher_tests.rs
@@ -62,6 +62,16 @@ impl Drop for EnvScope {
     }
 }
 
+struct DropSignal(Option<oneshot::Sender<()>>);
+
+impl Drop for DropSignal {
+    fn drop(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
+}
+
 #[test]
 fn infers_agent_from_command_or_uses_override() {
     let command = RunOverrides {
@@ -2009,6 +2019,32 @@ async fn gateway_failure_terminates_the_agent_and_restores_private_state() {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
     }
+}
+
+#[tokio::test]
+async fn gateway_stop_interrupt_aborts_a_stuck_task() {
+    let (shutdown_tx, _shutdown_rx) = oneshot::channel();
+    let (started_tx, started_rx) = oneshot::channel();
+    let (dropped_tx, dropped_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let _drop_signal = DropSignal(Some(dropped_tx));
+        let _ = started_tx.send(());
+        std::future::pending::<Result<(), CliError>>().await
+    });
+    started_rx.await.unwrap();
+    let gateway = RunningGateway { shutdown_tx, task };
+
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        gateway.stop_with_interrupt(async { Ok(()) }),
+    )
+    .await
+    .expect("interrupt did not force gateway shutdown")
+    .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), dropped_rx)
+        .await
+        .expect("interrupted gateway task was not dropped")
+        .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Overview

Keep Ctrl-C effective while a transparent Relay gateway is shutting down, so users can immediately escape cleanup blocked by an in-flight provider request.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Relay installs Tokio signal handling while supervising the coding-agent process. After the agent exits, the launcher stops polling the child supervisor and awaits gateway cleanup. If Axum graceful shutdown is blocked by a stuck request, a subsequent Ctrl-C is handled process-wide but no active cleanup path consumes it, leaving the wrapper unresponsive.

This change subscribes to Ctrl-C while `RunningGateway::stop` awaits the server task. An interrupt aborts and joins the stuck task immediately. Normal graceful shutdown remains unchanged when the task completes first.

This is independent from, and complementary to, #578: that PR adds an automatic deadline; this PR provides an explicit user escape hatch.

Validation:

- `cargo test -p nemo-relay-cli gateway_stop_interrupt_aborts_a_stuck_task`
- `cargo test -p nemo-relay-cli --lib` (1,121 passed)
- `cargo clippy -p nemo-relay-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

#### Where should the reviewer start?

Start with `RunningGateway::stop_with_interrupt` in `crates/cli/src/process/launcher.rs`. The regression test injects an interrupt while the gateway task is permanently pending and verifies that the task is aborted and dropped.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #577.
- Relates to #578.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway shutdown handling when an interrupt occurs.
  * Prevented shutdown from hanging on unresponsive gateway tasks.
  * Ensured interrupted shutdowns complete cleanly and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->