### PR TITLE
docs: update Nemotron integration examples

### DIFF
--- a/docs/supported-integrations/deepagents.mdx
+++ b/docs/supported-integrations/deepagents.mdx
@@ -61,7 +61,7 @@ from nemo_relay.integrations.deepagents import (
 
 agent = create_deep_agent(
     **add_nemo_relay_integration(
-        model="nvidia:nvidia/nemotron-3-nano-30b-a3b",
+        model="nvidia:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         tools=[],
         name="main-agent",
     )

--- a/docs/supported-integrations/langchain.mdx
+++ b/docs/supported-integrations/langchain.mdx
@@ -64,7 +64,7 @@ def get_weather(location: str) -> str:
     return f"The weather in {location} is sunny and 72 degrees."
 
 agent = create_agent(
-    model="nvidia:nvidia/nemotron-3-nano-30b-a3b",
+    model="nvidia:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
     tools=[get_weather],
     middleware=[NemoRelayMiddleware()],
     system_prompt="Use tools when they are relevant. Keep the final answer brief.",

--- a/docs/supported-integrations/langgraph.mdx
+++ b/docs/supported-integrations/langgraph.mdx
@@ -74,7 +74,7 @@ from langchain_core.runnables import RunnableConfig
 from nemo_relay.integrations.langgraph import NemoRelayMiddleware
 
 agent = create_agent(
-    model="nvidia:nvidia/nemotron-3-nano-30b-a3b",
+    model="nvidia:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
     tools=[],
     middleware=[NemoRelayMiddleware()],
 )


### PR DESCRIPTION
#### Overview

Update integration examples to use `nemotron-3-nano-omni-30b-a3b-reasoning`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace the deprecated Nemotron model identifier in the LangChain, LangGraph, and Deep Agents integration examples.

#### Where should the reviewer start?

Review the model configuration lines in `docs/supported-integrations/`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Deep Agents, LangChain, and LangGraph examples to use the NVIDIA Nemotron-3 Nano Omni reasoning model.
  - Refreshed integration guidance to reflect the latest supported model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->