### PR TITLE
fix: expose effective upstream auth presence in CLI diagnostics

### DIFF
--- a/crates/cli/src/diagnostics/mod.rs
+++ b/crates/cli/src/diagnostics/mod.rs
@@ -123,10 +123,10 @@ pub(crate) async fn collect_report(
         configuration: collect_configuration(
             cwd.as_deref(),
             home.as_deref(),
+            &resolved,
             gateway_overrides,
             resolution,
             configured_agents,
-            &resolved.dynamic_plugins,
             &plugin_diagnostics,
         ),
         agents: collect_agents(target_agent, &resolved).await,
@@ -139,10 +139,10 @@ pub(crate) async fn collect_report(
 fn collect_configuration(
     cwd: Option<&Path>,
     home: Option<&Path>,
+    resolved: &ResolvedConfig,
     gateway_overrides: &GatewayOverrides,
     resolution: Check,
     configured_agents: Vec<String>,
-    dynamic_plugins: &[crate::configuration::ResolvedDynamicPluginConfig],
     plugin_diagnostics: &PluginConfigurationDiagnostics,
 ) -> ConfigurationInfo {
     let explicit_config = gateway_overrides.config.is_some();
@@ -171,6 +171,10 @@ fn collect_configuration(
         workspace,
         global,
         system,
+        upstream_auth: UpstreamAuthInfo::from_gateway_headers(
+            resolved.gateway.openai_auth_header.as_deref(),
+            resolved.gateway.anthropic_auth_header.as_deref(),
+        ),
         plugin_configs: diagnostic_plugin_config_paths(
             gateway_overrides.config.as_ref(),
             gateway_overrides.plugin_config_path.as_ref(),
@@ -190,7 +194,8 @@ fn collect_configuration(
         // out of FileConfig. Doctor reports `None` until that lands.
         default_agent: None,
         configured_agents,
-        dynamic_plugins: dynamic_plugins
+        dynamic_plugins: resolved
+            .dynamic_plugins
             .iter()
             .map(|plugin| DynamicPluginReferenceInfo {
                 plugin_id: plugin.plugin_id.clone(),

--- a/crates/cli/src/diagnostics/mod.rs
+++ b/crates/cli/src/diagnostics/mod.rs
@@ -165,16 +165,18 @@ fn collect_configuration(
         layer_status(&global_path)
     };
     let system = layer_status(&system_path);
+    let upstream_auth = if matches!(resolution.status, Status::Fail) {
+        UpstreamAuthInfo::unknown()
+    } else {
+        UpstreamAuthInfo::from_effective_gateway_auth(&resolved.gateway)
+    };
 
     ConfigurationInfo {
         explicit,
         workspace,
         global,
         system,
-        upstream_auth: UpstreamAuthInfo::from_gateway_headers(
-            resolved.gateway.openai_auth_header.as_deref(),
-            resolved.gateway.anthropic_auth_header.as_deref(),
-        ),
+        upstream_auth,
         plugin_configs: diagnostic_plugin_config_paths(
             gateway_overrides.config.as_ref(),
             gateway_overrides.plugin_config_path.as_ref(),

--- a/crates/cli/src/diagnostics/model.rs
+++ b/crates/cli/src/diagnostics/model.rs
@@ -55,12 +55,55 @@ pub(crate) struct ConfigurationInfo {
     pub workspace: ConfigLayer,
     pub global: ConfigLayer,
     pub system: ConfigLayer,
+    pub upstream_auth: UpstreamAuthInfo,
     pub plugin_configs: Vec<ConfigLayer>,
     pub plugin_resolution: Check,
     pub resolution: Check,
     pub default_agent: Option<String>,
     pub configured_agents: Vec<String>,
     pub dynamic_plugins: Vec<DynamicPluginReferenceInfo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct UpstreamAuthInfo {
+    pub openai: SecretPresence,
+    pub anthropic: SecretPresence,
+}
+
+impl UpstreamAuthInfo {
+    pub(crate) fn from_gateway_headers(
+        openai_auth_header: Option<&str>,
+        anthropic_auth_header: Option<&str>,
+    ) -> Self {
+        Self {
+            openai: SecretPresence::from_header(openai_auth_header),
+            anthropic: SecretPresence::from_header(anthropic_auth_header),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SecretPresence {
+    Configured,
+    Unset,
+}
+
+impl SecretPresence {
+    pub(crate) fn from_header(header: Option<&str>) -> Self {
+        if header.is_some() {
+            Self::Configured
+        } else {
+            Self::Unset
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Configured => "configured",
+            Self::Unset => "unset",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/cli/src/diagnostics/model.rs
+++ b/crates/cli/src/diagnostics/model.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::configuration::DynamicPluginHostConfigStatus;
+use crate::configuration::{DynamicPluginHostConfigStatus, GatewayConfig};
 
 /// Outcome of one check inside the doctor report.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -71,13 +71,23 @@ pub(crate) struct UpstreamAuthInfo {
 }
 
 impl UpstreamAuthInfo {
-    pub(crate) fn from_gateway_headers(
-        openai_auth_header: Option<&str>,
-        anthropic_auth_header: Option<&str>,
-    ) -> Self {
+    pub(crate) fn from_effective_gateway_auth(gateway: &GatewayConfig) -> Self {
         Self {
-            openai: SecretPresence::from_header(openai_auth_header),
-            anthropic: SecretPresence::from_header(anthropic_auth_header),
+            openai: SecretPresence::from_effective_provider_auth(
+                gateway.openai_auth_header.as_deref(),
+                "OPENAI_API_KEY",
+            ),
+            anthropic: SecretPresence::from_effective_provider_auth(
+                gateway.anthropic_auth_header.as_deref(),
+                "ANTHROPIC_API_KEY",
+            ),
+        }
+    }
+
+    pub(crate) fn unknown() -> Self {
+        Self {
+            openai: SecretPresence::Unknown,
+            anthropic: SecretPresence::Unknown,
         }
     }
 }
@@ -87,11 +97,15 @@ impl UpstreamAuthInfo {
 pub(crate) enum SecretPresence {
     Configured,
     Unset,
+    Unknown,
 }
 
 impl SecretPresence {
-    pub(crate) fn from_header(header: Option<&str>) -> Self {
-        if header.is_some() {
+    pub(crate) fn from_effective_provider_auth(
+        configured_auth_header: Option<&str>,
+        fallback_env_var: &str,
+    ) -> Self {
+        if configured_auth_header.is_some() || env_var_is_nonempty(fallback_env_var) {
             Self::Configured
         } else {
             Self::Unset
@@ -102,8 +116,16 @@ impl SecretPresence {
         match self {
             Self::Configured => "configured",
             Self::Unset => "unset",
+            Self::Unknown => "unknown",
         }
     }
+}
+
+fn env_var_is_nonempty(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .is_some()
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/cli/src/diagnostics/render.rs
+++ b/crates/cli/src/diagnostics/render.rs
@@ -111,6 +111,11 @@ pub(super) fn format_human_configuration(out: &mut String, report: &DoctorReport
         "    System     {}\n",
         format_layer(&report.configuration.system)
     ));
+    out.push_str(&format!(
+        "    Upstream   openai={} anthropic={}\n",
+        report.configuration.upstream_auth.openai.as_str(),
+        report.configuration.upstream_auth.anthropic.as_str()
+    ));
     if !matches!(report.configuration.resolution.status, Status::Pass) {
         out.push_str(&format!(
             "    Resolution {} {}\n",

--- a/crates/cli/src/process/launcher.rs
+++ b/crates/cli/src/process/launcher.rs
@@ -612,8 +612,16 @@ impl PreparedAgentLaunch {
         println!("gateway_url = {gateway_url}");
         println!("openai_base_url = {}", resolved.gateway.openai_base_url);
         println!(
+            "openai_auth = {}",
+            auth_presence_label(resolved.gateway.openai_auth_header.as_deref())
+        );
+        println!(
             "anthropic_base_url = {}",
             resolved.gateway.anthropic_base_url
+        );
+        println!(
+            "anthropic_auth = {}",
+            auth_presence_label(resolved.gateway.anthropic_auth_header.as_deref())
         );
         println!(
             "max_hook_payload_bytes = {}",
@@ -645,6 +653,14 @@ impl PreparedAgentLaunch {
         for note in &self.notes {
             println!("note = {note}");
         }
+    }
+}
+
+fn auth_presence_label(header: Option<&str>) -> &'static str {
+    if header.is_some() {
+        "configured"
+    } else {
+        "unset"
     }
 }
 

--- a/crates/cli/src/process/launcher.rs
+++ b/crates/cli/src/process/launcher.rs
@@ -19,6 +19,7 @@ use tokio::task::JoinHandle;
 
 use crate::agents::CodingAgent;
 use crate::configuration::{AgentConfigs, GatewayConfig, ResolvedConfig, resolve_run_config};
+use crate::diagnostics::UpstreamAuthInfo;
 use crate::error::CliError;
 use crate::plugins::lifecycle::ActiveDynamicPluginComponent;
 use crate::server;
@@ -608,21 +609,16 @@ impl PreparedAgentLaunch {
     // Prints the resolved transparent-run plan, including dynamic gateway URL, upstream base URLs,
     // argv/env injection, and any agent-specific notes or temporary files.
     fn print(&self, agent: CodingAgent, gateway_url: &str, resolved: &ResolvedConfig) {
+        let upstream_auth = UpstreamAuthInfo::from_effective_gateway_auth(&resolved.gateway);
         println!("agent = {}", agent.as_arg());
         println!("gateway_url = {gateway_url}");
         println!("openai_base_url = {}", resolved.gateway.openai_base_url);
-        println!(
-            "openai_auth = {}",
-            auth_presence_label(resolved.gateway.openai_auth_header.as_deref())
-        );
+        println!("openai_auth = {}", upstream_auth.openai.as_str());
         println!(
             "anthropic_base_url = {}",
             resolved.gateway.anthropic_base_url
         );
-        println!(
-            "anthropic_auth = {}",
-            auth_presence_label(resolved.gateway.anthropic_auth_header.as_deref())
-        );
+        println!("anthropic_auth = {}", upstream_auth.anthropic.as_str());
         println!(
             "max_hook_payload_bytes = {}",
             resolved.gateway.max_hook_payload_bytes
@@ -653,14 +649,6 @@ impl PreparedAgentLaunch {
         for note in &self.notes {
             println!("note = {note}");
         }
-    }
-}
-
-fn auth_presence_label(header: Option<&str>) -> &'static str {
-    if header.is_some() {
-        "configured"
-    } else {
-        "unset"
     }
 }
 

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -3305,6 +3305,44 @@ fn cli_doctor_reports_the_nearest_ancestor_workspace_config() {
 }
 
 #[test]
+fn cli_doctor_json_reports_effective_upstream_auth_presence() {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().join("workspace");
+    let nested = project.join("nested");
+    let project_config = project.join(".nemo-relay/config.toml");
+    std::fs::create_dir_all(project_config.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::write(
+        &project_config,
+        r#"
+[upstream]
+openai_base_url = "http://project-openai"
+openai_auth_header = "Bearer project-openai"
+anthropic_base_url = "http://project-anthropic"
+anthropic_auth_header = "Basic project-anthropic"
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(gateway_bin())
+        .current_dir(&nested)
+        .env("XDG_CONFIG_HOME", temp.path().join("xdg"))
+        .env("HOME", temp.path())
+        .env("NEMO_RELAY_OPENAI_BASE_URL", "http://env-openai")
+        .args(["doctor", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["configuration"]["upstream_auth"]["openai"], "unset");
+    assert_eq!(
+        report["configuration"]["upstream_auth"]["anthropic"],
+        "configured"
+    );
+}
+
+#[test]
 fn cli_doctor_explicit_config_reports_invalid_layered_workspace_config() {
     let temp = tempfile::tempdir().unwrap();
     let xdg = temp.path().join("xdg");
@@ -3650,6 +3688,41 @@ mode = "append"
     assert!(stdout.contains("argv = codex"));
     let expected_atof_path = std::path::Path::new("logs").join("events.jsonl");
     assert!(stdout.contains(&format!("ATOF {}", expected_atof_path.display())));
+}
+
+#[test]
+fn cli_run_dry_run_reports_effective_upstream_auth_presence() {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().join("project");
+    let nested = project.join("nested");
+    std::fs::create_dir_all(project.join(".nemo-relay")).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::write(
+        project.join(".nemo-relay/config.toml"),
+        r#"
+[upstream]
+openai_base_url = "http://project-openai"
+openai_auth_header = "Bearer project-openai"
+anthropic_base_url = "http://project-anthropic"
+anthropic_auth_header = "Basic project-anthropic"
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(gateway_bin())
+        .current_dir(&nested)
+        .env("XDG_CONFIG_HOME", temp.path().join("xdg"))
+        .env("HOME", temp.path())
+        .env("NEMO_RELAY_OPENAI_BASE_URL", "http://env-openai")
+        .args(["run", "--agent", "codex", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("openai_base_url = http://env-openai"));
+    assert!(stdout.contains("openai_auth = unset"));
+    assert!(stdout.contains("anthropic_auth = configured"));
 }
 
 #[test]

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -3334,11 +3334,47 @@ anthropic_auth_header = "Basic project-anthropic"
         .unwrap();
 
     assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Bearer project-openai"));
+    assert!(!stdout.contains("Basic project-anthropic"));
     let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(report["configuration"]["upstream_auth"]["openai"], "unset");
     assert_eq!(
         report["configuration"]["upstream_auth"]["anthropic"],
         "configured"
+    );
+}
+
+#[test]
+fn cli_doctor_json_reports_unknown_upstream_auth_when_resolution_fails() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("config.toml");
+    std::fs::write(
+        &config,
+        "[upstream]\nopenai_auth_header = \"\"\"\\\nBearer private\nsecret\"\"\"\n",
+    )
+    .unwrap();
+
+    let output = Command::new(gateway_bin())
+        .env("OPENAI_API_KEY", "sk-runtime")
+        .args(["--config", config.to_str().unwrap(), "doctor", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Bearer private"));
+    assert!(!stdout.contains("secret"));
+    assert!(!stdout.contains("sk-runtime"));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["configuration"]["resolution"]["status"], "fail");
+    assert_eq!(
+        report["configuration"]["upstream_auth"]["openai"],
+        "unknown"
+    );
+    assert_eq!(
+        report["configuration"]["upstream_auth"]["anthropic"],
+        "unknown"
     );
 }
 
@@ -3720,6 +3756,8 @@ anthropic_auth_header = "Basic project-anthropic"
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Bearer project-openai"));
+    assert!(!stdout.contains("Basic project-anthropic"));
     assert!(stdout.contains("openai_base_url = http://env-openai"));
     assert!(stdout.contains("openai_auth = unset"));
     assert!(stdout.contains("anthropic_auth = configured"));

--- a/crates/cli/tests/coverage/shared/doctor_tests.rs
+++ b/crates/cli/tests/coverage/shared/doctor_tests.rs
@@ -7,7 +7,7 @@ use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use crate::configuration::ResolvedDynamicPluginConfig;
+use crate::configuration::{GatewayConfig, ResolvedConfig, ResolvedDynamicPluginConfig};
 use crate::server::GatewayOverrides;
 use crate::test_support::{EnvScope, accept_bounded, read_headers};
 
@@ -74,6 +74,10 @@ fn empty_report() -> DoctorReport {
                 status: Status::Info,
                 active: false,
                 details: "not present".into(),
+            },
+            upstream_auth: UpstreamAuthInfo {
+                openai: SecretPresence::Unset,
+                anthropic: SecretPresence::Unset,
             },
             plugin_configs: vec![],
             plugin_resolution: Check {
@@ -248,6 +252,19 @@ fn format_human_distinguishes_plugin_files_from_plugin_resolution() {
 
     assert!(rendered.contains("Plugin files /tmp/plugins.toml"));
     assert!(rendered.contains("Plugins    · plugins.toml not configured"));
+}
+
+#[test]
+fn format_human_reports_effective_upstream_auth_presence() {
+    let mut report = empty_report();
+    report.configuration.upstream_auth = UpstreamAuthInfo {
+        openai: SecretPresence::Configured,
+        anthropic: SecretPresence::Unset,
+    };
+
+    let rendered = format_human(&report);
+
+    assert!(rendered.contains("Upstream   openai=configured anthropic=unset"));
 }
 
 #[test]
@@ -567,6 +584,7 @@ fn collect_configuration_uses_xdg_global_path_and_renders_resolution_branches() 
     let configuration = collect_configuration(
         Some(&workspace),
         Some(&home),
+        &ResolvedConfig::default(),
         &GatewayOverrides::default(),
         Check {
             name: "Resolution",
@@ -574,7 +592,6 @@ fn collect_configuration_uses_xdg_global_path_and_renders_resolution_branches() 
             details: "using fallback layer".into(),
         },
         vec!["codex".into(), "hermes".into()],
-        &[],
         &PluginConfigurationDiagnostics {
             sources: vec![],
             error: None,
@@ -590,6 +607,8 @@ fn collect_configuration_uses_xdg_global_path_and_renders_resolution_branches() 
     assert!(configuration.workspace.active);
     assert_eq!(configuration.global.path, global_config);
     assert_eq!(configuration.global.status, Status::Fail);
+    assert_eq!(configuration.upstream_auth.openai, SecretPresence::Unset);
+    assert_eq!(configuration.upstream_auth.anthropic, SecretPresence::Unset);
     assert!(configuration.global.details.contains("invalid TOML"));
 
     let mut report = empty_report();
@@ -842,6 +861,14 @@ fn configuration_and_path_helpers_cover_direct_paths_and_fallbacks() {
     let info = collect_configuration(
         Some(&workspace),
         Some(&home),
+        &ResolvedConfig {
+            gateway: GatewayConfig {
+                openai_auth_header: Some("Bearer openai".into()),
+                anthropic_auth_header: None,
+                ..GatewayConfig::default()
+            },
+            ..ResolvedConfig::default()
+        },
         &GatewayOverrides::default(),
         Check {
             name: "Resolution",
@@ -849,7 +876,6 @@ fn configuration_and_path_helpers_cover_direct_paths_and_fallbacks() {
             details: "valid".into(),
         },
         vec!["codex".into()],
-        &[],
         &PluginConfigurationDiagnostics {
             sources: vec![],
             error: None,
@@ -863,6 +889,8 @@ fn configuration_and_path_helpers_cover_direct_paths_and_fallbacks() {
     assert_eq!(info.workspace.status, Status::Pass);
     assert!(info.global.path.starts_with(&home));
     assert_eq!(info.configured_agents, vec!["codex".to_string()]);
+    assert_eq!(info.upstream_auth.openai, SecretPresence::Configured);
+    assert_eq!(info.upstream_auth.anthropic, SecretPresence::Unset);
 
     assert_eq!(
         crate::process::resolve_executable("definitely-missing"),

--- a/crates/cli/tests/coverage/shared/doctor_tests.rs
+++ b/crates/cli/tests/coverage/shared/doctor_tests.rs
@@ -268,6 +268,16 @@ fn format_human_reports_effective_upstream_auth_presence() {
 }
 
 #[test]
+fn format_human_reports_unknown_upstream_auth_presence() {
+    let mut report = empty_report();
+    report.configuration.upstream_auth = UpstreamAuthInfo::unknown();
+
+    let rendered = format_human(&report);
+
+    assert!(rendered.contains("Upstream   openai=unknown anthropic=unknown"));
+}
+
+#[test]
 fn format_human_reports_all_checks_passed_on_clean_report() {
     let report = empty_report();
     let rendered = format_human(&report);
@@ -908,6 +918,48 @@ fn configuration_and_path_helpers_cover_direct_paths_and_fallbacks() {
         crate::process::resolve_executable(binary.to_str().unwrap()).as_deref(),
         Some(binary.as_path())
     );
+}
+
+#[test]
+fn upstream_auth_info_reports_openai_env_fallback_as_configured() {
+    let _env = EnvScope::set(&[
+        ("OPENAI_API_KEY", Some(std::ffi::OsStr::new("sk-openai"))),
+        ("ANTHROPIC_API_KEY", None),
+    ]);
+
+    let info = UpstreamAuthInfo::from_effective_gateway_auth(&GatewayConfig::default());
+
+    assert_eq!(info.openai, SecretPresence::Configured);
+    assert_eq!(info.anthropic, SecretPresence::Unset);
+}
+
+#[test]
+fn upstream_auth_info_reports_anthropic_env_fallback_as_configured() {
+    let _env = EnvScope::set(&[
+        ("OPENAI_API_KEY", None),
+        (
+            "ANTHROPIC_API_KEY",
+            Some(std::ffi::OsStr::new("sk-anthropic")),
+        ),
+    ]);
+
+    let info = UpstreamAuthInfo::from_effective_gateway_auth(&GatewayConfig::default());
+
+    assert_eq!(info.openai, SecretPresence::Unset);
+    assert_eq!(info.anthropic, SecretPresence::Configured);
+}
+
+#[test]
+fn upstream_auth_info_treats_whitespace_env_values_as_unset() {
+    let _env = EnvScope::set(&[
+        ("OPENAI_API_KEY", Some(std::ffi::OsStr::new("   "))),
+        ("ANTHROPIC_API_KEY", Some(std::ffi::OsStr::new("\t  "))),
+    ]);
+
+    let info = UpstreamAuthInfo::from_effective_gateway_auth(&GatewayConfig::default());
+
+    assert_eq!(info.openai, SecretPresence::Unset);
+    assert_eq!(info.anthropic, SecretPresence::Unset);
 }
 
 #[test]


### PR DESCRIPTION
#### Overview

Expose effective upstream auth presence in CLI diagnostics without leaking secrets.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- add a redacted effective upstream auth signal for OpenAI and Anthropic in `doctor --json`, human `doctor` output, and `run --dry-run`
- derive effective auth presence from either configured auth headers or the runtime's supported environment fallback paths
- report `unknown` instead of misleading `unset` when configuration resolution fails before effective auth can be determined
- keep precedence cases visible, including when a higher-precedence endpoint override clears inherited auth
- add focused regression coverage for env-only auth, unresolved-config reporting, whitespace-only env values, and secret redaction in CLI output

#### Where should the reviewer start?

Start in `crates/cli/src/diagnostics/model.rs` and `crates/cli/src/diagnostics/mod.rs` for the effective auth-state model and collection logic, then `crates/cli/src/process/launcher.rs` for the `run --dry-run` rendering. The most relevant end-to-end coverage is in `crates/cli/tests/cli_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration diagnostics now show whether OpenAI and Anthropic authentication is configured, unset, or unknown.
  * Authentication status reflects configured gateway credentials and valid environment-variable fallbacks.
  * Dry-run output includes authentication status without revealing credential values.
* **Bug Fixes**
  * Corrected diagnostics when configuration resolution fails by reporting authentication as unknown.
  * Whitespace-only environment values are no longer treated as configured credentials.
* **Tests**
  * Added coverage for JSON, human-readable, and dry-run authentication diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->