### PR TITLE
fix: report logging config errors in doctor

### DIFF
--- a/crates/cli/src/commands/diagnostics.rs
+++ b/crates/cli/src/commands/diagnostics.rs
@@ -32,6 +32,7 @@ pub(crate) struct AgentsCommand {
 pub(super) async fn execute(
     command: DoctorCommand,
     server: &super::serve::ServerArgs,
+    logging_fallback_error: Option<&CliError>,
 ) -> Result<ExitCode, CliError> {
     if let Some(plugin) = command.plugin {
         return execute_plugin_doctor(plugin, command.install_dir, command.json);
@@ -41,6 +42,7 @@ pub(super) async fn execute(
         command.agent.map(Into::into),
         command.json,
         &gateway_overrides,
+        logging_fallback_error,
     )
     .await
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -55,7 +55,13 @@ pub(crate) async fn run(bootstrap_shutdown_token: Option<String>) -> ExitCode {
 // top-level server flags so transparent launch can share config parsing with daemon startup.
 fn configure_logging(
     cli: &Cli,
-) -> Result<Option<nemo_relay::logging::LoggingRuntime>, error::CliError> {
+) -> Result<
+    (
+        Option<nemo_relay::logging::LoggingRuntime>,
+        Option<error::CliError>,
+    ),
+    error::CliError,
+> {
     let initialize = match cli.command.as_ref() {
         Some(command) => !command.skips_logging(),
         None => {
@@ -64,7 +70,7 @@ fn configure_logging(
         }
     };
     if !initialize {
-        return Ok(None);
+        return Ok((None, None));
     }
 
     let user_only = matches!(cli.command.as_ref(), Some(Command::Mcp));
@@ -85,7 +91,7 @@ fn configure_logging(
         Err(error) => return Err(error),
     };
     let runtime = nemo_relay::logging::LoggingRuntime::configure(config)?;
-    if let Some(error) = fallback_error {
+    if let Some(error) = fallback_error.as_ref() {
         log::warn!(
             target: "nemo_relay.cli",
             event = "doctor_logging_fallback",
@@ -93,7 +99,7 @@ fn configure_logging(
             "Doctor fell back to default logging after resolution failure"
         );
     }
-    Ok(Some(runtime))
+    Ok((Some(runtime), fallback_error))
 }
 
 async fn dispatch(bootstrap_shutdown_token: Option<String>) -> Result<ExitCode, error::CliError> {
@@ -104,7 +110,7 @@ async fn dispatch(bootstrap_shutdown_token: Option<String>) -> Result<ExitCode, 
         .map(Command::log_name)
         .unwrap_or("default");
 
-    let _logging = configure_logging(&cli)?;
+    let (_logging, logging_fallback_error) = configure_logging(&cli)?;
 
     log::info!(
         target: "nemo_relay.cli",
@@ -114,7 +120,7 @@ async fn dispatch(bootstrap_shutdown_token: Option<String>) -> Result<ExitCode, 
     );
 
     let result = match cli.command {
-        Some(command) => run_command(command, &cli.server).await,
+        Some(command) => run_command(command, &cli.server, logging_fallback_error.as_ref()).await,
         None => run_default(&cli.server, bootstrap_shutdown_token).await,
     };
     match &result {
@@ -150,7 +156,11 @@ async fn dispatch(bootstrap_shutdown_token: Option<String>) -> Result<ExitCode, 
     result
 }
 
-async fn run_command(command: Command, server: &ServerArgs) -> Result<ExitCode, error::CliError> {
+async fn run_command(
+    command: Command,
+    server: &ServerArgs,
+    logging_fallback_error: Option<&error::CliError>,
+) -> Result<ExitCode, error::CliError> {
     match command {
         Command::HookForward(command) => {
             hook_forward::execute(command).await?;
@@ -166,7 +176,9 @@ async fn run_command(command: Command, server: &ServerArgs) -> Result<ExitCode, 
         Command::Config(command) => configure::execute(command, server).await,
         Command::Plugins(command) => plugins::execute(command, server),
         Command::ModelPricing(command) => model_pricing::execute(command),
-        Command::Doctor(command) => diagnostics::execute(command, server).await,
+        Command::Doctor(command) => {
+            diagnostics::execute(command, server, logging_fallback_error).await
+        }
         Command::Agents(command) => runtime_diagnostics::run_agents(command.json).await,
         Command::Completions(command) => completions::execute(command),
     }
@@ -218,7 +230,7 @@ async fn run_default(
         .await?;
         Ok(ExitCode::SUCCESS)
     } else if runtime_configuration::any_config_file_exists() {
-        runtime_diagnostics::run_doctor(None, false, &runtime_args).await
+        runtime_diagnostics::run_doctor(None, false, &runtime_args, None).await
     } else {
         configure::run(None, None).await?;
         Ok(ExitCode::SUCCESS)

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -53,15 +53,12 @@ pub(crate) async fn run(bootstrap_shutdown_token: Option<String>) -> ExitCode {
 
 // Dispatches CLI subcommands while keeping the no-subcommand path as server mode. `run` inherits
 // top-level server flags so transparent launch can share config parsing with daemon startup.
-fn configure_logging(
-    cli: &Cli,
-) -> Result<
-    (
-        Option<nemo_relay::logging::LoggingRuntime>,
-        Option<error::CliError>,
-    ),
-    error::CliError,
-> {
+struct LoggingSetup {
+    _runtime: Option<nemo_relay::logging::LoggingRuntime>,
+    fallback_error: Option<error::CliError>,
+}
+
+fn configure_logging(cli: &Cli) -> Result<LoggingSetup, error::CliError> {
     let initialize = match cli.command.as_ref() {
         Some(command) => !command.skips_logging(),
         None => {
@@ -70,7 +67,10 @@ fn configure_logging(
         }
     };
     if !initialize {
-        return Ok((None, None));
+        return Ok(LoggingSetup {
+            _runtime: None,
+            fallback_error: None,
+        });
     }
 
     let user_only = matches!(cli.command.as_ref(), Some(Command::Mcp));
@@ -99,7 +99,10 @@ fn configure_logging(
             "Doctor fell back to default logging after resolution failure"
         );
     }
-    Ok((Some(runtime), fallback_error))
+    Ok(LoggingSetup {
+        _runtime: Some(runtime),
+        fallback_error,
+    })
 }
 
 async fn dispatch(bootstrap_shutdown_token: Option<String>) -> Result<ExitCode, error::CliError> {
@@ -110,7 +113,7 @@ async fn dispatch(bootstrap_shutdown_token: Option<String>) -> Result<ExitCode, 
         .map(Command::log_name)
         .unwrap_or("default");
 
-    let (_logging, logging_fallback_error) = configure_logging(&cli)?;
+    let logging = configure_logging(&cli)?;
 
     log::info!(
         target: "nemo_relay.cli",
@@ -120,7 +123,7 @@ async fn dispatch(bootstrap_shutdown_token: Option<String>) -> Result<ExitCode, 
     );
 
     let result = match cli.command {
-        Some(command) => run_command(command, &cli.server, logging_fallback_error.as_ref()).await,
+        Some(command) => run_command(command, &cli.server, logging.fallback_error.as_ref()).await,
         None => run_default(&cli.server, bootstrap_shutdown_token).await,
     };
     match &result {

--- a/crates/cli/src/diagnostics/mod.rs
+++ b/crates/cli/src/diagnostics/mod.rs
@@ -1368,8 +1368,24 @@ pub(crate) async fn run_doctor(
     target_agent: Option<CodingAgent>,
     json: bool,
     gateway_overrides: &GatewayOverrides,
+    logging_fallback_error: Option<&CliError>,
 ) -> Result<std::process::ExitCode, CliError> {
-    let report = collect_report(target_agent, gateway_overrides).await?;
+    let mut report = collect_report(target_agent, gateway_overrides).await?;
+    if let Some(error) = logging_fallback_error {
+        let logging_details = format!(
+            "could not resolve logging configuration: {error}; repair or recreate the named logging configuration file"
+        );
+        if report.configuration.resolution.status == Status::Pass {
+            report.configuration.resolution.status = Status::Fail;
+            report.configuration.resolution.details = logging_details;
+        } else {
+            report
+                .configuration
+                .resolution
+                .details
+                .push_str(&format!("; additionally, {logging_details}"));
+        }
+    }
     log::info!(
         target: "nemo_relay.diagnostics",
         event = "diagnostics_completed",

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -3267,6 +3267,128 @@ fn cli_doctor_json_reports_a_missing_explicit_config() {
 }
 
 #[test]
+fn cli_doctor_reports_a_missing_explicit_logging_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let xdg = temp.path().join("xdg");
+    let cwd = temp.path().join("workdir");
+    let config = temp.path().join("missing/logging.toml");
+    std::fs::create_dir_all(&xdg).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let output = Command::new(gateway_bin())
+        .current_dir(&cwd)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env("HOME", temp.path())
+        .args(["--log-config-path"])
+        .arg(&config)
+        .arg("doctor")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Configuration"));
+    assert!(stdout.contains("Resolution"));
+    assert!(stdout.contains("could not resolve logging configuration"));
+    assert!(stdout.contains(config.to_str().unwrap()));
+    assert!(stdout.contains("Agents detected"));
+    assert!(stdout.contains("Some checks FAILED"));
+}
+
+#[test]
+fn cli_doctor_json_reports_a_missing_explicit_logging_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let xdg = temp.path().join("xdg");
+    let cwd = temp.path().join("workdir");
+    let config = temp.path().join("missing/logging.toml");
+    std::fs::create_dir_all(&xdg).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let output = Command::new(gateway_bin())
+        .current_dir(&cwd)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env("HOME", temp.path())
+        .args(["--log-config-path"])
+        .arg(&config)
+        .args(["doctor", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let resolution = &report["configuration"]["resolution"];
+    assert_eq!(resolution["status"], "fail");
+    assert!(
+        resolution["details"]
+            .as_str()
+            .unwrap()
+            .contains(config.to_str().unwrap())
+    );
+}
+
+#[test]
+fn cli_doctor_reports_invalid_explicit_logging_config_paths() {
+    let temp = tempfile::tempdir().unwrap();
+    let xdg = temp.path().join("xdg");
+    let cwd = temp.path().join("workdir");
+    std::fs::create_dir_all(&xdg).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    for (path, expected) in [
+        (PathBuf::from("logging.toml"), "must be absolute"),
+        (
+            temp.path().join("logging.json"),
+            "must identify a .toml file",
+        ),
+    ] {
+        let output = Command::new(gateway_bin())
+            .current_dir(&cwd)
+            .env("XDG_CONFIG_HOME", &xdg)
+            .env("HOME", temp.path())
+            .args(["--log-config-path"])
+            .arg(&path)
+            .args(["doctor", "--json"])
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success(), "path: {}", path.display());
+        let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let resolution = &report["configuration"]["resolution"];
+        assert_eq!(resolution["status"], "fail");
+        assert!(
+            resolution["details"].as_str().unwrap().contains(expected),
+            "path: {}, details: {}",
+            path.display(),
+            resolution["details"]
+        );
+    }
+}
+
+#[test]
+fn cli_doctor_accepts_a_valid_explicit_logging_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let xdg = temp.path().join("xdg");
+    let cwd = temp.path().join("workdir");
+    std::fs::create_dir_all(&xdg).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+    let (config, _log_path) = write_jsonl_logging_config(temp.path());
+
+    let output = Command::new(gateway_bin())
+        .current_dir(&cwd)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env("HOME", temp.path())
+        .args(["--log-config-path"])
+        .arg(&config)
+        .args(["doctor", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["configuration"]["resolution"]["status"], "pass");
+}
+
+#[test]
 fn cli_doctor_reports_the_nearest_ancestor_workspace_config() {
     let temp = tempfile::tempdir().unwrap();
     let project = temp.path().join("workspace");

--- a/crates/cli/tests/coverage/commands/main_tests.rs
+++ b/crates/cli/tests/coverage/commands/main_tests.rs
@@ -501,7 +501,7 @@ async fn run_command_dispatches_safe_plugin_and_install_paths() {
     ])
     .unwrap();
     assert_eq!(
-        run_command(cli.command.unwrap(), &cli.server)
+        run_command(cli.command.unwrap(), &cli.server, None)
             .await
             .unwrap(),
         ExitCode::SUCCESS
@@ -517,7 +517,7 @@ async fn run_command_dispatches_safe_plugin_and_install_paths() {
     ])
     .unwrap();
     assert_eq!(
-        run_command(cli.command.unwrap(), &cli.server)
+        run_command(cli.command.unwrap(), &cli.server, None)
             .await
             .unwrap(),
         ExitCode::SUCCESS


### PR DESCRIPTION
#### Overview

Report explicit logging configuration failures through `nemo-relay doctor` instead of silently falling back and reporting that all checks passed.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Preserve the logging resolution error when doctor falls back to default logging.
- Add the error to the existing Configuration `Resolution` check for both human and JSON output.
- Continue the remaining diagnostics while returning a failing process exit code.
- Cover missing, invalid, and valid explicit logging configuration paths.

Validation:

- Manual missing-file smoke: failed Resolution reported, remaining diagnostics completed, exit code 1.
- `cargo test -p nemo-relay-cli --test cli_tests cli_doctor_ -- --nocapture`: 12 passed.
- `cargo test -p nemo-relay-cli --lib run_command_dispatches_safe_plugin_and_install_paths -- --nocapture`: 1 passed.
- Commit hooks: formatting, Clippy, Cargo check, and applicable repository checks passed.
- `just test-all`: Rust stopped with 1068 passed and 86 unrelated failures beginning in existing core tests that use unsupported observability config version 1; push proceeded with an explicit waiver.

#### Where should the reviewer start?

Start with `crates/cli/src/diagnostics/mod.rs`, where the preserved logging error is merged into the existing configuration resolution result, then review the CLI regression cases in `crates/cli/tests/cli_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-634](https://linear.app/nvidia/issue/RELAY-634/nemo-relay070doctor-reports-all-checks-passed-for-an-unreadable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Doctor diagnostics for logging configuration issues.
  * Reports missing or invalid configuration files, including relative paths and unsupported formats.
  * Continues with default logging while preserving configuration errors in the diagnostic report.
  * Provides consistent results in human-readable and JSON output.

* **Tests**
  * Added coverage for valid and invalid logging configurations, including JSONL files, missing files, invalid paths, and path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->