### PR TITLE
docs: document Linux libc variants

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -219,10 +219,13 @@ virtual environment and do not have project metadata, use `uv pip install
 nemo-relay` instead. You can also use `pip install nemo-relay` if you are not
 managing the environment with `uv`.
 
-On supported x86_64 and ARM64 Linux systems, `pip` and `uv` automatically
-select the compatible wheel: `manylinux_2_17` on glibc-based distributions and
-`musllinux_1_2` on musl-based distributions such as Alpine Linux. Alpine users
-do not need a `--platform` override or a source build.
+NeMo Relay publishes CPython 3.11 ABI3 wheels for x86_64 and ARM64 Linux
+systems. On supported CPython 3.11 or newer environments, `pip` and `uv` select
+`manylinux_2_17` for glibc 2.17 or newer or `musllinux_1_2` for musl 1.2 or
+newer. Supported Alpine Linux environments do not need a `--platform` override
+or source build. Alpine environments outside this wheel coverage must use a
+supported Python version and
+[build from source](/contribute/development-setup#source-development).
 
 ## Node.js
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -103,11 +103,19 @@ user `PATH`; the Unix installer does not edit shell configuration.
 
 | Operating system | Architecture | Release target |
 | --- | --- | --- |
-| Linux | x86_64 | `x86_64-unknown-linux-musl` |
-| Linux | ARM64 | `aarch64-unknown-linux-musl` |
+| Linux (glibc) | x86_64 | `x86_64-unknown-linux-gnu` |
+| Linux (musl) | x86_64 | `x86_64-unknown-linux-musl` |
+| Linux (glibc) | ARM64 | `aarch64-unknown-linux-gnu` |
+| Linux (musl) | ARM64 | `aarch64-unknown-linux-musl` |
 | macOS | Apple Silicon | `aarch64-apple-darwin` |
 | Windows | x86_64 | `x86_64-pc-windows-msvc` |
 | Windows | ARM64 | `aarch64-pc-windows-msvc` |
+
+Use the GNU target on glibc-based distributions such as Ubuntu, Debian, and
+RHEL. Use the musl target on Alpine Linux and other musl-based systems. The
+Unix shell installer intentionally selects the portable musl target on Linux.
+PyPI and npm installations automatically select the target compatible with the
+host CPU and C library.
 
 The installer reports the detected operating system and architecture when no
 matching asset exists. Intel macOS is not supported because no matching release
@@ -177,9 +185,9 @@ new download before replacing the binary in the selected installation directory.
 
 ### Alternative Installation Methods
 
-The PyPI, npm, and installer methods all install the same release binary on
-supported platforms. Use Cargo on unsupported platforms or when you prefer to
-build from source:
+The PyPI, npm, and installer methods install the same CLI release with a binary
+compatible with the host platform. Use Cargo on unsupported platforms or when
+you prefer to build from source:
 
 ```bash
 cargo install nemo-relay-cli
@@ -210,6 +218,11 @@ virtual environment and do not have project metadata, use `uv pip install
 nemo-relay` instead. You can also use `pip install nemo-relay` if you are not
 managing the environment with `uv`.
 
+On supported x86_64 and ARM64 Linux systems, `pip` and `uv` automatically
+select the compatible wheel: `manylinux_2_17` on glibc-based distributions and
+`musllinux_1_2` on musl-based distributions such as Alpine Linux. Alpine users
+do not need a `--platform` override or a source build.
+
 ## Node.js
 
 Install the Node.js package when your application uses NeMo Relay through the
@@ -218,6 +231,9 @@ JavaScript API and owns the tool or LLM call boundary.
 ```bash
 npm install nemo-relay-node@0.7.0
 ```
+
+On supported x64 and ARM64 Linux systems, npm automatically installs the native
+package for the host C library, including the musl package on Alpine Linux.
 
 ## Rust
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -114,8 +114,9 @@ user `PATH`; the Unix installer does not edit shell configuration.
 Use the GNU target on glibc-based distributions such as Ubuntu, Debian, and
 RHEL. Use the musl target on Alpine Linux and other musl-based systems. The
 Unix shell installer intentionally selects the portable musl target on Linux.
-PyPI and npm installations automatically select the target compatible with the
-host CPU and C library.
+For package versions that publish the corresponding artifacts, `pip`, `uv`, and
+`npm` automatically select a target compatible with the host CPU and C library
+on supported platforms.
 
 The installer reports the detected operating system and architecture when no
 matching asset exists. Intel macOS is not supported because no matching release

--- a/docs/reference/support-matrix.mdx
+++ b/docs/reference/support-matrix.mdx
@@ -18,18 +18,26 @@ commitment. For release-specific changes and known limitations, refer to
 | Surface | Linux x86_64 | Linux ARM64 | macOS x86_64 | macOS ARM64 | Windows x86_64 | Windows ARM64 | Limitations |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Core Library | Required CI coverage | Required CI coverage | Not in the current CI matrix | Required CI coverage | Non-blocking CI coverage | Non-blocking CI coverage | Rust is the source of truth. Python and Node.js packages require their supported runtimes; Go and raw C FFI remain experimental and source-first. |
-| CLI Application | Published `x86_64-unknown-linux-musl` asset | Published `aarch64-unknown-linux-musl` asset | No published release asset | Published `aarch64-apple-darwin` asset | Published `x86_64-pc-windows-msvc` asset | Published `aarch64-pc-windows-msvc` asset | Intel macOS has no prebuilt CLI asset. Use a source install on unsupported platforms. |
+| CLI Application | Published `x86_64-unknown-linux-gnu` and `x86_64-unknown-linux-musl` assets | Published `aarch64-unknown-linux-gnu` and `aarch64-unknown-linux-musl` assets | No published release asset | Published `aarch64-apple-darwin` asset | Published `x86_64-pc-windows-msvc` asset | Published `aarch64-pc-windows-msvc` asset | Intel macOS has no prebuilt CLI asset. Use a source install on unsupported platforms. |
 | Native Plugins | Build for the host ABI | Build for the host ABI | Build and validate locally | Build for the host ABI | Build for the host ABI; CI is non-blocking | Build for the host ABI; CI is non-blocking | Native plugins run in-process and are not sandboxed. Rebuild for the host ABI and compatible Relay version. |
 | gRPC Worker Plugins | Depends on the selected worker runtime | Depends on the selected worker runtime | Build and validate locally | Depends on the selected worker runtime | Depends on the selected worker runtime | Depends on the selected worker runtime | Workers run as local child processes over `grpc-v1`, not as a security sandbox. Python workers are unsupported on Windows ARM64. Refer to the worker runtime matrix for runtime-specific requirements. |
 
 ### Linux Distribution Notes
 
-The published Linux CLI binaries use musl targets and are not tied to a
-distribution-specific package manager. Linux CI uses Ubuntu runners. NeMo Relay
-does not publish distribution-specific DEB or RPM packages or certify individual
-Ubuntu, Debian, RHEL-compatible, or Fedora releases. On an unsupported CPU,
-unsupported operating system, or a system whose local requirements prevent the
-release asset from running, install from source with Cargo.
+NeMo Relay publishes GNU and musl CLI binaries for each supported Linux
+architecture. The GNU variants are dynamically linked against glibc 2.17 or
+newer and are the performance-oriented choice for glibc-based distributions
+such as Ubuntu, Debian, and RHEL. The statically linked musl variants are
+required for musl-based distributions such as Alpine Linux and also run on
+glibc-based distributions. The Unix shell installer uses the musl variant for
+portability.
+
+The binaries are not tied to a distribution-specific package manager. Linux CI
+uses Ubuntu runners, and NeMo Relay does not publish distribution-specific DEB
+or RPM packages or certify individual Ubuntu, Debian, RHEL-compatible, or
+Fedora releases. On an unsupported CPU, unsupported operating system, or a
+system whose local requirements prevent the release asset from running,
+install from source with Cargo.
 
 ## Worker Runtime Compatibility
 


### PR DESCRIPTION
#### Overview

Apply the Linux GNU/glibc and musl installation guidance from #609 to the v0.7 release documentation. PR #609 was merged into `main` and is being reverted by #614 because this release-specific documentation belongs on `release/0.7`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- List the published GNU and musl CLI targets for x86_64 and ARM64 Linux systems.
- Explain when to use the glibc-linked GNU variant and the portable musl variant.
- Clarify that the Unix shell installer intentionally selects the musl target on Linux.
- Qualify automatic `pip`, `uv`, and npm target selection to supported platforms and package versions that publish corresponding artifacts.
- Document Alpine wheel coverage by Python version, architecture, and musl version, with the source-build path for unsupported environments.

Validation:

- `just docs`
- `uv run --no-sync pre-commit run --files docs/getting-started/installation.mdx docs/reference/support-matrix.mdx`

#### Where should the reviewer start?

Start with the supported-platform table and selection guidance in `docs/getting-started/installation.mdx`, then review the Linux CLI row and distribution notes in `docs/reference/support-matrix.mdx`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-606](https://linear.app/nvidia/issue/RELAY-606/nemo-relay070-nemo-relay070-rc2-documentation-nemo-relay-documentation)
- Relates to: #609
- Relates to: #614


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Linux support for glibc and musl platforms, including GNU and musl installation options.
  * Documented automatic platform detection and native x64/ARM64 package selection.
  * Added Python CPython 3.11+ ABI3 wheel and Alpine/musl compatibility details.
  * Updated the support matrix with available Linux CLI assets and guidance for unsupported platforms.
  * Clarified supported distribution characteristics and packaging limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->