### PR TITLE
docs: fix fork scope stack example result path

### DIFF
--- a/crates/core/src/api/runtime/scope_stack.rs
+++ b/crates/core/src/api/runtime/scope_stack.rs
@@ -452,7 +452,7 @@ pub fn create_scope_stack_from_propagation(
 /// # Examples
 ///
 /// ```no_run
-/// # async fn example() -> nemo_relay::Result<()> {
+/// # async fn example() -> nemo_relay::error::Result<()> {
 /// use nemo_relay::api::runtime::{TASK_SCOPE_STACK, fork_scope_stack};
 ///
 /// let stack = fork_scope_stack()?;


### PR DESCRIPTION
#### Overview

Correct the `fork_scope_stack` Rust example to use the public `nemo_relay::error::Result` alias so the core doctest compiles.

- [x] I confirm that this pull request has been tested locally and all tests have passed.
- [x] I searched existing pull requests and issues to avoid creating a duplicate.

#### Details

- Replace the nonexistent `nemo_relay::Result` path in the hidden doctest wrapper.
- Keep runtime behavior and the public API unchanged.
- Verify the focused doctest, workspace lint checks, and Rust, Python, Go, and Node test targets.
- The full `just test-rust` run encountered one unrelated shared-state CLI test failure after 1,153 tests passed; the failing test passed when rerun in isolation.

Validation:

- `cargo test -p nemo-relay --doc fork_scope_stack`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-python` (614 passed)
- `just test-go`
- `just test-node` (344 passed)
- All pre-commit hooks, including `cargo deny` and Rust attribution generation

#### Where should the reviewer start?

Start with `crates/core/src/api/runtime/scope_stack.rs` at the `fork_scope_stack` example.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the `fork_scope_stack` documentation example to use the proper result type reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->