### PR TITLE
fix: default operational logging to error

### DIFF
--- a/crates/cli/tests/coverage/shared/config_tests.rs
+++ b/crates/cli/tests/coverage/shared/config_tests.rs
@@ -3783,7 +3783,7 @@ fn logging_defaults_when_section_absent() {
     let resolved = resolve_server_config(&args).unwrap();
 
     assert_eq!(resolved.logging, LoggingConfig::default());
-    assert_eq!(resolved.logging.level, LogLevel::Info);
+    assert_eq!(resolved.logging.level, LogLevel::Error);
     assert_eq!(resolved.logging.stderr_format, LogFormat::Human);
     assert!(resolved.logging.sinks.is_empty());
 }

--- a/crates/core/src/logging/config.rs
+++ b/crates/core/src/logging/config.rs
@@ -55,7 +55,7 @@ pub struct LoggingConfig {
 impl Default for LoggingConfig {
     fn default() -> Self {
         Self {
-            level: LogLevel::Info,
+            level: LogLevel::Error,
             stderr_format: LogFormat::Human,
             sinks: Vec::new(),
             flush_interval_millis: DEFAULT_FILE_FLUSH_INTERVAL_MILLIS,

--- a/crates/core/tests/coverage/logging_tests.rs
+++ b/crates/core/tests/coverage/logging_tests.rs
@@ -563,6 +563,7 @@ fn logging_rotation_retains_newest_backups_and_complete_records() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("relay.log.jsonl");
     let config = LoggingConfig {
+        level: LogLevel::Info,
         sinks: vec![LogSinkConfig::File(FileLogSinkConfig {
             path: path.clone(),
             rotation: Some(FileLogRotationConfig::new(1, 2).unwrap()),
@@ -595,6 +596,7 @@ fn logging_rotation_rotates_existing_file_at_boundary() {
     let existing_record = "x".repeat(64);
     std::fs::write(&path, &existing_record).unwrap();
     let config = LoggingConfig {
+        level: LogLevel::Info,
         sinks: vec![LogSinkConfig::File(FileLogSinkConfig {
             path: path.clone(),
             rotation: Some(FileLogRotationConfig::new(64, 2).unwrap()),
@@ -900,7 +902,7 @@ fn logging_runtime_emits_initialized_and_shutdown_lifecycle_events() {
 #[test]
 fn default_logging_config_has_stderr_defaults_and_no_sinks() {
     let config = LoggingConfig::default();
-    assert_eq!(config.level, LogLevel::Info);
+    assert_eq!(config.level, LogLevel::Error);
     assert_eq!(config.stderr_format, LogFormat::Human);
     assert!(config.sinks.is_empty());
 }
@@ -1156,6 +1158,7 @@ fn periodic_flush_applies_to_all_file_sinks() {
     let path_b = temp.path().join("flush-b.log.jsonl");
     // Small global interval; rely solely on the periodic timer (no explicit flush/shutdown).
     let config = LoggingConfig {
+        level: LogLevel::Info,
         flush_interval_millis: 20,
         sinks: vec![
             LogSinkConfig::File(FileLogSinkConfig {
@@ -1277,6 +1280,7 @@ fn non_string_fields_are_coerced_to_json_strings() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("typed-fields.log.jsonl");
     let config = LoggingConfig {
+        level: LogLevel::Info,
         sinks: vec![LogSinkConfig::File(FileLogSinkConfig {
             path: path.clone(),
             ..FileLogSinkConfig::default()
@@ -1325,6 +1329,7 @@ fn shutdown_flushes_file_sink_when_periodic_flush_disabled() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("no-periodic-flush.log.jsonl");
     let config = LoggingConfig {
+        level: LogLevel::Info,
         // Periodic flush disabled: only the shutdown drain should reach disk.
         flush_interval_millis: 0,
         sinks: vec![LogSinkConfig::File(FileLogSinkConfig {

--- a/docs/reference/operational-logging.mdx
+++ b/docs/reference/operational-logging.mdx
@@ -18,7 +18,7 @@ copies of those records. Each record includes a root Relay ID for correlation.
 
 Without configuration, Relay uses:
 
-- `info` as the minimum log level
+- `error` as the minimum log level
 - Human-readable stderr output
 - No file sinks
 


### PR DESCRIPTION
#### Overview

Change the built-in operational logging threshold from `info` to `error` so unconfigured Relay processes emit only error-level logs to stderr by default.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Set `LoggingConfig::default().level` to `LogLevel::Error`.
- Updated core and CLI default-configuration regression tests.
- Set file-sink behavior tests to explicitly use `info` where they exercise info-level records.
- Updated operational logging documentation.

#### Where should the reviewer start?

Start with `crates/core/src/logging/config.rs` and `crates/core/tests/coverage/logging_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The default operational logging level is now **error**, reducing informational messages by default.
  * File-based and rotating logs continue to support explicitly configured **info-level** logging.
* **Documentation**
  * Updated the operational logging reference to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->