### PR TITLE
docs: align Node README install version

### DIFF
--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -61,7 +61,7 @@ The Node.js package provides the following capabilities:
 Install the npm package in a Node.js 24 or newer project:
 
 ```bash
-npm install nemo-relay-node@0.7.0
+npm install nemo-relay-node@0.8.0
 ```
 
 ## Getting Started


### PR DESCRIPTION
#### Overview

Update the Node.js package README so its install command matches the `0.8.0` package metadata and the current installation docs.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Change the `nemo-relay-node` install example from `0.7.0` to `0.8.0`.
- Keep the README shipped with the Node.js package consistent with the root README and getting-started docs.
- Validation: `uv run pre-commit run --files crates/node/README.md` and `uv run pre-commit run --all-files`.

#### Where should the reviewer start?

Start with the installation command in `crates/node/README.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented npm installation command to reference version 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->