### PR TITLE
docs: clarify ATOF and ATIF subscriber roles

### DIFF
--- a/docs/about-nemo-relay/concepts/subscribers.mdx
+++ b/docs/about-nemo-relay/concepts/subscribers.mdx
@@ -71,18 +71,20 @@ source of truth.
 
 ATOF and ATIF describe different stages of the observability path:
 
-| Format | What it represents | What subscribers or exporters do with it |
+| Format | What It Represents | What Subscribers or Exporters Do With It |
 | --- | --- | --- |
 | ATOF | The canonical record for each Relay scope lifecycle event or mark | Subscribers receive these events directly. The ATOF JSONL exporter writes one raw event per line. |
 | ATIF | A trajectory projection assembled from related ATOF events | The ATIF exporter maps model and tool activity into trajectory steps for analysis, replay, or evaluation. |
 
-Marks are point-in-time ATOF events, not ATIF trajectory steps, so they do not
-appear in ATIF `steps`. ATIF is designed primarily for evaluation and
+Marks are point-in-time ATOF events, not ATIF trajectory steps, so ATIF `steps`
+are not a lossless event log. ATIF is designed primarily for evaluation and
 visualization. Its steps do not represent the complete parent-child graph needed
 for perfect session replay. This limitation comes from the ATIF data model, not
-from converting ATOF events. Plugin-managed ATIF files preserve the raw events
-associated with the trajectory under `extra.observed_events`; this retains the
-observed marks without changing the ATIF step model. Refer to
+from converting ATOF events. Plugin-managed ATIF files preserve nested scope
+lineage and the raw events associated with the trajectory under
+`extra.observed_events`, including observed marks, for analysis and debugging.
+Those fields do not change the ATIF step model or make `steps` a complete replay
+log. Refer to
 [Agent Trajectory Interchange Format (ATIF)](/configure-plugins/observability/atif)
 for the complete projection and file contract.
 

--- a/docs/about-nemo-relay/concepts/subscribers.mdx
+++ b/docs/about-nemo-relay/concepts/subscribers.mdx
@@ -73,7 +73,7 @@ ATOF and ATIF describe different stages of the observability path:
 
 | Format | What It Represents | What Subscribers or Exporters Do With It |
 | --- | --- | --- |
-| ATOF | The canonical record for each Relay scope lifecycle event or mark | Subscribers receive these events directly. The ATOF JSONL exporter writes one raw event per line. |
+| ATOF | The canonical raw scope, tool, LLM, middleware, and mark event stream | Subscribers receive these events directly. The ATOF JSONL exporter writes one raw event per line. |
 | ATIF | A trajectory projection assembled from related ATOF events | The ATIF exporter maps model and tool activity into trajectory steps for analysis, replay, or evaluation. |
 
 Marks are point-in-time ATOF events, not ATIF trajectory steps, so ATIF `steps`
@@ -103,8 +103,8 @@ debugging logic.
 For host integrations that need a serialized event payload, use the event
 object's JSON serialization helpers instead of reconstructing payloads from
 native attributes. Python subscribers can call `event.to_dict()` or
-`event.to_json()` from the callback while still using the normal subscriber
-registration API.
+`event.to_json()` from the callback, while continuing to use the normal
+subscriber registration API.
 
 This pattern is useful when an agent runtime, framework adapter, or plugin host
 already has its own lifecycle hooks but wants NeMo Relay to be the shared

--- a/docs/about-nemo-relay/concepts/subscribers.mdx
+++ b/docs/about-nemo-relay/concepts/subscribers.mdx
@@ -15,7 +15,7 @@ execution.
 
 Subscribers are consumers of the NeMo Relay event stream. They receive emitted
 lifecycle events and use them for observation, forwarding, export, or analysis.
-On native Rust, Python, Node.js, and FFI surfaces, event-producing calls enqueue
+In the native Rust, Python, Node.js, and FFI bindings, event-producing calls enqueue
 subscriber delivery on a process-wide background dispatcher and return without
 waiting for subscriber callbacks or exporter work.
 
@@ -31,10 +31,10 @@ defined by its API. On native targets, these are separate milestones.
 
 That separation matters:
 
-- The runtime can emit one canonical event stream
-- Native event calls stay non-blocking for subscriber work
-- Many subscribers can consume that same stream
-- Observability behavior stays downstream from execution semantics
+- The runtime can emit one ATOF event stream.
+- Native event calls stay non-blocking for subscriber work.
+- Many subscribers can consume the same stream.
+- Observability behavior stays separate from call execution.
 
 ## Registration Levels
 
@@ -61,8 +61,8 @@ components.
 
 ## What Subscribers Consume
 
-Subscribers consume the canonical event stream. They do not define the event
-model. They react to it.
+Subscribers consume the ATOF event stream. They do not define the event model.
+They react to it.
 
 This lets plain subscribers, exporters, and tracing adapters share one runtime
 source of truth.
@@ -77,7 +77,10 @@ ATOF and ATIF describe different stages of the observability path:
 | ATIF | A trajectory projection assembled from related ATOF events | The ATIF exporter maps model and tool activity into trajectory steps for analysis, replay, or evaluation. |
 
 Marks are point-in-time ATOF events, not ATIF trajectory steps, so they do not
-appear in ATIF `steps`. Plugin-managed ATIF files preserve the raw events
+appear in ATIF `steps`. ATIF is designed primarily for evaluation and
+visualization. Its steps do not represent the complete parent-child graph needed
+for perfect session replay. This limitation comes from the ATIF data model, not
+from converting ATOF events. Plugin-managed ATIF files preserve the raw events
 associated with the trajectory under `extra.observed_events`; this retains the
 observed marks without changing the ATIF step model. Refer to
 [Agent Trajectory Interchange Format (ATIF)](/configure-plugins/observability/atif)
@@ -96,16 +99,17 @@ debugging logic.
 #### Host Integration Event JSON
 
 For host integrations that need a serialized event payload, use the event
-object's canonical JSON helpers instead of reconstructing payloads from native
-attributes. Python subscribers can call `event.to_dict()` or `event.to_json()`
-from the callback while still using the normal subscriber registration API.
+object's JSON serialization helpers instead of reconstructing payloads from
+native attributes. Python subscribers can call `event.to_dict()` or
+`event.to_json()` from the callback while still using the normal subscriber
+registration API.
 
 This pattern is useful when an agent runtime, framework adapter, or plugin host
 already has its own lifecycle hooks but wants NeMo Relay to be the shared
-telemetry representation. The host integration maps those hooks into NeMo Relay
-scopes, LLM calls, tool calls, or marks. NeMo Relay emits the canonical ATOF event
+ATOF event representation. The host integration maps those hooks into NeMo
+Relay scopes, LLM calls, tool calls, or marks. NeMo Relay emits the ATOF event
 stream, and each subscriber chooses whether to consume the native event object,
-the canonical JSON helper, or an exporter-specific translation.
+serialized event JSON, or an exporter-specific translation.
 
 <MermaidStyles />
 
@@ -137,11 +141,10 @@ flowchart
     Json -. host consumes canonical telemetry .-> Host
 ```
 
-The important boundary is that subscribers do not define the event schema. They
-receive the runtime event and can serialize it through the binding helper when
-they need a stable JSON payload. Exporter subscribers, such as the ATOF JSONL
-exporter, consume the same event stream and serialize the same canonical event
-shape for their target backend.
+Subscribers do not define the event schema. They receive the runtime event and
+can serialize it through a binding helper when they need JSON. Exporter
+subscribers, such as the ATOF JSONL exporter, consume the same event stream and
+serialize it for their target backend.
 
 Native subscribers are invoked by one process-wide worker thread in FIFO event
 order and subscriber snapshot order.
@@ -242,7 +245,7 @@ backends. Each subscriber uses one `full`, `gen_ai`, or `openinference`
 projection. Select `openinference` for model-centric OpenInference semantics;
 there is no separate OpenInference subscriber.
 
-Detailed setup, configuration, and API shape for this subscriber belongs in
+Detailed setup, configuration, and API behavior for this subscriber belongs in
 [Observability](/configure-plugins/observability/about).
 For configuration-driven setup, use the built-in
 [`observability` plugin](/configure-plugins/observability/configuration)
@@ -259,7 +262,7 @@ Use these practices when applying the concept in application or integration code
 - Use the exporter's documented barrier before inspecting exporter output.
 - Clear plugin-managed exporters during graceful shutdown.
 - Use `event.to_dict()` or `event.to_json()` when a host runtime or exporter
-  needs the canonical event JSON shape in-process.
+  needs the ATOF event as JSON in process.
 - Use a scope-local subscriber when the observation should disappear with the
   owning scope.
 - Use a plugin-installed subscriber when the behavior should be reusable and

--- a/docs/about-nemo-relay/concepts/subscribers.mdx
+++ b/docs/about-nemo-relay/concepts/subscribers.mdx
@@ -67,6 +67,22 @@ model. They react to it.
 This lets plain subscribers, exporters, and tracing adapters share one runtime
 source of truth.
 
+### ATOF Events and ATIF Trajectories
+
+ATOF and ATIF describe different stages of the observability path:
+
+| Format | What it represents | What subscribers or exporters do with it |
+| --- | --- | --- |
+| ATOF | The canonical record for each Relay scope lifecycle event or mark | Subscribers receive these events directly. The ATOF JSONL exporter writes one raw event per line. |
+| ATIF | A trajectory projection assembled from related ATOF events | The ATIF exporter maps model and tool activity into trajectory steps for analysis, replay, or evaluation. |
+
+Marks are point-in-time ATOF events, not ATIF trajectory steps, so they do not
+appear in ATIF `steps`. Plugin-managed ATIF files preserve the raw events
+associated with the trajectory under `extra.observed_events`; this retains the
+observed marks without changing the ATIF step model. Refer to
+[Agent Trajectory Interchange Format (ATIF)](/configure-plugins/observability/atif)
+for the complete projection and file contract.
+
 ## Common Subscriber Roles
 
 Subscribers are commonly used for in-process observation, counters, debugging, and


### PR DESCRIPTION
#### Overview

Clarifies the boundary between canonical ATOF events and projected ATIF trajectories.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Compares what ATOF and ATIF represent and how subscribers consume them.
- Explains why marks are omitted from ATIF `steps`.
- Documents where plugin-managed ATIF files retain the raw observed events.
- Leaves the existing subscriber delivery milestones unchanged.

#### Where should the reviewer start?

Review `ATOF Events and ATIF Trajectories` in `docs/about-nemo-relay/concepts/subscribers.mdx`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes [RELAY-623](https://linear.app/nvidia/issue/RELAY-623/clarify-atof-versus-atif-in-subscriber-guidance)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that ATOF event streams are the source for subscribers.
  * Explained the relationship between ATOF and ATIF representations, including exporter behavior.
  * Documented raw-event retention in ATIF metadata.
  * Updated host integration guidance with native events, serialized JSON, and exporter translations.
  * Simplified subscriber boundary and OpenTelemetry terminology.
  * Added practical JSON guidance that explicitly references ATOF events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->