### PR TITLE
chore: prepare 0.7 code freeze

### DIFF
--- a/.agents/skills/prepare-code-freeze/SKILL.md
+++ b/.agents/skills/prepare-code-freeze/SKILL.md
@@ -40,6 +40,12 @@ This workflow assumes `upstream` is the NVIDIA repository remote
    branch.
 6. Run `just set-version <next-version>` to bump all release-versioned package
    surfaces on `main`.
+   Regenerate the dynamic worker-plugin fixture lockfile so its path
+   dependencies use the new workspace version:
+
+   ```bash
+   cargo generate-lockfile --manifest-path crates/core/tests/fixtures/worker_plugin/Cargo.toml
+   ```
 7. Search documentation source for references to the old version and update
    current-version install commands, package examples, and configuration
    examples to `<next-version>` where appropriate:
@@ -56,6 +62,8 @@ This workflow assumes `upstream` is the NVIDIA repository remote
    ```bash
    ruby -e 'require "yaml"; YAML.load_file(".github/nightly-alpha-branches.yaml"); YAML.load_file(".github/workflows/nightly-alpha-tag.yaml")'
    just set-version <next-version>
+   cargo generate-lockfile --manifest-path crates/core/tests/fixtures/worker_plugin/Cargo.toml
+   cargo build --locked --manifest-path crates/core/tests/fixtures/worker_plugin/Cargo.toml
    rg -n '<old-version>' README.md docs fern --glob '!docs/_build/**' || true
    git diff --check
    ```

--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,3 +3,4 @@
 
 branches:
   - main
+  - release/0.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-adaptive"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "log",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-ffi"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-node"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "napi",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-pii-redaction"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "futures",
  "log",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "nemo-relay-types",
  "serde",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-python"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-switchyard"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "futures-util",
  "hyper-util",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker-proto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,23 +21,23 @@ exclude = [".tmp", ".uv-cache"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/NeMo-Relay"
 
 [workspace.dependencies]
-nemo-relay = { version = "0.7.0", path = "crates/core", default-features = false }
-nemo-relay-types = { version = "0.7.0", path = "crates/types" }
-nemo-relay-plugin = { version = "0.7.0", path = "crates/plugin" }
-nemo-relay-worker-proto = { version = "0.7.0", path = "crates/worker-proto" }
-nemo-relay-worker = { version = "0.7.0", path = "crates/worker" }
-nemo-relay-adaptive = { version = "0.7.0", path = "crates/adaptive" }
-nemo-relay-pii-redaction = { version = "0.7.0", path = "crates/pii-redaction" }
-nemo-relay-switchyard = { version = "0.7.0", path = "crates/switchyard" }
+nemo-relay = { version = "0.8.0", path = "crates/core", default-features = false }
+nemo-relay-types = { version = "0.8.0", path = "crates/types" }
+nemo-relay-plugin = { version = "0.8.0", path = "crates/plugin" }
+nemo-relay-worker-proto = { version = "0.8.0", path = "crates/worker-proto" }
+nemo-relay-worker = { version = "0.8.0", path = "crates/worker" }
+nemo-relay-adaptive = { version = "0.8.0", path = "crates/adaptive" }
+nemo-relay-pii-redaction = { version = "0.8.0", path = "crates/pii-redaction" }
+nemo-relay-switchyard = { version = "0.8.0", path = "crates/switchyard" }
 switchyard-translation = "0.1.0"
-nemo-relay-ffi = { version = "0.7.0", path = "crates/ffi" }
-nemo-relay-cli = { version = "0.7.0", path = "crates/cli" }
+nemo-relay-ffi = { version = "0.8.0", path = "crates/ffi" }
+nemo-relay-cli = { version = "0.8.0", path = "crates/cli" }
 opentelemetry = { version = "0.32", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.32.1", default-features = false, features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.32.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ uv add nemo-relay
 
 # Node.js
 # Requires Node.js 24 or newer.
-npm install nemo-relay-node@0.7.0
+npm install nemo-relay-node@0.8.0
 
 # Rust
 cargo add nemo-relay

--- a/crates/core/tests/fixtures/worker_plugin/Cargo.lock
+++ b/crates/core/tests/fixtures/worker_plugin/Cargo.lock
@@ -22,19 +22,19 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -121,9 +121,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -157,9 +157,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -209,47 +209,47 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -323,9 +323,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -368,9 +368,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -536,7 +536,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "futures-util",
  "hyper-util",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker-proto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -636,7 +636,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -652,14 +652,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -691,7 +691,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -705,7 +705,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -872,9 +872,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -882,29 +882,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -953,6 +953,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,29 +984,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.52.4"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1008,20 +1019,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1031,13 +1042,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -1080,7 +1092,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1105,7 +1117,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -1160,7 +1172,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1195,7 +1207,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1278,7 +1290,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -1312,7 +1324,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1323,7 +1335,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-node",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Node.js bindings for the NeMo Relay agent runtime.",
   "keywords": [
     "agents",

--- a/docs/build-plugins/dynamic-plugins/native-dynamic/rust-native-plugin-example.mdx
+++ b/docs/build-plugins/dynamic-plugins/native-dynamic/rust-native-plugin-example.mdx
@@ -29,7 +29,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-nemo-relay-plugin = "0.7.0"
+nemo-relay-plugin = "0.8.0"
 serde_json = "1"
 ```
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -123,7 +123,7 @@ refer to the [Support Matrix](/reference/support-matrix).
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | NEMO_RELAY_VERSION=0.7.0 sh
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | NEMO_RELAY_VERSION=0.8.0 sh
 ```
 
 Install into another directory:
@@ -147,7 +147,7 @@ Set the same environment variable before invoking the installer to install a
 specific version:
 
 ```powershell
-$env:NEMO_RELAY_VERSION = '0.7.0'
+$env:NEMO_RELAY_VERSION = '0.8.0'
 irm https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.ps1 | iex
 ```
 
@@ -201,7 +201,7 @@ Install the Python package when your application uses NeMo Relay through the
 Python wrapper and owns the tool or LLM call boundary.
 
 ```bash
-uv add nemo-relay@0.7.0
+uv add nemo-relay@0.8.0
 ```
 
 Use `uv add` from an application project that has a `pyproject.toml`; it records
@@ -216,7 +216,7 @@ Install the Node.js package when your application uses NeMo Relay through the
 JavaScript API and owns the tool or LLM call boundary.
 
 ```bash
-npm install nemo-relay-node@0.7.0
+npm install nemo-relay-node@0.8.0
 ```
 
 ## Rust
@@ -224,8 +224,8 @@ npm install nemo-relay-node@0.7.0
 Add the Rust crates when your application uses NeMo Relay directly from Rust.
 
 ```bash
-cargo add nemo-relay@0.7.0
-cargo add nemo-relay-adaptive@0.7.0
+cargo add nemo-relay@0.8.0
+cargo add nemo-relay-adaptive@0.8.0
 ```
 
 - `nemo-relay` provides the core runtime APIs for scopes, middleware, subscribers, plugins, tool calls, and LLM calls.
@@ -242,7 +242,7 @@ Install the OpenClaw plugin through OpenClaw so OpenClaw can register and manage
 the package:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.7.0
+openclaw plugins install npm:nemo-relay-openclaw@0.8.0
 openclaw gateway restart
 ```
 
@@ -280,7 +280,7 @@ Install the Python package with the supported framework extras when your
 application uses LangChain, LangGraph, or Deep Agents.
 
 ```bash
-uv add "nemo-relay[langchain,langgraph,deepagents]@0.7.0"
+uv add "nemo-relay[langchain,langgraph,deepagents]@0.8.0"
 ```
 
 The extras install the NeMo Relay Python package plus the dependencies needed by

--- a/docs/getting-started/quick-start/nodejs.mdx
+++ b/docs/getting-started/quick-start/nodejs.mdx
@@ -19,7 +19,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-npm install nemo-relay-node@0.7.0
+npm install nemo-relay-node@0.8.0
 ```
 
 ### Install from the Repository

--- a/docs/getting-started/quick-start/python.mdx
+++ b/docs/getting-started/quick-start/python.mdx
@@ -20,7 +20,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-uv add nemo-relay@0.8.0
+uv add nemo-relay==0.8.0
 ```
 
 Run `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/quick-start/python.mdx
+++ b/docs/getting-started/quick-start/python.mdx
@@ -20,7 +20,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-uv add nemo-relay@0.7.0
+uv add nemo-relay@0.8.0
 ```
 
 Run `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/quick-start/rust.mdx
+++ b/docs/getting-started/quick-start/rust.mdx
@@ -18,7 +18,7 @@ local checkout.
 Use the published crates when you are consuming a release:
 
 ```bash
-cargo add nemo-relay@0.7.0
+cargo add nemo-relay@0.8.0
 cargo add serde_json
 cargo add tokio --features macros,rt-multi-thread
 ```
@@ -27,7 +27,7 @@ Install the published NeMo Relay CLI separately when you need coding-agent hook
 and LLM gateway observability:
 
 ```bash
-cargo install nemo-relay-cli@0.7.0
+cargo install nemo-relay-cli@0.8.0
 ```
 
 ### Install from the Repository
@@ -47,7 +47,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 - `nemo-relay-adaptive` is a companion crate for adaptive runtime primitives and
   Redis-backed learning components when you need adaptive behavior later, but it
   is not required for this minimal direct-runtime example.
-- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.7.0`
+- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.8.0`
   when you need the NeMo Relay CLI.
 
 ## Run One Scope, One Tool Call, and One LLM Call

--- a/docs/supported-integrations/openclaw-plugin.mdx
+++ b/docs/supported-integrations/openclaw-plugin.mdx
@@ -42,7 +42,7 @@ Optional:
 Install the plugin with OpenClaw so OpenClaw can register and manage it:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.7.0
+openclaw plugins install npm:nemo-relay-openclaw@0.8.0
 openclaw gateway restart
 ```
 
@@ -55,7 +55,7 @@ If you manage OpenClaw plugin dependencies directly in a Node.js project,
 install the package with npm:
 
 ```bash
-npm install nemo-relay-openclaw@0.7.0
+npm install nemo-relay-openclaw@0.8.0
 ```
 
 Installing with npm makes the package available to that project. Use

--- a/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
+++ b/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Native Relay gateway lifecycle and Claude Code hooks for complete local observability.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/coding-agents/codex/.codex-plugin/plugin.json
+++ b/integrations/coding-agents/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Native Relay gateway lifecycle and Codex hooks for complete local observability.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-openclaw",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "NeMo Relay-authored observability plugin for OpenClaw.",
   "type": "module",
   "repository": {
@@ -63,7 +63,7 @@
     "openclaw": "^2026.7.1"
   },
   "dependencies": {
-    "nemo-relay-node": "0.7.0"
+    "nemo-relay-node": "0.8.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
     },
     "crates/node": {
       "name": "nemo-relay-node",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -464,10 +464,10 @@
     },
     "integrations/openclaw": {
       "name": "nemo-relay-openclaw",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nemo-relay-node": "0.7.0"
+        "nemo-relay-node": "0.8.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -5137,7 +5137,7 @@
     },
     "packages/cli-bin": {
       "name": "nemo-relay-cli-bin",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0"
     }
   }

--- a/packages/cli-bin/package.json
+++ b/packages/cli-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-cli-bin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Prebuilt NeMo Relay command-line interface.",
   "private": true,
   "license": "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ test = [
 
 [project.optional-dependencies]
 cli = [
-    "nemo-relay-cli-bin==0.7.0",
+    "nemo-relay-cli-bin==0.8.0",
 ]
 
 langchain = [

--- a/python/cli-bin/pyproject.toml
+++ b/python/cli-bin/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "nemo-relay-cli-bin"
-version = "0.7.0"
+version = "0.8.0"
 description = "Prebuilt NeMo Relay command-line interface."
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/python/plugin/pyproject.toml
+++ b/python/plugin/pyproject.toml
@@ -8,7 +8,7 @@ backend-path = ["."]
 
 [project]
 name = "nemo-relay-plugin"
-version = "0.7.0"
+version = "0.8.0"
 description = "Python SDK for NeMo Relay dynamic worker plugins."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1274,7 +1274,7 @@ wheels = [
 
 [package.optional-dependencies]
 zig = [
-    { name = "ziglang", marker = "sys_platform == 'linux'" },
+    { name = "ziglang" },
 ]
 
 [[package]]
@@ -1500,12 +1500,12 @@ test = [
 
 [[package]]
 name = "nemo-relay-cli-bin"
-version = "0.7.0"
+version = "0.8.0"
 source = { directory = "python/cli-bin" }
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "python/plugin" }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
#### Overview

Prepare `main` for the NeMo Relay 0.7 code freeze and post-freeze development on 0.8.0.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `release/0.7` to the nightly alpha branch configuration. Release-bound PRs should now target that branch.
- Runs `just set-version 0.8.0` to advance Cargo, Python, Node, CLI, OpenClaw, and coding-agent package surfaces on `main`.
- Updates current-version installation and plugin examples from 0.7.0 to 0.8.0.

#### Where should the reviewer start?

Start with `.github/nightly-alpha-branches.yaml` and `Cargo.toml`; the remainder is the synchronized 0.8.0 version and documentation update.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated the project, packages, plugins, and integrations to version 0.8.0.
  * Added the release/0.7 branch to nightly alpha builds.

* **Documentation**
  * Updated installation and quick-start examples across Node.js, Python, Rust, CLI, OpenClaw, and plugin integrations to reference version 0.8.0.

* **Validation**
  * Improved release preparation checks by regenerating fixture lockfiles and validating locked builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->