### PR TITLE
fix: reject invalid upstream shared config keys

### DIFF
--- a/crates/cli/src/configuration/mod.rs
+++ b/crates/cli/src/configuration/mod.rs
@@ -65,6 +65,7 @@ struct FileGatewayConfig {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct FileUpstreamConfig {
     openai_base_url: Option<String>,
     openai_auth_header: Option<String>,
@@ -1214,14 +1215,23 @@ pub(crate) fn user_config_dir() -> Option<PathBuf> {
 // Applies the typed TOML config model to the resolved runtime config. Missing sections and fields
 // are ignored, preserving defaults and prior merge layers.
 fn apply_file_config(resolved: &mut ResolvedConfig, value: toml::Value) -> Result<(), CliError> {
-    let config: FileConfig = value.try_into().map_err(|error| {
-        CliError::Config(format!("invalid gateway configuration shape: {error}"))
-    })?;
+    let config = parse_file_config(value)?;
     apply_file_gateway_config(&mut resolved.gateway, config.gateway)?;
     apply_file_upstream_config(&mut resolved.gateway, config.upstream)?;
     apply_file_agents_config(&mut resolved.agents, config.agents);
     logging::apply_file_logging_config(&mut resolved.logging, config.logging)?;
     Ok(())
+}
+
+pub(crate) fn validate_shared_config_shape(value: toml::Value) -> Result<(), CliError> {
+    let _ = parse_file_config(value)?;
+    Ok(())
+}
+
+fn parse_file_config(value: toml::Value) -> Result<FileConfig, CliError> {
+    value
+        .try_into()
+        .map_err(|error| CliError::Config(format!("invalid gateway configuration shape: {error}")))
 }
 
 fn apply_file_gateway_config(

--- a/crates/cli/src/diagnostics/mod.rs
+++ b/crates/cli/src/diagnostics/mod.rs
@@ -274,6 +274,40 @@ fn dynamic_plugin_host_config_check(plugin: &DynamicPluginReferenceInfo) -> Chec
 }
 
 fn layer_status(path: &Path) -> ConfigLayer {
+    let mut layer = toml_layer_status(path);
+    if !matches!(layer.status, Status::Pass) {
+        return layer;
+    }
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) => {
+            layer.status = Status::Fail;
+            layer.active = false;
+            layer.details = format!("unreadable: {err}");
+            return layer;
+        }
+    };
+    let table = match text.parse::<toml::Table>() {
+        Ok(table) => table,
+        Err(err) => {
+            layer.status = Status::Fail;
+            layer.active = false;
+            layer.details = format!("invalid TOML: {err}");
+            return layer;
+        }
+    };
+    match crate::configuration::validate_shared_config_shape(toml::Value::Table(table)) {
+        Ok(()) => layer,
+        Err(err) => ConfigLayer {
+            path: path.to_path_buf(),
+            status: Status::Fail,
+            active: false,
+            details: err.to_string(),
+        },
+    }
+}
+
+fn toml_layer_status(path: &Path) -> ConfigLayer {
     if !path.exists() {
         return ConfigLayer {
             path: path.to_path_buf(),
@@ -323,7 +357,7 @@ fn plugin_layer_status(
     contributing_paths: &[PathBuf],
     plugin_error: Option<&str>,
 ) -> ConfigLayer {
-    let mut layer = layer_status(path);
+    let mut layer = toml_layer_status(path);
     if let Some(error) = plugin_error.filter(|error| error.contains(&path.display().to_string()))
         && matches!(layer.status, Status::Pass)
     {

--- a/crates/cli/tests/coverage/shared/config_tests.rs
+++ b/crates/cli/tests/coverage/shared/config_tests.rs
@@ -3429,6 +3429,38 @@ fn malformed_shared_config_reports_context() {
 
     assert!(error.contains("invalid gateway configuration shape"));
 
+    let invalid_upstream_key = temp.path().join("invalid-upstream-key.toml");
+    std::fs::write(
+        &invalid_upstream_key,
+        "[upstream]\nopenai_baseurl = \"https://example.test/v1\"\n",
+    )
+    .unwrap();
+    let args = GatewayOverrides {
+        config: Some(invalid_upstream_key),
+        ..GatewayOverrides::default()
+    };
+
+    let error = resolve_server_config(&args).unwrap_err().to_string();
+
+    assert!(error.contains("invalid gateway configuration shape"));
+    assert!(error.contains("openai_baseurl"));
+
+    let invalid_nested_upstream = temp.path().join("invalid-nested-upstream.toml");
+    std::fs::write(
+        &invalid_nested_upstream,
+        "[upstream.openai]\nbase_url = \"https://example.test/v1\"\n",
+    )
+    .unwrap();
+    let args = GatewayOverrides {
+        config: Some(invalid_nested_upstream),
+        ..GatewayOverrides::default()
+    };
+
+    let error = resolve_server_config(&args).unwrap_err().to_string();
+
+    assert!(error.contains("invalid gateway configuration shape"));
+    assert!(error.contains("openai"));
+
     let plugin_config = temp.path().join("config-with-invalid-plugins.toml");
     std::fs::write(&plugin_config, "").unwrap();
     std::fs::write(temp.path().join("plugins.toml"), "version = [").unwrap();

--- a/crates/cli/tests/coverage/shared/doctor_tests.rs
+++ b/crates/cli/tests/coverage/shared/doctor_tests.rs
@@ -422,6 +422,7 @@ fn layer_status_reports_missing_valid_invalid_and_non_directory_paths() {
     .unwrap();
     let invalid_shape_layer = layer_status(&invalid_shape);
     assert_eq!(invalid_shape_layer.status, Status::Fail);
+    assert!(!invalid_shape_layer.active);
     assert!(
         invalid_shape_layer
             .details

--- a/crates/cli/tests/coverage/shared/doctor_tests.rs
+++ b/crates/cli/tests/coverage/shared/doctor_tests.rs
@@ -414,6 +414,21 @@ fn layer_status_reports_missing_valid_invalid_and_non_directory_paths() {
     assert_eq!(valid_layer.status, Status::Pass);
     assert!(valid_layer.active);
 
+    let invalid_shape = temp.path().join("invalid-shape.toml");
+    std::fs::write(
+        &invalid_shape,
+        "[upstream.openai]\nbase_url = \"http://local\"\n",
+    )
+    .unwrap();
+    let invalid_shape_layer = layer_status(&invalid_shape);
+    assert_eq!(invalid_shape_layer.status, Status::Fail);
+    assert!(
+        invalid_shape_layer
+            .details
+            .contains("invalid gateway configuration shape")
+    );
+    assert!(invalid_shape_layer.details.contains("openai"));
+
     let invalid = temp.path().join("invalid.toml");
     std::fs::write(&invalid, "[upstream\n").unwrap();
     let invalid_layer = layer_status(&invalid);


### PR DESCRIPTION
#### Overview

Reject typoed or wrongly nested shared `upstream` config keys and make CLI doctor fail those invalid shared-config files.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- reject unknown fields in shared `upstream` config so misspelled keys such as `openai_baseurl` and nested tables such as `[upstream.openai]` fail config resolution instead of being silently ignored
- make CLI doctor fail a shared-config layer when the file is valid TOML but not a valid Relay shared-config shape
- keep `plugins.toml` on the TOML-only validation path so this fix does not change plugin config behavior
- add regression coverage for both shared config resolution and doctor layer status
- validation:
  - `cargo test -p nemo-relay-cli malformed_shared_config_reports_context`
  - `cargo test -p nemo-relay-cli layer_status_reports_missing_valid_invalid_and_non_directory_paths`
  - `cargo test -p nemo-relay-cli plugin_layer_status_marks_a_discovered_plugins_toml_as_contributing`
  - `cargo fmt --all`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `just test-rust`
  - `uv run pre-commit run --files crates/cli/src/configuration/mod.rs crates/cli/src/diagnostics/mod.rs crates/cli/tests/coverage/shared/config_tests.rs crates/cli/tests/coverage/shared/doctor_tests.rs`
  - `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start in `crates/cli/src/configuration/mod.rs` at the shared file-config parsing path, then `crates/cli/src/diagnostics/mod.rs` at `layer_status()`. The new regressions in `crates/cli/tests/coverage/shared/config_tests.rs` and `crates/cli/tests/coverage/shared/doctor_tests.rs` cover the user-visible contract.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration checks now clearly report malformed or incorrectly structured gateway settings.
  - Unknown configuration fields and invalid nested sections are rejected with actionable diagnostics.
  - Diagnostic status accurately marks structurally invalid configuration files as inactive.

- **Tests**
  - Added coverage for misspelled keys, invalid nesting, and malformed gateway configuration shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->