### PR TITLE
ci: stop nightly tags for release/0.7

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,4 +3,3 @@
 
 branches:
   - main
-  - release/0.7


### PR DESCRIPTION
#### Overview

Remove `release/0.7` from the nightly alpha tag branch configuration so scheduled nightly tags continue only for `main`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Remove `release/0.7` from `.github/nightly-alpha-branches.yaml`.
- The nightly tag workflow will no longer create tags from the `release/0.7` branch.

#### Where should the reviewer start?

Start with `.github/nightly-alpha-branches.yaml`, which is the workflow's source of configured nightly-tag branches.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `release/0.7` branch from nightly alpha build monitoring.
  * Nightly alpha builds continue to track the `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->