### PR TITLE
fix(observability): reject invisible OTLP attribute mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,7 @@ dependencies = [
  "tonic",
  "tower",
  "typed-builder",
+ "unicode-general-category",
  "uuid",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -79,6 +79,7 @@ hyper-util = { version = "0.1", features = ["tokio"], optional = true }
 shell-words = "1"
 log = { version = "0.4", features = ["kv"] }
 spdlog-rs = { version = "0.5", features = ["log", "multi-thread"] }
+unicode-general-category = "1.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "sync", "test-util", "rt-multi-thread", "time"] }

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -246,10 +246,10 @@ pub fn validate_attribute_mappings(
 ) -> std::result::Result<(), String> {
     let mut aliases = std::collections::HashSet::new();
     for mapping in mappings {
-        if mapping.key.trim().is_empty() {
+        if is_blank_attribute_mapping_name(&mapping.key) {
             return Err("attribute mapping key must not be blank".to_string());
         }
-        if mapping.alias.trim().is_empty() {
+        if is_blank_attribute_mapping_name(&mapping.alias) {
             return Err("attribute mapping alias must not be blank".to_string());
         }
         if !aliases.insert(mapping.alias.trim()) {
@@ -260,6 +260,17 @@ pub fn validate_attribute_mappings(
         }
     }
     Ok(())
+}
+
+fn is_blank_attribute_mapping_name(value: &str) -> bool {
+    value.chars().all(|character| {
+        character.is_whitespace()
+            || matches!(
+                unicode_general_category::get_general_category(character),
+                unicode_general_category::GeneralCategory::Control
+                    | unicode_general_category::GeneralCategory::Format
+            )
+    })
 }
 
 /// Projects only top-level JSON fields as OTLP attributes.

--- a/crates/core/tests/unit/observability/attribute_projection_tests.rs
+++ b/crates/core/tests/unit/observability/attribute_projection_tests.rs
@@ -123,4 +123,22 @@ fn rejects_invalid_attribute_mappings() {
     assert!(
         super::validate_attribute_mappings(&[OtlpAttributeMapping::new("key", "   ")]).is_err()
     );
+    for invisible in ["\0", "\u{200b}", "\u{feff}", "\u{2060}"] {
+        assert!(
+            super::validate_attribute_mappings(&[OtlpAttributeMapping::new(invisible, "alias")])
+                .is_err()
+        );
+        assert!(
+            super::validate_attribute_mappings(&[OtlpAttributeMapping::new("key", invisible)])
+                .is_err()
+        );
+    }
+    assert!(
+        super::validate_attribute_mappings(&[OtlpAttributeMapping::new(
+            "key",
+            "tenant\u{200b}.id"
+        )])
+        .is_ok()
+    );
+    assert!(super::validate_attribute_mappings(&[OtlpAttributeMapping::new("key", ".")]).is_ok());
 }

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -741,6 +741,10 @@ fn opentelemetry_endpoint_rejects_invalid_attribute_mappings() {
             "attribute mapping alias must not be blank",
         ),
         (
+            json!([{"key": "nemo_relay.mark.metadata.source", "alias": "\u{200b}"}]),
+            "attribute mapping alias must not be blank",
+        ),
+        (
             json!([
                 {"key": "nemo_relay.model_name", "alias": "duplicate.alias"},
                 {"key": "nemo_relay.tool.name", "alias": "duplicate.alias"}


### PR DESCRIPTION
#### Overview

Reject all-invisible OTLP attribute mapping keys and aliases so configuration cannot activate with invisible emitted attribute names.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Treat names made entirely of Unicode whitespace, control, or format characters as blank in the shared attribute-mapping validator.
- Cover U+200B, U+FEFF, U+2060, and control characters while preserving visible Unicode and punctuation-only names.
- Add direct validator and plugin-initialization regression coverage.

Validation: focused Rust regression tests, cargo fmt, workspace Clippy, Python (610 passed), Node (344 passed), and repository-wide pre-commit all passed. The canonical Rust and Go suites retain unrelated failures from stale observability config-v2 guardrails fixtures; no RELAY-601 regression failed.

#### Where should the reviewer start?

Start with `validate_attribute_mappings` in `crates/core/src/observability/mod.rs`, then review the adjacent direct validation and plugin-component regression tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-601](https://linear.app/nvidia/issue/RELAY-601/nemo-relay070-nemo-relay070-rc2-validate-attribute-mappings-pr-580)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute-mapping validation to reject keys and aliases containing only whitespace, control characters, or invisible formatting characters.
  * Preserved support for valid keys containing zero-width characters and aliases such as `"."`.
  * Added coverage for invisible-character validation to prevent invalid OpenTelemetry mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->