### PR TITLE
test: tolerate OTLP collector read timeouts

### DIFF
--- a/crates/ffi/tests/unit/api/registry_tests.rs
+++ b/crates/ffi/tests/unit/api/registry_tests.rs
@@ -29,7 +29,18 @@ fn start_otlp_http_collector() -> (String, Receiver<Vec<u8>>, JoinHandle<()>) {
                     let mut request = Vec::new();
                     let mut buffer = [0_u8; 4096];
                     let (header_end, content_length) = loop {
-                        let read = stream.read(&mut buffer).unwrap();
+                        let read = match stream.read(&mut buffer) {
+                            Ok(read) => read,
+                            Err(error)
+                                if matches!(
+                                    error.kind(),
+                                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                                ) && Instant::now() < deadline =>
+                            {
+                                continue;
+                            }
+                            Err(error) => panic!("collector header read failed: {error}"),
+                        };
                         assert!(
                             read > 0,
                             "collector connection closed before request headers"
@@ -53,7 +64,18 @@ fn start_otlp_http_collector() -> (String, Receiver<Vec<u8>>, JoinHandle<()>) {
                         }
                     };
                     while request.len() < header_end + content_length {
-                        let read = stream.read(&mut buffer).unwrap();
+                        let read = match stream.read(&mut buffer) {
+                            Ok(read) => read,
+                            Err(error)
+                                if matches!(
+                                    error.kind(),
+                                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                                ) && Instant::now() < deadline =>
+                            {
+                                continue;
+                            }
+                            Err(error) => panic!("collector body read failed: {error}"),
+                        };
                         assert!(read > 0, "collector connection closed before request body");
                         request.extend_from_slice(&buffer[..read]);
                     }


### PR DESCRIPTION
#### Overview

Make the FFI test OTLP collector tolerate transient socket read timeouts under CI load.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Retry `WouldBlock` and `TimedOut` errors while reading OTLP HTTP headers and bodies.
- Bound retries by the collector's existing five-second deadline.
- Preserve immediate failures for other socket errors with more specific diagnostics.

Validation:

- `cargo fmt --all`
- Focused failing FFI integration test, 10 consecutive runs
- `just build-go`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --files crates/ffi/tests/unit/api/registry_tests.rs`
- Full pre-commit run passed all applicable checks except the Rust attribution generator, which rewrote attribution output despite no dependency change; that generated noise was reverted.
- `just test-rust` was attempted. The changed test passed, but the local full suite encountered unrelated ambient-state failures in CLI configuration and lifecycle tests.
- `cargo test -p nemo-relay-ffi` was attempted. The changed test passed, but a pre-existing plugin initialization failure poisoned a shared test lock and caused follow-on plugin test failures.

#### Where should the reviewer start?

Review `start_otlp_http_collector` in `crates/ffi/tests/unit/api/registry_tests.rs`, particularly the retry conditions and existing deadline bound.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #582


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of OTLP HTTP collector tests by retrying temporary socket read failures.
  * Added clearer error reporting when header or body data cannot be read before the test deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->