### PR TITLE
fix: warn when OpenTelemetry spans are dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,6 +1746,7 @@ dependencies = [
  "toml",
  "tonic",
  "tower",
+ "tracing",
  "typed-builder",
  "unicode-general-category",
  "uuid",
@@ -2131,6 +2132,7 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -65,7 +65,8 @@ typed-builder = "0.23.2"
 futures-util = "0.3"
 opentelemetry = { workspace = true, features = ["trace"] }
 opentelemetry-semantic-conventions.workspace = true
-opentelemetry_sdk = { workspace = true, features = ["trace"] }
+opentelemetry_sdk = { workspace = true, features = ["trace", "internal-logs"] }
+tracing = { version = "0.1", default-features = false, features = ["std", "log"] }
 libloading = "0.8"
 semver = "1"
 sha2 = "0.11"

--- a/crates/core/tests/coverage/logging_tests.rs
+++ b/crates/core/tests/coverage/logging_tests.rs
@@ -6,11 +6,17 @@ use crate::logging::{
     LoggingRuntime, MAX_FILE_SINK_QUEUE_ENTRIES, MAX_FILE_SINK_RETAINED_FILES, build_logger,
     format_event_for_test, init_logging,
 };
+use opentelemetry::trace::{Span as _, Tracer as _, TracerProvider as _};
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::trace::{
+    BatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider, SpanData, SpanExporter,
+};
 use serde_json::Value;
 use spdlog::Level;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Barrier, Mutex, MutexGuard};
+use std::sync::{Arc, Barrier, Condvar, Mutex, MutexGuard};
+use std::time::Duration;
 
 static LOGGING_TEST_LOCK: Mutex<()> = Mutex::new(());
 const FOREIGN_LOGGER_CHILD_ENV: &str = "NEMO_RELAY_TEST_FOREIGN_LOGGER_CHILD";
@@ -28,6 +34,59 @@ impl log::Log for ForeignLogger {
 }
 
 static FOREIGN_LOGGER: ForeignLogger = ForeignLogger;
+
+#[derive(Clone, Debug, Default)]
+struct BlockingSpanExporter {
+    state: Arc<(Mutex<BlockingExporterState>, Condvar)>,
+}
+
+#[derive(Debug, Default)]
+struct BlockingExporterState {
+    export_started: bool,
+    release_export: bool,
+}
+
+impl BlockingSpanExporter {
+    fn wait_until_export_starts(&self) {
+        let (state, changed) = &*self.state;
+        let guard = state.lock().unwrap_or_else(|error| error.into_inner());
+        let (guard, timeout) = changed
+            .wait_timeout_while(guard, Duration::from_secs(5), |state| !state.export_started)
+            .unwrap_or_else(|error| error.into_inner());
+        assert!(
+            guard.export_started && !timeout.timed_out(),
+            "batch exporter did not start"
+        );
+    }
+
+    fn release(&self) {
+        let (state, changed) = &*self.state;
+        let mut state = state.lock().unwrap_or_else(|error| error.into_inner());
+        state.release_export = true;
+        changed.notify_all();
+    }
+}
+
+impl Drop for BlockingSpanExporter {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+impl SpanExporter for BlockingSpanExporter {
+    async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+        let (state, changed) = &*self.state;
+        let mut state = state.lock().unwrap_or_else(|error| error.into_inner());
+        state.export_started = true;
+        changed.notify_all();
+        while !state.release_export {
+            state = changed
+                .wait(state)
+                .unwrap_or_else(|error| error.into_inner());
+        }
+        Ok(())
+    }
+}
 
 fn lock_logging_tests() -> MutexGuard<'static, ()> {
     LOGGING_TEST_LOCK
@@ -543,6 +602,99 @@ fn wait_for_log_line(path: &std::path::Path, ready: impl Fn(&str) -> bool) -> St
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
     std::fs::read_to_string(path).unwrap_or_default()
+}
+
+#[test]
+fn opentelemetry_batch_processor_logs_dropped_spans() {
+    let _lock = lock_logging_tests();
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("otel-dropped-spans.log.jsonl");
+    let config = LoggingConfig {
+        level: LogLevel::Warn,
+        sinks: vec![LogSinkConfig::File(FileLogSinkConfig {
+            path: path.clone(),
+            level: LogLevel::Warn,
+            format: LogFormat::Jsonl,
+            ..FileLogSinkConfig::default()
+        })],
+        ..default_config()
+    };
+    let runtime = init_logging(&config).unwrap();
+
+    let exporter = BlockingSpanExporter::default();
+    let processor = BatchSpanProcessor::builder(exporter.clone())
+        .with_batch_config(
+            BatchConfigBuilder::default()
+                .with_max_queue_size(1)
+                .with_max_export_batch_size(1)
+                .with_scheduled_delay(Duration::from_secs(60))
+                .build(),
+        )
+        .build();
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+    let tracer = provider.tracer("dropped-span-logging-test");
+
+    tracer.start("export-in-progress").end();
+    exporter.wait_until_export_starts();
+    tracer.start("queued").end();
+    tracer.start("dropped-1").end();
+    tracer.start("dropped-2").end();
+
+    runtime.logger.flush();
+    let immediate = wait_for_log_line(&path, |contents| {
+        contents.contains("BatchSpanProcessor.SpanDroppingStarted")
+    });
+    assert_eq!(
+        immediate
+            .matches("BatchSpanProcessor.SpanDroppingStarted")
+            .count(),
+        1,
+        "the processor should warn only for the first drop: {immediate}"
+    );
+    let first_drop: Value = immediate
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .find(|record: &Value| {
+            record["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("BatchSpanProcessor.SpanDroppingStarted"))
+        })
+        .expect("first-drop warning");
+    assert_eq!(first_drop["level"], "warn");
+    assert_eq!(first_drop["target"], "opentelemetry_sdk");
+
+    exporter.release();
+    provider.shutdown().unwrap();
+    runtime.logger.flush();
+    let summary = wait_for_log_line(&path, |contents| {
+        contents.contains("BatchSpanProcessor.SpansDropped")
+            && contents.contains("dropped_span_count=2")
+    });
+    runtime.shutdown();
+
+    assert_eq!(
+        summary
+            .matches("BatchSpanProcessor.SpanDroppingStarted")
+            .count(),
+        1,
+        "later drops should not emit another first-drop warning: {summary}"
+    );
+    let drop_summary: Value = summary
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .find(|record: &Value| {
+            record["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("BatchSpanProcessor.SpansDropped"))
+        })
+        .expect("shutdown drop summary");
+    assert_eq!(drop_summary["level"], "warn");
+    assert_eq!(drop_summary["target"], "opentelemetry_sdk");
+    let message = drop_summary["message"].as_str().unwrap();
+    assert!(message.contains("dropped_span_count=2"), "{message}");
+    assert!(message.contains("max_queue_size=1"), "{message}");
 }
 
 fn read_single_jsonl_record(path: &Path) -> Value {

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -146,6 +146,13 @@ their values cannot be isolated between endpoints.
   changes content must return a new request object.
 - Native subscriber callbacks arrive asynchronously. Flush subscribers before
   depending on their side effects, captured events, files, or exporter output.
+- OpenTelemetry endpoints use finite batch queues. A burst that fills an
+  endpoint queue drops completed spans without applying backpressure and can
+  leave an incomplete trace, including a missing root span. The SDK warns on
+  the first drop and reports the exact dropped-span count during graceful
+  shutdown. Increase `OTEL_BSP_MAX_QUEUE_SIZE` before plugin activation to
+  reduce the risk for a known burst size; endpoint-specific batch sizing is not
+  available, and a larger finite queue does not guarantee lossless telemetry.
 - Operational logging configuration and sink lifecycle are available, but broad
   operational log coverage across commands is not yet available.
 

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -83,6 +83,14 @@ returns the first teardown error after all attempts finish. Clear the plugin
 during graceful shutdown so queued subscriber work can drain and every
 exporter receives a teardown attempt.
 
+NeMo Relay shuts down OpenTelemetry endpoint providers sequentially. A slow or
+unreachable collector can delay `plugin.clear()` or process shutdown by
+approximately the OpenTelemetry SDK's five-second shutdown bound plus one
+endpoint export timeout. Use each endpoint's `timeout_millis` value to bound
+that export attempt. This timeout behavior does not make a full batch queue
+lossless; refer to [OpenTelemetry](/configure-plugins/observability/opentelemetry#batch-processor-environment-variables)
+for queue sizing and drop-warning behavior.
+
 Top-level component `config` lists concatenate across configuration layers,
 with higher-precedence entries first. The observability destination lists
 `atof.sinks`, `opentelemetry.endpoints`, and `atif.storage` follow the same

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -105,19 +105,38 @@ batch sizing is not supported.
 
 Use positive integer values. The SDK falls back to its defaults for malformed
 values but accepts zero; do not use zero values. Queue capacity counts spans,
-not bytes. A full queue drops completed spans rather than applying backpressure
-to application work.
+not bytes.
+
+<Warning>
+A full queue drops completed spans instead of applying backpressure to
+application work. Bursts can therefore drop spans that finish late, including
+an enclosing root span, and leave an incomplete trace in the backend.
+
+The OpenTelemetry SDK logs
+`BatchSpanProcessor.SpanDroppingStarted` at warning level when each endpoint
+first drops a span. It suppresses additional first-drop warnings for that
+endpoint to avoid a log storm. During graceful shutdown, it logs
+`BatchSpanProcessor.SpansDropped` with the endpoint processor's exact
+`dropped_span_count` and `max_queue_size`. The SDK diagnostics do not include
+the Relay endpoint index or URL.
+</Warning>
+
+Increasing `OTEL_BSP_MAX_QUEUE_SIZE` can reduce the risk for a known burst
+size, but a finite queue does not guarantee lossless telemetry. Always clear
+the plugin during graceful shutdown so the SDK can report its final drop count
+and attempt to export queued spans.
 
 ## Endpoint Capacity and Sizing
 
 NeMo Relay does not impose a maximum number of OpenTelemetry endpoints. Each
-endpoint owns an exporter, tracer provider, batch queue, and exporter runtime.
-Queue capacity and memory are per endpoint, and total export traffic grows
-approximately with endpoint count and trace payload size.
+endpoint owns an exporter, tracer provider, batch processor, batch queue, and
+exporter runtime resources. Nothing in that export stack is shared between
+endpoints. Queue capacity and memory are per endpoint, and total export traffic
+is approximately the trace payload size multiplied by the endpoint count.
 
-Use only the endpoints required by your deployment. Validate configurations
-with tens or hundreds of endpoints against the process thread, memory, and
-network limits.
+Typical deployments need one to three endpoints. Validate configurations with
+tens or hundreds of endpoints against the process limits for threads, memory,
+and network egress before deploying them.
 
 Use `header_env` for secrets so configuration files contain only environment
 variable names. Each variable contains the complete header value. NeMo Relay


### PR DESCRIPTION
#### Overview

Enable OpenTelemetry SDK diagnostics so finite batch-queue overflow is visible immediately and summarized exactly during graceful shutdown. Complete the related 0.7 operator documentation for queue-loss and endpoint-sizing behavior.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Enable the `opentelemetry_sdk` `internal-logs` feature and the `tracing` log compatibility feature without enabling `log-always`.
- Add deterministic coverage using a blocking exporter and a one-span queue. The test verifies one first-drop warning, suppression for later drops, warning severity and target, and the exact shutdown aggregate.
- Document finite-queue loss, incomplete or rootless traces, process-wide batch settings, conservative endpoint sizing, sequential endpoint shutdown, and the 0.7 known issue.
- Leave public configuration, bindings, README entry points, and agent skills unchanged.

Validation:

- `cargo fmt --all -- --check`
- `cargo test -p nemo-relay opentelemetry_batch_processor_logs_dropped_spans`
- `cargo clippy -p nemo-relay --all-targets -- -D warnings`
- Commit-time pre-commit hooks, including workspace Cargo clippy, Cargo deny, attribution, lockfile, formatting, and documentation link checks
- `just docs`
- `just docs-linkcheck`

An earlier exhaustive `just test-rust` run completed the core tests but encountered four local-environment CLI integration failures unrelated to this change. Per review scope, validation was narrowed to the affected core and documentation surfaces.

#### Where should the reviewer start?

Start with `crates/core/Cargo.toml` for diagnostic routing, then review `opentelemetry_batch_processor_logs_dropped_spans` in `crates/core/tests/coverage/logging_tests.rs` for the expected warning cadence and shutdown count.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-602
- Relates to: RELAY-604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics for OpenTelemetry span queue saturation, including a warning when spans are first dropped and a shutdown summary of dropped spans and queue capacity.
* **Documentation**
  * Documented queue overflow behavior, potential incomplete traces, endpoint shutdown timing, export timeouts, and per-endpoint resource usage.
  * Added guidance for increasing queue capacity and clarified that shutdown settings do not guarantee lossless delivery.
* **Tests**
  * Added coverage validating span-drop warnings and shutdown reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->