### PR TITLE
fix: skip disabled plugin configuration layers

### DIFF
--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -1715,7 +1715,12 @@ fn resolve_default_file_plugin_config() -> Result<DiscoveredPluginConfig> {
 
 struct DiscoveredPluginConfig {
     value: Json,
-    enabled_sources: HashMap<String, PathBuf>,
+    enabled_sources: HashMap<String, ComponentEnabledSource>,
+}
+
+struct ComponentEnabledSource {
+    enabled: bool,
+    path: PathBuf,
 }
 
 use std::path::{Path, PathBuf};
@@ -1751,7 +1756,9 @@ where
     Ok(documents)
 }
 
-fn component_enabled_sources(documents: &[(PathBuf, Json)]) -> HashMap<String, PathBuf> {
+fn component_enabled_sources(
+    documents: &[(PathBuf, Json)],
+) -> HashMap<String, ComponentEnabledSource> {
     let mut sources = HashMap::new();
     for (path, document) in documents {
         let Some(components) = document.get("components").and_then(Json::as_array) else {
@@ -1761,8 +1768,14 @@ fn component_enabled_sources(documents: &[(PathBuf, Json)]) -> HashMap<String, P
             let Some(kind) = component_kind(component) else {
                 continue;
             };
-            if component.get("enabled").and_then(Json::as_bool).is_some() {
-                sources.insert(kind.to_string(), path.clone());
+            if let Some(enabled) = component.get("enabled").and_then(Json::as_bool) {
+                sources.insert(
+                    kind.to_string(),
+                    ComponentEnabledSource {
+                        enabled,
+                        path: path.clone(),
+                    },
+                );
             }
         }
     }
@@ -1771,7 +1784,7 @@ fn component_enabled_sources(documents: &[(PathBuf, Json)]) -> HashMap<String, P
 
 fn programmatic_enable_override_diagnostics(
     discovered: &Json,
-    enabled_sources: &HashMap<String, PathBuf>,
+    enabled_sources: &HashMap<String, ComponentEnabledSource>,
     programmatic: &PluginConfig,
 ) -> Vec<ConfigDiagnostic> {
     let Some(discovered_components) = discovered.get("components").and_then(Json::as_array) else {
@@ -1785,18 +1798,21 @@ fn programmatic_enable_override_diagnostics(
             nth_component_by_kind(discovered_components, &component.kind, *nth)
                 .and_then(|index| discovered_components.get(index));
         *nth += 1;
-        if !component.enabled
-            || discovered_component
-                .and_then(|component| component.get("enabled"))
-                .and_then(Json::as_bool)
-                != Some(false)
-        {
+        let discovered_enabled = discovered_component
+            .and_then(|component| component.get("enabled"))
+            .and_then(Json::as_bool);
+        let file_disabled = discovered_enabled == Some(false)
+            || (discovered_enabled.is_none()
+                && enabled_sources
+                    .get(&component.kind)
+                    .is_some_and(|source| !source.enabled));
+        if !component.enabled || !file_disabled {
             continue;
         }
 
         let source = enabled_sources
             .get(&component.kind)
-            .map(|path| format!(" from {}", path.display()))
+            .map(|source| format!(" from {}", source.path.display()))
             .unwrap_or_default();
         diagnostics.push(ConfigDiagnostic {
             level: DiagnosticLevel::Warning,
@@ -1842,13 +1858,23 @@ where
 {
     let mut merged = Json::Object(Map::new());
     let mut sources = Vec::new();
-    for (path, document) in documents {
+    for (path, mut document) in documents {
         validate_plugin_config_version(&path, &document)?;
         validate_unique_component_kinds(&path, &document)?;
+
+        filter_disabled_plugin_components(&mut document);
         layer_config(&mut merged, document);
         sources.push(path);
     }
     Ok((!sources.is_empty()).then_some((merged, sources)))
+}
+
+/// Removes disabled components from one discovered plugin document before layering.
+fn filter_disabled_plugin_components(document: &mut Json) {
+    let Some(components) = document.get_mut("components").and_then(Json::as_array_mut) else {
+        return;
+    };
+    components.retain(|component| component.get("enabled").and_then(Json::as_bool) != Some(false));
 }
 
 /// Rejects a file with an unsupported top-level plugin config version before layering can

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -2259,8 +2259,8 @@ fn test_load_plugin_config_files_merges_files_by_precedence() {
     assert_eq!(observability["kind"], json!("observability"));
     assert_eq!(
         observability["enabled"],
-        json!(false),
-        "the system layer wins shared scalar fields"
+        json!(true),
+        "a disabled system component does not override lower layers"
     );
     assert_eq!(
         observability["config"]["output_directory"],
@@ -2269,13 +2269,13 @@ fn test_load_plugin_config_files_merges_files_by_precedence() {
     );
     assert_eq!(
         observability["config"]["mode"],
-        json!("system"),
-        "the system layer wins recursively merged config fields"
+        json!("project"),
+        "a disabled system component does not contribute configuration"
     );
     assert_eq!(
         observability["config"]["values"],
-        json!(["system", "project", "lower"]),
-        "list entries aggregate from highest to lowest precedence"
+        json!(["project", "lower"]),
+        "a disabled system component does not contribute list entries"
     );
     assert_eq!(
         components[1]["kind"],
@@ -2287,6 +2287,34 @@ fn test_load_plugin_config_files_merges_files_by_precedence() {
         json!("system_only"),
         "a system-only component kind is appended"
     );
+}
+
+#[test]
+fn test_load_plugin_config_files_omits_components_disabled_in_every_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let lower = dir.path().join("lower.toml");
+    let higher = dir.path().join("higher.toml");
+    std::fs::write(
+        &lower,
+        "[[components]]\n\
+         kind = \"observability\"\n\
+         enabled = false\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &higher,
+        "[[components]]\n\
+         kind = \"observability\"\n\
+         enabled = false\n",
+    )
+    .unwrap();
+
+    let (merged, sources) = load_plugin_config_files([lower.clone(), higher.clone()])
+        .unwrap()
+        .expect("the files exist");
+
+    assert_eq!(sources, vec![lower, higher]);
+    assert_eq!(merged["components"], json!([]));
 }
 
 #[test]
@@ -2470,7 +2498,13 @@ fn test_programmatic_enable_override_diagnostic_matches_positionally_and_names_s
             { "kind": "observability", "enabled": false }
         ]
     });
-    let enabled_sources = HashMap::from([("observability".to_string(), source.clone())]);
+    let enabled_sources = HashMap::from([(
+        "observability".to_string(),
+        ComponentEnabledSource {
+            enabled: false,
+            path: source.clone(),
+        },
+    )]);
     let programmatic = PluginConfig {
         components: vec![
             PluginComponentSpec::new("observability"),
@@ -2492,6 +2526,39 @@ fn test_programmatic_enable_override_diagnostic_matches_positionally_and_names_s
         diagnostic.message.contains(&source.display().to_string()),
         "{}",
         diagnostic.message
+    );
+}
+
+#[test]
+fn test_programmatic_reenable_diagnostic_survives_disabled_component_normalization() {
+    let source = PathBuf::from("/etc/nemo-relay/plugins.toml");
+    let documents = vec![(
+        source.clone(),
+        json!({
+            "components": [{ "kind": "observability", "enabled": false }]
+        }),
+    )];
+    let enabled_sources = component_enabled_sources(&documents);
+    let (discovered, _) = merge_plugin_config_documents(documents)
+        .unwrap()
+        .expect("the file-backed configuration exists");
+    assert_eq!(discovered["components"], json!([]));
+
+    let diagnostics = programmatic_enable_override_diagnostics(
+        &discovered,
+        &enabled_sources,
+        &PluginConfig {
+            components: vec![PluginComponentSpec::new("observability")],
+            ..PluginConfig::default()
+        },
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, "plugin.component_reenabled");
+    assert!(
+        diagnostics[0]
+            .message
+            .contains(&source.display().to_string())
     );
 }
 

--- a/docs/configure-plugins/plugin-configuration-files.mdx
+++ b/docs/configure-plugins/plugin-configuration-files.mdx
@@ -319,10 +319,16 @@ The effective Agent Trajectory Observability Format (ATOF) configuration keeps
 `version` and `enabled` from the user file. Its `sinks` list contains the system
 sink first, followed by the user sink.
 
-The top-level `components` array is special. Relay matches components by `kind`
-across files. A higher-precedence component with the same `kind` merges into the
-lower-precedence component. Relay adds a component with a different `kind` to
-the effective configuration.
+The top-level `components` array is special. Relay matches enabled components
+by `kind` across files. A higher-precedence component with the same `kind`
+merges into the lower-precedence component. Relay adds a component with a
+different `kind` to the effective configuration.
+
+A component entry that explicitly sets `enabled = false` is skipped before
+matching and merging. It does not change a lower-precedence component's enabled
+state or contribute any `config` fields or list entries. If every layer for a
+component kind sets `enabled = false`, that kind is absent from the effective
+configuration.
 
 This behavior applies to list fields declared at the top level of a component's
 `config`. It also applies to the observability destination lists


### PR DESCRIPTION
#### Overview

Disabled plugin component entries no longer contribute configuration during layered resolution, while programmatic re-enablement remains visible in diagnostics.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Ignore component entries that explicitly set `enabled = false` when merging plugin configuration layers, including the first file-backed layer.
- Retain disabled-state metadata so a programmatic re-enable still emits `plugin.component_reenabled`.
- Add regression coverage for lower-priority configuration, all-disabled inputs, and the diagnostic fallback.
- Document that disabled component entries neither override lower layers nor contribute configuration.

#### Where should the reviewer start?

`crates/core/src/plugin.rs`, specifically `merge_plugin_config_documents`, `component_enabled_sources`, and `programmatic_enable_override_diagnostics`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes: RELAY-633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled plugin components are now excluded from configuration layering and cannot contribute settings or override enabled components.
  * Diagnostics identify the configuration source when programmatic settings re-enable a component disabled in a configuration file.
  * Components disabled across all configuration layers are omitted from the merged configuration.

* **Documentation**
  * Clarified how enabled and disabled plugin components are matched and merged across configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->