### PR TITLE
fix(node): isolate subscriber callback failures

### DIFF
--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -103,6 +103,9 @@ the native dispatcher and waits for managed terminal publications registered
 before the call and the JavaScript subscriber callbacks they queue, without
 blocking the Node.js event loop. Native events emitted by a JavaScript subscriber
 are separate publications; flush again if those events must also be observed.
+Subscribers may return Promises. A subscriber throw or rejected Promise is isolated:
+it does not terminate the host or reject `flushSubscribers()`, and Relay reports the
+failure to stderr and through `getLastCallbackError()`.
 
 The main runtime API is exported from `nemo-relay-node`. Additional entry points
 are available at `nemo-relay-node/typed`, `nemo-relay-node/plugin`,

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -103,7 +103,7 @@ the native dispatcher and waits for managed terminal publications registered
 before the call and the JavaScript subscriber callbacks they queue, without
 blocking the Node.js event loop. Native events emitted by a JavaScript subscriber
 are separate publications; flush again if those events must also be observed.
-Subscribers can return `Promise` objects. A subscriber throw or rejected `Promise` is isolated:
+Subscribers can return `Promise` objects. A synchronous throw or a rejected `Promise` from a subscriber is isolated:
 it does not terminate the host or reject `flushSubscribers()`, and Relay reports the
 failure to `stderr` and through `getLastCallbackError()`.
 

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -103,9 +103,9 @@ the native dispatcher and waits for managed terminal publications registered
 before the call and the JavaScript subscriber callbacks they queue, without
 blocking the Node.js event loop. Native events emitted by a JavaScript subscriber
 are separate publications; flush again if those events must also be observed.
-Subscribers can return Promises. A subscriber throw or rejected Promise is isolated:
+Subscribers can return `Promise` objects. A subscriber throw or rejected `Promise` is isolated:
 it does not terminate the host or reject `flushSubscribers()`, and Relay reports the
-failure to stderr and through `getLastCallbackError()`.
+failure to `stderr` and through `getLastCallbackError()`.
 
 The main runtime API is exported from `nemo-relay-node`. Additional entry points
 are available at `nemo-relay-node/typed`, `nemo-relay-node/plugin`,

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -103,7 +103,7 @@ the native dispatcher and waits for managed terminal publications registered
 before the call and the JavaScript subscriber callbacks they queue, without
 blocking the Node.js event loop. Native events emitted by a JavaScript subscriber
 are separate publications; flush again if those events must also be observed.
-Subscribers may return Promises. A subscriber throw or rejected Promise is isolated:
+Subscribers can return Promises. A subscriber throw or rejected Promise is isolated:
 it does not terminate the host or reject `flushSubscribers()`, and Relay reports the
 failure to stderr and through `getLastCallbackError()`.
 

--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -189,8 +189,11 @@ export interface ToolExecutionInterceptOutcome {
 
 /** Component-scoped registration context passed to plugin handlers. */
 export interface PluginContext {
-  /** Register an infallible event subscriber for this component. */
-  registerSubscriber(name: string, callback: (event: Json) => void): void;
+  /**
+   * Register an event subscriber for this component. Callback failures are isolated and reported
+   * through the Node binding's callback-error channel; flushSubscribers waits for returned promises.
+   */
+  registerSubscriber(name: string, callback: (event: Json) => void | Promise<void>): void;
   /** Register a mark event sanitizer for this component. */
   registerMarkSanitizeGuardrail(
     name: string,

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -3303,7 +3303,11 @@ pub fn deregister_llm_stream_execution_intercept(name: String) -> Result<bool> {
 /// isolated, reported to stderr and `getLastCallbackError()`, and do not reject
 /// `flushSubscribers()`. Throws if a subscriber with the same `name` already exists.
 #[napi]
-pub fn register_subscriber(env: Env, name: String, callback: JsFunction) -> Result<()> {
+pub fn register_subscriber(
+    env: Env,
+    name: String,
+    #[napi(ts_arg_type = "(event: Json) => void | Promise<void>")] callback: JsFunction,
+) -> Result<()> {
     let callback = callable::wrap_js_event_subscriber(&env, name.clone(), callback)?;
     core_subscriber_api::register_subscriber(&name, callback).map_err(to_napi_err)
 }
@@ -3942,7 +3946,7 @@ pub fn scope_register_subscriber(
     env: Env,
     scope_uuid: String,
     name: String,
-    callback: JsFunction,
+    #[napi(ts_arg_type = "(event: Json) => void | Promise<void>")] callback: JsFunction,
 ) -> Result<()> {
     let uuid = uuid::Uuid::parse_str(&scope_uuid)
         .map_err(|e| napi::Error::from_reason(format!("invalid UUID: {e}")))?;

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -688,10 +688,9 @@ fn build_plugin_context(
         move |ctx| {
             let name = format!("{}{}", subscriber_namespace, ctx.get::<String>(0)?);
             let callback = ctx.get::<JsFunction>(1)?;
-            let tsfn = json_callback_tsfn(ctx.env, &callback)?;
             core_subscriber_api::register_subscriber(
                 &name,
-                callable::wrap_js_event_subscriber(tsfn),
+                callable::wrap_js_event_subscriber(ctx.env, name.clone(), callback)?,
             )
             .map_err(to_napi_err)?;
 
@@ -3299,16 +3298,14 @@ pub fn deregister_llm_stream_execution_intercept(name: String) -> Result<bool> {
 
 /// Register a named event subscriber that receives all lifecycle events.
 ///
-/// The `callback` receives each event as the canonical JSON event object. Events are
-/// delivered asynchronously and non-blocking. Throws if a subscriber with the same `name`
-/// already exists.
+/// The `callback` receives each event as the canonical JSON event object and may return a
+/// Promise. Events are delivered asynchronously and non-blocking. Callback failures are
+/// isolated, reported to stderr and `getLastCallbackError()`, and do not reject
+/// `flushSubscribers()`. Throws if a subscriber with the same `name` already exists.
 #[napi]
-pub fn register_subscriber(
-    name: String,
-    callback: ThreadsafeFunction<Json, ErrorStrategy::Fatal>,
-) -> Result<()> {
-    core_subscriber_api::register_subscriber(&name, callable::wrap_js_event_subscriber(callback))
-        .map_err(to_napi_err)
+pub fn register_subscriber(env: Env, name: String, callback: JsFunction) -> Result<()> {
+    let callback = callable::wrap_js_event_subscriber(&env, name.clone(), callback)?;
+    core_subscriber_api::register_subscriber(&name, callback).map_err(to_napi_err)
 }
 
 /// Deregister an event subscriber by name.
@@ -3935,23 +3932,22 @@ pub fn scope_deregister_llm_stream_execution_intercept(
 /// Register a scope-local named event subscriber that receives lifecycle events
 /// for the specified scope.
 ///
-/// The `callback` receives each event as the canonical JSON event object. Events are
-/// delivered asynchronously and non-blocking. Throws if a subscriber with the same `name`
-/// already exists on the specified scope.
+/// The `callback` receives each event as the canonical JSON event object and may return a
+/// Promise. Events are delivered asynchronously and non-blocking. Callback failures are
+/// isolated, reported to stderr and `getLastCallbackError()`, and do not reject
+/// `flushSubscribers()`. Throws if a subscriber with the same `name` already exists on the
+/// specified scope.
 #[napi]
 pub fn scope_register_subscriber(
+    env: Env,
     scope_uuid: String,
     name: String,
-    callback: ThreadsafeFunction<Json, ErrorStrategy::Fatal>,
+    callback: JsFunction,
 ) -> Result<()> {
     let uuid = uuid::Uuid::parse_str(&scope_uuid)
         .map_err(|e| napi::Error::from_reason(format!("invalid UUID: {e}")))?;
-    core_subscriber_api::scope_register_subscriber(
-        &uuid,
-        &name,
-        callable::wrap_js_event_subscriber(callback),
-    )
-    .map_err(to_napi_err)
+    let callback = callable::wrap_js_event_subscriber(&env, name.clone(), callback)?;
+    core_subscriber_api::scope_register_subscriber(&uuid, &name, callback).map_err(to_napi_err)
 }
 
 /// Deregister a scope-local event subscriber by name.

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -1237,13 +1237,18 @@ pub fn wrap_js_event_subscriber(
                     .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                     .is_ok()
                 {
-                    complete_js_subscriber_callback(callback_id);
                     if ctx.length > 0 {
-                        let message = ctx.get::<String>(0)?;
-                        record_callback_error(format!(
-                            "nemo_relay: JS event subscriber '{callback_name}' failed: {message}"
-                        ));
+                        match ctx.get::<String>(0) {
+                            Ok(message) => record_callback_error(format!(
+                                "nemo_relay: JS event subscriber '{callback_name}' failed: {message}"
+                            )),
+                            Err(error) => record_callback_error(format!(
+                                "nemo_relay: failed to read JS event subscriber \
+                                 '{callback_name}' failure: {error}"
+                            )),
+                        }
                     }
+                    complete_js_subscriber_callback(callback_id);
                 }
                 ctx.env.get_undefined()
             },
@@ -1278,10 +1283,10 @@ pub fn wrap_js_event_subscriber(
             ThreadsafeFunctionCallMode::NonBlocking,
         );
         if status != napi::Status::Ok {
-            complete_js_subscriber_callback(callback_id);
             record_callback_error(format!(
                 "nemo_relay: failed to queue JS event subscriber '{queue_error_name}' callback: {status:?}"
             ));
+            complete_js_subscriber_callback(callback_id);
         }
     }))
 }

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -12,10 +12,13 @@
 use std::collections::BTreeSet;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
 use napi::bindgen_prelude::ToNapiValue;
-use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use napi::threadsafe_function::{
+    ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
+};
 use napi::{Env, JsFunction, JsObject, JsUnknown, NapiRaw, NapiValue};
 use napi_derive::napi;
 use nemo_relay::api::runtime::{
@@ -1180,37 +1183,107 @@ pub fn wrap_js_finalizer_fn(
     })
 }
 
-/// Wrap a JS function for event subscriber: `(event: JsEvent) => void`.
+struct JsSubscriberCallbackCall {
+    event: Json,
+    callback_id: u64,
+}
+
+fn safe_subscriber_callback(env: &Env, func: &JsFunction) -> napi::Result<JsFunction> {
+    let factory: JsFunction = env.run_script(
+        r#"((fn) => function __nemo_relay_subscriber_wrapper(error, event, complete) {
+  const messageFor = (error) => {
+    try {
+      return String(error?.message ?? error);
+    } catch {
+      return 'JavaScript callback failed';
+    }
+  };
+  if (error != null) {
+    if (typeof complete === 'function') complete(messageFor(error));
+    return;
+  }
+  Promise.resolve()
+    .then(() => fn(event))
+    .then(() => complete(), (error) => complete(messageFor(error)));
+})"#,
+    )?;
+    let func_unknown = unsafe { JsUnknown::from_raw_unchecked(env.raw(), func.raw()) };
+    let wrapper_unknown = factory.call(None, &[func_unknown])?;
+    Ok(unsafe { wrapper_unknown.cast::<JsFunction>() })
+}
+
+/// Wrap a JS function for event subscriber: `(event: JsEvent) => void | Promise<void>`.
 pub fn wrap_js_event_subscriber(
-    func: ThreadsafeFunction<Json, ErrorStrategy::Fatal>,
-) -> EventSubscriberFn {
+    env: &Env,
+    name: String,
+    callback: JsFunction,
+) -> napi::Result<EventSubscriberFn> {
+    let callback = safe_subscriber_callback(env, &callback)?;
+    let queue_error_name = name.clone();
+    let mut func = callback.create_threadsafe_function::<
+        JsSubscriberCallbackCall,
+        JsUnknown,
+        _,
+        ErrorStrategy::CalleeHandled,
+    >(0, move |ctx: ThreadSafeCallContext<JsSubscriberCallbackCall>| {
+        let JsSubscriberCallbackCall { event, callback_id } = ctx.value;
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_callback = Arc::clone(&completed);
+        let callback_name = name.clone();
+        let complete = ctx.env.create_function_from_closure(
+            "__nemo_relay_complete_subscriber_callback",
+            move |ctx| {
+                if completed_callback
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    complete_js_subscriber_callback(callback_id);
+                    if ctx.length > 0 {
+                        let message = ctx.get::<String>(0)?;
+                        record_callback_error(format!(
+                            "nemo_relay: JS event subscriber '{callback_name}' failed: {message}"
+                        ));
+                    }
+                }
+                ctx.env.get_undefined()
+            },
+        )?;
+        let event = unsafe {
+            JsUnknown::from_raw_unchecked(
+                ctx.env.raw(),
+                Json::to_napi_value(ctx.env.raw(), event)?,
+            )
+        };
+        let complete = unsafe { JsUnknown::from_raw_unchecked(ctx.env.raw(), complete.raw()) };
+        Ok(vec![event, complete])
+    })?;
+    func.unref(env)?;
     let func = Arc::new(func);
-    Arc::new(move |event: &Event| {
+    Ok(Arc::new(move |event: &Event| {
         let event_json = match JsEvent::try_from_event(event) {
             Ok(event) => event.into_json(),
             Err(error) => {
                 record_callback_error(format!(
-                    "nemo_relay: failed to serialize JS event subscriber payload: {error}"
+                    "nemo_relay: failed to serialize JS event subscriber '{queue_error_name}' payload: {error}"
                 ));
                 return;
             }
         };
         let callback_id = reserve_js_subscriber_callback();
-        let status = func.call_with_return_value(
-            event_json,
+        let status = func.call(
+            Ok(JsSubscriberCallbackCall {
+                event: event_json,
+                callback_id,
+            }),
             ThreadsafeFunctionCallMode::NonBlocking,
-            move |_value: JsUnknown| {
-                complete_js_subscriber_callback(callback_id);
-                Ok(())
-            },
         );
         if status != napi::Status::Ok {
             complete_js_subscriber_callback(callback_id);
             record_callback_error(format!(
-                "nemo_relay: failed to queue JS event subscriber callback: {status:?}"
+                "nemo_relay: failed to queue JS event subscriber '{queue_error_name}' callback: {status:?}"
             ));
         }
-    })
+    }))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/node/tests/scope_tests.mjs
+++ b/crates/node/tests/scope_tests.mjs
@@ -87,11 +87,16 @@ function runSubscriberFailureChild({ callback, registration = 'global' }) {
       process.exitCode = 1;
     });
   `;
-  const output = execFileSync(process.execPath, ['--eval', script], {
-    cwd: nodeDir,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  let output;
+  try {
+    output = execFileSync(process.execPath, ['--eval', script], {
+      cwd: nodeDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    throw new Error(`subscriber failure child failed (${registration}):\n${error.stdout ?? ''}${error.stderr ?? ''}`);
+  }
   assert.match(output, /subscriber failure isolated/);
 }
 
@@ -448,6 +453,32 @@ describe('Subscribers', () => {
       assert.equal(called, true);
     } finally {
       deregisterSubscriber('node_flush_js_callback');
+    }
+  });
+
+  it('flushSubscribers waits for a fulfilled JavaScript subscriber promise', async () => {
+    let release;
+    let settled = false;
+    let flushed = false;
+    const deferred = new Promise((resolve) => {
+      release = resolve;
+    });
+    registerSubscriber('node_flush_js_promise_callback', async () => {
+      await deferred;
+      settled = true;
+    });
+    try {
+      event('node_flush_js_promise_callback_mark', null, null, null);
+      const flushing = flushSubscribers().then(() => {
+        flushed = true;
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(flushed, false);
+      release();
+      await flushing;
+      assert.equal(settled, true);
+    } finally {
+      deregisterSubscriber('node_flush_js_promise_callback');
     }
   });
 

--- a/crates/node/tests/scope_tests.mjs
+++ b/crates/node/tests/scope_tests.mjs
@@ -3,10 +3,14 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const lib = require('../index.js');
+const nodeDir = fileURLToPath(new URL('..', import.meta.url));
 
 const {
   getHandle,
@@ -24,6 +28,72 @@ const {
 
 const SCOPE_ATTR_PARALLEL = 0b01;
 const SCOPE_ATTR_RELOCATABLE = 0b10;
+
+function runSubscriberFailureChild({ callback, registration = 'global' }) {
+  const register = {
+    global: "registerSubscriber('bad', () => { " + callback + ' });',
+    scope: [
+      "globalThis.scope = pushScope('subscriber_failure_scope', ScopeType.Agent, null, null);",
+      "scopeRegisterSubscriber(scope.uuid, 'bad', () => { " + callback + ' });',
+    ].join('\n'),
+    plugin: [
+      "process.chdir(require('node:os').tmpdir());",
+      'globalThis.plugin = require(' + JSON.stringify(path.join(nodeDir, 'plugin.js')) + ');',
+      "globalThis.pluginKind = 'node.test.subscriber-failure';",
+      'plugin.register(pluginKind, {',
+      '  register(_config, context) {',
+      "    context.registerSubscriber('bad', () => { " + callback + ' });',
+      '  },',
+      '});',
+      "await plugin.initialize({ version: 1, components: [plugin.ComponentSpec('observability', { version: 3 }), plugin.ComponentSpec(pluginKind)] });",
+    ].join('\n'),
+  }[registration];
+  const scopeEvent = registration === 'scope' ? 'scope' : 'null';
+  const cleanup = {
+    global: "deregisterSubscriber('bad');",
+    scope: "scopeDeregisterSubscriber(scope.uuid, 'bad'); popScope(scope);",
+    plugin: 'plugin.clear(); plugin.deregister(pluginKind);',
+  }[registration];
+  const script = `
+    const lib = require(${JSON.stringify(path.join(nodeDir, 'index.js'))});
+    const {
+      ScopeType, clearLastCallbackError, deregisterSubscriber, event, flushSubscribers,
+      getLastCallbackError, pushScope, popScope, registerSubscriber,
+      scopeDeregisterSubscriber, scopeRegisterSubscriber,
+    } = lib;
+    (async () => {
+      clearLastCallbackError();
+      let healthyCalls = 0;
+      registerSubscriber('healthy', (event) => {
+        if (event.name === 'subscriber_failure_mark') healthyCalls += 1;
+      });
+      try {
+        ${register}
+        event('subscriber_failure_mark', ${scopeEvent}, null, null);
+        await flushSubscribers();
+        if (healthyCalls !== 1) throw new Error('healthy subscriber did not receive the event');
+        const error = getLastCallbackError() ?? '';
+        if (!/bad/.test(error) || !/subscriber boom/.test(error)) {
+          throw new Error('missing subscriber error: ' + error);
+        }
+        console.log('subscriber failure isolated');
+      } finally {
+        ${cleanup}
+        deregisterSubscriber('healthy');
+        clearLastCallbackError();
+      }
+    })().catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  `;
+  const output = execFileSync(process.execPath, ['--eval', script], {
+    cwd: nodeDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  assert.match(output, /subscriber failure isolated/);
+}
 
 function rejectWithPrimitive(value) {
   return Promise.reject(value);
@@ -379,6 +449,32 @@ describe('Subscribers', () => {
     } finally {
       deregisterSubscriber('node_flush_js_callback');
     }
+  });
+
+  it('isolates a synchronous global subscriber throw', () => {
+    runSubscriberFailureChild({
+      callback: "throw new Error('sync subscriber boom');",
+    });
+  });
+
+  it('isolates a rejected global subscriber promise', () => {
+    runSubscriberFailureChild({
+      callback: "return Promise.reject(new Error('async subscriber boom'));",
+    });
+  });
+
+  it('uses the safe adapter for scope-local subscribers', () => {
+    runSubscriberFailureChild({
+      registration: 'scope',
+      callback: "throw new Error('scope subscriber boom');",
+    });
+  });
+
+  it('uses the safe adapter for plugin subscribers', () => {
+    runSubscriberFailureChild({
+      registration: 'plugin',
+      callback: "return Promise.reject(new Error('plugin subscriber boom'));",
+    });
   });
 
   it('subscriber event properties', async () => {


### PR DESCRIPTION
#### Overview

Prevent one faulty Node event subscriber from aborting the host process, while preserving asynchronous delivery and adding Promise-aware flushing.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace the fatal N-API subscriber callback path with a CalleeHandled adapter that isolates synchronous throws and rejected Promises.
- Wait for subscriber Promise settlement during `flushSubscribers()`, without rejecting it for an isolated subscriber failure.
- Record the named failure through stderr and `getLastCallbackError()`.
- Cover global, scope-local, and plugin-context subscribers with child-process crash regressions; document the Promise-returning callback contract.

Validation:

- `cargo check -p nemo-relay-node`
- `cargo clippy -p nemo-relay-node --all-targets -- -D warnings`
- `node --test --test-force-exit crates/node/tests/scope_tests.mjs` (32 passing)
- Node public-docstring check
- Commit-time pre-commit checks

#### Where should the reviewer start?

Start with `crates/node/src/callable.rs`, which introduces the subscriber adapter and its completion/error handling. Then review the child-process regressions in `crates/node/tests/scope_tests.mjs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriber callbacks can now be asynchronous and return Promises.
  * `flushSubscribers()` waits for asynchronous callbacks to complete.
  * Callback failures are isolated, reported to stderr, and available through `getLastCallbackError()`.
  * Healthy subscribers continue receiving events when another subscriber throws or rejects.

* **Tests**
  * Added coverage for synchronous and asynchronous subscriber failures across global, scoped, and plugin registrations.

* **Documentation**
  * Updated guidance for asynchronous subscribers and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->