### PR TITLE
feat: record provider request and response sizes

### DIFF
--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -182,6 +182,7 @@ async fn run_unmanaged_gateway(
     let status = response.status();
     let headers = response_headers(response.headers());
     let bytes = response.bytes().await?;
+    emit_provider_body_size("gateway.provider.response", bytes.len());
     build_response(status, headers, Body::from(bytes))
 }
 
@@ -368,6 +369,7 @@ fn build_buffered_func(
                     );
                 }
             };
+            emit_provider_body_size("gateway.provider.response", bytes.len());
             if !status.is_success() {
                 if retry_aware {
                     return Err(FlowError::Upstream(http_failure(
@@ -563,6 +565,7 @@ fn build_streaming_func(
                         );
                     }
                 };
+                emit_provider_body_size("gateway.provider.response", bytes.len());
                 if retry_aware {
                     return Err(FlowError::Upstream(http_failure(
                         status,
@@ -593,13 +596,16 @@ fn sse_json_stream(response: reqwest::Response) -> LlmJsonStream {
     let mut decoder = SseEventDecoder::new();
     let mut bytes = response.bytes_stream();
     let stream = stream! {
+        let mut body_size_bytes = 0usize;
         while let Some(chunk) = bytes.next().await {
             match chunk {
                 Ok(buffer) => {
+                    body_size_bytes = body_size_bytes.saturating_add(buffer.len());
                     for result in decoder.push_bytes_results(&buffer) {
                         match result {
                             Ok(event) => yield Ok(event.data),
                             Err(error) => {
+                                emit_provider_body_size("gateway.provider.response", body_size_bytes);
                                 yield Err(error);
                                 return;
                             }
@@ -607,6 +613,7 @@ fn sse_json_stream(response: reqwest::Response) -> LlmJsonStream {
                     }
                 }
                 Err(error) => {
+                    emit_provider_body_size("gateway.provider.response", body_size_bytes);
                     yield Err(FlowError::Internal(error.to_string()));
                     return;
                 }
@@ -617,6 +624,7 @@ fn sse_json_stream(response: reqwest::Response) -> LlmJsonStream {
             Ok(None) => {}
             Err(error) => yield Err(error),
         }
+        emit_provider_body_size("gateway.provider.response", body_size_bytes);
     };
     LlmJsonStream::new(stream)
 }
@@ -804,6 +812,7 @@ async fn forward_upstream_request(
         url,
         forwarding.source_route,
     );
+    emit_provider_body_size("gateway.provider.request", effective.body_bytes.len());
     let configured_auth_header = forwarding.configured_auth_header(effective.target_route);
     let mut upstream = http
         .request(method.clone(), &effective.url)
@@ -824,6 +833,15 @@ async fn forward_upstream_request(
         configured_auth_header,
     );
     upstream.send().await
+}
+
+fn emit_provider_body_size(name: &'static str, body_size_bytes: usize) {
+    let _ = nemo_relay::api::scope::event(
+        nemo_relay::api::scope::EmitMarkEventParams::builder()
+            .name(name)
+            .data(serde_json::json!({"body_size_bytes": body_size_bytes}))
+            .build(),
+    );
 }
 
 #[derive(Clone)]
@@ -1113,9 +1131,14 @@ async fn passthrough_streaming(
     let headers = response_headers(response.headers());
     let mut bytes = response.bytes_stream();
     let body = Body::from_stream(stream! {
+        let mut body_size_bytes = 0usize;
         while let Some(chunk) = bytes.next().await {
+            if let Ok(buffer) = &chunk {
+                body_size_bytes = body_size_bytes.saturating_add(buffer.len());
+            }
             yield chunk;
         }
+        emit_provider_body_size("gateway.provider.response", body_size_bytes);
     });
     build_response(status, headers, body)
 }

--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -622,7 +622,11 @@ fn sse_json_stream(response: reqwest::Response) -> LlmJsonStream {
         match decoder.finish() {
             Ok(Some(event)) => yield Ok(event.data),
             Ok(None) => {}
-            Err(error) => yield Err(error),
+            Err(error) => {
+                emit_provider_body_size("gateway.provider.response", body_size_bytes);
+                yield Err(error);
+                return;
+            }
         }
         emit_provider_body_size("gateway.provider.response", body_size_bytes);
     };
@@ -1133,10 +1137,17 @@ async fn passthrough_streaming(
     let body = Body::from_stream(stream! {
         let mut body_size_bytes = 0usize;
         while let Some(chunk) = bytes.next().await {
-            if let Ok(buffer) = &chunk {
-                body_size_bytes = body_size_bytes.saturating_add(buffer.len());
+            match chunk {
+                Ok(buffer) => {
+                    body_size_bytes = body_size_bytes.saturating_add(buffer.len());
+                    yield Ok(buffer);
+                }
+                Err(error) => {
+                    emit_provider_body_size("gateway.provider.response", body_size_bytes);
+                    yield Err(error);
+                    return;
+                }
             }
-            yield chunk;
         }
         emit_provider_body_size("gateway.provider.response", body_size_bytes);
     });

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -974,6 +974,19 @@ fn structured_upstream_failure_classification_matches_retry_policy() {
 
 #[tokio::test]
 async fn sse_json_stream_yields_valid_event_before_later_batch_error() {
+    let subscriber_name = "gateway-streaming-provider-response-body-size-test";
+    let _ = nemo_relay::api::subscriber::deregister_subscriber(subscriber_name);
+    let captured_data = Arc::new(Mutex::new(None::<Value>));
+    let captured = captured_data.clone();
+    nemo_relay::api::subscriber::register_subscriber(
+        subscriber_name,
+        Arc::new(move |event| {
+            if event.name() == "gateway.provider.response" {
+                *captured.lock().unwrap() = event.data().cloned();
+            }
+        }),
+    )
+    .unwrap();
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let sse_body = concat!(
@@ -1009,6 +1022,12 @@ async fn sse_json_stream_yields_valid_event_before_later_batch_error() {
     assert!(stream.next().await.is_none());
 
     server.await.unwrap();
+    nemo_relay::api::subscriber::flush_subscribers().unwrap();
+    nemo_relay::api::subscriber::deregister_subscriber(subscriber_name).unwrap();
+    assert_eq!(
+        captured_data.lock().unwrap().as_ref().unwrap()["body_size_bytes"],
+        json!(sse_body.len())
+    );
 }
 
 #[tokio::test]
@@ -1143,6 +1162,26 @@ async fn buffered_body_read_failure_stays_structured() {
 
 #[tokio::test]
 async fn buffered_invalid_json_becomes_safe_upstream_failure() {
+    let subscriber_name = "gateway-provider-request-body-size-test";
+    let _ = nemo_relay::api::subscriber::deregister_subscriber(subscriber_name);
+    let captured_data = Arc::new(Mutex::new(HashMap::<String, Value>::new()));
+    let captured = captured_data.clone();
+    nemo_relay::api::subscriber::register_subscriber(
+        subscriber_name,
+        Arc::new(move |event| {
+            if matches!(
+                event.name(),
+                "gateway.provider.request" | "gateway.provider.response"
+            ) && let Some(data) = event.data()
+            {
+                captured
+                    .lock()
+                    .unwrap()
+                    .insert(event.name().to_string(), data.clone());
+            }
+        }),
+    )
+    .unwrap();
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let server = tokio::spawn(async move {
@@ -1179,9 +1218,11 @@ async fn buffered_invalid_json_becomes_safe_upstream_failure() {
     );
     let mut request_headers = Map::new();
     request_headers.insert(INTERNAL_RETRY_AWARE_HEADER.to_string(), json!("true"));
+    let request_content = json!({"model": "rewritten"});
+    let expected_body_size = serde_json::to_vec(&request_content).unwrap().len();
     let error = func(LlmRequest {
         headers: request_headers,
-        content: json!({}),
+        content: request_content,
     })
     .await
     .unwrap_err();
@@ -1200,6 +1241,17 @@ async fn buffered_invalid_json_becomes_safe_upstream_failure() {
         Some(&"provider-request".to_string())
     );
     server.await.unwrap();
+    nemo_relay::api::subscriber::flush_subscribers().unwrap();
+    nemo_relay::api::subscriber::deregister_subscriber(subscriber_name).unwrap();
+    let captured_data = captured_data.lock().unwrap();
+    assert_eq!(
+        captured_data["gateway.provider.request"]["body_size_bytes"],
+        json!(expected_body_size)
+    );
+    assert_eq!(
+        captured_data["gateway.provider.response"]["body_size_bytes"],
+        json!(22)
+    );
 }
 
 #[test]

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -1031,6 +1031,113 @@ async fn sse_json_stream_yields_valid_event_before_later_batch_error() {
 }
 
 #[tokio::test]
+async fn incomplete_sse_error_emits_provider_response_body_size() {
+    let subscriber_name = "gateway-incomplete-sse-provider-response-body-size-test";
+    let _ = nemo_relay::api::subscriber::deregister_subscriber(subscriber_name);
+    let captured_data = Arc::new(Mutex::new(None::<Value>));
+    let captured = captured_data.clone();
+    nemo_relay::api::subscriber::register_subscriber(
+        subscriber_name,
+        Arc::new(move |event| {
+            if event.name() == "gateway.provider.response" {
+                *captured.lock().unwrap() = event.data().cloned();
+            }
+        }),
+    )
+    .unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let sse_body = "data: {not valid json";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        sse_body.len(),
+        sse_body
+    );
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0_u8; 1024];
+        let _ = socket.read(&mut request).await.unwrap();
+        socket.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let response = test_http_client()
+        .get(format!("http://{address}"))
+        .send()
+        .await
+        .unwrap();
+    let mut stream = sse_json_stream(response);
+
+    assert!(stream.next().await.unwrap().is_err());
+    drop(stream);
+    server.await.unwrap();
+    nemo_relay::api::subscriber::flush_subscribers().unwrap();
+    nemo_relay::api::subscriber::deregister_subscriber(subscriber_name).unwrap();
+    assert_eq!(
+        captured_data.lock().unwrap().as_ref().unwrap()["body_size_bytes"],
+        json!(sse_body.len())
+    );
+}
+
+#[tokio::test]
+async fn passthrough_transport_error_emits_provider_response_body_size() {
+    let subscriber_name = "gateway-passthrough-provider-response-body-size-test";
+    let _ = nemo_relay::api::subscriber::deregister_subscriber(subscriber_name);
+    let captured_data = Arc::new(Mutex::new(None::<Value>));
+    let captured = captured_data.clone();
+    nemo_relay::api::subscriber::register_subscriber(
+        subscriber_name,
+        Arc::new(move |event| {
+            if event.name() == "gateway.provider.response" {
+                *captured.lock().unwrap() = event.data().cloned();
+            }
+        }),
+    )
+    .unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let partial_body = "partial";
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0_u8; 1024];
+        let _ = socket.read(&mut request).await.unwrap();
+        socket
+            .write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/octet-stream\r\ncontent-length: 64\r\nconnection: close\r\n\r\n{partial_body}"
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+    });
+    let state = AppState::new(GatewayConfig::default());
+    let prepared = PreparedGatewayRequest {
+        method: Method::POST,
+        headers: HeaderMap::new(),
+        path: "/v1/models".into(),
+        provider: ProviderRoute::OpenAiModels,
+        upstream_url: format!("http://{address}/v1/models"),
+        body_bytes: Bytes::new(),
+        request_json: Value::Null,
+        streaming: true,
+        authorization: crate::provider_auth::ProviderRequestAuthorization {
+            source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
+            allow_environment_provider_auth: false,
+        },
+    };
+
+    let response = passthrough_streaming(state, prepared).await.unwrap();
+    assert!(response.into_body().collect().await.is_err());
+    server.await.unwrap();
+    nemo_relay::api::subscriber::flush_subscribers().unwrap();
+    nemo_relay::api::subscriber::deregister_subscriber(subscriber_name).unwrap();
+    assert_eq!(
+        captured_data.lock().unwrap().as_ref().unwrap()["body_size_bytes"],
+        json!(partial_body.len())
+    );
+}
+
+#[tokio::test]
 async fn streaming_provider_error_does_not_poison_the_next_request() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();

--- a/docs/nemo-relay-cli/basic-usage.mdx
+++ b/docs/nemo-relay-cli/basic-usage.mdx
@@ -49,6 +49,12 @@ payload schemas. It removes only hop-by-hop transport headers, forwards
 streaming responses as streams, and emits NeMo Relay LLM start and end events
 under the active session scope.
 
+The gateway emits `gateway.provider.request` and `gateway.provider.response`
+telemetry events containing the exact `body_size_bytes` sent to and received
+from each provider. Request bytes are measured after interceptors and JSON
+re-encoding; streaming response bytes are counted before SSE decoding. The
+`full` and `openinference` OpenTelemetry projections export them as span events.
+
 ## Transparent Run
 
 Use the agent shortcuts for no-install local observability. The wrapper starts


### PR DESCRIPTION
#### Overview

Record the exact HTTP request and response body sizes exchanged between the gateway and each inference provider in exported OpenTelemetry traces.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Emit `gateway.provider.request` immediately before upstream dispatch, after request interceptors and provider JSON re-encoding.
- Emit `gateway.provider.response` after reading buffered response bodies and while counting raw streaming chunks before SSE decoding.
- Emit partial response sizes before terminal SSE decoding and passthrough transport errors so downstream stream cancellation cannot discard the event.
- Record the exact effective body length as `body_size_bytes` in both events.
- Export one Full/OpenInference OpenTelemetry span event per provider request and response, including retry attempts and HTTP error bodies.
- Keep the change limited to provider network body bytes; it does not report Relay semantic JSON or gateway ingress sizes.

Validation:

- `cargo fmt --all -- --check`
- `PYO3_PYTHON=.venv/bin/python cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p nemo-relay-cli gateway::tests` (71 passed)
- `cargo test -p nemo-relay-cli provider_response_body_size` (2 passed)
- `uv run pre-commit run --all-files`: formatting, hygiene, Python, docs-link, Clippy, FFI, Go, and Node hooks passed. Environment-only blockers were missing `just`, `cargo-deny`, and `cargo-about`, plus local Rust 1.96.0 being older than the repository-pinned 1.96.1.

`just test-rust` was not available because `just` is not installed in the local environment. A direct full CLI run reached 1,065 passing tests; 135 environment/configuration tests failed under the raw parallel Cargo runner.

#### Where should the reviewer start?

Start with `emit_provider_body_size` and its buffered/streaming call sites in `crates/cli/src/gateway/mod.rs`, then review the buffered and streaming assertions in `crates/cli/tests/coverage/shared/gateway_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added telemetry for upstream provider requests and responses, including serialized body sizes.
  * Request sizes reflect any applied interception or rewriting before forwarding.
  * Response sizes are captured for buffered, streaming, and passthrough responses, including partial or failed streams.
  * Supported exporting these events as OpenTelemetry span events through the available projections.

* **Documentation**
  * Added guidance describing gateway provider request and response telemetry events and their exported metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
