### PR TITLE
test: stabilize terminal job-control coverage

### DIFF
--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -4077,8 +4077,9 @@ try:
     read_until("RELAY_SHELL> ")
     assert os.tcgetpgrp(master) == pid, (os.tcgetpgrp(master), pid, buffer)
 
-    os.write(master, b"bg\n")
-    read_until("RELAY_SHELL> ")
+    # Continue Relay's stopped shell job directly. Shell `bg` bookkeeping varies across the
+    # macOS runner shell, but Relay only observes the process-group SIGCONT.
+    os.killpg(relay_group, signal.SIGCONT)
     time.sleep(0.1)
     assert os.tcgetpgrp(master) == pid, (os.tcgetpgrp(master), pid, buffer)
     os.write(master, b"echo BG_SHELL_OK\n")
@@ -4099,8 +4100,7 @@ try:
     read_until("AGENT_DELAY_ARMED")
     os.write(master, b"\x1a")
     read_until("RELAY_SHELL> ")
-    os.write(master, b"bg\n")
-    read_until("RELAY_SHELL> ")
+    os.killpg(relay_group, signal.SIGCONT)
     wait_until_present("AGENT_BG_DELAY")
     assert os.tcgetpgrp(master) == pid, (os.tcgetpgrp(master), pid, buffer)
     os.write(master, b"fg\n")


### PR DESCRIPTION
#### Overview

Stabilize the macOS PTY job-control regression test by making its background-resume transition deterministic.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

The test previously issued the interactive shell `bg` command and waited for its prompt. On macOS CI, shell job bookkeeping could re-stop the job before the fake agent's `SIGCONT` handler ran, causing a timeout. The PTY driver now sends `SIGCONT` directly to Relay's stopped shell process group, which is the transition Relay must handle, while retaining the terminal ownership and foreground-handoff assertions.

#### Where should the reviewer start?

`crates/cli/tests/cli_tests.rs`, in `cli_transparent_run_preserves_interactive_terminal_job_control`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix terminal tests for resuming stopped Relay processes, providing more reliable validation of process continuation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->