### PR TITLE
ci: update NVSkills CI request workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -24,6 +24,6 @@ jobs:
       contents: read
       pull-requests: read
       statuses: read
-    uses: NVIDIA/skills/.github/workflows/team-request.yml@053f17aaf44aca0291cf7f62525bb39d581648d6 # main as of 2026-08-07
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@4f1e9e3e0e6913fbd5822acf4757aa6631e87cef # main as of 2026-08-10
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}

--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -6,11 +6,14 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
@@ -20,6 +23,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+      statuses: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@053f17aaf44aca0291cf7f62525bb39d581648d6 # main as of 2026-08-07
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
#### Overview

Updates the NVSkills CI request workflow to trigger on pull request lifecycle events and use the pinned team-request reusable workflow revision.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add pull request triggers for opened, reopened, synchronize, and ready_for_review events.
- Allow pull request events to request NVSkills CI.
- Grant the reusable workflow read access to commit statuses.
- Pin the reusable workflow to the requested 2026-08-07 main revision.

#### Where should the reviewer start?

Start with `.github/workflows/request-nvskills-ci.yml`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation to run on selected pull request events.
  * Improved workflow permissions for status checks.
  * Pinned the reusable workflow to a specific version for more consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->