### PR TITLE
ci: package Android Python wheels

### DIFF
--- a/.github/ci-path-filters.yml
+++ b/.github/ci-path-filters.yml
@@ -106,6 +106,8 @@ python_package:
   - 'python/nemo_relay/**'
   - 'rust-toolchain.toml'
   - 'scripts/package-cli-bin.py'
+  - 'scripts/package_python_musllinux.py'
+  - 'scripts/python_package_version.py'
   - 'uv.lock'
 
 python_integration_langchain:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,7 +181,15 @@ jobs:
     name: Python
     needs: [prepare, ci_changes, ci_check]
     uses: ./.github/workflows/ci_python.yml
-    if: ${{ needs.ci_check.result == 'success' && ( needs.ci_changes.outputs.run_python == 'true' || needs.ci_changes.outputs.run_python_integration_langchain == 'true' ) }}
+    if: >-
+      ${{
+        needs.ci_check.result == 'success'
+        && (
+          needs.ci_changes.outputs.run_python == 'true'
+          || needs.ci_changes.outputs.run_python_integration_langchain == 'true'
+          || needs.ci_changes.outputs.run_python_package == 'true'
+        )
+      }}
     permissions:
       contents: read
     secrets:
@@ -189,7 +197,7 @@ jobs:
     with:
       ref_type: ${{ github.ref_type }}
       ref_name: ${{ github.ref_name }}
-      run_package: ${{ ( needs.ci_changes.outputs.run_python == 'true' || needs.ci_changes.outputs.run_python_integration_langchain == 'true' ) }}
+      run_package: ${{ needs.ci_changes.outputs.run_python_package == 'true' }}
       run_integration_langchain: ${{ needs.ci_changes.outputs.run_python_integration_langchain == 'true' }}
 
   ci_required:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,7 +314,7 @@ jobs:
             node_npm=(nemo-relay-node-npm-*.tgz)
             expect_count 7 "CLI binary" "${cli_binaries[@]}"
             expect_count 7 "CLI wheel" "${cli_wheels[@]}"
-            expect_count 7 "Python API wheel" "${python_api_wheels[@]}"
+            expect_count 9 "Python API wheel" "${python_api_wheels[@]}"
             expect_count 8 "CLI npm" "${cli_npm[@]}"
             expect_count 8 "Node npm" "${node_npm[@]}"
 

--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -221,9 +221,10 @@ jobs:
             pre-commit run --from-ref "$base_ref" --to-ref HEAD --show-diff-on-failure
           fi
 
-      - name: Test binary package assembly
+      - name: Test packaging scripts
         working-directory: ${{ env.NEMO_RELAY_CI_WORKSPACE }}
         run: >-
           uv run --no-project python -m unittest
           scripts.tests.test_package_cli_bin
           scripts.tests.test_package_node_bin
+          scripts.tests.test_python_package_version

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -251,7 +251,7 @@ jobs:
             PIP_CONSTRAINT=${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/android-build-constraints.txt
           CIBW_PLATFORM: android
           CIBW_TEST_COMMAND: ${{ matrix.architecture == 'x86_64' && 'python -c "import nemo_relay"' || '' }}
-          CIBW_TEST_RUNTIME_ANDROID: "args: --managed minVersion"
+          CIBW_TEST_RUNTIME_ANDROID: "args: --managed maxVersion"
         with:
           output-dir: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/android-wheels
 

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -201,9 +201,21 @@ jobs:
           cache-all-crates: true
           cache-bin: false
 
-      - name: Derive Python package version
+      - name: Derive packaging configuration
         run: |
           set -euo pipefail
+          maturin_version="$(awk '
+            $0 == "name = \"maturin\"" { found = 1; next }
+            found && /^version = / {
+              gsub(/"/, "", $3)
+              print $3
+              exit
+            }
+          ' uv.lock)"
+          if [[ -z "$maturin_version" ]]; then
+            echo "Error: failed to read maturin version from uv.lock" >&2
+            exit 1
+          fi
           version="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -n1)"
           if [[ -z "$version" ]]; then
             echo "Error: failed to read workspace version from Cargo.toml" >&2
@@ -214,6 +226,9 @@ jobs:
           else
             version="${version}+${GITHUB_SHA::8}"
           fi
+          mkdir -p "${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}"
+          printf 'maturin==%s\n' "$maturin_version" > \
+            "${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/android-build-constraints.txt"
           printf 'NEMO_RELAY_PACKAGE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
 
       - name: Materialize Python package version
@@ -226,8 +241,11 @@ jobs:
           CIBW_ARCHS: ${{ matrix.architecture }}
           CIBW_BUILD: cp313-*
           CIBW_BUILD_VERBOSITY: "1"
+          CIBW_ENVIRONMENT_ANDROID: >-
+            PIP_CONSTRAINT=${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/android-build-constraints.txt
           CIBW_PLATFORM: android
           CIBW_TEST_COMMAND: ${{ matrix.architecture == 'x86_64' && 'python -c "import nemo_relay"' || '' }}
+          CIBW_TEST_RUNTIME_ANDROID: "args: --managed minVersion"
         with:
           output-dir: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/android-wheels
 

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -163,6 +163,91 @@ jobs:
         working-directory: ${{ env.NEMO_RELAY_CI_WORKSPACE }}
         run: uv cache prune --ci
 
+  Package-android:
+    name: Package (android-${{ matrix.architecture }})
+    needs: [Test]
+    if: ${{ inputs.run_package && !cancelled() && needs.Test.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: x86_64
+            rust_target: x86_64-linux-android
+          - architecture: arm64_v8a
+            rust_target: aarch64-linux-android
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Load CI tool versions
+        id: ci-config
+        uses: ./.github/actions/load-ci-tool-versions
+
+      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          cache: false
+          toolchain: ${{ steps.ci-config.outputs.rust_version }}
+          target: ${{ matrix.rust_target }}
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: nemo-relay-rust-android-${{ matrix.architecture }}-${{ steps.ci-config.outputs.rust_version }}
+          workspaces: . -> target
+          cache-all-crates: true
+          cache-bin: false
+
+      - name: Derive Python package version
+        run: |
+          set -euo pipefail
+          version="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -n1)"
+          if [[ -z "$version" ]]; then
+            echo "Error: failed to read workspace version from Cargo.toml" >&2
+            exit 1
+          fi
+          if [[ "${{ inputs.ref_type }}" == "tag" ]]; then
+            version="${{ inputs.ref_name }}"
+          else
+            version="${version}+${GITHUB_SHA::8}"
+          fi
+          printf 'NEMO_RELAY_PACKAGE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
+      - name: Materialize Python package version
+        run: python scripts/python_package_version.py --version "$NEMO_RELAY_PACKAGE_VERSION"
+
+      - name: Build and smoke test Android wheel
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        env:
+          ANDROID_API_LEVEL: "24"
+          CIBW_ARCHS: ${{ matrix.architecture }}
+          CIBW_BUILD: cp313-*
+          CIBW_BUILD_VERBOSITY: "1"
+          CIBW_PLATFORM: android
+          CIBW_TEST_COMMAND: ${{ matrix.architecture == 'x86_64' && 'python -c "import nemo_relay"' || '' }}
+        with:
+          output-dir: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/android-wheels
+
+      - name: Verify wheel platform tag
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=("${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/android-wheels"/*-cp311-abi3-android_24_${{ matrix.architecture }}.whl)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            echo "Error: expected one cp311-abi3 Android wheel for ${{ matrix.architecture }}, found ${#wheels[@]}" >&2
+            exit 1
+          fi
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: wheel-android-${{ matrix.architecture }}
+          path: ${{ env.NEMO_RELAY_CI_WORKSPACE_TMP }}/android-wheels/*.whl
+          if-no-files-found: error
+
   Package-musllinux:
     name: Package (musllinux-${{ matrix.architecture }})
     needs: [Test]

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -234,6 +234,12 @@ jobs:
       - name: Materialize Python package version
         run: python scripts/python_package_version.py --version "$NEMO_RELAY_PACKAGE_VERSION"
 
+      - name: Install Android emulator
+        if: matrix.architecture == 'x86_64'
+        run: |
+          set -euo pipefail
+          "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" "emulator"
+
       - name: Build and smoke test Android wheel
         uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -227,6 +227,12 @@ or source build. Alpine environments outside this wheel coverage must use a
 supported Python version and
 [build from source](/contribute/development-setup#source-development).
 
+NeMo Relay also publishes `android_24` wheels for x86_64 and ARM64. These
+wheels require official Android CPython 3.13 or newer, which implements the
+PEP 738 Android platform tags. Older Termux Python environments that report a
+Linux platform while linking against Android Bionic do not select these wheels
+and are not supported.
+
 ## Node.js
 
 Install the Node.js package when your application uses NeMo Relay through the

--- a/scripts/package_python_musllinux.py
+++ b/scripts/package_python_musllinux.py
@@ -6,51 +6,12 @@
 from __future__ import annotations
 
 import argparse
-import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
-VERSION_PATTERN = re.compile(
-    r"^(?P<release>\d+\.\d+\.\d+)"
-    r"(?:-(?P<pre_label>alpha|beta|rc)(?:\.(?P<pre_num>\d+))?)?"
-    r"(?:\+(?P<local>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
-)
-
-
-def semver_to_pep440(version: str) -> str:
-    """Translate the release version used by Cargo into a PEP 440 version."""
-    match = VERSION_PATTERN.fullmatch(version)
-    if not match:
-        raise ValueError(
-            "Unsupported Python package version format. Expected SemVer with optional "
-            "alpha/beta/rc prerelease and optional build metadata."
-        )
-
-    pep440 = match.group("release")
-    pre_label = match.group("pre_label")
-    if pre_label:
-        pre_map = {"alpha": "a", "beta": "b", "rc": "rc"}
-        pep440 += f"{pre_map[pre_label]}{match.group('pre_num') or '0'}"
-
-    local = match.group("local")
-    if local:
-        normalized_local = ".".join(part.lower() for part in re.split(r"[._-]+", local) if part)
-        if not normalized_local:
-            raise ValueError("Python package local version metadata cannot be empty")
-        pep440 += f"+{normalized_local}"
-
-    return pep440
-
-
-def materialize_python_version(source: Path, version: str) -> None:
-    """Set the explicit Python package version in a disposable source copy."""
-    pyproject = source / "pyproject.toml"
-    text = pyproject.read_text()
-    if 'dynamic = ["version"]' not in text:
-        raise ValueError("Failed to find dynamic version field in pyproject.toml")
-    pyproject.write_text(text.replace('dynamic = ["version"]', f'version = "{version}"', 1))
+from python_package_version import materialize_python_version, semver_to_pep440
 
 
 def copy_source(source: Path, destination: Path) -> None:

--- a/scripts/python_package_version.py
+++ b/scripts/python_package_version.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Materialize a PEP 440 Python package version for release packaging."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+VERSION_PATTERN = re.compile(
+    r"^(?P<release>\d+\.\d+\.\d+)"
+    r"(?:-(?P<pre_label>alpha|beta|rc)(?:\.(?P<pre_num>\d+))?)?"
+    r"(?:\+(?P<local>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+def semver_to_pep440(version: str) -> str:
+    """Translate the release version used by Cargo into a PEP 440 version."""
+    match = VERSION_PATTERN.fullmatch(version)
+    if not match:
+        raise ValueError(
+            "Unsupported Python package version format. Expected SemVer with optional "
+            "alpha/beta/rc prerelease and optional build metadata."
+        )
+
+    pep440 = match.group("release")
+    pre_label = match.group("pre_label")
+    if pre_label:
+        pre_map = {"alpha": "a", "beta": "b", "rc": "rc"}
+        pep440 += f"{pre_map[pre_label]}{match.group('pre_num') or '0'}"
+
+    local = match.group("local")
+    if local:
+        normalized_local = ".".join(part.lower() for part in re.split(r"[._-]+", local) if part)
+        if not normalized_local:
+            raise ValueError("Python package local version metadata cannot be empty")
+        pep440 += f"+{normalized_local}"
+
+    return pep440
+
+
+def materialize_python_version(source: Path, version: str) -> None:
+    """Set the explicit Python package version in a packaging source tree."""
+    pyproject = source / "pyproject.toml"
+    text = pyproject.read_text()
+    if 'dynamic = ["version"]' not in text:
+        raise ValueError("Failed to find dynamic version field in pyproject.toml")
+    pyproject.write_text(text.replace('dynamic = ["version"]', f'version = "{version}"', 1))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Raw SemVer release version")
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path.cwd(),
+        help="Packaging source tree containing pyproject.toml",
+    )
+    args = parser.parse_args()
+    materialize_python_version(args.source.resolve(), semver_to_pep440(args.version))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/python_package_version.py
+++ b/scripts/python_package_version.py
@@ -47,7 +47,16 @@ def materialize_python_version(source: Path, version: str) -> None:
     text = pyproject.read_text()
     if 'dynamic = ["version"]' not in text:
         raise ValueError("Failed to find dynamic version field in pyproject.toml")
-    pyproject.write_text(text.replace('dynamic = ["version"]', f'version = "{version}"', 1))
+    updated = text.replace('dynamic = ["version"]', f'version = "{version}"', 1)
+    updated, count = re.subn(
+        r'("nemo-relay-cli-bin==)[^"]+(")',
+        rf"\g<1>{version}\g<2>",
+        updated,
+        count=1,
+    )
+    if count != 1:
+        raise ValueError("Failed to update the nemo-relay CLI extra version")
+    pyproject.write_text(updated)
 
 
 def main() -> None:

--- a/scripts/tests/test_python_package_version.py
+++ b/scripts/tests/test_python_package_version.py
@@ -33,11 +33,26 @@ class PythonPackageVersionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             source = Path(temporary)
             pyproject = source / "pyproject.toml"
-            pyproject.write_text('[project]\ndynamic = ["version"]\n')
+            pyproject.write_text(
+                '[project]\ndynamic = ["version"]\n'
+                '[project.optional-dependencies]\ncli = ["nemo-relay-cli-bin==0.8.0"]\n'
+            )
 
             PYTHON_PACKAGE_VERSION.materialize_python_version(source, "0.8.0rc1")
 
-            self.assertEqual(pyproject.read_text(), '[project]\nversion = "0.8.0rc1"\n')
+            self.assertEqual(
+                pyproject.read_text(),
+                '[project]\nversion = "0.8.0rc1"\n'
+                '[project.optional-dependencies]\ncli = ["nemo-relay-cli-bin==0.8.0rc1"]\n',
+            )
+
+    def test_rejects_missing_cli_extra(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary)
+            (source / "pyproject.toml").write_text('[project]\ndynamic = ["version"]\n')
+
+            with self.assertRaisesRegex(ValueError, "CLI extra version"):
+                PYTHON_PACKAGE_VERSION.materialize_python_version(source, "0.8.0")
 
     def test_rejects_unsupported_version(self) -> None:
         with self.assertRaisesRegex(ValueError, "Unsupported Python package version"):

--- a/scripts/tests/test_python_package_version.py
+++ b/scripts/tests/test_python_package_version.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Python release version materialization."""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("python_package_version", ROOT / "scripts" / "python_package_version.py")
+assert SPEC is not None and SPEC.loader is not None
+PYTHON_PACKAGE_VERSION = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PYTHON_PACKAGE_VERSION)
+
+
+class PythonPackageVersionTests(unittest.TestCase):
+    def test_converts_release_versions_to_pep440(self) -> None:
+        cases = {
+            "0.8.0": "0.8.0",
+            "0.8.0-alpha.1": "0.8.0a1",
+            "0.8.0-beta.2": "0.8.0b2",
+            "0.8.0-rc.3": "0.8.0rc3",
+            "0.8.0+ABC-def.1": "0.8.0+abc.def.1",
+        }
+
+        for version, expected in cases.items():
+            with self.subTest(version=version):
+                self.assertEqual(PYTHON_PACKAGE_VERSION.semver_to_pep440(version), expected)
+
+    def test_materializes_version_in_pyproject(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary)
+            pyproject = source / "pyproject.toml"
+            pyproject.write_text('[project]\ndynamic = ["version"]\n')
+
+            PYTHON_PACKAGE_VERSION.materialize_python_version(source, "0.8.0rc1")
+
+            self.assertEqual(pyproject.read_text(), '[project]\nversion = "0.8.0rc1"\n')
+
+    def test_rejects_unsupported_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unsupported Python package version"):
+            PYTHON_PACKAGE_VERSION.semver_to_pep440("0.8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Overview

Add PEP 738 Android wheel builds for the NeMo Relay Python package without treating Android Bionic as musllinux.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Build CPython 3.13 ABI3 wheels for `android_24_x86_64` and `android_24_arm64_v8a` with cibuildwheel.
- Install and import the x86_64 wheel on a managed x86_64 Android emulator during CI. The ARM64 wheel is cross-built because GitHub's hosted x86_64 runner cannot execute it.
- Pin the Android PEP 517 build to the Maturin version in `uv.lock`.
- Include both Android artifacts in release validation and the existing PyPI publication path.
- Share the SemVer-to-PEP-440 materialization helper with the existing musllinux build. The helper also keeps the optional CLI package pin aligned for prereleases and local builds.
- Route packaging-only file changes through the Python packaging workflow and run the helper regression tests in the standard CI check job.
- Document the boundary between official Android CPython and older Termux Python environments that report Linux while linking against Bionic.
- Add no runtime dependencies and make no runtime behavior changes.

Validation completed locally:

- `uv run pre-commit run --all-files`
- `just test-python` (614 passed)
- `just docs`
- `uv run --no-project python -m unittest scripts.tests.test_package_cli_bin scripts.tests.test_package_node_bin scripts.tests.test_python_package_version` (8 passed)
- Release-style native wheel build, clean-environment install, import, and scope lifecycle smoke
- Real `pyproject.toml` prerelease/local-version materialization smoke
- cibuildwheel Android build identifiers verified for x86_64 and ARM64

The PR CI jobs provide the authoritative Android NDK builds, wheel-tag checks, and x86_64 managed-emulator smoke test.

#### Where should the reviewer start?

Start with `.github/workflows/ci_python.yml`, especially the Android architecture matrix, locked build backend, managed x86_64 emulator smoke test, and wheel-tag verification. Then review `scripts/python_package_version.py` and the packaging-path wiring in `.github/workflows/ci.yaml`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #637
- Relates to https://github.com/NousResearch/hermes-agent/pull/76643

