### PR TITLE
feat(plugin)!: expose typed async middleware in Rust dynamic plugins

### DIFF
--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -4,7 +4,7 @@
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use nemo_relay_plugin::{
     AsyncLlmStream, AsyncLlmStreamEvent, AsyncStreamControl, AsyncStreamWrite, CategoryProfile,
@@ -22,10 +22,46 @@ use serde_json::{Map, json};
 struct FixtureNativePlugin;
 
 static ASYNC_PENDING_ENTERED: AtomicBool = AtomicBool::new(false);
+static TYPED_ASYNC_LLM_ENTERED: AtomicUsize = AtomicUsize::new(0);
+static TYPED_ASYNC_LLM_CANCELLATION_ENTERED: AtomicBool = AtomicBool::new(false);
+static TYPED_ASYNC_LLM_CANCELLED: AtomicBool = AtomicBool::new(false);
+static TYPED_ASYNC_STREAM_CANCELLATION_ENTERED: AtomicBool = AtomicBool::new(false);
+static TYPED_ASYNC_STREAM_CANCELLED: AtomicBool = AtomicBool::new(false);
+static TYPED_ASYNC_STREAM_BACKPRESSURED: AtomicBool = AtomicBool::new(false);
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nemo_relay_fixture_async_pending_entered() -> bool {
     ASYNC_PENDING_ENTERED.swap(false, Ordering::AcqRel)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nemo_relay_fixture_typed_async_llm_entered() -> usize {
+    TYPED_ASYNC_LLM_ENTERED.load(Ordering::Acquire)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nemo_relay_fixture_typed_async_llm_cancellation_entered() -> bool {
+    TYPED_ASYNC_LLM_CANCELLATION_ENTERED.load(Ordering::Acquire)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nemo_relay_fixture_typed_async_llm_cancelled() -> bool {
+    TYPED_ASYNC_LLM_CANCELLED.load(Ordering::Acquire)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nemo_relay_fixture_typed_async_stream_cancellation_entered() -> bool {
+    TYPED_ASYNC_STREAM_CANCELLATION_ENTERED.load(Ordering::Acquire)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nemo_relay_fixture_typed_async_stream_cancelled() -> bool {
+    TYPED_ASYNC_STREAM_CANCELLED.load(Ordering::Acquire)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn nemo_relay_fixture_typed_async_stream_backpressured() -> bool {
+    TYPED_ASYNC_STREAM_BACKPRESSURED.load(Ordering::Acquire)
 }
 
 impl NativePlugin for FixtureNativePlugin {
@@ -712,9 +748,25 @@ impl NativePlugin for FixtureAsyncPlugin {
         ctx.register_async_llm_execution_intercept(
             "fixture_async_llm_execution",
             0,
-            |_name, request, output| {
+            |name, request, output| {
+                TYPED_ASYNC_LLM_ENTERED.fetch_add(1, Ordering::AcqRel);
+                if name == "async-typed-cancel" {
+                    TYPED_ASYNC_LLM_CANCELLATION_ENTERED.store(true, Ordering::Release);
+                    std::thread::spawn(move || {
+                        for _ in 0..5_000 {
+                            if output.is_cancelled() {
+                                TYPED_ASYNC_LLM_CANCELLED.store(true, Ordering::Release);
+                                return;
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(1));
+                        }
+                        let _ = output.reject("timed out waiting for Relay cancellation");
+                    });
+                    return Ok(());
+                }
+                let delay = if name == "async-typed-slow" { 400 } else { 10 };
                 std::thread::spawn(move || {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    std::thread::sleep(std::time::Duration::from_millis(delay));
                     let _ = output.continue_with(request);
                 });
                 Ok(())
@@ -723,7 +775,24 @@ impl NativePlugin for FixtureAsyncPlugin {
         ctx.register_async_llm_stream_execution_intercept(
             "fixture_async_llm_stream",
             0,
-            |_name, request, output| forward_typed_async_stream(request, output),
+            |name, request, output| {
+                if name == "async-typed-stream-cancel" {
+                    TYPED_ASYNC_STREAM_CANCELLATION_ENTERED.store(true, Ordering::Release);
+                    std::thread::spawn(move || {
+                        for _ in 0..5_000 {
+                            if output.is_cancelled() {
+                                TYPED_ASYNC_STREAM_CANCELLED.store(true, Ordering::Release);
+                                return;
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(1));
+                        }
+                        drop(output);
+                    });
+                    Ok(())
+                } else {
+                    forward_typed_async_stream(request, output)
+                }
+            },
         )?;
         Ok(())
     }
@@ -751,6 +820,10 @@ fn forward_typed_async_stream(
                     .try_push(&chunk)
                 {
                     Ok(AsyncStreamWrite::Accepted) => AsyncStreamControl::Continue,
+                    Ok(AsyncStreamWrite::Backpressured) => {
+                        TYPED_ASYNC_STREAM_BACKPRESSURED.store(true, Ordering::Release);
+                        AsyncStreamControl::Stop
+                    }
                     _ => AsyncStreamControl::Stop,
                 }
             }

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -235,7 +235,7 @@ impl NativePlugin for FixtureNativePlugin {
                 ))
             },
         )?;
-        ctx.register_llm_execution_intercept(
+        ctx.register_sync_llm_execution_intercept(
             "fixture_llm_execution",
             0,
             |_name, request, next| {
@@ -246,7 +246,7 @@ impl NativePlugin for FixtureNativePlugin {
                 Ok(mark_json(response, "native_plugin_llm_execution"))
             },
         )?;
-        ctx.register_llm_stream_execution_intercept(
+        ctx.register_sync_llm_stream_execution_intercept(
             "fixture_llm_stream_execution",
             0,
             |_name, request, next| {
@@ -763,7 +763,7 @@ impl NativePlugin for FixtureAsyncPlugin {
                 return Err(format!("async registration failed: {status:?}"));
             }
         }
-        ctx.register_async_llm_execution_intercept(
+        ctx.register_llm_execution_intercept(
             "fixture_async_llm_execution",
             0,
             |name, request, output| {
@@ -791,7 +791,7 @@ impl NativePlugin for FixtureAsyncPlugin {
                 Ok(())
             },
         )?;
-        ctx.register_async_llm_stream_execution_intercept(
+        ctx.register_llm_stream_execution_intercept(
             "fixture_async_llm_stream",
             0,
             |name, request, output| {

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -5,6 +5,7 @@ use std::ffi::c_void;
 use std::ptr;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use nemo_relay_plugin::{
     AsyncLlmStream, AsyncLlmStreamEvent, AsyncStreamControl, AsyncStreamWrite, CategoryProfile,
@@ -28,6 +29,23 @@ static TYPED_ASYNC_LLM_CANCELLED: AtomicBool = AtomicBool::new(false);
 static TYPED_ASYNC_STREAM_CANCELLATION_ENTERED: AtomicBool = AtomicBool::new(false);
 static TYPED_ASYNC_STREAM_CANCELLED: AtomicBool = AtomicBool::new(false);
 static TYPED_ASYNC_STREAM_BACKPRESSURED: AtomicBool = AtomicBool::new(false);
+
+const ASYNC_TYPED_CANCEL_NAME: &str = "async-typed-cancel";
+const ASYNC_TYPED_SLOW_NAME: &str = "async-typed-slow";
+const ASYNC_TYPED_STREAM_CANCEL_NAME: &str = "async-typed-stream-cancel";
+const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(1);
+const CANCELLATION_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn wait_for_cancellation(mut is_cancelled: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + CANCELLATION_TIMEOUT;
+    while Instant::now() < deadline {
+        if is_cancelled() {
+            return true;
+        }
+        std::thread::sleep(CANCELLATION_POLL_INTERVAL);
+    }
+    is_cancelled()
+}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn nemo_relay_fixture_async_pending_entered() -> bool {
@@ -750,21 +768,22 @@ impl NativePlugin for FixtureAsyncPlugin {
             0,
             |name, request, output| {
                 TYPED_ASYNC_LLM_ENTERED.fetch_add(1, Ordering::AcqRel);
-                if name == "async-typed-cancel" {
+                if name == ASYNC_TYPED_CANCEL_NAME {
                     TYPED_ASYNC_LLM_CANCELLATION_ENTERED.store(true, Ordering::Release);
                     std::thread::spawn(move || {
-                        for _ in 0..5_000 {
-                            if output.is_cancelled() {
-                                TYPED_ASYNC_LLM_CANCELLED.store(true, Ordering::Release);
-                                return;
-                            }
-                            std::thread::sleep(std::time::Duration::from_millis(1));
+                        if wait_for_cancellation(|| output.is_cancelled()) {
+                            TYPED_ASYNC_LLM_CANCELLED.store(true, Ordering::Release);
+                            return;
                         }
                         let _ = output.reject("timed out waiting for Relay cancellation");
                     });
                     return Ok(());
                 }
-                let delay = if name == "async-typed-slow" { 400 } else { 10 };
+                let delay = if name == ASYNC_TYPED_SLOW_NAME {
+                    400
+                } else {
+                    10
+                };
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_millis(delay));
                     let _ = output.continue_with(request);
@@ -776,17 +795,12 @@ impl NativePlugin for FixtureAsyncPlugin {
             "fixture_async_llm_stream",
             0,
             |name, request, output| {
-                if name == "async-typed-stream-cancel" {
+                if name == ASYNC_TYPED_STREAM_CANCEL_NAME {
                     TYPED_ASYNC_STREAM_CANCELLATION_ENTERED.store(true, Ordering::Release);
                     std::thread::spawn(move || {
-                        for _ in 0..5_000 {
-                            if output.is_cancelled() {
-                                TYPED_ASYNC_STREAM_CANCELLED.store(true, Ordering::Release);
-                                return;
-                            }
-                            std::thread::sleep(std::time::Duration::from_millis(1));
+                        if wait_for_cancellation(|| output.is_cancelled()) {
+                            TYPED_ASYNC_STREAM_CANCELLED.store(true, Ordering::Release);
                         }
-                        drop(output);
                     });
                     Ok(())
                 } else {

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -3,7 +3,6 @@
 
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
@@ -814,54 +813,48 @@ impl NativePlugin for FixtureAsyncPlugin {
 
 fn forward_typed_async_stream(
     request: LlmRequest,
-    output: AsyncLlmStream,
+    mut output: AsyncLlmStream,
 ) -> nemo_relay_plugin::Result<()> {
-    let output = Arc::new(Mutex::new(Some(output)));
-    let callback_output = Arc::clone(&output);
-    output
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .as_ref()
-        .expect("typed async stream output is present")
-        .invoke_next(&request, move |event| match event {
-            AsyncLlmStreamEvent::Chunk(chunk) => {
-                let output = callback_output
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                match output
-                    .as_ref()
-                    .expect("typed async stream output is present")
-                    .try_push(&chunk)
-                {
-                    Ok(AsyncStreamWrite::Accepted) => AsyncStreamControl::Continue,
+    std::thread::spawn(move || {
+        let (event_tx, event_rx) = std::sync::mpsc::channel();
+        let invoke_result = output.invoke_next(&request, move |event| {
+            let terminal = matches!(
+                &event,
+                AsyncLlmStreamEvent::Error(_) | AsyncLlmStreamEvent::Done
+            );
+            if event_tx.send(event).is_err() || terminal {
+                AsyncStreamControl::Stop
+            } else {
+                AsyncStreamControl::Continue
+            }
+        });
+        if let Err(error) = invoke_result {
+            let _ = output.try_reject(&error);
+            return;
+        }
+
+        while let Ok(event) = event_rx.recv() {
+            match event {
+                AsyncLlmStreamEvent::Chunk(chunk) => match output.try_push(&chunk) {
+                    Ok(AsyncStreamWrite::Accepted) => {}
                     Ok(AsyncStreamWrite::Backpressured) => {
                         TYPED_ASYNC_STREAM_BACKPRESSURED.store(true, Ordering::Release);
-                        AsyncStreamControl::Stop
+                        return;
                     }
-                    _ => AsyncStreamControl::Stop,
-                }
-            }
-            AsyncLlmStreamEvent::Error(error) => {
-                if let Some(mut output) = callback_output
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .take()
-                {
+                    _ => return,
+                },
+                AsyncLlmStreamEvent::Error(error) => {
                     let _ = output.try_reject(&error);
+                    return;
                 }
-                AsyncStreamControl::Stop
-            }
-            AsyncLlmStreamEvent::Done => {
-                if let Some(output) = callback_output
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .take()
-                {
+                AsyncLlmStreamEvent::Done => {
                     let _ = output.finish();
+                    return;
                 }
-                AsyncStreamControl::Stop
             }
-        })
+        }
+    });
+    Ok(())
 }
 
 unsafe extern "C" fn raw_async_allow_callback(

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -3,14 +3,16 @@
 
 use std::ffi::c_void;
 use std::ptr;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use nemo_relay_plugin::{
-    CategoryProfile, ConfigDiagnostic, DiagnosticLevel, Event, EventCategory, EventSanitizeFields,
-    Json, LlmJsonStream, LlmRequest, LlmRequestInterceptOutcome, NativePlugin,
+    AsyncLlmStream, AsyncLlmStreamEvent, AsyncStreamControl, AsyncStreamWrite, CategoryProfile,
+    ConfigDiagnostic, DiagnosticLevel, Event, EventCategory, EventSanitizeFields, Json,
+    LlmJsonStream, LlmRequest, LlmRequestInterceptOutcome, NativePlugin,
     NemoRelayNativeAsyncCallbackState, NemoRelayNativeAsyncMiddlewareCb,
-    NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeAsyncNext, NemoRelayNativeAsyncStream,
-    NemoRelayNativeHostApiV1, NemoRelayNativeHostApiV3, NemoRelayNativePluginContext,
+    NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeHostApiV1, NemoRelayNativeHostApiV3,
+    NemoRelayNativePluginContext,
     NemoRelayNativePluginV1, NemoRelayNativeString, NemoRelayNativeToolNextFn, NemoRelayStatus,
     PendingMarkSpec, PluginContext, PluginRuntime, ScopeCategory, ScopeType,
     ToolExecutionInterceptOutcome,
@@ -629,7 +631,7 @@ impl NativePlugin for FixtureAsyncPlugin {
             NemoRelayNativeAsyncMiddlewareKind,
             &str,
             NemoRelayNativeAsyncMiddlewareCb,
-        ); 13] = [
+        ); 12] = [
             (
                 NemoRelayNativeAsyncMiddlewareKind::ToolSanitizeRequest,
                 "fixture_async_tool_sanitize_request",
@@ -676,11 +678,6 @@ impl NativePlugin for FixtureAsyncPlugin {
                 raw_async_passthrough_callback,
             ),
             (
-                NemoRelayNativeAsyncMiddlewareKind::LlmExecutionIntercept,
-                "fixture_async_llm_execution",
-                raw_async_tool_execution_callback,
-            ),
-            (
                 NemoRelayNativeAsyncMiddlewareKind::MarkSanitize,
                 "fixture_async_mark",
                 raw_async_passthrough_callback,
@@ -712,107 +709,72 @@ impl NativePlugin for FixtureAsyncPlugin {
                 return Err(format!("async registration failed: {status:?}"));
             }
         }
-        let status = unsafe {
-            ctx.register_async_stream_middleware_raw(
-                "fixture_async_llm_stream",
-                0,
-                raw_async_stream_callback,
-                user_data,
-                None,
-            )
-        };
-        if status != NemoRelayStatus::Ok {
-            return Err(format!("async stream registration failed: {status:?}"));
-        }
+        ctx.register_async_llm_execution_intercept(
+            "fixture_async_llm_execution",
+            0,
+            |_name, request, output| {
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    let _ = output.continue_with(request);
+                });
+                Ok(())
+            },
+        )?;
+        ctx.register_async_llm_stream_execution_intercept(
+            "fixture_async_llm_stream",
+            0,
+            |_name, request, output| forward_typed_async_stream(request, output),
+        )?;
         Ok(())
     }
 }
 
-struct AsyncStreamForward {
-    host: NemoRelayNativeHostApiV3,
-    stream: *const NemoRelayNativeAsyncStream,
-}
-
-unsafe extern "C" fn raw_async_stream_forward(
-    user_data: *mut c_void,
-    chunk: *const NemoRelayNativeString,
-    error: *const NemoRelayNativeString,
-    done: bool,
-) -> bool {
-    let state = unsafe { &*(user_data as *const AsyncStreamForward) };
-    if !chunk.is_null() {
-        if unsafe { (state.host.async_stream_push_json)(state.stream, chunk) }
-            == NemoRelayStatus::Ok
-        {
-            return true;
-        }
-        unsafe {
-            (state.host.async_stream_release)(state.stream);
-            drop(Box::from_raw(user_data as *mut AsyncStreamForward));
-        }
-        return false;
-    }
-    if !error.is_null() {
-        unsafe { (state.host.async_stream_reject)(state.stream, error) };
-    } else if done {
-        unsafe { (state.host.async_stream_finish)(state.stream) };
-    } else {
-        return true;
-    }
-    unsafe {
-        (state.host.async_stream_release)(state.stream);
-        drop(Box::from_raw(user_data as *mut AsyncStreamForward));
-    }
-    false
-}
-
-unsafe extern "C" fn raw_async_stream_callback(
-    user_data: *mut c_void,
-    invocation_json: *const NemoRelayNativeString,
-    next: *const NemoRelayNativeAsyncNext,
-    stream: *const NemoRelayNativeAsyncStream,
-) -> u32 {
-    let Some(host) = (unsafe { (user_data as *const NemoRelayNativeHostApiV3).as_ref() }) else {
-        return NemoRelayNativeAsyncCallbackState::Complete as u32;
-    };
-    let request = unsafe { raw_host_string_value(&host.v1, invocation_json) }
-        .and_then(|json| serde_json::from_str::<Json>(&json).ok())
-        .and_then(|invocation| invocation.get("request").cloned())
-        .and_then(|request| serde_json::to_string(&request).ok())
-        .map(|request| unsafe { raw_host_string(&host.v1, &request) });
-    let Some(request) = request.filter(|request| !request.is_null()) else {
-        unsafe {
-            (host.async_next_release)(next);
-            (host.async_stream_release)(stream);
-        }
-        return NemoRelayNativeAsyncCallbackState::Complete as u32;
-    };
-    let state = Box::into_raw(Box::new(AsyncStreamForward {
-        host: *host,
-        stream,
-    }));
-    let status = unsafe {
-        (host.async_next_invoke_stream)(
-            next,
-            request,
-            stream,
-            raw_async_stream_forward,
-            state.cast(),
-        )
-    };
-    unsafe {
-        (host.v1.string_free)(request);
-        (host.async_next_release)(next);
-    }
-    if status == NemoRelayStatus::Ok {
-        NemoRelayNativeAsyncCallbackState::Pending as u32
-    } else {
-        unsafe {
-            drop(Box::from_raw(state));
-            (host.async_stream_release)(stream);
-        }
-        NemoRelayNativeAsyncCallbackState::Complete as u32
-    }
+fn forward_typed_async_stream(
+    request: LlmRequest,
+    output: AsyncLlmStream,
+) -> nemo_relay_plugin::Result<()> {
+    let output = Arc::new(Mutex::new(Some(output)));
+    let callback_output = Arc::clone(&output);
+    output
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .expect("typed async stream output is present")
+        .invoke_next(&request, move |event| match event {
+            AsyncLlmStreamEvent::Chunk(chunk) => {
+                let output = callback_output
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                match output
+                    .as_ref()
+                    .expect("typed async stream output is present")
+                    .try_push(&chunk)
+                {
+                    Ok(AsyncStreamWrite::Accepted) => AsyncStreamControl::Continue,
+                    _ => AsyncStreamControl::Stop,
+                }
+            }
+            AsyncLlmStreamEvent::Error(error) => {
+                if let Some(mut output) = callback_output
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .take()
+                {
+                    let _ = output.try_reject(&error);
+                }
+                AsyncStreamControl::Stop
+            }
+            AsyncLlmStreamEvent::Done => {
+                if let Some(output) = callback_output
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .take()
+                {
+                    let _ = output.finish();
+                }
+                AsyncStreamControl::Stop
+            }
+        })
 }
 
 unsafe extern "C" fn raw_async_allow_callback(

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -24,6 +24,7 @@ use nemo_relay::api::scope::{
 use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
 use nemo_relay::api::tool::{ToolCallExecuteParams, tool_call_execute, tool_request_intercepts};
 use nemo_relay::codec::response::AnnotatedLlmResponse;
+use nemo_relay::error::FlowError;
 use nemo_relay::plugin::dynamic::{
     DynamicPluginActivationSpec, DynamicPluginKind, NativePluginLoadSpec, PluginHostActivation,
     load_native_plugins,
@@ -658,7 +659,7 @@ async fn sdk_cdylib_registers_tool_request_intercept() {
     activation.clear();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn native_v3_async_registration_supports_all_middleware_kinds() {
     let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
     let fixture = build_fixture_plugin();
@@ -679,6 +680,46 @@ async fn native_v3_async_registration_supports_all_middleware_kinds() {
         *fixture_library
             .get::<unsafe extern "C" fn() -> bool>(b"nemo_relay_fixture_async_pending_entered\0")
             .expect("v3 async native fixture should export its pending-entry signal")
+    };
+    let typed_llm_entered = unsafe {
+        *fixture_library
+            .get::<unsafe extern "C" fn() -> usize>(b"nemo_relay_fixture_typed_async_llm_entered\0")
+            .expect("v3 async native fixture should export its typed LLM entry count")
+    };
+    let typed_llm_cancellation_entered = unsafe {
+        *fixture_library
+            .get::<unsafe extern "C" fn() -> bool>(
+                b"nemo_relay_fixture_typed_async_llm_cancellation_entered\0",
+            )
+            .expect("v3 async native fixture should export its typed LLM cancellation entry")
+    };
+    let typed_llm_cancelled = unsafe {
+        *fixture_library
+            .get::<unsafe extern "C" fn() -> bool>(
+                b"nemo_relay_fixture_typed_async_llm_cancelled\0",
+            )
+            .expect("v3 async native fixture should export its typed LLM cancellation signal")
+    };
+    let typed_stream_cancellation_entered = unsafe {
+        *fixture_library
+            .get::<unsafe extern "C" fn() -> bool>(
+                b"nemo_relay_fixture_typed_async_stream_cancellation_entered\0",
+            )
+            .expect("v3 async native fixture should export its typed stream cancellation entry")
+    };
+    let typed_stream_cancelled = unsafe {
+        *fixture_library
+            .get::<unsafe extern "C" fn() -> bool>(
+                b"nemo_relay_fixture_typed_async_stream_cancelled\0",
+            )
+            .expect("v3 async native fixture should export its typed stream cancellation signal")
+    };
+    let typed_stream_backpressured = unsafe {
+        *fixture_library
+            .get::<unsafe extern "C" fn() -> bool>(
+                b"nemo_relay_fixture_typed_async_stream_backpressured\0",
+            )
+            .expect("v3 async native fixture should export its typed stream backpressure signal")
     };
     // This pointer remains valid only while `activation` keeps the fixture
     // library loaded; never call it after clearing the plugin configuration.
@@ -773,6 +814,182 @@ async fn native_v3_async_registration_supports_all_middleware_kinds() {
     );
     assert!(stream.next().await.is_none());
     flush_subscribers().expect("async native LLM stream events should flush");
+
+    let backpressure_chunks = Arc::new(Mutex::new(Vec::<Json>::new()));
+    let collected_backpressure_chunks = backpressure_chunks.clone();
+    let finalized_backpressure_chunks = backpressure_chunks.clone();
+    let mut backpressured_stream = llm_stream_call_execute(
+        LlmStreamCallExecuteParams::builder()
+            .name("async-typed-stream-backpressure")
+            .request(LlmRequest {
+                headers: Map::new(),
+                content: json!({"prompt": "fill native async stream"}),
+            })
+            .func(Arc::new(|_request| {
+                let chunks = (0..128)
+                    .map(|index| Ok::<Json, FlowError>(json!({"index": index})))
+                    .collect::<Vec<_>>();
+                Box::pin(async move { Ok(LlmJsonStream::new(tokio_stream::iter(chunks))) })
+            }))
+            .collector(Box::new(move |chunk| {
+                collected_backpressure_chunks.lock().unwrap().push(chunk);
+                Ok(())
+            }))
+            .finalizer(Box::new(move || {
+                Json::Array(finalized_backpressure_chunks.lock().unwrap().clone())
+            }))
+            .build(),
+    )
+    .await
+    .expect("typed backpressure stream should start");
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !unsafe { typed_stream_backpressured() } {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("typed stream writes should report bounded-queue backpressure");
+    let observed_chunks = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        let mut observed = 0;
+        while let Some(chunk) = backpressured_stream.next().await {
+            chunk.expect("accepted chunks should remain valid");
+            observed += 1;
+        }
+        observed
+    })
+    .await
+    .expect("backpressured typed stream should terminate without blocking");
+    assert!(observed_chunks > 0);
+    assert!(observed_chunks < 128);
+
+    let baseline_entries = unsafe { typed_llm_entered() };
+    let slow_calls = (0..2)
+        .map(|_| {
+            tokio::spawn(async {
+                let request = LlmRequest {
+                    headers: Map::new(),
+                    content: json!({"prompt": "slow native async"}),
+                };
+                llm_call_execute(
+                    LlmCallExecuteParams::builder()
+                        .name("async-typed-slow")
+                        .request(request)
+                        .func(Arc::new(|_request| {
+                            Box::pin(async { Ok(json!({"content": "slow response"})) })
+                        }))
+                        .build(),
+                )
+                .await
+            })
+        })
+        .collect::<Vec<_>>();
+    tokio::time::timeout(std::time::Duration::from_millis(200), async {
+        while unsafe { typed_llm_entered() } < baseline_entries + slow_calls.len() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("typed callbacks should release both Relay workers before slow work completes");
+    let unrelated = tokio::time::timeout(
+        std::time::Duration::from_millis(200),
+        tool_call_execute(
+            ToolCallExecuteParams::builder()
+                .name("unrelated-during-typed-async")
+                .args(json!({"input": true}))
+                .func(Arc::new(|args| Box::pin(async move { Ok(args) })))
+                .build(),
+        ),
+    )
+    .await
+    .expect("unrelated managed work should remain responsive")
+    .expect("unrelated managed work should succeed");
+    assert_eq!(unrelated["input"], true);
+    for slow_call in slow_calls {
+        assert_eq!(
+            slow_call
+                .await
+                .expect("slow typed callback task should not panic")
+                .expect("slow typed callback should settle")["content"],
+            "slow response"
+        );
+    }
+
+    let cancelled_llm = tokio::spawn(async {
+        let request = LlmRequest {
+            headers: Map::new(),
+            content: json!({"prompt": "cancel native async"}),
+        };
+        llm_call_execute(
+            LlmCallExecuteParams::builder()
+                .name("async-typed-cancel")
+                .request(request)
+                .func(Arc::new(|_request| Box::pin(std::future::pending())))
+                .build(),
+        )
+        .await
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !unsafe { typed_llm_cancellation_entered() } {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("typed buffered callback should retain its completion");
+    cancelled_llm.abort();
+    assert!(
+        cancelled_llm
+            .await
+            .expect_err("buffered managed call should be cancelled")
+            .is_cancelled()
+    );
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !unsafe { typed_llm_cancelled() } {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("Relay cancellation should reach the typed buffered plugin task");
+
+    let cancelled_chunks = Arc::new(Mutex::new(Vec::<Json>::new()));
+    let collected_cancelled_chunks = cancelled_chunks.clone();
+    let finalized_cancelled_chunks = cancelled_chunks.clone();
+    let request = LlmRequest {
+        headers: Map::new(),
+        content: json!({"prompt": "cancel native async stream"}),
+    };
+    let cancelled_stream = llm_stream_call_execute(
+        LlmStreamCallExecuteParams::builder()
+            .name("async-typed-stream-cancel")
+            .request(request)
+            .func(Arc::new(|_request| {
+                Box::pin(async move { Ok(LlmJsonStream::new(tokio_stream::empty())) })
+            }))
+            .collector(Box::new(move |chunk| {
+                collected_cancelled_chunks.lock().unwrap().push(chunk);
+                Ok(())
+            }))
+            .finalizer(Box::new(move || {
+                Json::Array(finalized_cancelled_chunks.lock().unwrap().clone())
+            }))
+            .build(),
+    )
+    .await
+    .expect("typed cancellation stream should start");
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !unsafe { typed_stream_cancellation_entered() } {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("typed stream callback should retain its output handle");
+    drop(cancelled_stream);
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !unsafe { typed_stream_cancelled() } {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("Relay cancellation should reach the typed stream plugin task");
 
     let pending = tokio::spawn(async {
         tool_request_intercepts("async-pending", json!({"input": true})).await

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -43,6 +43,9 @@ use uuid::Uuid;
 
 static NATIVE_PLUGIN_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 const PLUGIN_DISCOVERY_TEST_CHILD: &str = "NEMO_RELAY_PLUGIN_DISCOVERY_TEST_CHILD";
+const ASYNC_TYPED_CANCEL_NAME: &str = "async-typed-cancel";
+const ASYNC_TYPED_SLOW_NAME: &str = "async-typed-slow";
+const ASYNC_TYPED_STREAM_CANCEL_NAME: &str = "async-typed-stream-cancel";
 
 struct ReplacementRegistryPlugin;
 
@@ -872,7 +875,7 @@ async fn native_v3_async_registration_supports_all_middleware_kinds() {
                 };
                 llm_call_execute(
                     LlmCallExecuteParams::builder()
-                        .name("async-typed-slow")
+                        .name(ASYNC_TYPED_SLOW_NAME)
                         .request(request)
                         .func(Arc::new(|_request| {
                             Box::pin(async { Ok(json!({"content": "slow response"})) })
@@ -921,7 +924,7 @@ async fn native_v3_async_registration_supports_all_middleware_kinds() {
         };
         llm_call_execute(
             LlmCallExecuteParams::builder()
-                .name("async-typed-cancel")
+                .name(ASYNC_TYPED_CANCEL_NAME)
                 .request(request)
                 .func(Arc::new(|_request| Box::pin(std::future::pending())))
                 .build(),
@@ -959,7 +962,7 @@ async fn native_v3_async_registration_supports_all_middleware_kinds() {
     };
     let cancelled_stream = llm_stream_call_execute(
         LlmStreamCallExecuteParams::builder()
-            .name("async-typed-stream-cancel")
+            .name(ASYNC_TYPED_STREAM_CANCEL_NAME)
             .request(request)
             .func(Arc::new(|_request| {
                 Box::pin(async move { Ok(LlmJsonStream::new(tokio_stream::empty())) })

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -893,8 +893,10 @@ async fn native_v3_async_registration_supports_all_middleware_kinds() {
     })
     .await
     .expect("typed callbacks should release both Relay workers before slow work completes");
+    // Keep this timeout below the fixture's 400 ms slow-branch delay so a
+    // blocked Relay worker still fails the responsiveness assertion.
     let unrelated = tokio::time::timeout(
-        std::time::Duration::from_millis(200),
+        std::time::Duration::from_millis(300),
         tool_call_execute(
             ToolCallExecuteParams::builder()
                 .name("unrelated-during-typed-async")

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -3126,18 +3126,23 @@ where
         return false;
     }
     let state = unsafe { &*user_data.cast::<AsyncNextStreamCallback<F>>() };
-    let terminal = done || !error.is_null();
-    let event = if !error.is_null() {
-        match read_host_string(&state.host, error) {
-            Ok(message) => AsyncLlmStreamEvent::Error(message),
-            Err(_) => AsyncLlmStreamEvent::Error("invalid downstream stream error".into()),
-        }
+    let (event, terminal) = if !error.is_null() {
+        (
+            match read_host_string(&state.host, error) {
+                Ok(message) => AsyncLlmStreamEvent::Error(message),
+                Err(_) => AsyncLlmStreamEvent::Error("invalid downstream stream error".into()),
+            },
+            true,
+        )
     } else if done {
-        AsyncLlmStreamEvent::Done
+        (AsyncLlmStreamEvent::Done, true)
     } else {
         match read_json_value(&state.host, chunk_json, "downstream LLM stream event") {
-            Ok(chunk) => AsyncLlmStreamEvent::Chunk(chunk),
-            Err(_) => AsyncLlmStreamEvent::Error("invalid downstream LLM stream event".into()),
+            Ok(chunk) => (AsyncLlmStreamEvent::Chunk(chunk), false),
+            Err(_) => (
+                AsyncLlmStreamEvent::Error("invalid downstream LLM stream event".into()),
+                true,
+            ),
         }
     };
     let control = catch_unwind(AssertUnwindSafe(|| {

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -1154,7 +1154,7 @@ enum AsyncCancellationHandle {
 
 /// Borrowed cancellation probe for pending native middleware work.
 ///
-/// The probe may be moved into a cancellation future while the owning
+/// The probe may be moved into plugin-owned asynchronous work while the owning
 /// completion or stream remains responsible for settlement and release.
 pub struct AsyncCancellation<'a> {
     host: NemoRelayNativeHostApiV3,
@@ -1218,7 +1218,7 @@ impl AsyncLlmExecution {
         unsafe { (self.host.async_completion_is_cancelled)(self.completion) }
     }
 
-    /// Borrows a probe that can be moved into a cancellation future.
+    /// Borrows a probe that can be moved into plugin-owned asynchronous work.
     pub fn cancellation(&self) -> AsyncCancellation<'_> {
         AsyncCancellation {
             host: self.host,
@@ -1338,7 +1338,7 @@ impl AsyncLlmStream {
         unsafe { (self.host.async_stream_is_cancelled)(self.stream) }
     }
 
-    /// Borrows a probe that can be moved into a cancellation future.
+    /// Borrows a probe that can be moved into plugin-owned asynchronous work.
     pub fn cancellation(&self) -> AsyncCancellation<'_> {
         AsyncCancellation {
             host: self.host,

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -1003,9 +1003,9 @@ pub struct NemoRelayNativeHostApiV3 {
     ) -> NemoRelayStatus,
     /// Pushes one JSON chunk to an incremental native stream without blocking.
     ///
-    /// A full bounded host queue returns [`NemoRelayStatus::Internal`] and
-    /// records a backpressure message in the host's last-error slot. The
-    /// producer may retry the logical chunk after the consumer advances.
+    /// [`NemoRelayStatus::Internal`] is reserved for a full bounded host queue
+    /// and records a backpressure diagnostic in the host's last-error slot.
+    /// The producer may retry the logical chunk after the consumer advances.
     pub async_stream_push_json: unsafe extern "C" fn(
         stream: *const NemoRelayNativeAsyncStream,
         chunk_json: *const NemoRelayNativeString,
@@ -1015,8 +1015,8 @@ pub struct NemoRelayNativeHostApiV3 {
         unsafe extern "C" fn(stream: *const NemoRelayNativeAsyncStream) -> NemoRelayStatus,
     /// Rejects an incremental native stream without blocking.
     ///
-    /// A full bounded queue returns [`NemoRelayStatus::Internal`]; the caller
-    /// may retry the rejection after the consumer advances.
+    /// [`NemoRelayStatus::Internal`] is reserved for a full bounded queue; the
+    /// caller may retry the rejection after the consumer advances.
     pub async_stream_reject: unsafe extern "C" fn(
         stream: *const NemoRelayNativeAsyncStream,
         message: *const NemoRelayNativeString,
@@ -3024,12 +3024,11 @@ impl<'a> PluginContext<'a> {
     /// # Safety
     /// The callback and user data must remain valid until deregistration or
     /// `free_fn`; callback-owned `next` and `stream` handles must each be
-    /// released exactly once. Stream pushes and rejection are nonblocking:
-    /// `Internal` with a host last-error containing `backpressured` means the
-    /// bounded queue is full and the operation may be retried. The output
-    /// stream owns the callback lifetime. `next` may be invoked repeatedly or
-    /// concurrently until that stream settles; Relay then rejects or cancels
-    /// unfinished and later calls.
+    /// released exactly once. Stream pushes and rejection are nonblocking;
+    /// `Internal` is reserved for bounded-queue backpressure and means the
+    /// operation may be retried. The output stream owns the callback lifetime.
+    /// `next` may be invoked repeatedly or concurrently until that stream
+    /// settles; Relay then rejects or cancels unfinished and later calls.
     pub unsafe fn register_async_stream_middleware_raw(
         &mut self,
         name: &str,
@@ -3211,6 +3210,8 @@ fn native_async_status(status: NemoRelayStatus, operation: &str) -> Result<()> {
 }
 
 fn async_stream_write_status(status: NemoRelayStatus, operation: &str) -> Result<AsyncStreamWrite> {
+    // ABI v3 reserves Internal from nonblocking stream writes for queue-full
+    // backpressure. The host table exposes no last-error getter to plugins.
     match status {
         NemoRelayStatus::Ok => Ok(AsyncStreamWrite::Accepted),
         NemoRelayStatus::Internal => Ok(AsyncStreamWrite::Backpressured),

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -1115,6 +1115,352 @@ pub type Result<T> = std::result::Result<T, String>;
 /// Synchronous JSON chunk stream used by native LLM stream intercept helpers.
 pub type LlmJsonStream = Box<dyn Iterator<Item = Result<Json>> + Send>;
 
+/// Result of a nonblocking write to an asynchronous native output stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AsyncStreamWrite {
+    /// Relay accepted the value.
+    Accepted,
+    /// Relay's bounded output queue is full and the value may be retried.
+    Backpressured,
+    /// The output stream has already closed or been cancelled.
+    Closed,
+}
+
+/// Item delivered by an asynchronously invoked downstream LLM stream.
+#[derive(Debug)]
+pub enum AsyncLlmStreamEvent {
+    /// One downstream provider event.
+    Chunk(Json),
+    /// The downstream stream failed or was cancelled.
+    Error(String),
+    /// The downstream stream completed normally.
+    Done,
+}
+
+/// Controls whether Relay should continue a downstream LLM stream invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AsyncStreamControl {
+    /// Continue delivering downstream events.
+    Continue,
+    /// Cancel downstream production after the current callback.
+    Stop,
+}
+
+#[derive(Clone, Copy)]
+enum AsyncCancellationHandle {
+    Completion(*const NemoRelayNativeAsyncCompletion),
+    Stream(*const NemoRelayNativeAsyncStream),
+}
+
+/// Borrowed cancellation probe for pending native middleware work.
+///
+/// The probe may be moved into a cancellation future while the owning
+/// completion or stream remains responsible for settlement and release.
+pub struct AsyncCancellation<'a> {
+    host: NemoRelayNativeHostApiV3,
+    handle: AsyncCancellationHandle,
+    _owner: PhantomData<&'a ()>,
+}
+
+// Cancellation queries are read-only host operations designed to race with
+// cancellation and settlement on the Relay side.
+unsafe impl Send for AsyncCancellation<'_> {}
+
+impl AsyncCancellation<'_> {
+    /// Returns whether Relay has cancelled the associated operation.
+    pub fn is_cancelled(&self) -> bool {
+        unsafe {
+            match self.handle {
+                AsyncCancellationHandle::Completion(completion) => {
+                    (self.host.async_completion_is_cancelled)(completion)
+                }
+                AsyncCancellationHandle::Stream(stream) => {
+                    (self.host.async_stream_is_cancelled)(stream)
+                }
+            }
+        }
+    }
+}
+
+/// Owned completion for one asynchronous native LLM execution intercept.
+///
+/// Move this value to plugin-owned asynchronous work. The operation must
+/// eventually be resolved, rejected, or continued. Dropping it unsettled
+/// rejects the middleware invocation and releases all host handles.
+pub struct AsyncLlmExecution {
+    host: NemoRelayNativeHostApiV3,
+    completion: *const NemoRelayNativeAsyncCompletion,
+    next: *const NemoRelayNativeAsyncNext,
+    parent: *mut NemoRelayNativeScopeHandle,
+    settled: bool,
+}
+
+// ABI-v3 explicitly permits retained handles to move to plugin-owned threads.
+unsafe impl Send for AsyncLlmExecution {}
+
+impl AsyncLlmExecution {
+    fn new(
+        host: NemoRelayNativeHostApiV3,
+        completion: *const NemoRelayNativeAsyncCompletion,
+        next: *const NemoRelayNativeAsyncNext,
+    ) -> Self {
+        Self {
+            parent: capture_parent_scope(&host.v1),
+            host,
+            completion,
+            next,
+            settled: false,
+        }
+    }
+
+    /// Returns whether Relay has cancelled the managed invocation.
+    pub fn is_cancelled(&self) -> bool {
+        unsafe { (self.host.async_completion_is_cancelled)(self.completion) }
+    }
+
+    /// Borrows a probe that can be moved into a cancellation future.
+    pub fn cancellation(&self) -> AsyncCancellation<'_> {
+        AsyncCancellation {
+            host: self.host,
+            handle: AsyncCancellationHandle::Completion(self.completion),
+            _owner: PhantomData,
+        }
+    }
+
+    /// Emits a mark under the scope active when the interceptor was invoked.
+    pub fn emit_mark(
+        &self,
+        name: &str,
+        data: Option<&Json>,
+        metadata: Option<&Json>,
+    ) -> Result<()> {
+        emit_mark_with_parent(&self.host.v1, self.parent, name, data, metadata)
+    }
+
+    /// Resolves the middleware invocation without calling the remaining chain.
+    pub fn resolve(mut self, response: Json) -> Result<()> {
+        let response = HostString::from_json(&self.host.v1, &response)
+            .ok_or_else(|| "failed to allocate async LLM response".to_string())?;
+        let status = unsafe {
+            (self.host.async_completion_resolve_json)(self.completion, response.as_ptr())
+        };
+        drop(response);
+        self.settled = true;
+        self.release();
+        native_async_status(status, "resolve async LLM execution")
+    }
+
+    /// Rejects the middleware invocation without calling the remaining chain.
+    pub fn reject(mut self, message: impl AsRef<str>) -> Result<()> {
+        let status = reject_async_completion(&self.host, self.completion, message.as_ref());
+        self.settled = true;
+        self.release();
+        native_async_status(status, "reject async LLM execution")
+    }
+
+    /// Continues the remaining LLM execution chain with a replacement request.
+    pub fn continue_with(mut self, request: LlmRequest) -> Result<()> {
+        let request = HostString::from_json(&self.host.v1, &request)
+            .ok_or_else(|| "failed to allocate async LLM request".to_string())?;
+        let status =
+            unsafe { (self.host.async_next_invoke)(self.next, request.as_ptr(), self.completion) };
+        drop(request);
+        if status != NemoRelayStatus::Ok {
+            let _ = reject_async_completion(
+                &self.host,
+                self.completion,
+                "Relay rejected async LLM continuation",
+            );
+        }
+        self.settled = true;
+        self.release();
+        native_async_status(status, "continue async LLM execution")
+    }
+
+    fn release(&mut self) {
+        if !self.next.is_null() {
+            unsafe { (self.host.async_next_release)(self.next) };
+            self.next = ptr::null();
+        }
+        if !self.completion.is_null() {
+            unsafe { (self.host.async_completion_release)(self.completion) };
+            self.completion = ptr::null();
+        }
+        free_parent_scope(&self.host.v1, &mut self.parent);
+    }
+}
+
+impl Drop for AsyncLlmExecution {
+    fn drop(&mut self) {
+        if !self.settled && !self.completion.is_null() {
+            let _ = reject_async_completion(
+                &self.host,
+                self.completion,
+                "async LLM execution dropped without settlement",
+            );
+        }
+        self.release();
+    }
+}
+
+/// Owned output and continuation handles for one asynchronous LLM stream intercept.
+///
+/// Move this value to plugin-owned asynchronous work. Dropping it unfinished
+/// closes the stream with an error and releases all host handles.
+pub struct AsyncLlmStream {
+    host: NemoRelayNativeHostApiV3,
+    stream: *const NemoRelayNativeAsyncStream,
+    next: *const NemoRelayNativeAsyncNext,
+    parent: *mut NemoRelayNativeScopeHandle,
+    finished: bool,
+}
+
+// ABI-v3 explicitly permits retained handles to move to plugin-owned threads.
+unsafe impl Send for AsyncLlmStream {}
+
+impl AsyncLlmStream {
+    fn new(
+        host: NemoRelayNativeHostApiV3,
+        stream: *const NemoRelayNativeAsyncStream,
+        next: *const NemoRelayNativeAsyncNext,
+    ) -> Self {
+        Self {
+            parent: capture_parent_scope(&host.v1),
+            host,
+            stream,
+            next,
+            finished: false,
+        }
+    }
+
+    /// Returns whether Relay has cancelled the caller-facing stream.
+    pub fn is_cancelled(&self) -> bool {
+        unsafe { (self.host.async_stream_is_cancelled)(self.stream) }
+    }
+
+    /// Borrows a probe that can be moved into a cancellation future.
+    pub fn cancellation(&self) -> AsyncCancellation<'_> {
+        AsyncCancellation {
+            host: self.host,
+            handle: AsyncCancellationHandle::Stream(self.stream),
+            _owner: PhantomData,
+        }
+    }
+
+    /// Emits a mark under the scope active when the interceptor was invoked.
+    pub fn emit_mark(
+        &self,
+        name: &str,
+        data: Option<&Json>,
+        metadata: Option<&Json>,
+    ) -> Result<()> {
+        emit_mark_with_parent(&self.host.v1, self.parent, name, data, metadata)
+    }
+
+    /// Attempts to push one event into Relay's bounded output queue.
+    pub fn try_push(&self, event: &Json) -> Result<AsyncStreamWrite> {
+        let event = HostString::from_json(&self.host.v1, event)
+            .ok_or_else(|| "failed to allocate async LLM stream event".to_string())?;
+        let status = unsafe { (self.host.async_stream_push_json)(self.stream, event.as_ptr()) };
+        async_stream_write_status(status, "push async LLM stream event")
+    }
+
+    /// Attempts to reject the output stream.
+    pub fn try_reject(&mut self, message: &str) -> Result<AsyncStreamWrite> {
+        let message = HostString::try_new(&self.host.v1, message).ok();
+        let status = unsafe {
+            (self.host.async_stream_reject)(
+                self.stream,
+                message.as_ref().map_or(ptr::null(), HostString::as_ptr),
+            )
+        };
+        let result = async_stream_write_status(status, "reject async LLM stream")?;
+        drop(message);
+        if result != AsyncStreamWrite::Backpressured {
+            self.finished = true;
+            self.release();
+        }
+        Ok(result)
+    }
+
+    /// Finishes the caller-facing stream successfully.
+    pub fn finish(mut self) -> Result<()> {
+        let status = unsafe { (self.host.async_stream_finish)(self.stream) };
+        self.finished = true;
+        self.release();
+        native_async_status(status, "finish async LLM stream")
+    }
+
+    /// Invokes the remaining stream chain and receives its events incrementally.
+    ///
+    /// Relay invokes `callback` on Relay runtime workers. It must not block.
+    pub fn invoke_next<F>(&self, request: &LlmRequest, callback: F) -> Result<()>
+    where
+        F: FnMut(AsyncLlmStreamEvent) -> AsyncStreamControl + Send + 'static,
+    {
+        let request = HostString::from_json(&self.host.v1, request)
+            .ok_or_else(|| "failed to allocate async downstream LLM request".to_string())?;
+        let state = Box::new(AsyncNextStreamCallback {
+            host: self.host.v1,
+            callback: Mutex::new(callback),
+        });
+        let user_data = Box::into_raw(state).cast::<c_void>();
+        let status = unsafe {
+            (self.host.async_next_invoke_stream)(
+                self.next,
+                request.as_ptr(),
+                self.stream,
+                async_next_stream_trampoline::<F>,
+                user_data,
+            )
+        };
+        if status == NemoRelayStatus::Ok {
+            Ok(())
+        } else {
+            unsafe {
+                drop(Box::from_raw(
+                    user_data.cast::<AsyncNextStreamCallback<F>>(),
+                ))
+            };
+            Err(format!(
+                "invoke async downstream LLM stream failed: {status:?}"
+            ))
+        }
+    }
+
+    fn release(&mut self) {
+        if !self.next.is_null() {
+            unsafe { (self.host.async_next_release)(self.next) };
+            self.next = ptr::null();
+        }
+        if !self.stream.is_null() {
+            unsafe { (self.host.async_stream_release)(self.stream) };
+            self.stream = ptr::null();
+        }
+        free_parent_scope(&self.host.v1, &mut self.parent);
+    }
+}
+
+impl Drop for AsyncLlmStream {
+    fn drop(&mut self) {
+        if !self.finished && !self.stream.is_null() {
+            let message =
+                HostString::try_new(&self.host.v1, "async LLM stream dropped without settlement")
+                    .ok();
+            let status = unsafe {
+                (self.host.async_stream_reject)(
+                    self.stream,
+                    message.as_ref().map_or(ptr::null(), HostString::as_ptr),
+                )
+            };
+            if status == NemoRelayStatus::Internal {
+                let _ = unsafe { (self.host.async_stream_finish)(self.stream) };
+            }
+        }
+        self.release();
+    }
+}
+
 /// Cloneable high-level runtime handle for host APIs available to native plugins.
 #[derive(Clone)]
 pub struct PluginRuntime {
@@ -2216,6 +2562,88 @@ impl<'a> PluginContext<'a> {
         )
     }
 
+    /// Registers a completion-based typed LLM execution intercept.
+    ///
+    /// The callback must move the supplied operation to plugin-owned work or
+    /// settle it before returning. Relay's runtime worker is released as soon
+    /// as this callback returns.
+    pub fn register_async_llm_execution_intercept<F>(
+        &mut self,
+        name: &str,
+        priority: i32,
+        callback: F,
+    ) -> Result<()>
+    where
+        F: Fn(String, LlmRequest, AsyncLlmExecution) -> Result<()> + Send + Sync + 'static,
+    {
+        let host = self.async_host()?;
+        let name = HostString::try_new(&host.v1, name)
+            .map_err(|status| status_error(&host.v1, status, "async LLM execution name"))?;
+        let user_data = typed_async_callback_user_data(host, callback);
+        let status = unsafe {
+            (host.plugin_context_register_async_middleware)(
+                self.raw,
+                NemoRelayNativeAsyncMiddlewareKind::LlmExecutionIntercept as u32,
+                name.as_ptr(),
+                priority,
+                false,
+                typed_async_llm_execution_trampoline::<F>,
+                user_data,
+                Some(drop_typed_async_callback::<F>),
+            )
+        };
+        // ABI v3 owns user_data from the moment registration is attempted.
+        if status == NemoRelayStatus::Ok {
+            Ok(())
+        } else {
+            Err(status_error(
+                &host.v1,
+                status,
+                "async LLM execution intercept",
+            ))
+        }
+    }
+
+    /// Registers a completion-based typed LLM stream execution intercept.
+    ///
+    /// The callback must move the supplied stream to plugin-owned work or
+    /// settle it before returning. Stream writes are nonblocking and report
+    /// bounded-queue backpressure through [`AsyncStreamWrite`].
+    pub fn register_async_llm_stream_execution_intercept<F>(
+        &mut self,
+        name: &str,
+        priority: i32,
+        callback: F,
+    ) -> Result<()>
+    where
+        F: Fn(String, LlmRequest, AsyncLlmStream) -> Result<()> + Send + Sync + 'static,
+    {
+        let host = self.async_host()?;
+        let name = HostString::try_new(&host.v1, name)
+            .map_err(|status| status_error(&host.v1, status, "async LLM stream name"))?;
+        let user_data = typed_async_callback_user_data(host, callback);
+        let status = unsafe {
+            (host.plugin_context_register_async_stream_middleware)(
+                self.raw,
+                name.as_ptr(),
+                priority,
+                typed_async_llm_stream_trampoline::<F>,
+                user_data,
+                Some(drop_typed_async_callback::<F>),
+            )
+        };
+        // ABI v3 owns user_data from the moment registration is attempted.
+        if status == NemoRelayStatus::Ok {
+            Ok(())
+        } else {
+            Err(status_error(
+                &host.v1,
+                status,
+                "async LLM stream execution intercept",
+            ))
+        }
+    }
+
     /// Registers a raw event subscriber callback.
     ///
     /// # Safety
@@ -2617,6 +3045,15 @@ impl<'a> PluginContext<'a> {
         })
     }
 
+    fn async_host(&self) -> Result<NemoRelayNativeHostApiV3> {
+        if self.host.abi_version < NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE
+            || self.host.struct_size < std::mem::size_of::<NemoRelayNativeHostApiV3>()
+        {
+            return Err("Relay host does not support asynchronous native middleware".into());
+        }
+        Ok(unsafe { *(self.host as *const _ as *const NemoRelayNativeHostApiV3) })
+    }
+
     fn with_name(
         &self,
         name: &str,
@@ -2635,6 +3072,16 @@ struct TypedCallback<F> {
     callback: F,
 }
 
+struct TypedAsyncCallback<F> {
+    host: NemoRelayNativeHostApiV3,
+    callback: F,
+}
+
+struct AsyncNextStreamCallback<F> {
+    host: NemoRelayNativeHostApiV1,
+    callback: Mutex<F>,
+}
+
 fn typed_callback_user_data<F>(host: &NemoRelayNativeHostApiV1, callback: F) -> *mut c_void {
     Box::into_raw(Box::new(TypedCallback {
         host: *host,
@@ -2650,6 +3097,68 @@ unsafe extern "C" fn drop_typed_callback<F>(user_data: *mut c_void) {
             set_last_error(&host, "native plugin typed callback state drop panicked");
         }
     }
+}
+
+fn typed_async_callback_user_data<F>(host: NemoRelayNativeHostApiV3, callback: F) -> *mut c_void {
+    Box::into_raw(Box::new(TypedAsyncCallback { host, callback })).cast()
+}
+
+unsafe extern "C" fn drop_typed_async_callback<F>(user_data: *mut c_void) {
+    if !user_data.is_null() {
+        let callback = unsafe { Box::from_raw(user_data.cast::<TypedAsyncCallback<F>>()) };
+        let host = callback.host.v1;
+        if catch_unwind(AssertUnwindSafe(|| drop(callback))).is_err() {
+            set_last_error(&host, "native plugin async callback state drop panicked");
+        }
+    }
+}
+
+unsafe extern "C" fn async_next_stream_trampoline<F>(
+    user_data: *mut c_void,
+    chunk_json: *const NemoRelayNativeString,
+    error: *const NemoRelayNativeString,
+    done: bool,
+) -> bool
+where
+    F: FnMut(AsyncLlmStreamEvent) -> AsyncStreamControl + Send + 'static,
+{
+    if user_data.is_null() {
+        return false;
+    }
+    let state = unsafe { &*user_data.cast::<AsyncNextStreamCallback<F>>() };
+    let terminal = done || !error.is_null();
+    let event = if !error.is_null() {
+        match read_host_string(&state.host, error) {
+            Ok(message) => AsyncLlmStreamEvent::Error(message),
+            Err(_) => AsyncLlmStreamEvent::Error("invalid downstream stream error".into()),
+        }
+    } else if done {
+        AsyncLlmStreamEvent::Done
+    } else {
+        match read_json_value(&state.host, chunk_json, "downstream LLM stream event") {
+            Ok(chunk) => AsyncLlmStreamEvent::Chunk(chunk),
+            Err(_) => AsyncLlmStreamEvent::Error("invalid downstream LLM stream event".into()),
+        }
+    };
+    let control = catch_unwind(AssertUnwindSafe(|| {
+        let mut callback = state
+            .callback
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (callback)(event)
+    }));
+    let keep_going = matches!(control, Ok(AsyncStreamControl::Continue)) && !terminal;
+    if control.is_err() {
+        set_last_error(&state.host, "async downstream stream callback panicked");
+    }
+    if terminal || !keep_going {
+        unsafe {
+            drop(Box::from_raw(
+                user_data.cast::<AsyncNextStreamCallback<F>>(),
+            ))
+        };
+    }
+    keep_going
 }
 
 fn finish_typed_registration<F>(
@@ -2680,6 +3189,182 @@ fn callback_error(host: &NemoRelayNativeHostApiV1, message: String) -> NemoRelay
 fn callback_panic(host: &NemoRelayNativeHostApiV1, label: &str) -> NemoRelayStatus {
     set_last_error(host, &format!("{label} panicked"));
     NemoRelayStatus::Internal
+}
+
+fn native_async_status(status: NemoRelayStatus, operation: &str) -> Result<()> {
+    if status == NemoRelayStatus::Ok {
+        Ok(())
+    } else {
+        Err(format!("{operation} failed: {status:?}"))
+    }
+}
+
+fn async_stream_write_status(status: NemoRelayStatus, operation: &str) -> Result<AsyncStreamWrite> {
+    match status {
+        NemoRelayStatus::Ok => Ok(AsyncStreamWrite::Accepted),
+        NemoRelayStatus::Internal => Ok(AsyncStreamWrite::Backpressured),
+        NemoRelayStatus::InvalidArg => Ok(AsyncStreamWrite::Closed),
+        other => Err(format!("{operation} failed: {other:?}")),
+    }
+}
+
+fn reject_async_completion(
+    host: &NemoRelayNativeHostApiV3,
+    completion: *const NemoRelayNativeAsyncCompletion,
+    message: &str,
+) -> NemoRelayStatus {
+    let message = HostString::try_new(&host.v1, message).ok();
+    unsafe {
+        (host.async_completion_reject)(
+            completion,
+            message.as_ref().map_or(ptr::null(), HostString::as_ptr),
+        )
+    }
+}
+
+fn capture_parent_scope(host: &NemoRelayNativeHostApiV1) -> *mut NemoRelayNativeScopeHandle {
+    let mut parent = ptr::null_mut();
+    let status = unsafe { (host.scope_get_current)(&mut parent) };
+    if status == NemoRelayStatus::Ok {
+        parent
+    } else {
+        ptr::null_mut()
+    }
+}
+
+fn free_parent_scope(
+    host: &NemoRelayNativeHostApiV1,
+    parent: &mut *mut NemoRelayNativeScopeHandle,
+) {
+    if !parent.is_null() {
+        unsafe { (host.scope_handle_free)(*parent) };
+        *parent = ptr::null_mut();
+    }
+}
+
+fn emit_mark_with_parent(
+    host: &NemoRelayNativeHostApiV1,
+    parent: *mut NemoRelayNativeScopeHandle,
+    name: &str,
+    data: Option<&Json>,
+    metadata: Option<&Json>,
+) -> Result<()> {
+    let name = HostString::try_new(host, name)
+        .map_err(|status| format!("failed to allocate mark name: {status:?}"))?;
+    let data = OptionalHostJson::new(host, data)?;
+    let metadata = OptionalHostJson::new(host, metadata)?;
+    let status = unsafe {
+        (host.emit_mark)(
+            name.as_ptr(),
+            parent,
+            data.as_ptr(),
+            metadata.as_ptr(),
+            ptr::null(),
+        )
+    };
+    native_async_status(status, "emit async plugin mark")
+}
+
+#[derive(serde::Deserialize)]
+struct AsyncLlmInvocation {
+    name: String,
+    request: LlmRequest,
+}
+
+unsafe extern "C" fn typed_async_llm_execution_trampoline<F>(
+    user_data: *mut c_void,
+    invocation_json: *const NemoRelayNativeString,
+    next: *const NemoRelayNativeAsyncNext,
+    completion: *const NemoRelayNativeAsyncCompletion,
+) -> u32
+where
+    F: Fn(String, LlmRequest, AsyncLlmExecution) -> Result<()> + Send + Sync + 'static,
+{
+    if user_data.is_null() {
+        return NemoRelayNativeAsyncCallbackState::Complete as u32;
+    }
+    let state = unsafe { &*user_data.cast::<TypedAsyncCallback<F>>() };
+    if next.is_null() || completion.is_null() {
+        if !next.is_null() {
+            unsafe { (state.host.async_next_release)(next) };
+        }
+        if !completion.is_null() {
+            let _ = reject_async_completion(
+                &state.host,
+                completion,
+                "async LLM execution requires next and completion handles",
+            );
+            unsafe { (state.host.async_completion_release)(completion) };
+        }
+        return NemoRelayNativeAsyncCallbackState::Pending as u32;
+    }
+    let operation = AsyncLlmExecution::new(state.host, completion, next);
+    let invocation = read_json_value::<AsyncLlmInvocation>(
+        &state.host.v1,
+        invocation_json,
+        "async LLM invocation",
+    );
+    let result = catch_unwind(AssertUnwindSafe(|| match invocation {
+        Ok(invocation) => (state.callback)(invocation.name, invocation.request, operation),
+        Err(_) => Err("invalid async LLM invocation".into()),
+    }));
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(message)) => set_last_error(&state.host.v1, &message),
+        Err(_) => set_last_error(&state.host.v1, "async LLM execution callback panicked"),
+    }
+    NemoRelayNativeAsyncCallbackState::Pending as u32
+}
+
+unsafe extern "C" fn typed_async_llm_stream_trampoline<F>(
+    user_data: *mut c_void,
+    invocation_json: *const NemoRelayNativeString,
+    next: *const NemoRelayNativeAsyncNext,
+    stream: *const NemoRelayNativeAsyncStream,
+) -> u32
+where
+    F: Fn(String, LlmRequest, AsyncLlmStream) -> Result<()> + Send + Sync + 'static,
+{
+    if user_data.is_null() {
+        return NemoRelayNativeAsyncCallbackState::Complete as u32;
+    }
+    let state = unsafe { &*user_data.cast::<TypedAsyncCallback<F>>() };
+    if next.is_null() || stream.is_null() {
+        if !next.is_null() {
+            unsafe { (state.host.async_next_release)(next) };
+        }
+        if !stream.is_null() {
+            let message = HostString::try_new(
+                &state.host.v1,
+                "async LLM stream requires next and stream handles",
+            )
+            .ok();
+            let _ = unsafe {
+                (state.host.async_stream_reject)(
+                    stream,
+                    message.as_ref().map_or(ptr::null(), HostString::as_ptr),
+                )
+            };
+            unsafe { (state.host.async_stream_release)(stream) };
+        }
+        return NemoRelayNativeAsyncCallbackState::Pending as u32;
+    }
+    let operation = AsyncLlmStream::new(state.host, stream, next);
+    let invocation = read_json_value::<AsyncLlmInvocation>(
+        &state.host.v1,
+        invocation_json,
+        "async LLM stream invocation",
+    );
+    let result = catch_unwind(AssertUnwindSafe(|| match invocation {
+        Ok(invocation) => (state.callback)(invocation.name, invocation.request, operation),
+        Err(_) => Err("invalid async LLM stream invocation".into()),
+    }));
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(message)) => set_last_error(&state.host.v1, &message),
+        Err(_) => set_last_error(&state.host.v1, "async LLM stream callback panicked"),
+    }
+    NemoRelayNativeAsyncCallbackState::Pending as u32
 }
 
 unsafe extern "C" fn typed_subscriber_trampoline<F>(

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -2505,8 +2505,12 @@ impl<'a> PluginContext<'a> {
         finish_typed_registration::<F>(self.host, status, user_data, "llm request intercept")
     }
 
-    /// Registers a typed LLM execution intercept.
-    pub fn register_llm_execution_intercept<F>(
+    /// Registers a synchronous typed LLM execution intercept.
+    ///
+    /// Prefer [`Self::register_llm_execution_intercept`] for work that may
+    /// wait on I/O. This callback runs on a Relay runtime worker until it
+    /// returns.
+    pub fn register_sync_llm_execution_intercept<F>(
         &mut self,
         name: &str,
         priority: i32,
@@ -2528,11 +2532,13 @@ impl<'a> PluginContext<'a> {
         finish_typed_registration::<F>(self.host, status, user_data, "llm execution intercept")
     }
 
-    /// Registers a typed LLM stream execution intercept.
+    /// Registers a synchronous typed LLM stream execution intercept.
     ///
     /// Native ABI v2 represents stream execution as one JSON result. The host
     /// wraps that result as a one-chunk stream.
-    pub fn register_llm_stream_execution_intercept<F>(
+    /// Prefer [`Self::register_llm_stream_execution_intercept`] for work that
+    /// may wait on I/O.
+    pub fn register_sync_llm_stream_execution_intercept<F>(
         &mut self,
         name: &str,
         priority: i32,
@@ -2567,7 +2573,7 @@ impl<'a> PluginContext<'a> {
     /// The callback must move the supplied operation to plugin-owned work or
     /// settle it before returning. Relay's runtime worker is released as soon
     /// as this callback returns.
-    pub fn register_async_llm_execution_intercept<F>(
+    pub fn register_llm_execution_intercept<F>(
         &mut self,
         name: &str,
         priority: i32,
@@ -2609,7 +2615,7 @@ impl<'a> PluginContext<'a> {
     /// The callback must move the supplied stream to plugin-owned work or
     /// settle it before returning. Stream writes are nonblocking and report
     /// bounded-queue backpressure through [`AsyncStreamWrite`].
-    pub fn register_async_llm_stream_execution_intercept<F>(
+    pub fn register_llm_stream_execution_intercept<F>(
         &mut self,
         name: &str,
         priority: i32,

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -3100,11 +3100,9 @@ fn typed_llm_callbacks_reject_null_abi_pointers_before_decoding_inputs() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_llm_execution_intercept(
-        "llm-exec",
-        0,
-        |_name, request, _next| Ok(request.content),
-    )
+    ctx.register_sync_llm_execution_intercept("llm-exec", 0, |_name, request, _next| {
+        Ok(request.content)
+    })
     .unwrap();
     let registration = take_llm_execution_registration();
     let name = host_string(&host, "llm");
@@ -3147,7 +3145,7 @@ fn typed_llm_callbacks_reject_null_abi_pointers_before_decoding_inputs() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
+    ctx.register_sync_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
         Ok(Box::new(std::iter::empty()))
     })
     .unwrap();
@@ -3474,11 +3472,9 @@ fn typed_conditional_execution_and_llm_callbacks_report_invalid_json() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_llm_execution_intercept(
-        "llm-exec",
-        0,
-        |_name, request, _next| Ok(request.content),
-    )
+    ctx.register_sync_llm_execution_intercept("llm-exec", 0, |_name, request, _next| {
+        Ok(request.content)
+    })
     .unwrap();
     let registration = take_llm_execution_registration();
     let name = host_string(&host, "llm");
@@ -3507,7 +3503,7 @@ fn typed_conditional_execution_and_llm_callbacks_report_invalid_json() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
+    ctx.register_sync_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
         Ok(Box::new(std::iter::empty()))
     })
     .unwrap();
@@ -3655,7 +3651,7 @@ fn typed_callbacks_map_additional_callback_errors() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_llm_execution_intercept("llm-exec", 0, |_name, _request, _next| {
+    ctx.register_sync_llm_execution_intercept("llm-exec", 0, |_name, _request, _next| {
         Err("llm execution failed".into())
     })
     .unwrap();
@@ -3687,11 +3683,9 @@ fn typed_callbacks_map_additional_callback_errors() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_llm_execution_intercept(
-        "llm-exec",
-        0,
-        |_name, request, _next| Ok(request.content),
-    )
+    ctx.register_sync_llm_execution_intercept("llm-exec", 0, |_name, request, _next| {
+        Ok(request.content)
+    })
     .unwrap();
     let registration = take_llm_execution_registration();
     let name = host_string(&host, "llm");
@@ -3718,7 +3712,7 @@ fn typed_callbacks_map_additional_callback_errors() {
     }
 
     let mut ctx = test_context(&host);
-    ctx.register_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
+    ctx.register_sync_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
         Err("llm stream failed".into())
     })
     .unwrap();
@@ -4581,7 +4575,7 @@ fn typed_llm_execution_surfaces_next_status_failures() {
     let host = test_host();
     let called = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
-    ctx.register_llm_execution_intercept("llm", 0, |_name, request, next: LlmNext<'_>| {
+    ctx.register_sync_llm_execution_intercept("llm", 0, |_name, request, next: LlmNext<'_>| {
         next.call(request)
     })
     .unwrap();
@@ -4625,7 +4619,7 @@ fn typed_llm_execution_surfaces_invalid_next_json() {
     let host = test_host();
     let called = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
-    ctx.register_llm_execution_intercept("llm", 0, |_name, request, next: LlmNext<'_>| {
+    ctx.register_sync_llm_execution_intercept("llm", 0, |_name, request, next: LlmNext<'_>| {
         next.call(request)
     })
     .unwrap();
@@ -4671,7 +4665,7 @@ fn typed_llm_execution_surfaces_null_next_output() {
     let host = test_host();
     let called = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
-    ctx.register_llm_execution_intercept("llm", 31, |_name, request, next: LlmNext<'_>| {
+    ctx.register_sync_llm_execution_intercept("llm", 31, |_name, request, next: LlmNext<'_>| {
         next.call(request)
     })
     .unwrap();
@@ -4719,7 +4713,7 @@ fn typed_llm_stream_execution_wraps_next_chunks() {
     let cancelled = Arc::new(AtomicUsize::new(0));
     let dropped = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
-    ctx.register_llm_stream_execution_intercept(
+    ctx.register_sync_llm_stream_execution_intercept(
         "llm-stream",
         31,
         |_name, request, next: LlmStreamNext<'_>| {
@@ -4820,7 +4814,7 @@ fn typed_llm_stream_drop_catches_stream_state_panics() {
     let _guard = begin_test();
     let host = test_host();
     let mut ctx = test_context(&host);
-    ctx.register_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
+    ctx.register_sync_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
         let stream: LlmJsonStream = Box::new(PanicIterator {
             _panic_on_drop: PanicOnDrop("LLM stream state drop panic"),
         });
@@ -4865,7 +4859,7 @@ fn typed_llm_stream_execution_surfaces_next_failures() {
     let cancelled = Arc::new(AtomicUsize::new(0));
     let dropped = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
-    ctx.register_llm_stream_execution_intercept(
+    ctx.register_sync_llm_stream_execution_intercept(
         "llm-stream",
         0,
         |_name, request, next: LlmStreamNext<'_>| {
@@ -4922,7 +4916,7 @@ fn typed_llm_stream_execution_surfaces_chunk_errors() {
     let _guard = begin_test();
     let host = test_host();
     let mut ctx = test_context(&host);
-    ctx.register_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
+    ctx.register_sync_llm_stream_execution_intercept("llm-stream", 0, |_name, _request, _next| {
         let stream: LlmJsonStream = Box::new(std::iter::once(Err("chunk failed".into())));
         Ok(stream)
     })
@@ -4971,7 +4965,7 @@ fn typed_llm_stream_execution_cancels_unconsumed_next_stream() {
     let cancelled = Arc::new(AtomicUsize::new(0));
     let dropped = Arc::new(AtomicUsize::new(0));
     let mut ctx = test_context(&host);
-    ctx.register_llm_stream_execution_intercept(
+    ctx.register_sync_llm_stream_execution_intercept(
         "llm-stream",
         0,
         |_name, request, next: LlmStreamNext<'_>| {

--- a/docs/build-plugins/dynamic-plugins/native-dynamic/about.mdx
+++ b/docs/build-plugins/dynamic-plugins/native-dynamic/about.mdx
@@ -74,7 +74,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-nemo-relay-plugin = "0.5.0"
+nemo-relay-plugin = "0.7.1"
 serde_json = "1"
 ```
 
@@ -161,6 +161,8 @@ short, bounded work and returns immediately. Do not wait for network I/O, an
 external service, or a plugin-owned async runtime from a synchronous callback.
 Relay invokes the callback on the Tokio worker that is running the managed
 call, so blocking the callback also blocks that worker.
+
+The following example registers a completion-based LLM execution intercept:
 
 ```rust
 context.register_llm_execution_intercept(

--- a/docs/build-plugins/dynamic-plugins/native-dynamic/about.mdx
+++ b/docs/build-plugins/dynamic-plugins/native-dynamic/about.mdx
@@ -138,6 +138,48 @@ typed `NativePlugin` APIs continue to work unchanged. Raw ABI plugins can use
 later. The callback receives a JSON invocation, an optional continuation for
 execution intercepts, and a one-shot completion handle.
 
+### Choose Synchronous or Completion-Based Callbacks
+
+Use the existing synchronous typed registrations when the callback performs
+short, bounded work and can return immediately. Do not wait for network I/O,
+an external service, or a plugin-owned async runtime from a synchronous
+callback. Relay invokes the callback on the Tokio worker that is running the
+managed call, so blocking the callback also blocks that worker.
+
+Use `register_async_llm_execution_intercept` or
+`register_async_llm_stream_execution_intercept` when the plugin must wait for
+I/O. These typed Rust helpers wrap the ABI v3 completion and stream handles.
+Move the supplied operation into work scheduled by the plugin, then return
+from the registration callback. Relay continues the managed call when the
+plugin resolves, rejects, or continues the operation.
+
+```rust
+context.register_async_llm_execution_intercept(
+    "acme.route",
+    0,
+    |_name, request, operation| {
+        // A production plugin should submit this work to its existing async
+        // executor. This thread only illustrates transferring ownership.
+        std::thread::spawn(move || {
+            if !operation.is_cancelled() {
+                let _ = operation.continue_with(request);
+            }
+        });
+        Ok(())
+    },
+)?;
+```
+
+`AsyncLlmExecution` exposes `resolve`, `reject`, `continue_with`, and a
+borrowed cancellation probe. `AsyncLlmStream` exposes nonblocking `try_push`,
+`try_reject`, and `finish` operations. A full stream queue returns
+`AsyncStreamWrite::Backpressured`; retry from plugin-owned work after allowing
+the consumer to advance. Check cancellation during longer operations. Dropping
+an unsettled operation releases its host handles and attempts to terminate the
+managed call rather than leaving it pending.
+
+### Raw ABI Callbacks
+
 Return `Complete` after resolving or rejecting the completion before the
 callback returns. Return `Pending` only when retaining the completion; settle
 it exactly once, call `async_completion_release`, and release an async `next`

--- a/docs/build-plugins/dynamic-plugins/native-dynamic/about.mdx
+++ b/docs/build-plugins/dynamic-plugins/native-dynamic/about.mdx
@@ -132,29 +132,38 @@ extern "C" fn nemo_relay_register_plugin(
 
 The v3 host table retains the frozen legacy prefix and appends a
 completion-based asynchronous middleware extension. An entry that rejects the
-v3 table with `InvalidArg` is retried with the legacy table. Rust plugins using the
-typed `NativePlugin` APIs continue to work unchanged. Raw ABI plugins can use
-`PluginContext::register_async_middleware_raw` when a callback must complete
+v3 table with `InvalidArg` is retried with the legacy table. Raw ABI plugins can
+use `PluginContext::register_async_middleware_raw` when a callback must complete
 later. The callback receives a JSON invocation, an optional continuation for
 execution intercepts, and a one-shot completion handle.
 
 ### Choose Synchronous or Completion-Based Callbacks
 
-Use the existing synchronous typed registrations when the callback performs
-short, bounded work and can return immediately. Do not wait for network I/O,
-an external service, or a plugin-owned async runtime from a synchronous
-callback. Relay invokes the callback on the Tokio worker that is running the
-managed call, so blocking the callback also blocks that worker.
+<Warning>
+In 0.7.1, the typed Rust methods `register_llm_execution_intercept` and
+`register_llm_stream_execution_intercept` changed from synchronous callbacks
+to completion-based callbacks. Rename an existing synchronous registration to
+`register_sync_llm_execution_intercept` or
+`register_sync_llm_stream_execution_intercept` when rebuilding the plugin.
+This is a Rust SDK source change; it does not change the native ABI or plugin
+manifest format.
+</Warning>
 
-Use `register_async_llm_execution_intercept` or
-`register_async_llm_stream_execution_intercept` when the plugin must wait for
-I/O. These typed Rust helpers wrap the ABI v3 completion and stream handles.
-Move the supplied operation into work scheduled by the plugin, then return
-from the registration callback. Relay continues the managed call when the
-plugin resolves, rejects, or continues the operation.
+`register_llm_execution_intercept` and
+`register_llm_stream_execution_intercept` are completion-based. Move the
+supplied operation into work scheduled by the plugin, then return from the
+registration callback. Relay continues the managed call when the plugin
+resolves, rejects, or continues the operation.
+
+Use `register_sync_llm_execution_intercept` or
+`register_sync_llm_stream_execution_intercept` only when the callback performs
+short, bounded work and returns immediately. Do not wait for network I/O, an
+external service, or a plugin-owned async runtime from a synchronous callback.
+Relay invokes the callback on the Tokio worker that is running the managed
+call, so blocking the callback also blocks that worker.
 
 ```rust
-context.register_async_llm_execution_intercept(
+context.register_llm_execution_intercept(
     "acme.route",
     0,
     |_name, request, operation| {

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -377,6 +377,15 @@ The plugin manifest value remains `compat.native_api = "1"`. This manifest
 contract version is separate from the host ABI version; do not change it to
 `"2"`.
 
+Starting in 0.7.1, the typed Rust methods
+`register_llm_execution_intercept` and
+`register_llm_stream_execution_intercept` use completion-based callbacks. An
+existing synchronous callback must use
+`register_sync_llm_execution_intercept` or
+`register_sync_llm_stream_execution_intercept` when it is recompiled. This is
+a Rust SDK source change only. The native ABI and plugin manifest format are
+unchanged.
+
 Request and response callbacks now receive distinct context structures. Each
 structure contains structured codec identity and a borrowed directional codec
 handle. The request handle supports decode and encode host operations. The

--- a/examples/rust-native-plugin/src/lib.rs
+++ b/examples/rust-native-plugin/src/lib.rs
@@ -274,7 +274,7 @@ impl NativePlugin for ExampleNativePlugin {
                 ))
             }
         })?;
-        ctx.register_llm_execution_intercept("example_llm_execution", 30, {
+        ctx.register_sync_llm_execution_intercept("example_llm_execution", 30, {
             let tag = config.tag.clone();
             move |_name, request, next| {
                 let request = tag_llm_request(request, "native_llm_execution_request", &tag);
@@ -282,7 +282,7 @@ impl NativePlugin for ExampleNativePlugin {
                 Ok(tag_json(response, "native_llm_execution_response", &tag))
             }
         })?;
-        ctx.register_llm_stream_execution_intercept("example_llm_stream_execution", 30, {
+        ctx.register_sync_llm_stream_execution_intercept("example_llm_stream_execution", 30, {
             let tag = config.tag;
             move |_name, request, next| {
                 let request = tag_llm_request(request, "native_llm_stream_execution_request", &tag);


### PR DESCRIPTION
> [!WARNING]
> **Breaking change:** In 0.7.1, `register_llm_execution_intercept` and `register_llm_stream_execution_intercept` use completion-based callback signatures. Rust dynamic plugins using the previous synchronous signatures must update their callbacks to complete asynchronously. Short, bounded synchronous callbacks can instead rename their registrations to `register_sync_llm_execution_intercept` or `register_sync_llm_stream_execution_intercept`. The native ABI and plugin manifest format are unchanged.

#### Overview

Expose safe typed completion-based LLM middleware to Rust dynamic plugins and make the standard typed registration methods async-first.

- [X] I confirm that there is no existing issue or PR already covering this work.
- [X] I searched the repository and issue tracker before opening this PR.

#### Details

* Adds owned completion, cancellation, continuation, and bounded stream handles over native ABI v3.
* Makes `register_llm_execution_intercept` and `register_llm_stream_execution_intercept` completion-based.
* Retains synchronous typed callbacks under explicit `register_sync_*` method names.
* Adds integration coverage for completion, rejection, continuation, cancellation, runtime responsiveness, stream lifecycle, and bounded backpressure.
* Updates the native plugin guide, migration guide, fixtures, and example plugin.

The completion API keeps plugin-owned I/O off Relay runtime workers without introducing a Rust `Future` or executor contract across the C ABI boundary.

Validation:

* `cargo test -p nemo-relay-plugin`
* `cargo test -p nemo-relay --test native_plugin_integration -- --test-threads=1`
* `cargo check --manifest-path examples/rust-native-plugin/Cargo.toml`
* `cargo clippy --workspace --all-targets -- -D warnings`
* `just docs`
* `uv run pre-commit run --all-files`

Two full `just test-rust` runs each reached an unrelated, order-dependent failure on the `release/0.7` test matrix. The failing Switchyard and CLI tests both passed when rerun independently; all plugin and ABI coverage passed in both full runs.

#### Where should reviewer start?

Start with the typed registration methods and completion handles in `crates/plugin/src/lib.rs`, then review the ABI v3 integration coverage in `crates/core/tests/fixtures/native_plugin/src/lib.rs` and `crates/core/tests/integration/native_plugin_tests.rs`.

#### Related Issues or PRs

* Closes NVIDIA/NeMo-Relay#716

## Summary by CodeRabbit

* **New Features**
  * Added completion-based asynchronous LLM execution and streaming interceptors.
  * Added cancellation handling, timeout awareness, incremental stream delivery, and backpressure controls.
  * Improved stream completion and error handling for more reliable processing.
* **Documentation**
  * Added guidance for asynchronous callbacks, cancellation, backpressure, and ABI compatibility.
  * Documented migration steps for existing synchronous integrations.
* **Breaking Changes**
  * Existing synchronous interceptors now use explicitly synchronous registration methods.