### PR TITLE
chore: reduce release artifact sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,14 @@ missing_docs = "deny"
 
 [workspace.lints.clippy]
 cognitive_complexity = "deny"
+
+# Release artifacts are distributed in Python wheels, split Node.js packages,
+# and as standalone CLI binaries. Thin LTO with size optimization is the first
+# profile that keeps symbols and panic unwinding while meeting the distribution
+# size budget.
+[profile.release]
+opt-level = "s"
+lto = "thin"
+codegen-units = 1
+strip = "debuginfo"
+panic = "unwind"


### PR DESCRIPTION
#### Overview

Configure the shared Rust release profile to reduce the size of Python wheels, Node native packages, and CLI artifacts while retaining function symbols and panic unwinding.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project’s license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Set `opt-level = "s"`, thin LTO, and one codegen unit for workspace release builds.
- Strip debug information while retaining function symbols.
- Keep `panic = "unwind"` for existing `catch_unwind` boundaries.
- Apply the profile centrally so Maturin, N-API, and CLI builds share the same policy.

Local macOS arm64 evaluation against the prior release profile measured:

- CLI: 25.1% smaller raw binary and 25.6% smaller wheel.
- Python: 30.4% smaller wheel and 30.7% smaller native payload.
- Node: 30.4% smaller package archive and 30.1% smaller native payload.

Validation:

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `uv run pre-commit run --files Cargo.toml`
- `uv run pre-commit run --all-files`
- Release builds and smoke checks for the macOS CLI, Python extension, and Node native binding during profile evaluation.

No public APIs, package commands, features, or installation behavior change.

#### Where should the reviewer start?

Review the workspace `[profile.release]` settings in `Cargo.toml` and the choice of size optimization with thin LTO.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved release build optimization to produce smaller, more efficient distributed artifacts.
  * Reduced embedded debug information in release builds.
  * Configured streamlined release behavior for improved deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->