### PR TITLE
ci: publish musl npm packages to Artifactory

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -325,12 +325,12 @@ publish:artifactory:npm:
       npm config set registry "$registry_url"
       npm config set "${registry_key}:_auth" "$npm_auth"
 
-      for platform in linux-x64 linux-arm64 darwin-arm64 win32-x64 win32-arm64; do
+      for platform in linux-x64 linux-arm64 linux-x64-musl linux-arm64-musl darwin-arm64 win32-x64 win32-arm64; do
         package="collected/node/nemo-relay-node-npm-${platform}-${CI_COMMIT_TAG}.tgz"
         npm publish --tag dev "$package"
       done
       npm publish --tag dev "collected/node/nemo-relay-node-npm-${CI_COMMIT_TAG}.tgz"
-      for platform in linux-x64 linux-arm64 darwin-arm64 win32-x64 win32-arm64; do
+      for platform in linux-x64 linux-arm64 linux-x64-musl linux-arm64-musl darwin-arm64 win32-x64 win32-arm64; do
         package="collected/cli-npm/nemo-relay-bin-npm-${platform}-${CI_COMMIT_TAG}.tgz"
         npm publish --tag dev "$package"
       done


### PR DESCRIPTION
#### Overview

Publish the Linux x64 and ARM64 musl npm packages to Artifactory for both the Node.js library and CLI.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `linux-x64-musl` and `linux-arm64-musl` to the Artifactory Node.js native-package publish loop.
- Add the same musl platforms to the Artifactory CLI native-package publish loop.

#### Where should the reviewer start?

Review the two platform lists in `.gitlab-ci.yml` under `publish:artifactory:npm`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added npm package publishing for Linux x64-musl and Linux arm64-musl platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->