### PR TITLE
fix: validate OTLP attribute mappings in plugin config

### DIFF
--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -55,6 +55,7 @@ use crate::observability::otel::{
 };
 use crate::observability::{
     MarkProjection, OpenTelemetryType, OtlpAttributeMapping, default_mark_exclude_names,
+    validate_attribute_mappings,
 };
 use crate::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
@@ -2218,6 +2219,16 @@ fn validate_opentelemetry_section(
                 Some("opentelemetry".to_string()),
                 Some(format!("endpoints[{index}].transport")),
                 "OpenTelemetry endpoint transport must be 'http_binary' or 'grpc'".to_string(),
+            );
+        }
+        if let Err(error) = validate_attribute_mappings(&endpoint.attribute_mappings) {
+            push_policy_diag(
+                diagnostics,
+                policy.unsupported_value,
+                "observability.unsupported_value",
+                Some("opentelemetry".to_string()),
+                Some(format!("endpoints[{index}].attribute_mappings")),
+                error,
             );
         }
         validate_opentelemetry_headers(diagnostics, policy, index, endpoint);

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -730,6 +730,71 @@ fn opentelemetry_endpoint_accepts_legacy_projection_controls_and_rejects_unknown
 }
 
 #[test]
+fn opentelemetry_endpoint_rejects_invalid_attribute_mappings() {
+    let invalid_mappings = [
+        (
+            json!([{"key": "", "alias": "some.alias"}]),
+            "attribute mapping key must not be blank",
+        ),
+        (
+            json!([{"key": "nemo_relay.mark.metadata.source", "alias": " "}]),
+            "attribute mapping alias must not be blank",
+        ),
+        (
+            json!([
+                {"key": "nemo_relay.model_name", "alias": "duplicate.alias"},
+                {"key": "nemo_relay.tool.name", "alias": "duplicate.alias"}
+            ]),
+            "attribute mapping alias \"duplicate.alias\" is duplicated",
+        ),
+    ];
+
+    for (attribute_mappings, expected_message) in invalid_mappings {
+        let config = plugin_config(json!({
+            "opentelemetry": {
+                "enabled": true,
+                "endpoints": [{
+                    "type": "full",
+                    "endpoint": "http://localhost:4318/v1/traces",
+                    "attribute_mappings": attribute_mappings
+                }]
+            }
+        }));
+        let report = validate_plugin_config(&config);
+        assert!(report.has_errors());
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "observability.unsupported_value"
+                && diagnostic.field.as_deref() == Some("endpoints[0].attribute_mappings")
+                && diagnostic.message.contains(expected_message)
+        }));
+        assert!(futures::executor::block_on(initialize_plugins_exact(config)).is_err());
+    }
+}
+
+#[test]
+fn opentelemetry_endpoint_accepts_valid_attribute_mappings() {
+    let report = validate_plugin_config(&plugin_config(json!({
+        "opentelemetry": {
+            "enabled": true,
+            "endpoints": [{
+                "type": "full",
+                "endpoint": "http://localhost:4318/v1/traces",
+                "attribute_mappings": [{
+                    "key": "nemo_relay.model_name",
+                    "alias": "model.alias"
+                }]
+            }]
+        }
+    })));
+
+    assert!(
+        !report.has_errors(),
+        "valid attribute mapping produced diagnostics: {:?}",
+        report.diagnostics
+    );
+}
+
+#[test]
 fn opentelemetry_endpoint_rejects_invalid_and_case_duplicate_headers() {
     let report = validate_plugin_config(&plugin_config(json!({
         "opentelemetry": {


### PR DESCRIPTION
#### Overview

Restore fail-closed validation for per-endpoint OpenTelemetry `attribute_mappings` during shared plugin configuration validation. This prevents malformed mappings from being accepted during plugin activation and failing only when an exporter is constructed.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Call the existing shared `validate_attribute_mappings` helper for every typed OpenTelemetry endpoint.
- Report blank keys, blank aliases, and duplicate aliases as `observability.unsupported_value` diagnostics at `endpoints[N].attribute_mappings`.
- Add regression coverage for validation diagnostics, plugin activation rejection, and valid mappings.
- Validation: `cargo fmt --all`, `just test-rust`, workspace Clippy with warnings denied, `just test-python` (564 passed), `just test-node` (294 passed), and targeted pre-commit hooks passed.
- `just test-go` completed with two unrelated existing failures because Go fixtures still use observability config version 2 while core requires version 3: `TestTopLevelPluginValidationAndLifecycle` and `TestConfigureAdaptiveComponentLifecycle`; all other Go packages passed.
- The repository-wide pre-commit run was interrupted by disk exhaustion in cache/build hooks; rerunning pre-commit against the two changed files passed all applicable hooks.

#### Where should the reviewer start?

Start with `validate_opentelemetry_section` in `crates/core/src/observability/plugin_component.rs`, then review `opentelemetry_endpoint_rejects_invalid_attribute_mappings` in the adjacent plugin-component tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-587](https://linear.app/nvidia/issue/RELAY-587/nemo-relay070-bad-otlp-attribute-mappings-are-accepted-after-556-blank)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for OpenTelemetry endpoint attribute mappings.
  * Invalid mappings now produce clear configuration diagnostics and prevent plugin initialization.
  * Valid attribute mappings are accepted as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->