### PR TITLE
ci: publish local npm archives by path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -523,13 +523,13 @@ jobs:
               echo "${name} ${version} already exists on npm; skipping"
               continue
             fi
-            npm publish "$pkg" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+            npm publish "./$pkg" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
           done
           metapackage="node-packages/nemo-relay-node-npm-${version}.tgz"
           if npm view "nemo-relay-node@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
             echo "nemo-relay-node ${version} already exists on npm; skipping"
           else
-            npm publish "$metapackage" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+            npm publish "./$metapackage" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
           fi
 
       - name: Publish CLI packages to npm
@@ -542,13 +542,13 @@ jobs:
               echo "${name} ${version} already exists on npm; skipping"
               continue
             fi
-            npm publish "$pkg" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+            npm publish "./$pkg" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
           done
           launcher="cli-packages/nemo-relay-bin-npm-${version}.tgz"
           if npm view "nemo-relay-cli-bin@${version}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
             echo "nemo-relay-cli-bin ${version} already exists on npm; skipping"
           else
-            npm publish "$launcher" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
+            npm publish "./$launcher" --access public --tag "${NEMO_RELAY_NPM_DIST_TAG}"
           fi
 
       - name: Publish OpenClaw plugin package to npm


### PR DESCRIPTION
#### Overview

Ensure release publishing treats downloaded npm tarballs as local files.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Prefix Node and CLI npm archive arguments with `./` in the release publish job.
- Preserve existing package selection and dist-tag behavior.

#### Where should the reviewer start?

Review `.github/workflows/ci.yaml`, specifically the Node and CLI `npm publish` commands.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package publishing reliability by standardizing archive path handling across platform packages and launchers.
  * Existing skip checks and publishing tags remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->