### PR TITLE
test: stabilize flaky Rust tests

### DIFF
--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -4170,6 +4170,7 @@ try:
     # terminal to the child without requiring a second `fg`.
     os.write(master, b"delay-next-continue\n")
     read_until("AGENT_DELAY_ARMED")
+    read_until("\n")
     os.write(master, b"\x1a")
     read_until("RELAY_SHELL> ")
     os.killpg(relay_group, signal.SIGCONT)

--- a/crates/switchyard/tests/unit/component_tests.rs
+++ b/crates/switchyard/tests/unit/component_tests.rs
@@ -21,7 +21,11 @@ use nemo_relay::api::llm::{
     LlmCallExecuteParams, LlmStreamCallExecuteParams, llm_call_execute, llm_stream_call_execute,
 };
 use nemo_relay::api::runtime::{LlmExecutionNextFn, LlmStreamExecutionNextFn, LlmStreamInner};
-use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
+use nemo_relay::api::scope::get_handle;
+use nemo_relay::api::subscriber::{
+    deregister_subscriber, flush_subscribers, register_subscriber, scope_deregister_subscriber,
+    scope_register_subscriber,
+};
 use nemo_relay::codec::optimization::LlmOptimizationSummaryStatus;
 use nemo_relay::error::{UpstreamFailure, UpstreamFailureClass};
 use nemo_relay::plugin::rollback_registrations;
@@ -1234,7 +1238,9 @@ async fn managed_buffered_events(
     let subscriber_name = format!("switchyard-accounting-{}", uuid::Uuid::now_v7());
     let events = Arc::new(Mutex::new(Vec::<Event>::new()));
     let captured = Arc::clone(&events);
-    register_subscriber(
+    let scope_uuid = get_handle().unwrap().uuid;
+    scope_register_subscriber(
+        &scope_uuid,
         &subscriber_name,
         Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
     )
@@ -1259,7 +1265,7 @@ async fn managed_buffered_events(
     .await
     .unwrap();
     flush_subscribers().unwrap();
-    deregister_subscriber(&subscriber_name).unwrap();
+    scope_deregister_subscriber(&scope_uuid, &subscriber_name).unwrap();
     Arc::try_unwrap(events).unwrap().into_inner().unwrap()
 }
 
@@ -1270,7 +1276,9 @@ async fn managed_stream_events(
     let subscriber_name = format!("switchyard-stream-accounting-{}", uuid::Uuid::now_v7());
     let events = Arc::new(Mutex::new(Vec::<Event>::new()));
     let captured = Arc::clone(&events);
-    register_subscriber(
+    let scope_uuid = get_handle().unwrap().uuid;
+    scope_register_subscriber(
+        &scope_uuid,
         &subscriber_name,
         Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
     )
@@ -1299,7 +1307,7 @@ async fn managed_stream_events(
     while stream.next().await.is_some() {}
     drop(stream);
     flush_subscribers().unwrap();
-    deregister_subscriber(&subscriber_name).unwrap();
+    scope_deregister_subscriber(&scope_uuid, &subscriber_name).unwrap();
     Arc::try_unwrap(events).unwrap().into_inner().unwrap()
 }
 


### PR DESCRIPTION
#### Overview

Stabilize two Rust tests that could fail under parallel CI load: the interactive terminal job-control regression and Switchyard accounting-event assertions.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

The PTY driver previously matched `AGENT_DELAY_ARMED` before Python had necessarily written the trailing newline. Under load, it could suspend the agent between those writes and then time out waiting for the SIGCONT marker. Consume the remainder of the acknowledgment line before injecting the terminal suspend character.

Switchyard's managed-call test helpers previously registered process-global subscribers. Parallel tests could therefore contribute unrelated optimization events and make exact accounting assertions fail. Register those captures against the current task-local scope so each test observes only its own events.

Validation:

- 20 consecutive focused CLI test runs
- 20 consecutive Switchyard library test runs (720 tests total)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-rust`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start with the scope-local subscriber change in `crates/switchyard/tests/unit/component_tests.rs`, then review the PTY synchronization change in `crates/cli/tests/cli_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal command handling reliability, including more consistent processing of command output.
  * Improved isolation of accounting event handling to prevent cross-context interference during operations.
* **Tests**
  * Strengthened coverage for terminal job control and accounting event processing to help ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->