### PR TITLE
ci: resolve `ty` script imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
       - id: ty
         name: ty (type check)
-        entry: uv run ty check . --extra-search-path python/plugin/src --exclude docs/** --exclude fern/** --exclude ./examples/** --exclude .cache/** --exclude .claude/** --exclude python/plugin/src/nemo_relay_plugin/_proto/**
+        entry: uv run ty check . --extra-search-path python/plugin/src --extra-search-path scripts/docs --extra-search-path scripts/licensing --exclude docs/** --exclude fern/** --exclude ./examples/** --exclude .cache/** --exclude .claude/** --exclude python/plugin/src/nemo_relay_plugin/_proto/**
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
#### Overview

Add Ty module search paths for the repository-local script helpers.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `scripts/docs` and `scripts/licensing` as Ty extra search paths.
- Keep Ty type checking enabled for all files under `scripts/`.

#### Where should the reviewer start?

Review the Ty hook command in `.pre-commit-config.yaml`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated type checking by including documentation and licensing script paths in validation.
  * Existing exclusion rules remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->