### PR TITLE
Revert "docs: document Linux libc variants"

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -103,20 +103,11 @@ user `PATH`; the Unix installer does not edit shell configuration.
 
 | Operating system | Architecture | Release target |
 | --- | --- | --- |
-| Linux (glibc) | x86_64 | `x86_64-unknown-linux-gnu` |
-| Linux (musl) | x86_64 | `x86_64-unknown-linux-musl` |
-| Linux (glibc) | ARM64 | `aarch64-unknown-linux-gnu` |
-| Linux (musl) | ARM64 | `aarch64-unknown-linux-musl` |
+| Linux | x86_64 | `x86_64-unknown-linux-musl` |
+| Linux | ARM64 | `aarch64-unknown-linux-musl` |
 | macOS | Apple Silicon | `aarch64-apple-darwin` |
 | Windows | x86_64 | `x86_64-pc-windows-msvc` |
 | Windows | ARM64 | `aarch64-pc-windows-msvc` |
-
-Use the GNU target on glibc-based distributions such as Ubuntu, Debian, and
-RHEL. Use the musl target on Alpine Linux and other musl-based systems. The
-Unix shell installer intentionally selects the portable musl target on Linux.
-For package versions that publish the corresponding artifacts, `pip`, `uv`, and
-`npm` automatically select a target compatible with the host CPU and C library
-on supported platforms.
 
 The installer reports the detected operating system and architecture when no
 matching asset exists. Intel macOS is not supported because no matching release
@@ -186,9 +177,9 @@ new download before replacing the binary in the selected installation directory.
 
 ### Alternative Installation Methods
 
-The PyPI, npm, and installer methods install the same CLI release with a binary
-compatible with the host platform. Use Cargo on unsupported platforms or when
-you prefer to build from source:
+The PyPI, npm, and installer methods all install the same release binary on
+supported platforms. Use Cargo on unsupported platforms or when you prefer to
+build from source:
 
 ```bash
 cargo install nemo-relay-cli
@@ -219,14 +210,6 @@ virtual environment and do not have project metadata, use `uv pip install
 nemo-relay` instead. You can also use `pip install nemo-relay` if you are not
 managing the environment with `uv`.
 
-NeMo Relay publishes CPython 3.11 ABI3 wheels for x86_64 and ARM64 Linux
-systems. On supported CPython 3.11 or newer environments, `pip` and `uv` select
-`manylinux_2_17` for glibc 2.17 or newer or `musllinux_1_2` for musl 1.2 or
-newer. Supported Alpine Linux environments do not need a `--platform` override
-or source build. Alpine environments outside this wheel coverage must use a
-supported Python version and
-[build from source](/contribute/development-setup#source-development).
-
 ## Node.js
 
 Install the Node.js package when your application uses NeMo Relay through the
@@ -235,9 +218,6 @@ JavaScript API and owns the tool or LLM call boundary.
 ```bash
 npm install nemo-relay-node@0.8.0
 ```
-
-On supported x64 and ARM64 Linux systems, npm automatically installs the native
-package for the host C library, including the musl package on Alpine Linux.
 
 ## Rust
 

--- a/docs/reference/support-matrix.mdx
+++ b/docs/reference/support-matrix.mdx
@@ -18,26 +18,18 @@ commitment. For release-specific changes and known limitations, refer to
 | Surface | Linux x86_64 | Linux ARM64 | macOS x86_64 | macOS ARM64 | Windows x86_64 | Windows ARM64 | Limitations |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Core Library | Required CI coverage | Required CI coverage | Not in the current CI matrix | Required CI coverage | Non-blocking CI coverage | Non-blocking CI coverage | Rust is the source of truth. Python and Node.js packages require their supported runtimes; Go and raw C FFI remain experimental and source-first. |
-| CLI Application | Published `x86_64-unknown-linux-gnu` and `x86_64-unknown-linux-musl` assets | Published `aarch64-unknown-linux-gnu` and `aarch64-unknown-linux-musl` assets | No published release asset | Published `aarch64-apple-darwin` asset | Published `x86_64-pc-windows-msvc` asset | Published `aarch64-pc-windows-msvc` asset | Intel macOS has no prebuilt CLI asset. Use a source install on unsupported platforms. |
+| CLI Application | Published `x86_64-unknown-linux-musl` asset | Published `aarch64-unknown-linux-musl` asset | No published release asset | Published `aarch64-apple-darwin` asset | Published `x86_64-pc-windows-msvc` asset | Published `aarch64-pc-windows-msvc` asset | Intel macOS has no prebuilt CLI asset. Use a source install on unsupported platforms. |
 | Native Plugins | Build for the host ABI | Build for the host ABI | Build and validate locally | Build for the host ABI | Build for the host ABI; CI is non-blocking | Build for the host ABI; CI is non-blocking | Native plugins run in-process and are not sandboxed. Rebuild for the host ABI and compatible Relay version. |
 | gRPC Worker Plugins | Depends on the selected worker runtime | Depends on the selected worker runtime | Build and validate locally | Depends on the selected worker runtime | Depends on the selected worker runtime | Depends on the selected worker runtime | Workers run as local child processes over `grpc-v1`, not as a security sandbox. Python workers are unsupported on Windows ARM64. Refer to the worker runtime matrix for runtime-specific requirements. |
 
 ### Linux Distribution Notes
 
-NeMo Relay publishes GNU and musl CLI binaries for each supported Linux
-architecture. The GNU variants are dynamically linked against glibc 2.17 or
-newer and are the performance-oriented choice for glibc-based distributions
-such as Ubuntu, Debian, and RHEL. The statically linked musl variants are
-required for musl-based distributions such as Alpine Linux and also run on
-glibc-based distributions. The Unix shell installer uses the musl variant for
-portability.
-
-The binaries are not tied to a distribution-specific package manager. Linux CI
-uses Ubuntu runners, and NeMo Relay does not publish distribution-specific DEB
-or RPM packages or certify individual Ubuntu, Debian, RHEL-compatible, or
-Fedora releases. On an unsupported CPU, unsupported operating system, or a
-system whose local requirements prevent the release asset from running,
-install from source with Cargo.
+The published Linux CLI binaries use musl targets and are not tied to a
+distribution-specific package manager. Linux CI uses Ubuntu runners. NeMo Relay
+does not publish distribution-specific DEB or RPM packages or certify individual
+Ubuntu, Debian, RHEL-compatible, or Fedora releases. On an unsupported CPU,
+unsupported operating system, or a system whose local requirements prevent the
+release asset from running, install from source with Cargo.
 
 ## Worker Runtime Compatibility
 


### PR DESCRIPTION
Reverts NVIDIA/NeMo-Relay#609. Should have targeted release/0.7 branch, not main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to list Linux support by architecture using musl-based release targets.
  * Clarified that PyPI, npm, and installer methods provide the same release binary.
  * Updated the support matrix to reflect that GNU/Linux release assets are no longer published.
  * Added guidance for unsupported environments, including installation from Cargo source.
  * Clarified that distribution-specific packages and certifications are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->