### PR TITLE
docs: deprecate Switchyard plugin

### DIFF
--- a/crates/switchyard/README.md
+++ b/crates/switchyard/README.md
@@ -20,8 +20,8 @@ Decision API. It adds routing-aware LLM execution intercepts to the Relay
 runtime while preserving Relay ownership of provider credentials, target
 bindings, dispatch, retries, fallbacks, and observability.
 
-NeMo Relay 0.6.0 uses a separately running Switchyard Decision API from the
-`topic/nemo-relay-integration` branch.
+NeMo Relay 0.6.0 and 0.7.0 use a separately running Switchyard Decision API
+from the `topic/nemo-relay-integration` branch.
 
 Install it from crates.io, or build it from the NeMo Relay source checkout with
 the optional CLI feature while the Switchyard Decision API contract and

--- a/crates/switchyard/README.md
+++ b/crates/switchyard/README.md
@@ -9,6 +9,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # NeMo Relay Switchyard Plugin
 
+> **Deprecated:** The experimental `nemo-relay-switchyard` plugin will be
+> removed in NeMo Relay 0.8 and replaced by a Switchyard-owned native plugin.
+> The NeMo Relay 0.8 documentation will include an updated configuration guide
+> and migration plan when the replacement is available.
+
 `nemo-relay-switchyard` is NeMo Relay's experimental integration
 with the [NVIDIA NeMo Switchyard](https://github.com/NVIDIA-NeMo/Switchyard)
 Decision API. It adds routing-aware LLM execution intercepts to the Relay

--- a/docs/configure-plugins/about.mdx
+++ b/docs/configure-plugins/about.mdx
@@ -33,9 +33,10 @@ entries in `plugins.toml`.
   Guardrails-backed policy checks.
 - [PII Redaction](/configure-plugins/pii-redaction/about) sanitizes sensitive
   data in observability payloads.
-- [Switchyard (Experimental)](/configure-plugins/switchyard/about) routes
-  requests using decisions from a separately running Switchyard Decision API
-  service.
+- [Switchyard (Deprecated)](/configure-plugins/switchyard/about) routes requests
+  using decisions from a separately running Switchyard Decision API service.
+  The experimental plugin will be removed in NeMo Relay 0.8 and replaced by a
+  Switchyard-owned native plugin.
 - [Model Pricing](/configure-plugins/model-pricing) configures catalog sources
   for cost estimates on managed LLM responses.
 

--- a/docs/configure-plugins/switchyard/about.mdx
+++ b/docs/configure-plugins/switchyard/about.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Switchyard (Deprecated)"
 sidebar-title: "Switchyard (Deprecated)"
-description: "Set up and validate the deprecated Switchyard Decision API integration for NeMo Relay 0.6.0."
+description: "Set up and validate the deprecated Switchyard Decision API integration for NeMo Relay 0.6.0 and 0.7.0."
 position: 5
 ---
 import { MermaidStyles } from "@/components/MermaidStyles";
@@ -9,19 +9,21 @@ import { MermaidStyles } from "@/components/MermaidStyles";
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-> **Deprecated:** The experimental `nemo-relay-switchyard` plugin will be
-> removed in NeMo Relay 0.8 and replaced by a Switchyard-owned native plugin.
-> Continue using this page for the existing integration. The NeMo Relay 0.8
-> documentation will include an updated configuration guide and migration plan
-> when the replacement is available.
+<Warning title="Deprecated">
+The experimental `nemo-relay-switchyard` plugin will be removed in NeMo Relay
+0.8 and replaced by a Switchyard-owned native plugin. Continue using this page
+for the existing integration. The NeMo Relay 0.8 documentation will include an
+updated configuration guide and migration plan when the replacement is
+available.
+</Warning>
 
 > **Experimental:** The Switchyard integration is an early-access feature. It
 > is not enabled in default Relay builds, its configuration and contracts can
 > change, and the current deployment requires a separately running Switchyard
 > Decision API service.
 
-> **NeMo Relay 0.6.0 architecture:** This release uses the external Switchyard
-> Decision API from the
+> **NeMo Relay 0.6.0 and 0.7.0 architecture:** These releases use the external
+> Switchyard Decision API from the
 > [`topic/nemo-relay-integration`](https://github.com/NVIDIA-NeMo/Switchyard/tree/topic/nemo-relay-integration)
 > branch.
 
@@ -33,7 +35,7 @@ and a complex prompt to a more capable model.
 
 ## Architecture
 
-The following diagram shows the NeMo Relay 0.6.0 service boundary:
+The following diagram shows the NeMo Relay 0.6.0 and 0.7.0 service boundary:
 
 <MermaidStyles />
 
@@ -71,7 +73,7 @@ Install the following prerequisites before you start:
 
 | Requirement | Version or Value |
 | --- | --- |
-| NeMo Relay | Tag `0.6.0` |
+| NeMo Relay | Tags `0.6.0` and `0.7.0` |
 | Rust | `1.96.1` |
 | Switchyard branch | `topic/nemo-relay-integration` |
 | Switchyard commit | `8f9db9a6a47f848cdff1d262276ba25a8ae9cbc8` |

--- a/docs/configure-plugins/switchyard/about.mdx
+++ b/docs/configure-plugins/switchyard/about.mdx
@@ -1,13 +1,19 @@
 ---
-title: "Switchyard (Experimental)"
-sidebar-title: "Switchyard (Experimental)"
-description: "Set up and validate the experimental Switchyard Decision API integration for NeMo Relay 0.6.0."
+title: "Switchyard (Deprecated)"
+sidebar-title: "Switchyard (Deprecated)"
+description: "Set up and validate the deprecated Switchyard Decision API integration for NeMo Relay 0.6.0."
 position: 5
 ---
 import { MermaidStyles } from "@/components/MermaidStyles";
 
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
+
+> **Deprecated:** The experimental `nemo-relay-switchyard` plugin will be
+> removed in NeMo Relay 0.8 and replaced by a Switchyard-owned native plugin.
+> Continue using this page for the existing integration. The NeMo Relay 0.8
+> documentation will include an updated configuration guide and migration plan
+> when the replacement is available.
 
 > **Experimental:** The Switchyard integration is an early-access feature. It
 > is not enabled in default Relay builds, its configuration and contracts can

--- a/docs/configure-plugins/switchyard/configuration.mdx
+++ b/docs/configure-plugins/switchyard/configuration.mdx
@@ -1,11 +1,16 @@
 ---
 title: "Switchyard Configuration"
 sidebar-title: "Configuration"
-description: "Configure the experimental Relay-native Switchyard Decision API plugin."
+description: "Configure the deprecated Relay-native Switchyard Decision API plugin."
 position: 2
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
+
+> **Deprecated:** The experimental `nemo-relay-switchyard` plugin will be
+> removed in NeMo Relay 0.8 and replaced by a Switchyard-owned native plugin.
+> The NeMo Relay 0.8 documentation will include an updated configuration guide
+> and migration plan when the replacement is available.
 
 > **Experimental NeMo Relay 0.6.0 integration:** This release calls a separately
 > running Switchyard Decision API.

--- a/docs/configure-plugins/switchyard/configuration.mdx
+++ b/docs/configure-plugins/switchyard/configuration.mdx
@@ -7,16 +7,18 @@ position: 2
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-> **Deprecated:** The experimental `nemo-relay-switchyard` plugin will be
-> removed in NeMo Relay 0.8 and replaced by a Switchyard-owned native plugin.
-> The NeMo Relay 0.8 documentation will include an updated configuration guide
-> and migration plan when the replacement is available.
+<Warning title="Deprecated">
+The experimental `nemo-relay-switchyard` plugin will be removed in NeMo Relay
+0.8 and replaced by a Switchyard-owned native plugin. The NeMo Relay 0.8
+documentation will include an updated configuration guide and migration plan
+when the replacement is available.
+</Warning>
 
-> **Experimental NeMo Relay 0.6.0 integration:** This release calls a separately
-> running Switchyard Decision API.
+> **Experimental NeMo Relay 0.6.0 and 0.7.0 integration:** These releases call a
+> separately running Switchyard Decision API.
 
 Start with the
-[Switchyard 0.6.0 setup and validation guide](./about.mdx)
+[Switchyard setup and validation guide](./about.mdx)
 before using this page as the complete configuration reference.
 
 The Switchyard component connects Relay's CLI gateway to a separately running

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -41,7 +41,7 @@ navigation:
         title: "PII Redaction"
         title-source: frontmatter
       - folder: ./configure-plugins/switchyard
-        title: "Switchyard (Experimental)"
+        title: "Switchyard (Deprecated)"
         title-source: frontmatter
       - page: "Model Pricing"
         path: ./configure-plugins/model-pricing.mdx

--- a/examples/switchyard/README.md
+++ b/examples/switchyard/README.md
@@ -5,6 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 
 # Switchyard Integration Examples
 
+> **Deprecated:** These examples exercise the experimental
+> `nemo-relay-switchyard` plugin, which will be removed in NeMo Relay 0.8 and
+> replaced by a Switchyard-owned native plugin. The NeMo Relay 0.8 documentation
+> will include updated examples and a migration plan when the replacement is
+> available.
+
 These examples exercise the experimental NeMo Relay 0.6.0 integration with a separately running
 Switchyard Decision API service and the in-process Switchyard translation library. They are
 manual, local validation workflows rather than production startup orchestration.

--- a/examples/switchyard/README.md
+++ b/examples/switchyard/README.md
@@ -11,9 +11,10 @@ SPDX-License-Identifier: Apache-2.0
 > will include updated examples and a migration plan when the replacement is
 > available.
 
-These examples exercise the experimental NeMo Relay 0.6.0 integration with a separately running
-Switchyard Decision API service and the in-process Switchyard translation library. They are
-manual, local validation workflows rather than production startup orchestration.
+These examples exercise the experimental NeMo Relay 0.6.0 and 0.7.0 integration with a
+separately running Switchyard Decision API service and the in-process Switchyard translation
+library. They are manual, local validation workflows rather than production startup
+orchestration.
 
 For the canonical architecture, setup, configuration, validation, and troubleshooting workflow,
 refer to the
@@ -21,7 +22,7 @@ refer to the
 
 ## Required Switchyard Revision
 
-The NeMo Relay 0.6.0 scripts require the following public topic branch and commit:
+The scripts for NeMo Relay 0.6.0 and 0.7.0 require the following public topic branch and commit:
 
 ```text
 https://github.com/NVIDIA-NeMo/Switchyard/tree/topic/nemo-relay-integration


### PR DESCRIPTION
#### Overview

Deprecates the experimental `nemo-relay-switchyard` plugin ahead of its removal in NeMo Relay 0.8 and replacement by a Switchyard-owned native plugin. Clarifies that the existing integration is supported by NeMo Relay 0.6.0 and 0.7.0.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Mark the Switchyard docs landing page and navigation entry as deprecated.
- Render the deprecation message as a native warning callout on the MDX documentation pages.
- Add removal and replacement notices to the configuration guide, crate README, and example README.
- Document support for the existing integration in NeMo Relay 0.6.0 and 0.7.0 across the landing page, architecture description, prerequisite table, configuration guide, crate README, and examples.
- Tell readers that the NeMo Relay 0.8 documentation will provide updated configuration guidance and a migration plan when the replacement is available.
- Keep the notice independent of any specific upstream pull request or provisional migration commands.

Validation:

- Targeted pre-commit checks passed for all six changed files, including YAML validation and docs link checking.
- `git diff --check` passed.
- The repository-wide pre-commit run completed all applicable formatting, lint, type, Cargo, Go, Node, attribution, and docs-link checks successfully. The generated Python worker-protocol check could not run because `just` is not installed.
- `just docs` could not run because `just` is not installed in the environment.

#### Where should the reviewer start?

Start with `docs/configure-plugins/switchyard/about.mdx`, which contains the canonical deprecation warning and the supported-version language reused by the other entry points.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked the Switchyard integration as deprecated across guides, navigation, and examples.
  * Documented compatibility with NeMo Relay 0.6.0 and 0.7.0.
  * Added notice that the integration will be removed in Relay 0.8 and replaced by a native Switchyard plugin.
  * Updated setup guidance and example instructions for supported Relay versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->