### PR TITLE
docs: clarify rootless propagation trace semantics

### DIFF
--- a/crates/core/src/api/runtime/scope_stack.rs
+++ b/crates/core/src/api/runtime/scope_stack.rs
@@ -41,14 +41,15 @@ pub struct ScopeStack {
 /// Applications are responsible for serializing, transporting, authenticating,
 /// and trusting this value. It intentionally contains only Relay identifiers;
 /// OpenTelemetry `traceparent` and `tracestate` remain transport sidecars. A
-/// context without a `root_uuid` preserves Relay event parentage but starts a
-/// new local OpenTelemetry trace when imported.
+/// context without a `root_uuid` preserves Relay event parentage when imported.
+/// The first local OpenTelemetry span created after import starts a new trace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PropagationContext {
     /// Wire-format version. Version 1 is the only currently supported value.
     pub version: u16,
-    /// Stable session root when the sending application knows one. Omitting
-    /// this root starts a new OpenTelemetry trace at the receiving boundary.
+    /// Stable session root when the sending application knows one. When this
+    /// root is omitted, the first local OpenTelemetry span after import starts
+    /// a new trace.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub root_uuid: Option<Uuid>,
     /// Immediate Relay event or scope that caused the boundary crossing.

--- a/crates/core/src/api/runtime/scope_stack.rs
+++ b/crates/core/src/api/runtime/scope_stack.rs
@@ -40,12 +40,15 @@ pub struct ScopeStack {
 ///
 /// Applications are responsible for serializing, transporting, authenticating,
 /// and trusting this value. It intentionally contains only Relay identifiers;
-/// OpenTelemetry `traceparent` and `tracestate` remain transport sidecars.
+/// OpenTelemetry `traceparent` and `tracestate` remain transport sidecars. A
+/// context without a `root_uuid` preserves Relay event parentage but starts a
+/// new local OpenTelemetry trace when imported.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PropagationContext {
     /// Wire-format version. Version 1 is the only currently supported value.
     pub version: u16,
-    /// Stable session root when the sending application knows one.
+    /// Stable session root when the sending application knows one. Omitting
+    /// this root starts a new OpenTelemetry trace at the receiving boundary.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub root_uuid: Option<Uuid>,
     /// Immediate Relay event or scope that caused the boundary crossing.
@@ -441,7 +444,9 @@ pub fn create_scope_stack_from_propagation(
 ///
 /// Capture the parent before spawning concurrent work, then install the
 /// returned stack with `TASK_SCOPE_STACK.scope(...)`. The fork preserves event
-/// parentage but does not transfer scope-local registrations.
+/// parentage but does not transfer scope-local registrations. Because the fork
+/// does not assert a root UUID, its first local OpenTelemetry span starts a new
+/// trace.
 ///
 /// # Examples
 ///
@@ -462,6 +467,11 @@ pub fn fork_scope_stack() -> Result<ScopeStackHandle> {
 }
 
 /// Capture the current causal parent without asserting a session root.
+///
+/// Importing the returned context preserves Relay event parentage but starts a
+/// new local OpenTelemetry trace. Use [`capture_propagation_context_with_root`]
+/// when the receiver should participate in a Relay-derived trace rooted at a
+/// stable application UUID.
 pub fn capture_propagation_context() -> Result<PropagationContext> {
     capture_propagation_context_with_root(None)
 }

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -9,9 +9,9 @@ use crate::api::event::{
     tool_attributes_to_strings,
 };
 use crate::api::runtime::{
-    NemoRelayContextState, PropagationContext, ThreadScopeStackBinding, capture_thread_scope_stack,
-    create_scope_stack_from_propagation, global_context, restore_thread_scope_stack,
-    set_thread_scope_stack,
+    NemoRelayContextState, PropagationContext, ThreadScopeStackBinding,
+    capture_propagation_context, capture_thread_scope_stack, create_scope_stack_from_propagation,
+    fork_scope_stack, global_context, restore_thread_scope_stack, set_thread_scope_stack,
 };
 use crate::api::scope::ScopeType;
 use crate::api::scope::{event, pop_scope, push_scope};
@@ -385,6 +385,18 @@ fn rootless_propagation_starts_a_new_otel_trace() {
     })
     .unwrap();
     set_thread_scope_stack(imported_stack);
+
+    let captured = capture_propagation_context().unwrap();
+    assert_eq!(captured.root_uuid, None);
+    assert_eq!(captured.parent_uuid, parent_uuid);
+
+    let forked_stack = fork_scope_stack().unwrap();
+    {
+        let forked_stack = forked_stack.read().unwrap();
+        assert_eq!(forked_stack.root_uuid(), parent_uuid);
+        assert_eq!(forked_stack.top().uuid, parent_uuid);
+    }
+    set_thread_scope_stack(forked_stack);
 
     let (provider, exporter) = make_provider();
     let mut processor = OtelEventProcessor::new(provider, "test".into());

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -373,6 +373,46 @@ fn propagated_root_parent_projects_as_a_remote_otel_parent() {
     assert_eq!(span_context.span_id(), relay_span_id(root_uuid));
 }
 
+#[test]
+fn rootless_propagation_starts_a_new_otel_trace() {
+    let parent_uuid = Uuid::now_v7();
+    let local_uuid = Uuid::now_v7();
+    let _restore_guard = RestoreThreadScopeStackGuard(capture_thread_scope_stack());
+    let imported_stack = create_scope_stack_from_propagation(&PropagationContext {
+        version: PropagationContext::VERSION,
+        root_uuid: None,
+        parent_uuid,
+    })
+    .unwrap();
+    set_thread_scope_stack(imported_stack);
+
+    let (provider, exporter) = make_provider();
+    let mut processor = OtelEventProcessor::new(provider, "test".into());
+    processor.process(&make_start_event(
+        local_uuid,
+        Some(parent_uuid),
+        "receiver-tool",
+        ScopeType::Tool,
+        None,
+    ));
+    processor.process(&make_end_event(
+        local_uuid,
+        Some(parent_uuid),
+        "receiver-tool",
+        ScopeType::Tool,
+        None,
+    ));
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.span_context.trace_id(), relay_trace_id(local_uuid));
+    assert_eq!(span.span_context.span_id(), relay_span_id(local_uuid));
+    assert_eq!(span.parent_span_id, SpanId::INVALID);
+    assert!(!span.parent_span_is_remote);
+}
+
 fn make_start_event_with_metadata(
     uuid: Uuid,
     parent_uuid: Option<Uuid>,

--- a/docs/about-nemo-relay/concepts/scopes.mdx
+++ b/docs/about-nemo-relay/concepts/scopes.mdx
@@ -147,7 +147,8 @@ Use this when:
 Fork a scope stack before starting concurrent work when the child should remain
 part of the parent's event tree without sharing its mutable stack. The fork
 preserves the immediate parent but does not transfer scope-local middleware or
-subscribers.
+subscribers. This is Relay event-tree continuity: the rootless fork starts a
+new OpenTelemetry trace from its first local span.
 
 <Tabs>
 <Tab title="Python" language="python">
@@ -214,6 +215,12 @@ only for request handling. Its first local event becomes a child of
 The transport is application-owned: authenticate and authorize inbound context
 before importing it. Relay does not send headers, make IPC connections, or
 trust remote identifiers automatically.
+
+A rootless context, including the value returned by the default
+`capture_propagation_context()` API, preserves this Relay event parentage but
+does not assert OpenTelemetry trace continuity. The first local span starts a
+new trace. Supply a stable `root_uuid` when the receiver should participate in
+the Relay-derived trace rooted at that UUID.
 
 Relay context is distinct from W3C propagation. An integration may carry
 `traceparent` and `tracestate` alongside Relay's JSON context when it needs to

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -29,6 +29,11 @@ with collector or backend schemas.
 NeMo Relay uses OpenTelemetry Rust `0.32`. It deterministically derives
 compliant trace and span IDs from Relay lifecycle UUIDs, so endpoints that
 receive the same event stream use the same identifiers and parentage.
+Rooted Relay propagation continues the Relay-derived trace across the import
+boundary. Rootless propagation retains Relay event parentage but starts a new
+OpenTelemetry trace from the first local event. Carry W3C `traceparent` and
+`tracestate` alongside Relay propagation when an integration also needs to
+preserve upstream OpenTelemetry sampling or vendor state.
 
 ## `plugins.toml` Example
 


### PR DESCRIPTION
#### Overview

Clarify that importing a rootless Relay `PropagationContext` preserves Relay event parentage while its first local span intentionally starts a new OpenTelemetry trace.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Document the rootless trace boundary on `PropagationContext`, `capture_propagation_context()`, and `fork_scope_stack()`.
- Clarify the same contract in the scope propagation and OpenTelemetry documentation.
- Add focused coverage for rootless capture and fork semantics, then assert that the first local span uses its local Relay UUID for its trace and span IDs and has no OTel parent.
- Leave runtime behavior unchanged; rooted propagation continues to synthesize the existing remote Relay-derived OTel parent.

Validation:

- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- `cargo test -p nemo-relay --lib rootless_propagation_starts_a_new_otel_trace` passed (1 test).

#### Where should the reviewer start?

Start with `rootless_propagation_starts_a_new_otel_trace` in `crates/core/tests/unit/observability/otel_tests.rs`, then review the public contract on `PropagationContext` in `crates/core/src/api/runtime/scope_stack.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to RELAY-608


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how propagation contexts and forked scopes affect Relay event parentage and OpenTelemetry trace continuity.
  * Documented behavior for rooted and rootless propagation, including local trace creation.
  * Added guidance for carrying W3C `traceparent` and `tracestate` alongside Relay propagation.

* **Tests**
  * Added coverage verifying rootless propagation creates a local trace while preserving the propagated parent relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->