### PR TITLE
fix: reject colliding typed OTLP destinations

### DIFF
--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -18,6 +18,7 @@
 //! metadata; their declared scope type is preserved in the exported event
 //! stream.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -52,6 +53,7 @@ use crate::observability::atof::{
 };
 use crate::observability::otel::{
     OpenTelemetryConfig as CoreOpenTelemetryConfig, OpenTelemetrySubscriber, OtlpTransport,
+    resolve_http_trace_endpoint,
 };
 use crate::observability::{
     MarkProjection, OpenTelemetryType, OtlpAttributeMapping, default_mark_exclude_names,
@@ -2286,8 +2288,10 @@ fn opentelemetry_destination_collision_errors(
     let mut errors = Vec::new();
     for (index, endpoint) in endpoints.iter().enumerate() {
         for (other_index, other) in endpoints[..index].iter().enumerate() {
+            let endpoint_destination = opentelemetry_destination(endpoint);
+            let other_destination = opentelemetry_destination(other);
             if endpoint.transport == other.transport
-                && endpoint.endpoint.trim() == other.endpoint.trim()
+                && endpoint_destination == other_destination
                 && endpoint.otel_type != other.otel_type
             {
                 errors.push(OpenTelemetryDestinationCollision {
@@ -2297,13 +2301,22 @@ fn opentelemetry_destination_collision_errors(
                         opentelemetry_type_name(other.otel_type),
                         opentelemetry_type_name(endpoint.otel_type),
                         endpoint.transport,
-                        endpoint.endpoint.trim(),
+                        endpoint_destination,
                     ),
                 });
             }
         }
     }
     errors
+}
+
+fn opentelemetry_destination(endpoint: &OpenTelemetryEndpointConfig) -> Cow<'_, str> {
+    let configured_endpoint = endpoint.endpoint.trim();
+    if endpoint.transport == "http_binary" {
+        resolve_http_trace_endpoint(configured_endpoint)
+    } else {
+        Cow::Borrowed(configured_endpoint)
+    }
 }
 
 const fn opentelemetry_type_name(otel_type: OpenTelemetryType) -> &'static str {

--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -974,6 +974,7 @@ fn register_opentelemetry(
             "enabled OpenTelemetry section requires at least one endpoint".to_string(),
         ));
     }
+    validate_distinct_opentelemetry_destinations(&section.endpoints)?;
     let subscribers = build_opentelemetry_subscribers(section.endpoints)?;
     for (index, _) in subscribers.iter().enumerate() {
         log::info!(
@@ -2233,7 +2234,67 @@ fn validate_opentelemetry_section(
         }
         validate_opentelemetry_headers(diagnostics, policy, index, endpoint);
     }
+    for error in opentelemetry_destination_collision_errors(&section.endpoints) {
+        diagnostics.push(ConfigDiagnostic {
+            level: DiagnosticLevel::Error,
+            code: "observability.unsafe_otel_destination_collision".to_string(),
+            component: Some("opentelemetry".to_string()),
+            field: Some(format!("endpoints[{}].endpoint", error.index)),
+            message: error.message,
+        });
+    }
     validate_opentelemetry_feature_support(diagnostics, policy, section);
+}
+
+struct OpenTelemetryDestinationCollision {
+    index: usize,
+    message: String,
+}
+
+fn validate_distinct_opentelemetry_destinations(
+    endpoints: &[OpenTelemetryEndpointConfig],
+) -> PluginResult<()> {
+    if let Some(error) = opentelemetry_destination_collision_errors(endpoints)
+        .into_iter()
+        .next()
+    {
+        return Err(PluginError::InvalidConfig(error.message));
+    }
+    Ok(())
+}
+
+fn opentelemetry_destination_collision_errors(
+    endpoints: &[OpenTelemetryEndpointConfig],
+) -> Vec<OpenTelemetryDestinationCollision> {
+    let mut errors = Vec::new();
+    for (index, endpoint) in endpoints.iter().enumerate() {
+        for (other_index, other) in endpoints[..index].iter().enumerate() {
+            if endpoint.transport == other.transport
+                && endpoint.endpoint.trim() == other.endpoint.trim()
+                && endpoint.otel_type != other.otel_type
+            {
+                errors.push(OpenTelemetryDestinationCollision {
+                    index,
+                    message: format!(
+                        "OpenTelemetry endpoints[{other_index}] ({}) and endpoints[{index}] ({}) use the same {} destination {:?}; different projection types must use independent destinations",
+                        opentelemetry_type_name(other.otel_type),
+                        opentelemetry_type_name(endpoint.otel_type),
+                        endpoint.transport,
+                        endpoint.endpoint.trim(),
+                    ),
+                });
+            }
+        }
+    }
+    errors
+}
+
+const fn opentelemetry_type_name(otel_type: OpenTelemetryType) -> &'static str {
+    match otel_type {
+        OpenTelemetryType::Full => "full",
+        OpenTelemetryType::GenAi => "gen_ai",
+        OpenTelemetryType::OpenInference => "openinference",
+    }
 }
 
 fn validate_opentelemetry_headers(

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -2552,12 +2552,12 @@ fn otlp_sections_register_inferred_subscribers_with_full_config() {
                 },
                 {
                     "type": "openinference",
-                    "endpoint": "http://127.0.0.1:4318/v1/traces",
+                    "endpoint": "http://127.0.0.1:4319/v1/traces",
                     "service_name": "oi-service"
                 },
                 {
                     "type": "gen_ai",
-                    "endpoint": "http://127.0.0.1:4318/v1/traces"
+                    "endpoint": "http://127.0.0.1:4320/v1/traces"
                 }
             ]
         }
@@ -2614,6 +2614,57 @@ fn opentelemetry_endpoints_fan_out_to_heterogeneous_and_repeated_types() {
             .expect("each configured endpoint should receive the exported span");
         assert!(!body.is_empty());
     }
+}
+
+#[test]
+fn opentelemetry_rejects_different_projection_types_at_the_same_destination() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+    reset_runtime();
+    let config = plugin_config(json!({
+        "policy": {"unsupported_value": "ignore"},
+        "opentelemetry": {
+            "enabled": true,
+            "endpoints": [
+                {"type": "full", "endpoint": " http://127.0.0.1:4318/v1/traces "},
+                {"type": "gen_ai", "endpoint": "http://127.0.0.1:4318/v1/traces"}
+            ]
+        }
+    }));
+
+    let report = validate_plugin_config(&config);
+    assert!(report.has_errors());
+    assert!(report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "observability.unsafe_otel_destination_collision"
+            && diagnostic.field.as_deref() == Some("endpoints[1].endpoint")
+            && diagnostic.message.contains("endpoints[0] (full)")
+            && diagnostic.message.contains("endpoints[1] (gen_ai)")
+            && diagnostic
+                .message
+                .contains("http://127.0.0.1:4318/v1/traces")
+    }));
+    assert!(futures::executor::block_on(initialize_plugins_exact(config)).is_err());
+    assert!(
+        !global_context()
+            .read()
+            .unwrap()
+            .event_subscribers
+            .contains_key("__nemo_relay_plugin__observability__opentelemetry")
+    );
+}
+
+#[test]
+fn opentelemetry_allows_repeated_projection_types_at_the_same_destination() {
+    let config = plugin_config(json!({
+        "opentelemetry": {
+            "enabled": true,
+            "endpoints": [
+                {"type": "full", "endpoint": "http://127.0.0.1:4318/v1/traces"},
+                {"type": "full", "endpoint": "http://127.0.0.1:4318/v1/traces"}
+            ]
+        }
+    }));
+
+    assert!(!validate_plugin_config(&config).has_errors());
 }
 
 #[test]

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -2617,7 +2617,7 @@ fn opentelemetry_endpoints_fan_out_to_heterogeneous_and_repeated_types() {
 }
 
 #[test]
-fn opentelemetry_rejects_different_projection_types_at_the_same_destination() {
+fn opentelemetry_rejects_different_projection_types_at_the_same_effective_destination() {
     let _guard = crate::observability::test_mutex().lock().unwrap();
     reset_runtime();
     let config = plugin_config(json!({
@@ -2625,7 +2625,7 @@ fn opentelemetry_rejects_different_projection_types_at_the_same_destination() {
         "opentelemetry": {
             "enabled": true,
             "endpoints": [
-                {"type": "full", "endpoint": " http://127.0.0.1:4318/v1/traces "},
+                {"type": "full", "endpoint": " http://127.0.0.1:4318 "},
                 {"type": "gen_ai", "endpoint": "http://127.0.0.1:4318/v1/traces"}
             ]
         }

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -69,7 +69,9 @@ Endpoint types can be combined. Repeated endpoint types can use the same
 endpoint and transport. Two different endpoint types must not use the same
 endpoint and transport: Relay
 rejects that configuration because their deterministic trace and span IDs would
-collide at the receiver. All endpoints are constructed before the plugin
+collide at the receiver. For `http_binary`, this comparison uses the effective
+trace destination, so a bare URL and the same URL with `/v1/traces` also
+collide. All endpoints are constructed before the plugin
 registers its fan-out subscriber.
 
 ## Multi-Endpoint Lifecycle

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -55,7 +55,7 @@ service_name = "agent-service"
 
 [[components.config.opentelemetry.endpoints]]
 type = "gen_ai"
-endpoint = "http://localhost:4318/v1/traces"
+endpoint = "http://localhost:4319/v1/traces"
 service_name = "agent-service"
 
 [[components.config.opentelemetry.endpoints]]
@@ -65,8 +65,11 @@ service_name = "agent-service"
 ```
 
 When OpenTelemetry is enabled, `endpoints` must contain at least one entry.
-Endpoint types can be combined or repeated with independent destinations. All
-endpoints are constructed before the plugin registers its fan-out subscriber.
+Endpoint types can be combined or repeated with independent destinations. Two
+different endpoint types must not use the same endpoint and transport: Relay
+rejects that configuration because their deterministic trace and span IDs would
+collide at the receiver. All endpoints are constructed before the plugin
+registers its fan-out subscriber.
 
 ## Multi-Endpoint Lifecycle
 

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -65,8 +65,9 @@ service_name = "agent-service"
 ```
 
 When OpenTelemetry is enabled, `endpoints` must contain at least one entry.
-Endpoint types can be combined or repeated with independent destinations. Two
-different endpoint types must not use the same endpoint and transport: Relay
+Endpoint types can be combined. Repeated endpoint types can use the same
+endpoint and transport. Two different endpoint types must not use the same
+endpoint and transport: Relay
 rejects that configuration because their deterministic trace and span IDs would
 collide at the receiver. All endpoints are constructed before the plugin
 registers its fan-out subscriber.

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -28,7 +28,10 @@ with collector or backend schemas.
 
 NeMo Relay uses OpenTelemetry Rust `0.32`. It deterministically derives
 compliant trace and span IDs from Relay lifecycle UUIDs, so endpoints that
-receive the same event stream use the same identifiers and parentage.
+receive the same event stream use the same identifiers and parentage. Different
+endpoint types must therefore use independent OTLP destinations; configuring
+them with the same endpoint and transport is rejected to prevent identifier
+collisions at the receiver.
 Rooted Relay propagation continues the Relay-derived trace across the import
 boundary. Rootless propagation retains Relay event parentage but starts a new
 OpenTelemetry trace from the first local event. Carry W3C `traceparent` and


### PR DESCRIPTION
#### Overview

Reject unsafe typed OpenTelemetry fan-out configurations that send different projections to the same OTLP destination.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this projects license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Reject different endpoint types that share the same trimmed endpoint and transport during validation and activation.
- Keep repeated endpoint types valid, and prevent policy configuration from suppressing the safety error.
- Update the multi-endpoint example and guidance to require independent destinations for different projections.

Validation: focused Rust regressions, Python, Go, and Node binding suites, docs and link checks, Cargo Clippy, and pre-commit checks. The full Rust suite was stopped after an unrelated native-plugin integration test stalled.

#### Where should the reviewer start?

Start with crates/core/src/observability/plugin_component.rs, which centralizes the destination-collision invariant used by validation and activation. Then review the regression coverage in crates/core/tests/unit/observability/plugin_component_tests.rs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented conflicting telemetry destinations when different endpoint types could produce duplicate trace or span identifiers.
  * Preserved support for repeated destinations using the same endpoint type.

* **Documentation**
  * Clarified endpoint compatibility rules and identifier behavior.
  * Updated the example GenAI endpoint to use port 4319.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->