### PR TITLE
docs: improve runtime guidance and visual accessibility

### DIFF
--- a/.agents/skills/contribute-docs/SKILL.md
+++ b/.agents/skills/contribute-docs/SKILL.md
@@ -35,6 +35,10 @@ Use this skill for docs-only or example-heavy changes.
 - In MDX files, top-of-file comments must use JSX comment delimiters:
   `{/*` to open and `*/}` to close. Do not use HTML comments for MDX SPDX
   headers.
+- Render images, diagrams, tables, and other visual content at representative
+  page widths. Size visual content for legibility and complete access without
+  clipping. Choose responsive scaling, reflow, or overflow based on the content,
+  and scope visual-specific styling as narrowly as practical.
 
 ## Checklist
 
@@ -45,6 +49,8 @@ Use this skill for docs-only or example-heavy changes.
 - [ ] Dynamic plugin entry pages link to native, worker, Rust example, Python
       example, and protocol pages when those pages exist
 - [ ] New or regenerated MDX files use `{/* ... */}` for top-of-file SPDX comments
+- [ ] Images, diagrams, tables, and custom visual content remain legible and
+      fully accessible at representative desktop and narrow page widths
 - [ ] Release-policy docs still point to GitHub Releases as the only release-history source of truth
 - [ ] Run `just docs` when the docs site changed; `./scripts/build-docs.sh html` remains the compatibility wrapper
 

--- a/.agents/skills/review-doc-style/assets/nvidia-style-technical-docs.md
+++ b/.agents/skills/review-doc-style/assets/nvidia-style-technical-docs.md
@@ -127,6 +127,9 @@ Flag accessibility issues that affect docs readers:
 - Long paragraphs or sentences that make scanning difficult.
 - Instructions that rely only on color, position, or visual appearance.
 - Low contrast when the change includes rendered images or custom HTML.
+- Images, diagrams, or other visual content sized so small that labels or
+  important details are illegible at representative page widths.
+- Wide visual content that is clipped or otherwise not fully reachable.
 
 ## UI References
 

--- a/docs/about-nemo-relay/agent-runtime-primer.mdx
+++ b/docs/about-nemo-relay/agent-runtime-primer.mdx
@@ -61,6 +61,15 @@ required step for every call.
 
 <MermaidStyles />
 
+<style>{`
+.mermaid-container svg,
+.mermaid-container-expanded svg,
+.mermaid svg {
+  min-width: 72rem;
+  max-width: none;
+}
+`}</style>
+
 ```mermaid
 flowchart LR
   boundary["App or framework boundary"]

--- a/docs/about-nemo-relay/agent-runtime-primer.mdx
+++ b/docs/about-nemo-relay/agent-runtime-primer.mdx
@@ -61,15 +61,6 @@ required step for every call.
 
 <MermaidStyles />
 
-<style>{`
-.mermaid-container svg,
-.mermaid-container-expanded svg,
-.mermaid svg {
-  min-width: 72rem;
-  max-width: none;
-}
-`}</style>
-
 ```mermaid
 flowchart LR
   boundary["App or framework boundary"]

--- a/docs/about-nemo-relay/overview.mdx
+++ b/docs/about-nemo-relay/overview.mdx
@@ -99,11 +99,14 @@ Rust is the source of truth for runtime behavior. The Python and Node.js
 bindings expose the same core model for primary application use. Go and raw C
 FFI are experimental and source-first surfaces.
 
-Developers building integrations should start by identifying who owns the real
-LLM or tool call. If Relay can wrap the real callback, use managed execution. If
-the framework exposes lifecycle hooks but not execution control, use explicit
-lifecycle APIs or hook replay. If provider-shaped payload capture matters,
-consider the gateway/provider path and treat it as production traffic.
+First, identify where the actual LLM or tool function is invoked. If that
+invocation can be routed through NeMo Relay, use managed execution: NeMo Relay
+runs the applicable middleware and then invokes the real function. If the
+framework retains control but provides before-and-after notifications, translate
+those lifecycle hooks into NeMo Relay events. NeMo Relay can then observe the
+call's lifecycle but does not execute or control it. If provider-native requests
+and responses must be intercepted, route the real provider traffic through the
+NeMo Relay gateway and treat NeMo Relay as a production dependency.
 
 <Warning>
 Do not add behavior to one primary binding without checking Rust, Python, and


### PR DESCRIPTION
#### Overview

Improve the clarity of NeMo Relay's runtime integration guidance and make the Agent Runtime Primer diagram easier to read across representative page widths.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Explain managed execution, lifecycle-hook translation, and provider routing in concrete runtime terms.
- Increase the runtime-primer Mermaid diagram's readable width while preserving horizontal access through the existing scrollable container.
- Add reusable contributor and reviewer guidance for visual legibility, responsive behavior, and clipping prevention.

#### Where should the reviewer start?

Start with `docs/about-nemo-relay/overview.mdx` for the clarified runtime-boundary guidance, then review `docs/about-nemo-relay/agent-runtime-primer.mdx` for the diagram behavior.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [RELAY-584](https://linear.app/nvidia/issue/RELAY-584/improve-nemo-relay-documentation-clarity-and-usability)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified integration options for managed execution, lifecycle observation, and provider traffic interception.
  * Improved Mermaid diagram readability by supporting wider content without clipping.
  * Added accessibility guidance for ensuring visual content remains legible across desktop and narrow layouts.
  * Expanded review guidance to identify unreadable or inaccessible visual content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->