### PR TITLE
docs: clarify middleware callback error semantics

### DIFF
--- a/docs/about-nemo-relay/concepts/middleware.mdx
+++ b/docs/about-nemo-relay/concepts/middleware.mdx
@@ -107,13 +107,16 @@ NeMo Relay has two major middleware families:
 ### Callback Error Handling
 
 Conditional-execution guardrails and request or execution intercepts fail
-closed. If one of these callbacks returns an error, raises an exception, or
-rejects a `Promise`, Relay stops at that middleware stage and surfaces the error
-to the managed caller. A conditional guardrail or request intercept therefore
-prevents the real callback from running when it fails. An execution intercept
-cannot undo work from a `next` continuation that it already invoked. This
-fail-closed contract is the same whether the callback completes directly or
-asynchronously.
+closed when their callbacks return a failure result. A failure returned
+directly or produced when a callback raises an exception or rejects a `Promise`
+stops Relay at that middleware stage, and Relay surfaces the failure to the
+managed caller. A conditional guardrail or request intercept therefore prevents
+the real callback from running when it fails. Separately, a
+conditional-execution guardrail can return its documented rejection message to
+block execution. A rejection is normal control flow, not a callback failure. An
+execution intercept cannot undo work from a `next` continuation that it already
+invoked. This fail-closed contract is the same whether the callback completes
+directly or asynchronously.
 
 ## Intercepts
 

--- a/docs/about-nemo-relay/concepts/middleware.mdx
+++ b/docs/about-nemo-relay/concepts/middleware.mdx
@@ -104,6 +104,17 @@ NeMo Relay has two major middleware families:
 - **Intercepts** change the real execution path
 - **Guardrails** block work or rewrite emitted observability payloads
 
+### Callback Error Handling
+
+Conditional-execution guardrails and request or execution intercepts fail
+closed. If one of these callbacks returns an error, raises an exception, or
+rejects a `Promise`, Relay stops at that middleware stage and surfaces the error
+to the managed caller. A conditional guardrail or request intercept therefore
+prevents the real callback from running when it fails. An execution intercept
+cannot undo work from a `next` continuation that it already invoked. This
+fail-closed contract is the same whether the callback completes directly or
+asynchronously.
+
 ## Intercepts
 
 Intercepts are middleware that change the real request or execution path.

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -46,6 +46,14 @@ existing error behavior for its middleware family.
 | Node.js | Direct return value | Direct return value or `Promise` |
 | Go / raw C FFI | Synchronous callback | Synchronous callback |
 
+Conditional-execution guardrails and request or execution intercepts retain a
+fail-closed exception contract in 0.7. Relay stops at the failing middleware
+stage and surfaces the error to the managed caller. Conditional guardrail and
+request-intercept failures prevent the real callback from running. This
+behavior is the same for callbacks that return directly and callbacks that
+complete asynchronously. An execution intercept cannot undo work from a `next`
+continuation that it already invoked before failing.
+
 The experimental Go and raw C FFI callbacks remain synchronous. Relay waits
 for each callback on a native thread, so blocking I/O and other long-running
 callback work occupy that thread. No completion-based registration API is

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -51,8 +51,9 @@ fail-closed exception contract in 0.7. Relay stops at the failing middleware
 stage and surfaces the error to the managed caller. Conditional guardrail and
 request-intercept failures prevent the real callback from running. This
 behavior is the same for callbacks that return directly and callbacks that
-complete asynchronously. An execution intercept cannot undo work from a `next`
-continuation that it already invoked before failing.
+complete asynchronously. If an execution intercept fails after invoking `next`,
+Relay cannot undo completed downstream work. Relay rejects `next` calls that
+remain unfinished and calls that begin after the interceptor settles.
 
 The experimental Go and raw C FFI callbacks remain synchronous. Relay waits
 for each callback on a native thread, so blocking I/O and other long-running


### PR DESCRIPTION
#### Overview

Document the fail-closed exception contract for conditional-execution guardrails and request or execution intercepts in NeMo Relay 0.7.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Explain that callback errors, exceptions, and rejected `Promise` values stop the middleware chain at the failing stage and surface to the managed caller.
- Clarify that conditional-guardrail and request-intercept failures prevent the real callback from running.
- Clarify that an execution intercept cannot undo work from a `next` continuation that it already invoked.
- Document parity between callbacks that complete directly and callbacks that complete asynchronously.
- Update both the middleware concepts page and the v0.6-to-v0.7 migration guide.
- Leave sanitizer exception semantics to #607 to avoid conflicting guidance.

Validation:

- `just docs` passed with 0 errors. Fern skipped the authenticated redirects check because `FERN_TOKEN` was unavailable.
- Targeted pre-commit checks passed for both changed files, including the documentation link checker.
- The all-files pre-commit run passed formatting, Ruff, type checks, documentation links, lockfile checks, Cargo formatting/clippy/check, attribution checks, and Node checks. The `cargo-deny`, `go fmt`, and `go vet` hooks could not run because `cargo-deny` and Go are not installed in the local environment.

#### Where should the reviewer start?

Start with the **Callback Error Handling** section in `docs/about-nemo-relay/concepts/middleware.mdx`, then compare the matching upgrade guidance in `docs/reference/migration-guides.mdx`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented fail-closed behavior when middleware callbacks encounter errors, throw exceptions, or reject asynchronously.
  * Clarified that failed guards and request intercepts stop processing before the main callback runs.
  * Explained execution-intercept continuation behavior, including work already started by `next`.
  * Added corresponding guidance to the migration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->