### PR TITLE
docs: clarify sanitizer delivery contract

### DIFF
--- a/docs/about-nemo-relay/concepts/middleware.mdx
+++ b/docs/about-nemo-relay/concepts/middleware.mdx
@@ -87,6 +87,10 @@ object.
 
 Guardrails are middleware that block execution or sanitize observability payloads.
 
+Sanitizers are pure transformations. Do not use a sanitizer callback for
+stateful side effects, such as metrics, logging, mutation, or I/O; Relay only
+guarantees the transformed observability payload.
+
 ### Conditional Execution
 
 Conditional-execution guardrails run before the real callback. They decide
@@ -113,10 +117,10 @@ tool and LLM payload APIs. Separate registries apply to marks, scope starts,
 and scope ends. They can rewrite `data`, `category_profile`, and `metadata`
 while receiving the complete event as immutable context.
 
-Scope event sanitizers run for every category. On tool and LLM scope events,
-they run after the specialized request or response sanitizer. Mark sanitizers
-cover explicit marks and marks materialized by middleware, plugins, and
-streaming lifecycle helpers.
+Scope event sanitizers run for every delivered event category. On tool and LLM
+scope events, they run after the specialized request or response sanitizer.
+Mark sanitizers cover delivered explicit marks and marks materialized by
+middleware, plugins, and streaming lifecycle helpers.
 
 Register event sanitizers globally, on an owning scope, or through a plugin
 context. For the callback contract and binding APIs, refer to

--- a/docs/reference/event-sanitizers.mdx
+++ b/docs/reference/event-sanitizers.mdx
@@ -18,15 +18,15 @@ Choose a registry based on the event that you want to sanitize.
 
 | Registry | Events |
 | --- | --- |
-| Mark sanitizer | Every mark, including explicit, pending, plugin-runtime, and streaming marks |
-| Scope-start sanitizer | Every scope category with `scope_category = "start"` |
-| Scope-end sanitizer | Every scope category with `scope_category = "end"` |
+| Mark sanitizer | Every delivered mark, including explicit, pending, plugin-runtime, and streaming marks |
+| Scope-start sanitizer | Every delivered scope category with `scope_category = "start"` |
+| Scope-end sanitizer | Every delivered scope category with `scope_category = "end"` |
 
-Scope sanitizers apply to every scope category, including `tool` and `llm`.
-For tool and LLM events, the specialized request or response sanitizers run
-first. Your scope sanitizer then receives the already-sanitized event fields,
-which lets a general event policy inspect them without changing the real
-request or response.
+Scope sanitizers apply to every delivered scope category, including `tool` and
+`llm`. For tool and LLM events, the specialized request or response sanitizers
+run first. Your scope sanitizer then receives the already-sanitized event
+fields, which lets a general event policy inspect them without changing the
+real request or response.
 
 ## Callback Contract
 
@@ -47,6 +47,10 @@ Sanitizers can change only `data`, `category_profile`, and `metadata`. They
 cannot change event identity, parentage, timestamps, kind, scope category,
 semantic category, attributes, semantic input and output meaning, or schemas.
 
+Sanitizers are pure transformations. Do not use their callbacks for stateful
+side effects, such as metrics, logging, mutation, or I/O; Relay only guarantees
+the transformed observability payload.
+
 Registries run in priority order. Lower priorities run first, and each
 callback receives the fields returned by the callback before it. Invalid
 binding callback results fail open and preserve the current fields. In Node.js,
@@ -60,6 +64,10 @@ visible sanitizer chain, and subscribers, then enqueue that snapshot for
 sanitization and publication on a serial background dispatcher. Subscribers
 and exporters therefore receive the sanitized event after the emission call
 returns.
+
+Event sanitizers run only for events captured for delivery to one or more
+subscribers or exporters. With no subscribers visible at emission, Relay does
+not invoke the sanitizer chain or start the dispatcher.
 
 The dispatcher processes snapshots in FIFO order, preserving scope start/end
 and mark ordering. Closing a scope or deregistering middleware after emission

--- a/docs/reference/event-sanitizers.mdx
+++ b/docs/reference/event-sanitizers.mdx
@@ -65,9 +65,9 @@ sanitization and publication on a serial background dispatcher. Subscribers
 and exporters therefore receive the sanitized event after the emission call
 returns.
 
-Event sanitizers run only for events captured for delivery to one or more
-subscribers or exporters. With no subscribers visible at emission, Relay does
-not invoke the sanitizer chain or start the dispatcher.
+Event sanitizers run only for events captured for delivery to a direct
+subscriber or an exporter-backed subscriber. With neither visible at emission,
+Relay does not invoke the sanitizer chain or start the dispatcher.
 
 The dispatcher processes snapshots in FIFO order, preserving scope start/end
 and mark ordering. Closing a scope or deregistering middleware after emission


### PR DESCRIPTION
#### Overview

Clarify the sanitizer contract for observability documentation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Define all sanitizers as pure transformations and prohibit stateful callback side effects.
- Document that event sanitizers run only for events captured for subscriber or exporter delivery.
- Clarify that no visible subscriber at emission skips both the sanitizer chain and dispatcher startup.

#### Where should the reviewer start?

Start with `docs/reference/event-sanitizers.mdx`, which defines the callback and publication contracts.

Validation:

- `just docs`
- `uv run pre-commit run --all-files`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [RELAY-595](https://linear.app/nvidia/issue/RELAY-595)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that sanitizer callbacks must be pure transformations with no stateful side effects.
  * Updated sanitizer execution order and coverage for scope events, request/response events, and both explicit and middleware/generated marks.
  * Clarified that sanitizer processing and background dispatch run only when an event is captured for delivery to at least one subscriber/exporter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->