### PR TITLE
feat: add async final-input worker policies

### DIFF
--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -35,8 +35,9 @@ use crate::api::scope::event;
 use crate::api::scope::{EmitMarkEventParams, ScopeHandle};
 use crate::api::shared::{
     ensure_runtime_owner, inject_dynamo_session_ids, metadata_with_otel_error,
-    metadata_with_otel_status, resolve_parent_uuid, run_request_intercepts_with_codec_and_recorder,
-    snapshot_event_sanitizers, snapshot_event_subscribers,
+    metadata_with_otel_status, resolve_parent_uuid, run_final_input_policies_with_codec,
+    run_request_intercepts_with_codec_and_recorder, snapshot_event_sanitizers,
+    snapshot_event_subscribers,
 };
 use crate::codec::request::{AnnotatedLlmRequest, Message};
 use crate::codec::response::{AnnotatedLlmResponse, attach_estimated_cost_for_provider};
@@ -46,7 +47,8 @@ use crate::json::Json;
 use crate::stream::LlmStreamWrapper;
 
 pub use nemo_relay_types::api::llm::{
-    LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA, LlmAttributes, LlmRequest, LlmRequestInterceptOutcome,
+    LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA, LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA, LlmAttributes,
+    LlmFinalInputPolicyOutcome, LlmRequest, LlmRequestInterceptOutcome,
 };
 
 const OBSERVABILITY_CREDENTIAL_HEADERS: [&str; 7] = [
@@ -1341,10 +1343,10 @@ impl Drop for ManagedLlmCompletion {
 
 /// Execute an LLM call through the managed middleware pipeline.
 ///
-/// This runs conditional-execution guardrails, request intercepts, and
-/// sanitize-request guardrails, emits the LLM-start event, then runs execution
-/// intercepts, the provider callback when it is not replaced, and
-/// sanitize-response guardrails in the runtime-defined order.
+/// This runs conditional-execution guardrails, request intercepts, final-input
+/// policies, and sanitize-request guardrails, emits the LLM-start event, then
+/// runs execution intercepts, the provider callback when it is not replaced,
+/// and sanitize-response guardrails in the runtime-defined order.
 ///
 /// # Parameters
 /// - `name`: Logical provider or model family name recorded on emitted events.
@@ -1367,8 +1369,9 @@ impl Drop for ManagedLlmCompletion {
 ///
 /// # Errors
 /// Returns [`FlowError::GuardrailRejected`] when conditional-execution
-/// guardrails block the call, or any error raised by request intercepts,
-/// execution intercepts, codecs, or the callback itself.
+/// guardrails or final-input policies block the call, or any error raised by
+/// request intercepts, final-input policies, execution intercepts, codecs, or
+/// the callback itself.
 ///
 /// # Notes
 /// The LLM-start event is emitted before execution intercepts run. Before
@@ -1453,6 +1456,15 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
             .await
         })
         .await?;
+    let (intercepted_request, annotated_request) = run_final_input_policies_with_codec(
+        &name,
+        intercepted_request,
+        annotated_request,
+        request_codec.clone(),
+        parent.as_ref(),
+        metadata.clone(),
+    )
+    .await?;
 
     let mut handle = create_llm_handle(
         CreateLlmHandleParams::builder()
@@ -1575,8 +1587,9 @@ pub async fn llm_call_execute(params: LlmCallExecuteParams) -> Result<Json> {
 ///
 /// # Errors
 /// Returns [`FlowError::GuardrailRejected`] when conditional-execution
-/// guardrails block the call, or any error raised by request intercepts,
-/// execution intercepts, stream callbacks, codecs, or the provider callback.
+/// guardrails or final-input policies block the call, or any error raised by
+/// request intercepts, final-input policies, execution intercepts, stream
+/// callbacks, codecs, or the provider callback.
 ///
 /// # Notes
 /// The LLM-start event is emitted before stream execution intercepts run.
@@ -1662,6 +1675,15 @@ pub async fn llm_stream_call_execute(params: LlmStreamCallExecuteParams) -> Resu
             .await
         })
         .await?;
+    let (intercepted_request, annotated_request) = run_final_input_policies_with_codec(
+        &name,
+        intercepted_request,
+        annotated_request,
+        request_codec.clone(),
+        parent.as_ref(),
+        metadata.clone(),
+    )
+    .await?;
 
     let mut handle = create_llm_handle(
         CreateLlmHandleParams::builder()

--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -5,9 +5,9 @@
 //! intercepts, and subscribers.
 
 use crate::api::runtime::{
-    EventSanitizeFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn, LlmSanitizeRequestFn,
-    LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn, ToolExecutionFn,
-    ToolInterceptFn, ToolSanitizeFn,
+    EventSanitizeFn, LlmConditionalFn, LlmExecutionFn, LlmFinalInputPolicyFn,
+    LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn,
+    ToolConditionalFn, ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::runtime::{current_scope_stack, global_context};
 use crate::api::shared::ensure_runtime_owner;
@@ -584,6 +584,16 @@ global_intercept_registry_api!(
     llm_request_intercepts,
     LlmRequestInterceptFn
 );
+global_guardrail_registry_api!(
+    /// Register a global LLM final-input policy.
+    /// Final-input policies run after request intercepts and before the managed
+    /// LLM scope, cache, routing, or provider execution begins.
+    register_llm_final_input_policy,
+    /// Deregister a global LLM final-input policy.
+    deregister_llm_final_input_policy,
+    llm_final_input_policies,
+    LlmFinalInputPolicyFn
+);
 global_execution_registry_api!(
     /// Register a global LLM execution intercept.
     /// Execution intercepts can wrap or replace the non-streaming provider
@@ -716,6 +726,14 @@ scope_intercept_registry_api!(
     scope_deregister_llm_request_intercept,
     llm_request_intercepts,
     LlmRequestInterceptFn
+);
+scope_guardrail_registry_api!(
+    /// Register a scope-local LLM final-input policy.
+    scope_register_llm_final_input_policy,
+    /// Deregister a scope-local LLM final-input policy.
+    scope_deregister_llm_final_input_policy,
+    llm_final_input_policies,
+    LlmFinalInputPolicyFn
 );
 scope_execution_registry_api!(
     /// Register a scope-local LLM execution intercept.

--- a/crates/core/src/api/runtime.rs
+++ b/crates/core/src/api/runtime.rs
@@ -12,8 +12,8 @@ pub mod subscriber_dispatcher;
 
 pub use callbacks::{
     BuiltinLlmCodec, EventSanitizeFn, EventSubscriberFn, LlmCodecIdentity, LlmCollectorFn,
-    LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmFinalizerFn, LlmJsonStream,
-    LlmRequestInterceptFn, LlmSanitizeRequestContext, LlmSanitizeRequestFn,
+    LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmFinalInputPolicyFn, LlmFinalizerFn,
+    LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestContext, LlmSanitizeRequestFn,
     LlmSanitizeResponseContext, LlmSanitizeResponseFn, LlmStreamExecutionFn,
     LlmStreamExecutionNextFn, LlmStreamInner, ToolConditionalFn, ToolExecutionFn,
     ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,

--- a/crates/core/src/api/runtime/callbacks.rs
+++ b/crates/core/src/api/runtime/callbacks.rs
@@ -16,7 +16,7 @@ use std::task::{Context, Poll};
 use tokio_stream::Stream;
 
 use crate::api::event::{Event, EventSanitizeFields};
-use crate::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
+use crate::api::llm::{LlmFinalInputPolicyOutcome, LlmRequest, LlmRequestInterceptOutcome};
 use crate::api::tool::ToolExecutionInterceptOutcome;
 use crate::codec::request::AnnotatedLlmRequest;
 use crate::codec::traits::{LlmCodec, LlmResponseCodec};
@@ -410,6 +410,21 @@ pub type LlmRequestInterceptFn = Arc<
             LlmRequest,
             Option<AnnotatedLlmRequest>,
         ) -> Pin<Box<dyn Future<Output = Result<LlmRequestInterceptOutcome>> + Send>>
+        + Send
+        + Sync,
+>;
+/// Evaluate the final LLM request immediately before managed execution.
+///
+/// Final-input policies run after request intercepts and can allow the current
+/// request, replace it, or reject execution with a caller-safe policy reason.
+/// The optional normalized annotation is authoritative for provider content
+/// whenever a request codec is active.
+pub type LlmFinalInputPolicyFn = Arc<
+    dyn Fn(
+            String,
+            LlmRequest,
+            Option<AnnotatedLlmRequest>,
+        ) -> Pin<Box<dyn Future<Output = Result<LlmFinalInputPolicyOutcome>> + Send>>
         + Send
         + Sync,
 >;

--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -25,13 +25,13 @@ use crate::api::event::{
     tool_attributes_to_strings,
 };
 use crate::api::llm::{CreateLlmHandleParams, EndLlmHandleParams};
-use crate::api::llm::{LlmHandle, LlmRequest};
+use crate::api::llm::{LlmFinalInputPolicyOutcome, LlmHandle, LlmRequest};
 use crate::api::registry::{ExecutionIntercept, Guardrail, Intercept};
 use crate::api::runtime::ScopeStackHandle;
 use crate::api::runtime::callbacks::{
     EventSanitizeFn, EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn,
-    LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestContext, LlmSanitizeRequestFn,
-    LlmSanitizeResponseContext, LlmSanitizeResponseFn, LlmStreamExecutionFn,
+    LlmFinalInputPolicyFn, LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestContext,
+    LlmSanitizeRequestFn, LlmSanitizeResponseContext, LlmSanitizeResponseFn, LlmStreamExecutionFn,
     LlmStreamExecutionNextFn, LlmStreamExecutionRegistryRefs, LlmStreamInner, ToolConditionalFn,
     ToolExecutionFn, ToolExecutionNextFn, ToolExecutionOutcomeNextFn, ToolInterceptFn,
     ToolSanitizeFn,
@@ -159,6 +159,22 @@ struct GuardrailScopeCompletion<'a> {
     pending_publication: Option<subscriber_dispatcher::PendingPublication>,
 }
 
+/// Result of evaluating every final-input policy visible to one LLM call.
+pub(crate) enum LlmFinalInputPolicyChainOutcome {
+    /// All policies allowed the request, possibly after one or more transforms.
+    Approved {
+        request: LlmRequest,
+        annotated_request: Option<Box<AnnotatedLlmRequest>>,
+        transformed: bool,
+    },
+    /// A policy rejected the request before managed execution began.
+    Rejected {
+        reason_code: String,
+        safe_message: String,
+        evidence: Option<Json>,
+    },
+}
+
 impl GuardrailScopeCompletion<'_> {
     fn new(
         handle: ScopeHandle,
@@ -236,6 +252,8 @@ pub struct NemoRelayContextState {
     pub(crate) llm_conditional_execution_guardrails: SortedRegistry<Guardrail<LlmConditionalFn>>,
     /// Global LLM request intercepts that can rewrite or annotate requests.
     pub(crate) llm_request_intercepts: SortedRegistry<Intercept<LlmRequestInterceptFn>>,
+    /// Global LLM policies that evaluate the final request before managed execution.
+    pub(crate) llm_final_input_policies: SortedRegistry<Guardrail<LlmFinalInputPolicyFn>>,
     /// Global non-streaming LLM execution intercepts that wrap callback execution.
     pub(crate) llm_execution_intercepts: SortedRegistry<ExecutionIntercept<LlmExecutionFn>>,
     /// Global streaming LLM execution intercepts that wrap stream-producing callbacks.
@@ -269,6 +287,7 @@ impl NemoRelayContextState {
             llm_sanitize_response_guardrails: SortedRegistry::new(),
             llm_conditional_execution_guardrails: SortedRegistry::new(),
             llm_request_intercepts: SortedRegistry::new(),
+            llm_final_input_policies: SortedRegistry::new(),
             llm_execution_intercepts: SortedRegistry::new(),
             llm_stream_execution_intercepts: SortedRegistry::new(),
             event_subscribers: HashMap::new(),
@@ -1569,6 +1588,157 @@ impl NemoRelayContextState {
             annotated_request: annotated_value,
             pending_marks,
             optimization_contributions,
+        })
+    }
+
+    /// Snapshot LLM final-input policies in priority order.
+    pub(crate) fn llm_final_input_policy_entries(
+        &self,
+        scope_locals: &[&SortedRegistry<Guardrail<LlmFinalInputPolicyFn>>],
+    ) -> Vec<Guardrail<LlmFinalInputPolicyFn>> {
+        merge_guardrail_entries(&self.llm_final_input_policies, scope_locals)
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Evaluate final-input policies after request transforms and before the
+    /// managed LLM scope or execution chain begins.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn llm_final_input_policy_snapshot_chain(
+        name: &str,
+        request: LlmRequest,
+        annotated_request: Option<AnnotatedLlmRequest>,
+        entries: &[Guardrail<LlmFinalInputPolicyFn>],
+        subscribers: &[EventSubscriberFn],
+        parent_uuid: Option<Uuid>,
+        metadata: Option<Json>,
+        codec_active: bool,
+    ) -> crate::error::Result<LlmFinalInputPolicyChainOutcome> {
+        let mut request_value = request;
+        let mut annotated_value = annotated_request;
+        let mut transformed = false;
+
+        for entry in entries {
+            let scope_stack = super::current_scope_stack();
+            let handle = Self::emit_guardrail_scope_start(
+                &entry.name,
+                parent_uuid,
+                metadata.clone(),
+                json!({
+                    "kind": "llm_final_input_policy",
+                }),
+                subscribers,
+                scope_stack.clone(),
+            );
+            let completion = GuardrailScopeCompletion::new(handle, subscribers, scope_stack);
+            let callback = Arc::clone(&entry.payload);
+            let callback_name = name.to_string();
+            let callback_request = request_value.clone();
+            let callback_annotated = annotated_value.clone();
+            let result = match AssertUnwindSafe(async move {
+                callback(callback_name, callback_request, callback_annotated).await
+            })
+            .catch_unwind()
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => Err(FlowError::Internal(format!(
+                    "LLM final-input policy '{}' panicked",
+                    entry.name
+                ))),
+            };
+
+            let outcome = match result {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    completion.finish(json!({
+                        "allowed": false,
+                        "error": error.to_string(),
+                    }));
+                    return Err(error);
+                }
+            };
+
+            match outcome {
+                LlmFinalInputPolicyOutcome::Allow { evidence } => {
+                    completion.finish(json!({
+                        "allowed": true,
+                        "rejected": false,
+                        "transformed": false,
+                        "evidence": evidence,
+                    }));
+                }
+                LlmFinalInputPolicyOutcome::Transform {
+                    request,
+                    annotated_request,
+                    evidence,
+                } => {
+                    if codec_active && request.content != request_value.content {
+                        completion.finish(json!({
+                            "allowed": false,
+                            "error": "policy changed request.content while a request codec is active",
+                        }));
+                        return Err(FlowError::InvalidArgument(format!(
+                            "LLM final-input policy '{}' changed request.content while a request codec is active; modify annotated_request instead",
+                            entry.name
+                        )));
+                    }
+                    if codec_active && annotated_request.is_none() {
+                        completion.finish(json!({
+                            "allowed": false,
+                            "error": "policy omitted annotated_request while a request codec is active",
+                        }));
+                        return Err(FlowError::InvalidArgument(format!(
+                            "LLM final-input policy '{}' omitted annotated_request while a request codec is active",
+                            entry.name
+                        )));
+                    }
+                    request_value = request;
+                    annotated_value = annotated_request.map(|annotated| *annotated);
+                    transformed = true;
+                    completion.finish(json!({
+                        "allowed": true,
+                        "rejected": false,
+                        "transformed": true,
+                        "evidence": evidence,
+                    }));
+                }
+                LlmFinalInputPolicyOutcome::Reject {
+                    reason_code,
+                    safe_message,
+                    evidence,
+                } => {
+                    if reason_code.trim().is_empty() || safe_message.trim().is_empty() {
+                        completion.finish(json!({
+                            "allowed": false,
+                            "error": "policy rejection omitted reason_code or safe_message",
+                        }));
+                        return Err(FlowError::InvalidArgument(format!(
+                            "LLM final-input policy '{}' returned a rejection with an empty reason_code or safe_message",
+                            entry.name
+                        )));
+                    }
+                    completion.finish(json!({
+                        "allowed": false,
+                        "rejected": true,
+                        "reason_code": reason_code,
+                        "safe_message": safe_message,
+                        "evidence": evidence,
+                    }));
+                    return Ok(LlmFinalInputPolicyChainOutcome::Rejected {
+                        reason_code,
+                        safe_message,
+                        evidence,
+                    });
+                }
+            }
+        }
+
+        Ok(LlmFinalInputPolicyChainOutcome::Approved {
+            request: request_value,
+            annotated_request: annotated_value.map(Box::new),
+            transformed,
         })
     }
 

--- a/crates/core/src/api/shared.rs
+++ b/crates/core/src/api/shared.rs
@@ -9,12 +9,12 @@ use crate::api::event::{Event, EventSanitizeFields, ScopeCategory};
 use crate::api::llm::LlmRequest;
 use crate::api::registry::Guardrail;
 use crate::api::runtime::global_context;
+use crate::api::runtime::state::LlmFinalInputPolicyChainOutcome;
 use crate::api::runtime::{
     EventSanitizeFn, EventSubscriberFn, NemoRelayContextState, ScopeStackHandle,
 };
 use crate::api::runtime::{current_scope_stack, task_scope_top};
-use crate::api::scope::ScopeHandle;
-use crate::api::scope::ScopeType;
+use crate::api::scope::{EmitMarkEventParams, ScopeHandle, ScopeType, event};
 use crate::codec::request::AnnotatedLlmRequest;
 use crate::codec::traits::LlmCodec;
 use crate::error::{FlowError, Result};
@@ -235,6 +235,100 @@ pub(crate) type InterceptedLlmRequest = (
     Vec<crate::api::event::PendingMarkSpec>,
     Vec<crate::codec::optimization::LlmOptimizationContribution>,
 );
+
+pub(crate) type FinalInputLlmRequest = (LlmRequest, Option<Arc<AnnotatedLlmRequest>>);
+
+/// Evaluate the final request visible after every request transform.
+///
+/// This is the last middleware phase before Relay creates the managed LLM
+/// scope and enters cache, routing, or provider execution.
+pub(crate) async fn run_final_input_policies_with_codec(
+    name: &str,
+    request: LlmRequest,
+    annotated_request: Option<Arc<AnnotatedLlmRequest>>,
+    codec: Option<Arc<dyn LlmCodec>>,
+    parent: Option<&ScopeHandle>,
+    metadata: Option<Json>,
+) -> Result<FinalInputLlmRequest> {
+    let (entries, subscribers, parent_uuid) = {
+        let scope_stack = current_scope_stack();
+        let scope_guard = scope_stack
+            .read()
+            .map_err(|error| FlowError::Internal(error.to_string()))?;
+        let scope_locals = scope_guard
+            .collect_scope_local_registries(|registries| &registries.llm_final_input_policies);
+        let scope_subscribers = scope_guard.collect_scope_local_subscribers();
+        let context = global_context();
+        let state = context
+            .read()
+            .map_err(|error| FlowError::Internal(error.to_string()))?;
+        (
+            state.llm_final_input_policy_entries(&scope_locals),
+            state.collect_event_subscribers(&scope_subscribers),
+            resolve_parent_uuid(parent),
+        )
+    };
+
+    if entries.is_empty() {
+        return Ok((request, annotated_request));
+    }
+
+    let outcome = NemoRelayContextState::llm_final_input_policy_snapshot_chain(
+        name,
+        request,
+        annotated_request.as_deref().cloned(),
+        &entries,
+        &subscribers,
+        parent_uuid,
+        metadata.clone(),
+        codec.is_some(),
+    )
+    .await?;
+
+    match outcome {
+        LlmFinalInputPolicyChainOutcome::Approved {
+            mut request,
+            annotated_request,
+            transformed,
+        } => {
+            if transformed && let Some(codec) = codec {
+                let annotated = annotated_request.as_ref().ok_or_else(|| {
+                    FlowError::InvalidArgument(
+                        "final-input policy omitted annotated_request while a request codec is active"
+                            .into(),
+                    )
+                })?;
+                let mut encoded = codec.encode(annotated, &request)?;
+                encoded.headers.extend(request.headers);
+                request = encoded;
+            }
+            Ok((
+                request,
+                annotated_request.map(|annotated| Arc::new(*annotated)),
+            ))
+        }
+        LlmFinalInputPolicyChainOutcome::Rejected {
+            reason_code,
+            safe_message,
+            evidence,
+        } => {
+            let _ = event(
+                EmitMarkEventParams::builder()
+                    .name(name)
+                    .parent_opt(parent)
+                    .data(serde_json::json!({
+                        "rejected": true,
+                        "reason_code": reason_code,
+                        "rejection_reason": safe_message,
+                        "evidence": evidence,
+                    }))
+                    .metadata_opt(metadata)
+                    .build(),
+            );
+            Err(FlowError::GuardrailRejected(safe_message))
+        }
+    }
+}
 
 #[cfg(test)]
 pub(crate) async fn run_request_intercepts_with_codec(

--- a/crates/core/src/context/registries.rs
+++ b/crates/core/src/context/registries.rs
@@ -11,9 +11,9 @@ use std::collections::HashMap;
 
 use crate::api::registry::{ExecutionIntercept, Guardrail, Intercept};
 use crate::api::runtime::{
-    EventSanitizeFn, EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn,
-    LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
-    ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
+    EventSanitizeFn, EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmFinalInputPolicyFn,
+    LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn,
+    ToolConditionalFn, ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::registry::SortedRegistry;
 
@@ -49,6 +49,8 @@ pub(crate) struct ScopeLocalRegistries {
     pub(crate) llm_conditional_execution_guardrails: SortedRegistry<Guardrail<LlmConditionalFn>>,
     /// LLM request intercepts that can rewrite or annotate requests.
     pub(crate) llm_request_intercepts: SortedRegistry<Intercept<LlmRequestInterceptFn>>,
+    /// LLM policies that evaluate the final request before managed execution.
+    pub(crate) llm_final_input_policies: SortedRegistry<Guardrail<LlmFinalInputPolicyFn>>,
     /// Non-streaming LLM execution intercepts that wrap callback execution.
     pub(crate) llm_execution_intercepts: SortedRegistry<ExecutionIntercept<LlmExecutionFn>>,
     /// Streaming LLM execution intercepts that wrap stream-producing callbacks.
@@ -78,6 +80,7 @@ impl ScopeLocalRegistries {
             llm_sanitize_response_guardrails: SortedRegistry::new(),
             llm_conditional_execution_guardrails: SortedRegistry::new(),
             llm_request_intercepts: SortedRegistry::new(),
+            llm_final_input_policies: SortedRegistry::new(),
             llm_execution_intercepts: SortedRegistry::new(),
             llm_stream_execution_intercepts: SortedRegistry::new(),
             event_subscribers: HashMap::new(),

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -24,13 +24,14 @@ use thiserror::Error;
 
 use crate::api::registry::{
     deregister_llm_conditional_execution_guardrail, deregister_llm_execution_intercept,
-    deregister_llm_request_intercept, deregister_llm_sanitize_request_guardrail,
-    deregister_llm_sanitize_response_guardrail, deregister_llm_stream_execution_intercept,
-    deregister_mark_sanitize_guardrail, deregister_scope_sanitize_end_guardrail,
-    deregister_scope_sanitize_start_guardrail, deregister_tool_conditional_execution_guardrail,
-    deregister_tool_execution_intercept, deregister_tool_request_intercept,
-    deregister_tool_sanitize_request_guardrail, deregister_tool_sanitize_response_guardrail,
-    register_llm_conditional_execution_guardrail, register_llm_execution_intercept,
+    deregister_llm_final_input_policy, deregister_llm_request_intercept,
+    deregister_llm_sanitize_request_guardrail, deregister_llm_sanitize_response_guardrail,
+    deregister_llm_stream_execution_intercept, deregister_mark_sanitize_guardrail,
+    deregister_scope_sanitize_end_guardrail, deregister_scope_sanitize_start_guardrail,
+    deregister_tool_conditional_execution_guardrail, deregister_tool_execution_intercept,
+    deregister_tool_request_intercept, deregister_tool_sanitize_request_guardrail,
+    deregister_tool_sanitize_response_guardrail, register_llm_conditional_execution_guardrail,
+    register_llm_execution_intercept, register_llm_final_input_policy,
     register_llm_request_intercept, register_llm_sanitize_request_guardrail,
     register_llm_sanitize_response_guardrail, register_llm_stream_execution_intercept,
     register_mark_sanitize_guardrail, register_scope_sanitize_end_guardrail,
@@ -39,9 +40,9 @@ use crate::api::registry::{
     register_tool_sanitize_request_guardrail, register_tool_sanitize_response_guardrail,
 };
 use crate::api::runtime::{
-    EventSanitizeFn, EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmRequestInterceptFn,
-    LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn, ToolConditionalFn,
-    ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
+    EventSanitizeFn, EventSubscriberFn, LlmConditionalFn, LlmExecutionFn, LlmFinalInputPolicyFn,
+    LlmRequestInterceptFn, LlmSanitizeRequestFn, LlmSanitizeResponseFn, LlmStreamExecutionFn,
+    ToolConditionalFn, ToolExecutionFn, ToolInterceptFn, ToolSanitizeFn,
 };
 use crate::api::subscriber::{deregister_subscriber, register_subscriber};
 pub use nemo_relay_types::plugin::{ConfigDiagnostic, DiagnosticLevel};
@@ -551,6 +552,35 @@ impl PluginRegistrationContext {
                     .map_err(|err| {
                         PluginError::RegistrationFailed(format!(
                             "llm request intercept deregistration failed: {err}"
+                        ))
+                    })
+            }),
+        ));
+        Ok(())
+    }
+
+    /// Registers an LLM final-input policy and records its rollback closure.
+    pub fn register_llm_final_input_policy(
+        &mut self,
+        name: &str,
+        priority: i32,
+        callback: LlmFinalInputPolicyFn,
+    ) -> Result<()> {
+        let qualified_name = self.qualify_name(name);
+        register_llm_final_input_policy(&qualified_name, priority, callback).map_err(|err| {
+            PluginError::RegistrationFailed(format!("llm final input policy: {err}"))
+        })?;
+
+        let name_owned = qualified_name;
+        self.registrations.push(PluginRegistration::new(
+            "plugin",
+            name_owned.clone(),
+            Box::new(move || {
+                deregister_llm_final_input_policy(&name_owned)
+                    .map(|_| ())
+                    .map_err(|err| {
+                        PluginError::RegistrationFailed(format!(
+                            "llm final input policy deregistration failed: {err}"
                         ))
                     })
             }),

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -26,9 +26,9 @@ use nemo_relay_worker_proto::v1::{
     LlmCodecKind, LlmInvocation, LlmNextRequest,
     LlmSanitizeRequestContext as ProtoLlmSanitizeRequestContext,
     LlmSanitizeResponseContext as ProtoLlmSanitizeResponseContext, LlmStreamNextRequest,
-    PopScopeRequest, PushScopeRequest, PushScopeResponse, RegisterRequest, RegisterResponse,
-    Registration, RegistrationSurface, ScopeContext, ShutdownRequest, StreamChunk, ToolInvocation,
-    ToolNextRequest, ValidateRequest, WorkerError,
+    PolicyFailureMode, PopScopeRequest, PushScopeRequest, PushScopeResponse, RegisterRequest,
+    RegisterResponse, Registration, RegistrationSurface, ScopeContext, ShutdownRequest,
+    StreamChunk, ToolInvocation, ToolNextRequest, ValidateRequest, WorkerError,
 };
 use nemo_relay_worker_proto::{WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, json_envelope};
 use semver::{Version, VersionReq};
@@ -59,7 +59,10 @@ use tokio_stream::wrappers::UnixListenerStream;
 use tower::service_fn;
 
 use crate::api::event::{Event, EventSanitizeFields};
-use crate::api::llm::{LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA, LlmRequest};
+use crate::api::llm::{
+    LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA, LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA,
+    LlmFinalInputPolicyOutcome, LlmRequest,
+};
 use crate::api::runtime::subscriber_dispatcher::{
     PublicationBuffer, capture_nested_publication_buffer, with_nested_publication_buffer,
 };
@@ -94,6 +97,9 @@ const WORKER_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 const WORKER_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKER_CONNECT_RETRY: Duration = Duration::from_millis(25);
 const MANAGED_ENVIRONMENTS_DIR: &str = ".dynamic-plugin-environments";
+const WORKER_POLICY_UNAVAILABLE_REASON: &str = "worker_policy_unavailable";
+const WORKER_POLICY_UNAVAILABLE_MESSAGE: &str =
+    "Request blocked because the required input policy could not be evaluated.";
 const PYTHON_WORKER_BOOTSTRAP: &str = r#"
 import asyncio
 import importlib
@@ -624,8 +630,12 @@ fn load_one_worker_plugin(
         register.registrations
     };
     if registrations.iter().any(|registration| {
-        RegistrationSurface::try_from(registration.surface)
-            .is_ok_and(|surface| surface == RegistrationSurface::LlmRequestIntercept)
+        RegistrationSurface::try_from(registration.surface).is_ok_and(|surface| {
+            matches!(
+                surface,
+                RegistrationSurface::LlmRequestIntercept | RegistrationSurface::LlmFinalInputPolicy
+            )
+        })
     }) {
         validate_annotated_request_consumer_compatibility(&relay_compat, &spec.plugin_id)?;
     }
@@ -1091,7 +1101,8 @@ impl WorkerPluginInstance {
                 | RegistrationSurface::LlmConditionalExecutionGuardrail
                 | RegistrationSurface::LlmRequestIntercept
                 | RegistrationSurface::LlmExecutionIntercept
-                | RegistrationSurface::LlmStreamExecutionIntercept => {
+                | RegistrationSurface::LlmStreamExecutionIntercept
+                | RegistrationSurface::LlmFinalInputPolicy => {
                     self.install_llm_registration(ctx, registration, surface)?
                 }
                 RegistrationSurface::Unspecified => {
@@ -1314,6 +1325,75 @@ impl WorkerPluginInstance {
                     })
                 }),
             ),
+            RegistrationSurface::LlmFinalInputPolicy => {
+                let timeout = Duration::from_millis(
+                    registration
+                        .timeout_ms
+                        .expect("validated final-input policy registration has a timeout"),
+                );
+                let failure_mode = PolicyFailureMode::try_from(registration.failure_mode)
+                    .expect("validated final-input policy registration has a failure mode");
+                ctx.register_llm_final_input_policy(
+                    name,
+                    priority,
+                    Arc::new(move |model_name, request, annotated| {
+                        let instance = instance.clone();
+                        let callback_name = callback_name.clone();
+                        Box::pin(async move {
+                            let result = instance
+                                .invoke_llm_final_input_policy(
+                                    &callback_name,
+                                    &model_name,
+                                    request,
+                                    annotated,
+                                    timeout,
+                                )
+                                .await;
+                            match result {
+                                Ok(outcome) => Ok(outcome),
+                                Err(error) if failure_mode == PolicyFailureMode::FailOpen => {
+                                    log::warn!(
+                                        target: "nemo_relay.worker",
+                                        event = "worker_policy_failed_open",
+                                        plugin_id = instance.plugin_kind.as_str(),
+                                        callback = callback_name.as_str(),
+                                        surface = RegistrationSurface::LlmFinalInputPolicy.as_str_name();
+                                        "Worker final-input policy failed open: {error}"
+                                    );
+                                    Ok(LlmFinalInputPolicyOutcome::allow_with_evidence(
+                                        serde_json::json!({
+                                            "policy_availability": {
+                                                "status": "bypassed",
+                                                "reason": "worker_callback_failed"
+                                            }
+                                        }),
+                                    ))
+                                }
+                                Err(error) => {
+                                    log::warn!(
+                                        target: "nemo_relay.worker",
+                                        event = "worker_policy_failed_closed",
+                                        plugin_id = instance.plugin_kind.as_str(),
+                                        callback = callback_name.as_str(),
+                                        surface = RegistrationSurface::LlmFinalInputPolicy.as_str_name();
+                                        "Worker final-input policy failed closed: {error}"
+                                    );
+                                    Ok(LlmFinalInputPolicyOutcome::reject(
+                                        WORKER_POLICY_UNAVAILABLE_REASON,
+                                        WORKER_POLICY_UNAVAILABLE_MESSAGE,
+                                    )
+                                    .with_evidence(serde_json::json!({
+                                        "policy_availability": {
+                                            "status": "unavailable",
+                                            "reason": "worker_callback_failed"
+                                        }
+                                    })))
+                                }
+                            }
+                        })
+                    }),
+                )
+            }
             RegistrationSurface::LlmExecutionIntercept => ctx.register_llm_execution_intercept(
                 name,
                 priority,
@@ -1742,6 +1822,48 @@ impl WorkerPluginCallback {
             Some(invoke_response_result::Result::Error(error)) => Err(worker_error_to_flow(error)),
             _ => Err(FlowError::Internal(
                 "worker LLM request intercept returned unexpected result".into(),
+            )),
+        }
+    }
+
+    async fn invoke_llm_final_input_policy(
+        &self,
+        registration_name: &str,
+        model_name: &str,
+        request: LlmRequest,
+        annotated: Option<AnnotatedLlmRequest>,
+        timeout: Duration,
+    ) -> FlowResult<LlmFinalInputPolicyOutcome> {
+        let invoke = self.base_request(
+            registration_name,
+            RegistrationSurface::LlmFinalInputPolicy,
+            None,
+            Some(invoke_request_payload_llm(
+                model_name,
+                Some(request),
+                annotated,
+                None,
+            )),
+        );
+        let response = self.invoke_async_with_timeout(invoke, timeout).await?;
+        match response.result {
+            Some(invoke_response_result::Result::LlmFinalInputPolicy(result)) => {
+                let outcome = required_envelope(result.outcome, "LLM final-input policy outcome")?;
+                if outcome.schema != LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA {
+                    return Err(FlowError::Internal(format!(
+                        "worker returned unsupported LLM final-input policy outcome schema: {}",
+                        outcome.schema
+                    )));
+                }
+                decode_json_envelope(&outcome).map_err(|err| {
+                    FlowError::Internal(format!(
+                        "worker returned invalid LLM final-input policy outcome: {err}"
+                    ))
+                })
+            }
+            Some(invoke_response_result::Result::Error(error)) => Err(worker_error_to_flow(error)),
+            _ => Err(FlowError::Internal(
+                "worker LLM final-input policy returned unexpected result".into(),
             )),
         }
     }
@@ -3163,6 +3285,39 @@ fn validate_registration_plan(
         if surface == RegistrationSurface::Unspecified {
             return Err(PluginError::RegistrationFailed(format!(
                 "worker plugin '{plugin_id}' returned unspecified registration surface"
+            )));
+        }
+        if surface == RegistrationSurface::LlmFinalInputPolicy {
+            if registration
+                .timeout_ms
+                .is_none_or(|timeout_ms| timeout_ms == 0)
+            {
+                return Err(PluginError::RegistrationFailed(format!(
+                    "worker plugin '{plugin_id}' final-input policy '{}' must declare a non-zero timeout_ms",
+                    registration.local_name
+                )));
+            }
+            if !matches!(
+                PolicyFailureMode::try_from(registration.failure_mode),
+                Ok(PolicyFailureMode::FailClosed | PolicyFailureMode::FailOpen)
+            ) {
+                return Err(PluginError::RegistrationFailed(format!(
+                    "worker plugin '{plugin_id}' final-input policy '{}' must declare fail-closed or fail-open behavior",
+                    registration.local_name
+                )));
+            }
+            if registration.break_chain {
+                return Err(PluginError::RegistrationFailed(format!(
+                    "worker plugin '{plugin_id}' final-input policy '{}' cannot set break_chain",
+                    registration.local_name
+                )));
+            }
+        } else if registration.timeout_ms.is_some()
+            || registration.failure_mode != PolicyFailureMode::Unspecified as i32
+        {
+            return Err(PluginError::RegistrationFailed(format!(
+                "worker plugin '{plugin_id}' registration '{}' may only set timeout_ms and failure_mode for an LLM final-input policy",
+                registration.local_name
             )));
         }
     }

--- a/crates/core/tests/fixtures/worker_plugin/src/main.rs
+++ b/crates/core/tests/fixtures/worker_plugin/src/main.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nemo_relay_worker::{
-    ConfigDiagnostic, DiagnosticLevel, EventSanitizeFields, Json, LlmRequest, PendingMarkSpec,
+    ConfigDiagnostic, DiagnosticLevel, EventSanitizeFields, Json, LlmFinalInputPolicyOutcome,
+    LlmRequest, PendingMarkSpec, PolicyFailureMode,
 };
 use nemo_relay_worker::{
     JsonStream, LlmNext, LlmStreamNext, PluginContext, ScopeType, ToolExecutionInterceptOutcome,
@@ -112,6 +113,9 @@ impl WorkerPlugin for FixtureWorkerPlugin {
             ctx,
             fixture_flag(config, "llm_request_error"),
             fixture_flag(config, "llm_stream_open_error"),
+            fixture_flag(config, "final_input_policy_error"),
+            fixture_flag(config, "final_input_policy_timeout"),
+            fixture_flag(config, "final_input_policy_fail_open"),
         );
         Ok(())
     }
@@ -216,6 +220,9 @@ fn register_fixture_llm_hooks(
     ctx: &mut PluginContext,
     llm_request_error: bool,
     llm_stream_open_error: bool,
+    final_input_policy_error: bool,
+    final_input_policy_timeout: bool,
+    final_input_policy_fail_open: bool,
 ) {
     ctx.register_llm_sanitize_request_guardrail(
         "fixture_llm_sanitize_request",
@@ -274,6 +281,54 @@ fn register_fixture_llm_hooks(
                             .build(),
                     ),
             )
+        },
+    );
+    ctx.register_llm_final_input_policy(
+        "fixture_llm_final_input_policy",
+        0,
+        if final_input_policy_timeout {
+            std::time::Duration::from_millis(25)
+        } else {
+            std::time::Duration::from_secs(2)
+        },
+        if final_input_policy_fail_open {
+            PolicyFailureMode::FailOpen
+        } else {
+            PolicyFailureMode::FailClosed
+        },
+        move |_name, request, annotated| async move {
+            if final_input_policy_timeout {
+                std::future::pending::<()>().await;
+            }
+            if final_input_policy_error {
+                return Err(WorkerSdkError::Callback(
+                    "fixture final-input policy error requested".into(),
+                ));
+            }
+            if request
+                .content
+                .get("reject_final_input")
+                .and_then(Json::as_bool)
+                .unwrap_or(false)
+            {
+                return Ok(LlmFinalInputPolicyOutcome::reject(
+                    "fixture_unsafe_input",
+                    "fixture final-input policy rejected the request",
+                ));
+            }
+            let (request, annotated) = match annotated {
+                Some(mut annotated) => {
+                    annotated
+                        .extra
+                        .insert("worker_plugin_final_input_policy".into(), json!(true));
+                    (request, Some(annotated))
+                }
+                None => (
+                    mark_llm_request(request, "worker_plugin_final_input_policy"),
+                    None,
+                ),
+            };
+            Ok(LlmFinalInputPolicyOutcome::transform(request, annotated))
         },
     );
     ctx.register_llm_execution_intercept(

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -27,17 +27,18 @@ use nemo_relay::api::llm::{
     LlmCallExecuteParams, LlmStreamCallExecuteParams, llm_call_execute, llm_request_intercepts,
     llm_stream_call_execute,
 };
-use nemo_relay::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
+use nemo_relay::api::llm::{LlmFinalInputPolicyOutcome, LlmRequest, LlmRequestInterceptOutcome};
 use nemo_relay::api::optimization::record_llm_optimization_contribution;
 use nemo_relay::api::registry::{
     deregister_llm_conditional_execution_guardrail, deregister_llm_execution_intercept,
-    deregister_llm_request_intercept, deregister_llm_sanitize_request_guardrail,
-    deregister_llm_sanitize_response_guardrail, deregister_llm_stream_execution_intercept,
-    deregister_mark_sanitize_guardrail, deregister_scope_sanitize_end_guardrail,
-    deregister_scope_sanitize_start_guardrail, deregister_tool_conditional_execution_guardrail,
-    deregister_tool_execution_intercept, deregister_tool_request_intercept,
-    deregister_tool_sanitize_request_guardrail, deregister_tool_sanitize_response_guardrail,
-    register_llm_conditional_execution_guardrail, register_llm_execution_intercept,
+    deregister_llm_final_input_policy, deregister_llm_request_intercept,
+    deregister_llm_sanitize_request_guardrail, deregister_llm_sanitize_response_guardrail,
+    deregister_llm_stream_execution_intercept, deregister_mark_sanitize_guardrail,
+    deregister_scope_sanitize_end_guardrail, deregister_scope_sanitize_start_guardrail,
+    deregister_tool_conditional_execution_guardrail, deregister_tool_execution_intercept,
+    deregister_tool_request_intercept, deregister_tool_sanitize_request_guardrail,
+    deregister_tool_sanitize_response_guardrail, register_llm_conditional_execution_guardrail,
+    register_llm_execution_intercept, register_llm_final_input_policy,
     register_llm_request_intercept, register_llm_sanitize_request_guardrail,
     register_llm_sanitize_response_guardrail, register_llm_stream_execution_intercept,
     register_mark_sanitize_guardrail, register_scope_sanitize_end_guardrail,
@@ -4298,6 +4299,195 @@ async fn test_llm_request_intercept_pending_marks_preserve_order_and_break_chain
     for name in ["pending_first", "pending_break", "pending_skipped"] {
         deregister_llm_request_intercept(name).unwrap();
     }
+}
+
+#[tokio::test]
+async fn test_final_input_policy_runs_after_request_intercepts_and_transforms_provider_request() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    register_llm_request_intercept(
+        "before_final_policy",
+        1,
+        false,
+        Arc::new(|_name, mut request, annotated| {
+            request
+                .headers
+                .insert("x-request-intercept".into(), json!(true));
+            ready(LlmRequestInterceptOutcome::new(request, annotated))
+        }),
+    )
+    .unwrap();
+    register_llm_final_input_policy(
+        "final_policy_transform",
+        1,
+        Arc::new(|_name, mut request, annotated| {
+            assert_eq!(request.headers["x-request-intercept"], true);
+            request.content["prompt"] = json!("approved prompt");
+            ready(
+                LlmFinalInputPolicyOutcome::transform(request, annotated)
+                    .with_evidence(json!({"rail": "input"})),
+            )
+        }),
+    )
+    .unwrap();
+    register_llm_final_input_policy(
+        "final_policy_observer",
+        2,
+        Arc::new(|_name, request, _annotated| {
+            assert_eq!(request.content["prompt"], "approved prompt");
+            ready(LlmFinalInputPolicyOutcome::allow())
+        }),
+    )
+    .unwrap();
+
+    let provider_request = Arc::new(Mutex::new(None::<LlmRequest>));
+    let captured_request = Arc::clone(&provider_request);
+    let response = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("final-input-transform")
+            .request(LlmRequest {
+                headers: serde_json::Map::new(),
+                content: json!({"prompt": "original"}),
+            })
+            .func(Arc::new(move |request| {
+                *captured_request.lock().unwrap() = Some(request);
+                Box::pin(async { Ok(json!({"response": "done"})) })
+            }))
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response, json!({"response": "done"}));
+    let provider_request = provider_request.lock().unwrap().clone().unwrap();
+    assert_eq!(provider_request.content["prompt"], "approved prompt");
+    assert_eq!(provider_request.headers["x-request-intercept"], true);
+
+    deregister_llm_final_input_policy("final_policy_observer").unwrap();
+    deregister_llm_final_input_policy("final_policy_transform").unwrap();
+    deregister_llm_request_intercept("before_final_policy").unwrap();
+}
+
+#[tokio::test]
+async fn test_final_input_policy_rejection_is_terminal_before_managed_start() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = Arc::clone(&events);
+    register_subscriber(
+        "final_policy_rejection_observer",
+        Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+    register_llm_final_input_policy(
+        "reject_final_input",
+        1,
+        Arc::new(|_name, _request, _annotated| {
+            ready(
+                LlmFinalInputPolicyOutcome::reject("unsafe_input", "request rejected")
+                    .with_evidence(json!({"rail": "jailbreak"})),
+            )
+        }),
+    )
+    .unwrap();
+
+    let provider_called = Arc::new(AtomicBool::new(false));
+    let called = Arc::clone(&provider_called);
+    let error = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("final-input-rejected")
+            .request(LlmRequest {
+                headers: serde_json::Map::new(),
+                content: json!({"prompt": "unsafe"}),
+            })
+            .func(Arc::new(move |_| {
+                called.store(true, Ordering::SeqCst);
+                Box::pin(async { Ok(json!({"response": "must not run"})) })
+            }))
+            .build(),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        FlowError::GuardrailRejected(ref reason) if reason == "request rejected"
+    ));
+    assert!(!provider_called.load(Ordering::SeqCst));
+    flush_subscribers().unwrap();
+
+    let events = events.lock().unwrap();
+    assert!(!events.iter().any(|event| {
+        event.name() == "final-input-rejected"
+            && event.scope_category() == Some(ScopeCategory::Start)
+            && event.scope_type() == Some(ScopeType::Llm)
+    }));
+    assert!(events.iter().any(|event| {
+        event.name() == "reject_final_input"
+            && event.scope_category() == Some(ScopeCategory::End)
+            && event.data().and_then(|data| data.get("reason_code")) == Some(&json!("unsafe_input"))
+    }));
+    assert!(events.iter().any(|event| {
+        event.name() == "final-input-rejected"
+            && event.data().and_then(|data| data.get("rejected")) == Some(&json!(true))
+            && event.data().and_then(|data| data.get("reason_code")) == Some(&json!("unsafe_input"))
+    }));
+    drop(events);
+
+    deregister_llm_final_input_policy("reject_final_input").unwrap();
+    deregister_subscriber("final_policy_rejection_observer").unwrap();
+}
+
+#[tokio::test]
+async fn test_final_input_policy_rejects_before_stream_provider_opens() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    register_llm_final_input_policy(
+        "reject_stream_final_input",
+        1,
+        Arc::new(|_name, _request, _annotated| {
+            ready(LlmFinalInputPolicyOutcome::reject(
+                "unsafe_input",
+                "stream request rejected",
+            ))
+        }),
+    )
+    .unwrap();
+
+    let provider_called = Arc::new(AtomicBool::new(false));
+    let called = Arc::clone(&provider_called);
+    let error = llm_stream_call_execute(
+        LlmStreamCallExecuteParams::builder()
+            .name("final-input-stream-rejected")
+            .request(LlmRequest {
+                headers: serde_json::Map::new(),
+                content: json!({"prompt": "unsafe"}),
+            })
+            .func(Arc::new(move |_| {
+                called.store(true, Ordering::SeqCst);
+                Box::pin(async { Ok(LlmJsonStream::new(tokio_stream::empty())) })
+            }))
+            .collector(Box::new(|_| Ok(())))
+            .finalizer(Box::new(|| json!({"response": "must not run"})))
+            .build(),
+    )
+    .await
+    .err()
+    .expect("final-input policy should reject before opening the provider stream");
+
+    assert!(matches!(
+        error,
+        FlowError::GuardrailRejected(ref reason) if reason == "stream request rejected"
+    ));
+    assert!(!provider_called.load(Ordering::SeqCst));
+
+    deregister_llm_final_input_policy("reject_stream_final_input").unwrap();
 }
 
 #[tokio::test]

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -4,6 +4,7 @@
 //! Integration coverage for gRPC worker dynamic plugins.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
@@ -303,6 +304,10 @@ async fn rust_worker_registers_and_invokes_all_current_surfaces() {
         llm_execute_response["request"]["worker_plugin_llm_execution_request"],
         true
     );
+    assert_eq!(
+        llm_execute_response["request"]["worker_plugin_final_input_policy"],
+        true
+    );
     flush_subscribers().expect("worker fixture LLM events should flush");
     let captured_events = events.lock().unwrap().clone();
     find_event(&captured_events, "fixture.worker.subscriber.mark", None);
@@ -365,6 +370,10 @@ async fn rust_worker_registers_and_invokes_all_current_surfaces() {
     assert_eq!(stream_value["worker_plugin_llm_stream_execution"], true);
     assert_eq!(
         stream_value["request"]["worker_plugin_llm_stream_execution_request"],
+        true
+    );
+    assert_eq!(
+        stream_value["request"]["worker_plugin_final_input_policy"],
         true
     );
 
@@ -588,6 +597,10 @@ async fn worker_llm_request_intercept_round_trips_annotations() {
     .expect("worker LLM request intercept should preserve annotations");
     assert_eq!(response["llm_callback"], true);
     assert_eq!(response["request"]["worker_plugin_annotated_request"], true);
+    assert_eq!(
+        response["request"]["worker_plugin_final_input_policy"],
+        true
+    );
 
     loaded.clear();
 }
@@ -625,6 +638,137 @@ async fn worker_llm_request_intercept_callback_error_surfaces_to_host() {
         "{error}"
     );
 
+    loaded.clear();
+}
+
+#[tokio::test]
+async fn worker_final_input_policy_is_terminal_and_applies_failure_mode() {
+    let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
+
+    let provider_called = Arc::new(AtomicBool::new(false));
+    let called = provider_called.clone();
+    let loaded = load_and_initialize_fixture(Map::new()).await;
+    let rejected = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("worker-fixture-final-input-reject")
+            .request(LlmRequest {
+                headers: Map::new(),
+                content: json!({ "reject_final_input": true }),
+            })
+            .func(Arc::new(move |_| {
+                called.store(true, Ordering::SeqCst);
+                Box::pin(async { Ok(json!({ "should_not_run": true })) })
+            }))
+            .build(),
+    )
+    .await
+    .expect_err("explicit final-input rejection should be terminal");
+    assert!(
+        rejected
+            .to_string()
+            .contains("fixture final-input policy rejected the request"),
+        "{rejected}"
+    );
+    assert!(!provider_called.load(Ordering::SeqCst));
+    loaded.clear();
+
+    let provider_called = Arc::new(AtomicBool::new(false));
+    let called = provider_called.clone();
+    let loaded = load_and_initialize_fixture(Map::from_iter([(
+        "final_input_policy_error".into(),
+        json!(true),
+    )]))
+    .await;
+    let failed_closed = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("worker-fixture-final-input-fail-closed")
+            .request(LlmRequest {
+                headers: Map::new(),
+                content: json!({ "prompt": "closed" }),
+            })
+            .func(Arc::new(move |_| {
+                called.store(true, Ordering::SeqCst);
+                Box::pin(async { Ok(json!({ "should_not_run": true })) })
+            }))
+            .build(),
+    )
+    .await
+    .expect_err("a fail-closed worker error should abort the request");
+    assert!(
+        failed_closed
+            .to_string()
+            .contains("Request blocked because the required input policy could not be evaluated"),
+        "{failed_closed}"
+    );
+    assert!(
+        !failed_closed
+            .to_string()
+            .contains("fixture final-input policy error requested"),
+        "{failed_closed}"
+    );
+    assert!(!provider_called.load(Ordering::SeqCst));
+    loaded.clear();
+
+    let loaded = load_and_initialize_fixture(Map::from_iter([
+        ("final_input_policy_error".into(), json!(true)),
+        ("final_input_policy_fail_open".into(), json!(true)),
+    ]))
+    .await;
+    let allowed = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("worker-fixture-final-input-fail-open")
+            .request(LlmRequest {
+                headers: Map::new(),
+                content: json!({ "prompt": "open" }),
+            })
+            .func(Arc::new(|request| {
+                Box::pin(async move { Ok(json!({ "request": request.content })) })
+            }))
+            .build(),
+    )
+    .await
+    .expect("a fail-open worker error should continue to the provider");
+    assert_eq!(
+        allowed["request"]["worker_plugin_llm_request_intercept"],
+        true
+    );
+    assert!(
+        allowed["request"]
+            .get("worker_plugin_final_input_policy")
+            .is_none()
+    );
+    loaded.clear();
+
+    let provider_called = Arc::new(AtomicBool::new(false));
+    let called = provider_called.clone();
+    let loaded = load_and_initialize_fixture(Map::from_iter([(
+        "final_input_policy_timeout".into(),
+        json!(true),
+    )]))
+    .await;
+    let timed_out = llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("worker-fixture-final-input-timeout")
+            .request(LlmRequest {
+                headers: Map::new(),
+                content: json!({ "prompt": "timeout" }),
+            })
+            .func(Arc::new(move |_| {
+                called.store(true, Ordering::SeqCst);
+                Box::pin(async { Ok(json!({ "should_not_run": true })) })
+            }))
+            .build(),
+    )
+    .await
+    .expect_err("a fail-closed final-input timeout should abort the request");
+    assert!(
+        timed_out
+            .to_string()
+            .contains("Request blocked because the required input policy could not be evaluated"),
+        "{timed_out}"
+    );
+    assert!(!timed_out.to_string().contains("timed out"), "{timed_out}");
+    assert!(!provider_called.load(Ordering::SeqCst));
     loaded.clear();
 }
 

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -440,6 +440,7 @@ fn registration_plan_and_scope_type_helpers_validate_edges() {
                 surface: RegistrationSurface::Subscriber as i32,
                 priority: 0,
                 break_chain: false,
+                ..Registration::default()
             }],
             error: None,
         },
@@ -455,6 +456,7 @@ fn registration_plan_and_scope_type_helpers_validate_edges() {
                 surface: 999,
                 priority: 0,
                 break_chain: false,
+                ..Registration::default()
             }],
             error: None,
         },
@@ -474,6 +476,7 @@ fn registration_plan_and_scope_type_helpers_validate_edges() {
                 surface: RegistrationSurface::Unspecified as i32,
                 priority: 0,
                 break_chain: false,
+                ..Registration::default()
             }],
             error: None,
         },
@@ -483,6 +486,65 @@ fn registration_plan_and_scope_type_helpers_validate_edges() {
         unspecified
             .to_string()
             .contains("unspecified registration surface")
+    );
+
+    let invalid_policy_timeout = validate_registration_plan(
+        "fixture_worker",
+        &RegisterResponse {
+            registrations: vec![Registration {
+                local_name: "policy".into(),
+                surface: RegistrationSurface::LlmFinalInputPolicy as i32,
+                priority: 0,
+                break_chain: false,
+                timeout_ms: None,
+                failure_mode: PolicyFailureMode::FailClosed as i32,
+            }],
+            error: None,
+        },
+    )
+    .expect_err("final-input policy timeout should be required");
+    assert!(invalid_policy_timeout.to_string().contains("timeout_ms"));
+
+    let invalid_policy_failure_mode = validate_registration_plan(
+        "fixture_worker",
+        &RegisterResponse {
+            registrations: vec![Registration {
+                local_name: "policy".into(),
+                surface: RegistrationSurface::LlmFinalInputPolicy as i32,
+                priority: 0,
+                break_chain: false,
+                timeout_ms: Some(30_000),
+                failure_mode: PolicyFailureMode::Unspecified as i32,
+            }],
+            error: None,
+        },
+    )
+    .expect_err("final-input policy failure mode should be required");
+    assert!(
+        invalid_policy_failure_mode
+            .to_string()
+            .contains("fail-closed or fail-open")
+    );
+
+    let invalid_non_policy_options = validate_registration_plan(
+        "fixture_worker",
+        &RegisterResponse {
+            registrations: vec![Registration {
+                local_name: "subscriber".into(),
+                surface: RegistrationSurface::Subscriber as i32,
+                priority: 0,
+                break_chain: false,
+                timeout_ms: Some(30_000),
+                failure_mode: PolicyFailureMode::FailOpen as i32,
+            }],
+            error: None,
+        },
+    )
+    .expect_err("non-policy registrations should reject policy-only options");
+    assert!(
+        invalid_non_policy_options
+            .to_string()
+            .contains("may only set timeout_ms and failure_mode")
     );
 
     let cases = [
@@ -1563,6 +1625,7 @@ async fn install_registrations_covers_registry_error_edges() {
         RegistrationSurface::LlmRequestIntercept,
         RegistrationSurface::LlmExecutionIntercept,
         RegistrationSurface::LlmStreamExecutionIntercept,
+        RegistrationSurface::LlmFinalInputPolicy,
     ] {
         let duplicate_name = format!("duplicate_worker_{surface:?}");
         let (instance, _shutdown) = fake_worker_instance(vec![
@@ -2696,6 +2759,12 @@ fn registration(surface: RegistrationSurface, local_name: &str) -> Registration 
         surface: surface as i32,
         priority: 0,
         break_chain: false,
+        timeout_ms: (surface == RegistrationSurface::LlmFinalInputPolicy).then_some(30_000),
+        failure_mode: if surface == RegistrationSurface::LlmFinalInputPolicy {
+            PolicyFailureMode::FailClosed as i32
+        } else {
+            PolicyFailureMode::Unspecified as i32
+        },
     }
 }
 

--- a/crates/types/src/api/llm.rs
+++ b/crates/types/src/api/llm.rs
@@ -16,6 +16,9 @@ use crate::codec::request::AnnotatedLlmRequest;
 /// Version 2 carries the version 2 annotated-request schema.
 pub const LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA: &str = "nemo.relay.LlmRequestInterceptOutcome@2";
 
+/// Versioned JSON envelope schema for [`LlmFinalInputPolicyOutcome`].
+pub const LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA: &str = "nemo.relay.LlmFinalInputPolicyOutcome@1";
+
 bitflags! {
     /// Bitflags that modify LLM-call behavior and observability.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -103,5 +106,101 @@ impl From<(LlmRequest, AnnotatedLlmRequest)> for LlmRequestInterceptOutcome {
 impl From<(LlmRequest, Option<AnnotatedLlmRequest>)> for LlmRequestInterceptOutcome {
     fn from((request, annotated_request): (LlmRequest, Option<AnnotatedLlmRequest>)) -> Self {
         Self::new(request, annotated_request)
+    }
+}
+
+/// Result of evaluating the final LLM input immediately before execution.
+///
+/// Final-input policies run after all request intercepts and before Relay
+/// creates the managed LLM scope or enters cache, routing, and provider
+/// execution. An allowed request is carried forward unchanged, a transformed
+/// request becomes authoritative for all later middleware, and a rejection is
+/// terminal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "snake_case")]
+pub enum LlmFinalInputPolicyOutcome {
+    /// Continue with the current request unchanged.
+    Allow {
+        /// Optional redacted, policy-specific decision evidence.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        evidence: Option<Json>,
+    },
+    /// Continue with a transformed request.
+    Transform {
+        /// Rewritten provider request when no request codec is active.
+        ///
+        /// With an active codec, headers remain writable but content is
+        /// read-only; provider-body changes must be expressed through
+        /// `annotated_request`.
+        request: LlmRequest,
+        /// Optional normalized request annotation to carry forward.
+        ///
+        /// This field is required when a request codec is active.
+        #[serde(default)]
+        annotated_request: Option<Box<AnnotatedLlmRequest>>,
+        /// Optional redacted, policy-specific decision evidence.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        evidence: Option<Json>,
+    },
+    /// Stop the request before managed execution begins.
+    Reject {
+        /// Stable, low-cardinality reason code suitable for policy metrics.
+        reason_code: String,
+        /// Caller-safe rejection message.
+        safe_message: String,
+        /// Optional redacted, policy-specific decision evidence.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        evidence: Option<Json>,
+    },
+}
+
+impl LlmFinalInputPolicyOutcome {
+    /// Allow the current request without additional evidence.
+    #[must_use]
+    pub fn allow() -> Self {
+        Self::Allow { evidence: None }
+    }
+
+    /// Return an allowed decision with redacted policy evidence.
+    #[must_use]
+    pub fn allow_with_evidence(evidence: Json) -> Self {
+        Self::Allow {
+            evidence: Some(evidence),
+        }
+    }
+
+    /// Transform the request without additional evidence.
+    #[must_use]
+    pub fn transform(request: LlmRequest, annotated_request: Option<AnnotatedLlmRequest>) -> Self {
+        Self::Transform {
+            request,
+            annotated_request: annotated_request.map(Box::new),
+            evidence: None,
+        }
+    }
+
+    /// Reject the request with a stable code and caller-safe message.
+    #[must_use]
+    pub fn reject(reason_code: impl Into<String>, safe_message: impl Into<String>) -> Self {
+        Self::Reject {
+            reason_code: reason_code.into(),
+            safe_message: safe_message.into(),
+            evidence: None,
+        }
+    }
+
+    /// Attach redacted policy evidence to any decision.
+    #[must_use]
+    pub fn with_evidence(mut self, evidence: Json) -> Self {
+        match &mut self {
+            Self::Allow { evidence: current }
+            | Self::Transform {
+                evidence: current, ..
+            }
+            | Self::Reject {
+                evidence: current, ..
+            } => *current = Some(evidence),
+        }
+        self
     }
 }

--- a/crates/types/tests/serialization_tests.rs
+++ b/crates/types/tests/serialization_tests.rs
@@ -9,7 +9,9 @@ use nemo_relay_types::api::event::{
     BaseEvent, CategoryProfile, Event, EventCategory, PendingMarkSpec, ScopeCategory, ScopeEvent,
     llm_attributes_to_strings,
 };
-use nemo_relay_types::api::llm::{LlmAttributes, LlmRequest, LlmRequestInterceptOutcome};
+use nemo_relay_types::api::llm::{
+    LlmAttributes, LlmFinalInputPolicyOutcome, LlmRequest, LlmRequestInterceptOutcome,
+};
 use nemo_relay_types::api::tool::ToolExecutionInterceptOutcome;
 use nemo_relay_types::codec::request::{AnnotatedLlmRequest, ContentPart, Message, MessageContent};
 use nemo_relay_types::codec::response::AnnotatedLlmResponse;
@@ -174,6 +176,38 @@ fn llm_request_intercept_outcome_converts_from_request_inputs() {
         optional_annotation,
         LlmRequestInterceptOutcome::new(request, Some(annotated_request))
     );
+}
+
+#[test]
+fn llm_final_input_policy_outcomes_have_stable_tagged_json() {
+    let allow = LlmFinalInputPolicyOutcome::allow_with_evidence(json!({"rail": "input"}));
+    let encoded = serde_json::to_value(&allow).expect("allow outcome should serialize");
+    assert_eq!(encoded["decision"], "allow");
+    assert_eq!(encoded["evidence"]["rail"], "input");
+
+    let transform = LlmFinalInputPolicyOutcome::transform(
+        LlmRequest {
+            headers: Map::new(),
+            content: json!({"prompt": "safe"}),
+        },
+        None,
+    )
+    .with_evidence(json!({"modified": true}));
+    let encoded = serde_json::to_value(&transform).expect("transform outcome should serialize");
+    assert_eq!(encoded["decision"], "transform");
+    assert_eq!(encoded["request"]["content"]["prompt"], "safe");
+    assert_eq!(encoded["evidence"]["modified"], true);
+
+    let reject = LlmFinalInputPolicyOutcome::reject("unsafe_input", "request rejected")
+        .with_evidence(json!({"rail": "jailbreak"}));
+    let encoded = serde_json::to_value(&reject).expect("reject outcome should serialize");
+    assert_eq!(encoded["decision"], "reject");
+    assert_eq!(encoded["reason_code"], "unsafe_input");
+    assert_eq!(encoded["safe_message"], "request rejected");
+
+    let decoded: LlmFinalInputPolicyOutcome =
+        serde_json::from_value(encoded).expect("reject outcome should deserialize");
+    assert_eq!(decoded, reject);
 }
 
 #[test]

--- a/crates/worker-proto/README.md
+++ b/crates/worker-proto/README.md
@@ -41,6 +41,9 @@ tooling.
   clients, servers, services, and messages.
 - **JSON envelope helpers**: `json_envelope` and `decode_json_envelope` for
   serializing Relay DTOs into protocol payloads.
+- **Policy controls**: The final-input policy surface carries a per-registration
+  deadline and explicit fail-open or fail-closed behavior; the existing
+  cancellation RPC remains the interruption mechanism when a deadline expires.
 
 ## Installation
 

--- a/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
+++ b/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
@@ -49,9 +49,16 @@ enum RegistrationSurface {
   LLM_REQUEST_INTERCEPT = 23;
   LLM_EXECUTION_INTERCEPT = 24;
   LLM_STREAM_EXECUTION_INTERCEPT = 25;
+  LLM_FINAL_INPUT_POLICY = 26;
   MARK_SANITIZE_GUARDRAIL = 30;
   SCOPE_SANITIZE_START_GUARDRAIL = 31;
   SCOPE_SANITIZE_END_GUARDRAIL = 32;
+}
+
+enum PolicyFailureMode {
+  POLICY_FAILURE_MODE_UNSPECIFIED = 0;
+  FAIL_CLOSED = 1;
+  FAIL_OPEN = 2;
 }
 
 enum LlmCodecKind {
@@ -143,6 +150,8 @@ message Registration {
   int32 priority = 3;
   bool break_chain = 4;
   reserved 5;
+  optional uint64 timeout_ms = 6;
+  PolicyFailureMode failure_mode = 7;
 }
 
 message InvokeRequest {
@@ -203,6 +212,7 @@ message InvokeResponse {
     LlmRequestInterceptResult llm_request = 4;
     WorkerError error = 5;
     ToolExecutionInterceptResult tool_execution = 6;
+    LlmFinalInputPolicyResult llm_final_input_policy = 7;
   }
 }
 
@@ -222,6 +232,10 @@ message LlmRequestInterceptResult {
 }
 
 message ToolExecutionInterceptResult {
+  JsonEnvelope outcome = 1;
+}
+
+message LlmFinalInputPolicyResult {
   JsonEnvelope outcome = 1;
 }
 

--- a/crates/worker-proto/tests/proto_tests.rs
+++ b/crates/worker-proto/tests/proto_tests.rs
@@ -4,7 +4,8 @@
 //! Tests for stable worker protocol helpers and enum values.
 
 use nemo_relay_worker_proto::v1::{
-    HandshakeRequest, HealthRequest, InvokeRequest, JsonEnvelope, RegistrationSurface, ScopeType,
+    HandshakeRequest, HealthRequest, InvokeRequest, JsonEnvelope, PolicyFailureMode,
+    RegistrationSurface, ScopeType,
 };
 use nemo_relay_worker_proto::{WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, json_envelope};
 use prost::Message;
@@ -38,9 +39,17 @@ fn registration_surface_values_are_stable() {
     assert_eq!(RegistrationSurface::LlmRequestIntercept as i32, 23);
     assert_eq!(RegistrationSurface::LlmExecutionIntercept as i32, 24);
     assert_eq!(RegistrationSurface::LlmStreamExecutionIntercept as i32, 25);
+    assert_eq!(RegistrationSurface::LlmFinalInputPolicy as i32, 26);
     assert_eq!(RegistrationSurface::MarkSanitizeGuardrail as i32, 30);
     assert_eq!(RegistrationSurface::ScopeSanitizeStartGuardrail as i32, 31);
     assert_eq!(RegistrationSurface::ScopeSanitizeEndGuardrail as i32, 32);
+}
+
+#[test]
+fn policy_failure_mode_values_are_stable() {
+    assert_eq!(PolicyFailureMode::Unspecified as i32, 0);
+    assert_eq!(PolicyFailureMode::FailClosed as i32, 1);
+    assert_eq!(PolicyFailureMode::FailOpen as i32, 2);
 }
 
 #[test]

--- a/crates/worker/README.md
+++ b/crates/worker/README.md
@@ -85,6 +85,18 @@ Relay supplies the socket, activation ID, and authentication token through the
 worker environment. Use `serve_plugin` for Relay-spawned workers; explicit
 server configuration is intended for tests and custom launchers.
 
+## Final-Input Policies
+
+`PluginContext::register_llm_final_input_policy` installs an async policy after
+request intercepts and before Relay enters cache, routing, or provider
+execution. The callback returns `LlmFinalInputPolicyOutcome::Allow`,
+`Transform`, or `Reject`. Each registration declares a host-enforced deadline
+and `PolicyFailureMode`; fail-open applies only to worker failures or timeouts,
+never to an explicit policy rejection. Fail-closed worker failures become a
+caller-safe terminal rejection while Relay logs the operational error. When a
+codec is active, transformations must preserve raw request content and return
+the transformed annotated request.
+
 ## Concurrency and Cancellation
 
 Unary and streaming callbacks run concurrently. Cancellation is cooperative:

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -29,13 +29,16 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use futures_util::{Stream, StreamExt};
 #[cfg(unix)]
 use hyper_util::rt::TokioIo;
 pub use nemo_relay_types::Json;
 pub use nemo_relay_types::api::event::{DataSchema, Event, EventSanitizeFields, PendingMarkSpec};
-pub use nemo_relay_types::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
+pub use nemo_relay_types::api::llm::{
+    LlmFinalInputPolicyOutcome, LlmRequest, LlmRequestInterceptOutcome,
+};
 pub use nemo_relay_types::api::scope::ScopeType;
 pub use nemo_relay_types::api::tool::ToolExecutionInterceptOutcome;
 pub use nemo_relay_types::codec::optimization::{
@@ -53,8 +56,9 @@ use nemo_relay_worker_proto::v1::{
     CancelInvocationRequest, CreateScopeStackRequest, DropScopeStackRequest, EmitMarkRequest,
     EmptyResult, GuardrailResult, HandshakeRequest, HandshakeResponse, HealthRequest,
     HealthResponse, InvokeRequest, InvokeResponse, JsonEnvelope, JsonResult, LlmCodecDecodeRequest,
-    LlmCodecDecodeResponse, LlmCodecEncodeRequest, LlmCodecKind, LlmNextRequest,
-    LlmRequestInterceptResult, LlmStreamNextRequest, PopScopeRequest, PushScopeRequest,
+    LlmCodecDecodeResponse, LlmCodecEncodeRequest, LlmCodecKind, LlmFinalInputPolicyResult,
+    LlmNextRequest, LlmRequestInterceptResult, LlmStreamNextRequest,
+    PolicyFailureMode as ProtoPolicyFailureMode, PopScopeRequest, PushScopeRequest,
     RegisterRequest, RegisterResponse, Registration, RegistrationSurface, ScopeContext,
     ShutdownRequest, StreamChunk, ToolExecutionInterceptResult, ToolNextRequest, ValidateRequest,
     ValidateResponse, WorkerAck, WorkerError,
@@ -80,6 +84,24 @@ pub type BoxFutureResult<T> = Pin<Box<dyn Future<Output = Result<T>> + Send>>;
 
 /// Boxed JSON stream returned by streaming worker callbacks.
 pub type JsonStream = Pin<Box<dyn tokio_stream::Stream<Item = Result<Json>> + Send>>;
+
+/// Host behavior when an out-of-process policy callback cannot return a decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyFailureMode {
+    /// Abort the Relay request when the policy worker fails or times out.
+    FailClosed,
+    /// Continue the Relay request with redacted bypass evidence.
+    FailOpen,
+}
+
+impl PolicyFailureMode {
+    fn as_proto(self) -> ProtoPolicyFailureMode {
+        match self {
+            Self::FailClosed => ProtoPolicyFailureMode::FailClosed,
+            Self::FailOpen => ProtoPolicyFailureMode::FailOpen,
+        }
+    }
+}
 
 const JSON_SCHEMA: &str = "nemo.relay.Json@1";
 const LLM_REQUEST_SCHEMA: &str = "nemo.relay.LlmRequest@1";
@@ -273,6 +295,15 @@ type LlmRequestFn = Arc<
         + Send
         + Sync,
 >;
+type LlmFinalInputPolicyFn = Arc<
+    dyn Fn(
+            String,
+            LlmRequest,
+            Option<AnnotatedLlmRequest>,
+        ) -> BoxFutureResult<LlmFinalInputPolicyOutcome>
+        + Send
+        + Sync,
+>;
 type LlmExecutionFn = Arc<dyn Fn(&str, LlmRequest, LlmNext) -> BoxFutureResult<Json> + Send + Sync>;
 type LlmStreamExecutionFn =
     Arc<dyn Fn(&str, LlmRequest, LlmStreamNext) -> BoxFutureResult<JsonStream> + Send + Sync>;
@@ -293,6 +324,7 @@ struct WorkerHandlers {
     llm_sanitize_responses: HashMap<String, LlmSanitizeResponseFn>,
     llm_conditionals: HashMap<String, LlmConditionalFn>,
     llm_requests: HashMap<String, LlmRequestFn>,
+    llm_final_input_policies: HashMap<String, LlmFinalInputPolicyFn>,
     llm_executions: HashMap<String, LlmExecutionFn>,
     llm_stream_executions: HashMap<String, LlmStreamExecutionFn>,
 }
@@ -626,6 +658,48 @@ impl PluginContext {
         );
     }
 
+    /// Registers a terminal async policy over the fully intercepted LLM input.
+    ///
+    /// Relay invokes this callback after request intercepts and before cache,
+    /// routing, or provider execution. The host enforces `timeout` and applies
+    /// `failure_mode` only to operational worker failures; an explicit reject
+    /// outcome remains terminal in either mode. Fail closed converts an
+    /// operational failure into a caller-safe terminal rejection after logging
+    /// the underlying error; fail open continues with redacted bypass evidence.
+    pub fn register_llm_final_input_policy<F, Fut>(
+        &mut self,
+        name: &str,
+        priority: i32,
+        timeout: Duration,
+        failure_mode: PolicyFailureMode,
+        callback: F,
+    ) where
+        F: Fn(String, LlmRequest, Option<AnnotatedLlmRequest>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<LlmFinalInputPolicyOutcome>> + Send + 'static,
+    {
+        assert!(
+            !timeout.is_zero(),
+            "final-input policy timeout must be non-zero"
+        );
+        let timeout_ms = u64::try_from(timeout.as_millis())
+            .unwrap_or(u64::MAX)
+            .max(1);
+        self.handlers.registrations.push(Registration {
+            local_name: name.into(),
+            surface: RegistrationSurface::LlmFinalInputPolicy as i32,
+            priority,
+            break_chain: false,
+            timeout_ms: Some(timeout_ms),
+            failure_mode: failure_mode.as_proto() as i32,
+        });
+        self.handlers.llm_final_input_policies.insert(
+            name.into(),
+            Arc::new(move |model_name, request, annotated| {
+                Box::pin(callback(model_name, request, annotated))
+            }),
+        );
+    }
+
     /// Registers an LLM execution intercept.
     ///
     /// [`LlmNext::call`] may run repeatedly or concurrently while the callback
@@ -691,6 +765,8 @@ impl PluginContext {
             surface: surface as i32,
             priority,
             break_chain,
+            timeout_ms: None,
+            failure_mode: ProtoPolicyFailureMode::Unspecified as i32,
         });
     }
 }
@@ -1699,7 +1775,8 @@ impl WorkerService {
             | RegistrationSurface::LlmSanitizeResponseGuardrail
             | RegistrationSurface::LlmConditionalExecutionGuardrail
             | RegistrationSurface::LlmRequestIntercept
-            | RegistrationSurface::LlmExecutionIntercept => {
+            | RegistrationSurface::LlmExecutionIntercept
+            | RegistrationSurface::LlmFinalInputPolicy => {
                 self.invoke_llm_response(request, &scope, surface).await
             }
             RegistrationSurface::LlmStreamExecutionIntercept | RegistrationSurface::Unspecified => {
@@ -1846,6 +1923,10 @@ impl WorkerService {
             RegistrationSurface::LlmRequestIntercept => {
                 self.invoke_llm_request_response(request, scope).await
             }
+            RegistrationSurface::LlmFinalInputPolicy => {
+                self.invoke_llm_final_input_policy_response(request, scope)
+                    .await
+            }
             RegistrationSurface::LlmExecutionIntercept => {
                 self.invoke_llm_execution_response(request, scope).await
             }
@@ -1922,6 +2003,31 @@ impl WorkerService {
         })
         .await?;
         llm_request_response(outcome)
+    }
+
+    async fn invoke_llm_final_input_policy_response(
+        &self,
+        request: InvokeRequest,
+        scope: &Option<ScopeContext>,
+    ) -> Result<InvokeResponse> {
+        let payload = llm_payload(request.payload)?;
+        let request_value = required_json::<LlmRequest>(payload.request, "llm request")?;
+        let annotated = payload
+            .annotated_request
+            .map(|value| {
+                decode_expected_json_envelope::<AnnotatedLlmRequest>(
+                    &value,
+                    "annotated llm request",
+                    ANNOTATED_LLM_REQUEST_SCHEMA,
+                )
+            })
+            .transpose()?;
+        let handler = self.llm_final_input_policy(&request.registration_name)?;
+        let outcome = with_thread_scope(scope, || {
+            handler(payload.model_name, request_value, annotated)
+        })
+        .await?;
+        llm_final_input_policy_response(outcome)
     }
 
     async fn invoke_llm_execution_response(
@@ -2081,6 +2187,20 @@ impl WorkerService {
             .cloned()
             .ok_or_else(|| {
                 WorkerSdkError::InvalidInput(format!("llm request '{name}' not registered"))
+            })
+    }
+
+    fn llm_final_input_policy(&self, name: &str) -> Result<LlmFinalInputPolicyFn> {
+        self.handlers
+            .lock()
+            .map_err(|err| WorkerSdkError::Callback(format!("handler lock poisoned: {err}")))?
+            .llm_final_input_policies
+            .get(name)
+            .cloned()
+            .ok_or_else(|| {
+                WorkerSdkError::InvalidInput(format!(
+                    "llm final-input policy '{name}' not registered"
+                ))
             })
     }
 
@@ -2272,6 +2392,21 @@ fn llm_request_response(outcome: LlmRequestInterceptOutcome) -> Result<InvokeRes
                 LlmRequestInterceptResult {
                     outcome: Some(json_envelope(
                         nemo_relay_types::api::llm::LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA,
+                        &outcome,
+                    )?),
+                },
+            ),
+        ),
+    })
+}
+
+fn llm_final_input_policy_response(outcome: LlmFinalInputPolicyOutcome) -> Result<InvokeResponse> {
+    Ok(InvokeResponse {
+        result: Some(
+            nemo_relay_worker_proto::v1::invoke_response::Result::LlmFinalInputPolicy(
+                LlmFinalInputPolicyResult {
+                    outcome: Some(json_envelope(
+                        nemo_relay_types::api::llm::LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA,
                         &outcome,
                     )?),
                 },
@@ -2534,6 +2669,7 @@ fn all_surfaces() -> Vec<RegistrationSurface> {
         RegistrationSurface::LlmRequestIntercept,
         RegistrationSurface::LlmExecutionIntercept,
         RegistrationSurface::LlmStreamExecutionIntercept,
+        RegistrationSurface::LlmFinalInputPolicy,
         RegistrationSurface::MarkSanitizeGuardrail,
         RegistrationSurface::ScopeSanitizeStartGuardrail,
         RegistrationSurface::ScopeSanitizeEndGuardrail,

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -19,10 +19,10 @@ use futures_util::{Stream, StreamExt};
 use hyper_util::rt::TokioIo;
 use nemo_relay_types::api::event::{BaseEvent, Event, MarkEvent, PendingMarkSpec};
 use nemo_relay_worker::{
-    ANNOTATED_LLM_REQUEST_SCHEMA, Json, JsonStream, LlmNext, LlmRequest, LlmStreamNext,
-    PluginContext, PluginRuntime, Result, ScopeType, ToolExecutionInterceptOutcome, ToolNext,
-    WorkerPlugin, WorkerSdkError, WorkerServerConfig, serve_plugin, serve_plugin_arc,
-    serve_plugin_arc_with_config,
+    ANNOTATED_LLM_REQUEST_SCHEMA, Json, JsonStream, LlmFinalInputPolicyOutcome, LlmNext,
+    LlmRequest, LlmStreamNext, PluginContext, PluginRuntime, PolicyFailureMode, Result, ScopeType,
+    ToolExecutionInterceptOutcome, ToolNext, WorkerPlugin, WorkerSdkError, WorkerServerConfig,
+    serve_plugin, serve_plugin_arc, serve_plugin_arc_with_config,
 };
 use nemo_relay_worker_proto::v1::plugin_worker_client::PluginWorkerClient;
 use nemo_relay_worker_proto::v1::relay_host_runtime_server::{
@@ -114,6 +114,11 @@ async fn worker_service_enforces_auth_and_reports_registrations() {
             .supported_surfaces
             .contains(&(RegistrationSurface::LlmStreamExecutionIntercept as i32))
     );
+    assert!(
+        handshake
+            .supported_surfaces
+            .contains(&(RegistrationSurface::LlmFinalInputPolicy as i32))
+    );
 
     let bad_health = client
         .health(Request::new(HealthRequest {
@@ -200,7 +205,7 @@ async fn worker_service_enforces_auth_and_reports_registrations() {
     assert_eq!(invalid_register_config.code(), tonic::Code::InvalidArgument);
 
     let registrations = register_plugin(&mut client).await;
-    assert_eq!(registrations.len(), 21);
+    assert_eq!(registrations.len(), 22);
     for local_name in [
         "llm-sanitize-request",
         "llm-sanitize-response",
@@ -229,6 +234,15 @@ async fn worker_service_enforces_auth_and_reports_registrations() {
             .filter(|registration| registration.local_name == "event-sanitize")
             .count(),
         3
+    );
+    let final_policy = registrations
+        .iter()
+        .find(|registration| registration.local_name == "llm-final-input")
+        .expect("final-input policy registration");
+    assert_eq!(final_policy.timeout_ms, Some(1_250));
+    assert_eq!(
+        final_policy.failure_mode,
+        nemo_relay_worker_proto::v1::PolicyFailureMode::FailClosed as i32
     );
 
     let invoke_err = client
@@ -730,6 +744,25 @@ async fn worker_service_invokes_every_registration_surface() {
         intercepted.content.get("phase"),
         Some(&json!("llm_request"))
     );
+    let final_policy = invoke_llm_final_input_policy(
+        &mut client,
+        llm_invoke(
+            "llm-final-input",
+            RegistrationSurface::LlmFinalInputPolicy,
+            llm_request(),
+            None,
+            None,
+        ),
+    )
+    .await;
+    assert!(matches!(
+        final_policy,
+        LlmFinalInputPolicyOutcome::Reject {
+            ref reason_code,
+            ref safe_message,
+            ..
+        } if reason_code == "unsafe_input" && safe_message == "request rejected"
+    ));
     let llm_exec = invoke_json(
         &mut client,
         llm_invoke(
@@ -1916,6 +1949,19 @@ impl WorkerPlugin for SurfacePlugin {
             },
         );
 
+        ctx.register_llm_final_input_policy(
+            "llm-final-input",
+            2,
+            Duration::from_millis(1_250),
+            PolicyFailureMode::FailClosed,
+            |_, _, _| async {
+                Ok(LlmFinalInputPolicyOutcome::reject(
+                    "unsafe_input",
+                    "request rejected",
+                ))
+            },
+        );
+
         ctx.register_llm_execution_intercept(
             "llm-exec",
             1,
@@ -2792,6 +2838,28 @@ async fn invoke_llm_request(
             )
             .expect("decode LLM request outcome")
             .request
+        }
+        other => panic!("unexpected invoke result: {other:?}"),
+    }
+}
+
+async fn invoke_llm_final_input_policy(
+    client: &mut PluginWorkerClient<Channel>,
+    request: InvokeRequest,
+) -> LlmFinalInputPolicyOutcome {
+    let response = client
+        .invoke(Request::new(request))
+        .await
+        .expect("invoke succeeds")
+        .into_inner();
+    match response.result.expect("invoke result") {
+        nemo_relay_worker_proto::v1::invoke_response::Result::LlmFinalInputPolicy(result) => {
+            let outcome = result.outcome.expect("LLM final-input policy outcome");
+            assert_eq!(
+                outcome.schema,
+                nemo_relay_types::api::llm::LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA
+            );
+            decode_json_envelope(&outcome).expect("decode LLM final-input policy outcome")
         }
         other => panic!("unexpected invoke result: {other:?}"),
     }

--- a/docs/about-nemo-relay/architecture.mdx
+++ b/docs/about-nemo-relay/architecture.mdx
@@ -136,11 +136,12 @@ It establishes:
 
 ### Middleware Registries
 
-The middleware registries hold the active intercepts and guardrails for tool and
-LLM execution. Request intercepts can rewrite real requests, conditional
-guardrails can reject execution, and sanitize guardrails can change emitted
-observability payloads. Managed helpers read those registries before invoking
-the real callback.
+The middleware registries hold the active intercepts, policies, and guardrails
+for tool and LLM execution. Request intercepts can rewrite real requests,
+conditional guardrails can reject execution, LLM final-input policies can
+govern the fully intercepted provider request, and sanitize guardrails can
+change emitted observability payloads. Managed helpers read those registries
+before invoking the real callback.
 
 Async middleware callbacks are awaited as part of managed execution. The
 managed call does not advance past that middleware callback until the callback
@@ -272,10 +273,12 @@ Managed tool and LLM execution follows the same high-level order:
 
 1. Conditional-execution guardrails decide whether work can proceed.
 2. Request intercepts can rewrite the real request.
-3. Sanitize-request guardrails can rewrite the emitted start-event payload.
-4. Execution intercepts wrap or replace the user callback.
-5. The user callback runs.
-6. Sanitize-response guardrails can rewrite the emitted end-event payload.
+3. For LLM calls, final-input policies can allow, replace, or reject the fully
+   intercepted provider request. Tool calls skip this step.
+4. Sanitize-request guardrails can rewrite the emitted start-event payload.
+5. Execution intercepts wrap or replace the user callback.
+6. The user callback runs.
+7. Sanitize-response guardrails can rewrite the emitted end-event payload.
 
 The following sequence shows where each middleware family runs during a managed
 call.
@@ -287,6 +290,7 @@ sequenceDiagram
     participant Runtime as NeMo Relay Runtime
     participant Conditional as Conditional Guardrails
     participant Request as Request Intercepts
+    participant FinalInput as LLM Final-Input Policies
     participant Sanitizers as Request / Response Sanitizers
     participant Execution as Execution Intercepts
     participant Callback as Real Callback
@@ -301,6 +305,10 @@ sequenceDiagram
         Conditional-->>Runtime: continue
         Runtime->>Request: transform real request
         Request-->>Runtime: intercepted request
+        opt LLM call
+            Runtime->>FinalInput: evaluate final provider-bound request
+            FinalInput-->>Runtime: allow, replacement, or rejection
+        end
         Runtime->>Sanitizers: sanitize event-only request copy
         Sanitizers-->>Runtime: start-event payload
         Runtime->>Dispatcher: enqueue start event
@@ -322,6 +330,7 @@ sequenceDiagram
 Two distinctions matter:
 
 - Intercepts affect the real execution path
+- LLM final-input policies govern the fully intercepted provider request
 - Sanitize guardrails affect the emitted observability payload
 
 For the expanded request-to-response runtime path, including streaming and

--- a/docs/about-nemo-relay/concepts/middleware.mdx
+++ b/docs/about-nemo-relay/concepts/middleware.mdx
@@ -47,8 +47,8 @@ synchronous: they create or close their handle immediately and queue observabili
 work rather than awaiting it.
 
 <Warning>
-Event sanitizers, conditional-execution guardrails, request intercepts,
-execution intercepts, and subscribers are not re-entrant. These callbacks must
+Event sanitizers, conditional-execution guardrails, final-input policies,
+request intercepts, execution intercepts, and subscribers are not re-entrant. These callbacks must
 not invoke another NeMo Relay API that runs middleware, flushes subscriber
 delivery, waits on an exporter, or clears plugins. Scope APIs remain supported:
 callbacks may create, push, or pop scopes at any nesting level and may replace
@@ -99,10 +99,12 @@ everything in application code.
 
 ## Middleware Families
 
-NeMo Relay has two major middleware families with three distinct purposes:
+NeMo Relay separates middleware by lifecycle purpose:
 
 - **Intercepts** change the real request or callback execution path.
 - **Conditional-execution guardrails** decide whether the real work runs.
+- **LLM final-input policies** evaluate the fully intercepted provider request
+  and can allow, transform, or reject it.
 - **Sanitize guardrails** change emitted observability without changing the real
   request or result.
 
@@ -111,8 +113,10 @@ NeMo Relay has two major middleware families with three distinct purposes:
 Choose the middleware type that matches the behavior you need:
 
 - Use a **conditional-execution guardrail** when the work should be allowed or
-  rejected.
+  rejected before request transformation.
 - Use a **request intercept** when the real request must change before the call.
+- Use an **LLM final-input policy** when policy must evaluate or replace the
+  final provider-bound request after all request intercepts have run.
 - Use an **execution intercept** when code must run before or after the callback.
 - Use a **sanitize guardrail** when only subscribers and exporters should see
   rewritten data.
@@ -124,8 +128,8 @@ Choose the middleware type that matches the behavior you need:
 
 ## Callback Error Handling
 
-Conditional-execution guardrails and request or execution intercepts fail
-closed when their callbacks return a failure result. A failure returned
+Conditional-execution guardrails, in-process final-input policies, and request
+or execution intercepts fail closed when their callbacks return a failure result. A failure returned
 directly or produced when a callback raises an exception or rejects a `Promise`
 stops Relay at that middleware stage, and Relay surfaces the failure to the
 managed caller. A conditional guardrail or request intercept therefore prevents
@@ -134,7 +138,12 @@ conditional-execution guardrail can return its documented rejection message to
 block execution. A rejection is normal control flow, not a callback failure. An
 execution intercept cannot undo work from a `next` continuation that it already
 invoked. This fail-closed contract is the same whether the callback completes
-directly or asynchronously.
+directly or asynchronously. A worker final-input policy declares both a timeout
+and whether operational failures fail open or fail closed. An explicit policy
+rejection is always terminal and is never converted into fail-open behavior.
+For a worker policy, fail closed returns a caller-safe terminal rejection while
+the host logs the underlying operational error; fail open continues with
+redacted policy-bypass evidence.
 
 ## Intercepts
 
@@ -184,6 +193,18 @@ whether execution may proceed.
 
 Use them when the runtime should block work based on policy, budget, or context.
 
+### LLM Final Input
+
+LLM final-input policies run after every LLM request intercept and before Relay
+creates the managed LLM scope or enters cache, routing, and provider execution.
+They receive the final provider-bound request and return one of three outcomes:
+allow it unchanged, replace it, or reject the call.
+
+Relay awaits policies sequentially in priority order. A replacement becomes the
+input to the next policy. When an LLM codec is active, a policy can edit the
+normalized annotated request and Relay re-encodes it into the original provider
+shape before execution continues.
+
 ### Sanitize Request
 
 Sanitize-request guardrails rewrite the payload recorded on emitted start events.
@@ -231,7 +252,8 @@ the callback failure and withholds the governed observability payload.
 ## Managed Execution Order
 
 Tool calls and buffered LLM calls follow one normal path grouped into request,
-execution, and response phases.
+execution, and response phases. LLM calls include the final-input stage; tool
+calls skip it.
 
 <MermaidStyles />
 
@@ -240,9 +262,10 @@ flowchart LR
     subgraph RequestPhase[Request Phase]
         Conditional[Conditional Guardrails]
         RequestIntercepts[Request Intercepts]
+        FinalInput[LLM Final-Input Policies]
         RequestSanitizers[Request Sanitizers]
         StartEvent[Scope-Start Sanitizers and Start Event]
-        Conditional --> RequestIntercepts --> RequestSanitizers --> StartEvent
+        Conditional --> RequestIntercepts --> FinalInput --> RequestSanitizers --> StartEvent
     end
 
     subgraph ExecutionPhase[Execution Phase]
@@ -264,9 +287,10 @@ flowchart LR
 The phases run as follows:
 
 1. **Request phase:** Conditional-execution guardrails allow the call, request
-   intercepts rewrite the real request, request sanitizers rewrite the
+   intercepts rewrite the real request, LLM final-input policies allow, replace,
+   or reject the fully intercepted request, request sanitizers rewrite the
    observability copy, and scope-start sanitizers run before Relay enqueues the
-   start event.
+   start event. Tool calls omit the final-input step.
 2. **Execution phase:** Execution intercepts wrap or replace the real callback.
 3. **Response phase:** Response sanitizers rewrite the observability copy, and
    scope-end sanitizers run before Relay enqueues the end event.
@@ -278,11 +302,16 @@ execution does not wait for subscriber or exporter callbacks.
 This ordering preserves the distinction between the families:
 
 - Use an intercept to change real execution.
+- Use an LLM final-input policy to govern the final provider-bound request.
 - Use a sanitize guardrail to change only emitted observability.
 
 ### Rejection Path
 
-A conditional-execution guardrail can reject the call during the request phase.
+A conditional-execution guardrail can reject the call before request
+transformation. An LLM final-input policy can reject it after every request
+intercept has produced the final provider-bound request. In either case, Relay
+does not invoke the provider callback.
+
 Relay emits a guardrail scope start/end pair for each conditional guardrail it
 evaluates. If a guardrail rejects the call, Relay skips the managed call start
 and end events and does not run request intercepts, execution intercepts, or the
@@ -304,8 +333,9 @@ flowchart LR
 
 ### Streaming LLM Path
 
-For streaming LLM flows, the same pre-execution order applies: the runtime
-applies request sanitizers and emits the LLM start event before the
+For streaming LLM flows, the same pre-execution order applies: the runtime runs
+request intercepts and final-input policies, then applies request sanitizers and
+emits the LLM start event before the
 stream execution intercept chain runs. Stream execution intercepts are the
 execution family for streaming provider callbacks. The runtime then collects
 chunks and finalizes the stream before response sanitizers rewrite

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -31,7 +31,11 @@ NVIDIA NeMo Relay 0.8 release notes are in preparation.
 
 ### Highlights
 
-- _Highlights will be added for the 0.8 release._
+- Dynamic Rust and Python workers can register asynchronous LLM final-input
+  policies that evaluate the fully intercepted request before managed scope
+  creation, cache, routing, and provider execution. Policies can allow,
+  transform, or reject the request and declare timeout and operational-failure
+  behavior.
 
 ### Support Matrix and Compatibility Updates
 

--- a/docs/build-plugins/dynamic-plugins/grpc-worker/about.mdx
+++ b/docs/build-plugins/dynamic-plugins/grpc-worker/about.mdx
@@ -70,6 +70,11 @@ Relay 0.6 host sends `nemo.relay.AnnotatedLlmRequest@2` and expects
 `nemo.relay.LlmRequestInterceptOutcome@2`; it rejects request-intercept
 registrations whose manifest still admits Relay 0.5.
 
+If the worker registers an LLM final-input policy, set
+`compat.relay = ">=0.8,<1.0"`, or another range that excludes earlier Relay
+versions. Relay 0.8 introduces the final-input registration surface and the
+`nemo.relay.LlmFinalInputPolicyOutcome@1` result envelope.
+
 The worker receives its activation ID, plugin ID, worker and host endpoints,
 and a local activation token through environment variables. Do not start the
 worker directly during normal operation. The host supplies these values.
@@ -79,6 +84,14 @@ worker directly during normal operation. The host supplies these values.
 Workers return declarative registrations. Relay owns registry mutation,
 namespacing, rollback, and deregistration. Relay DTOs use `JsonEnvelope`
 values, while protobuf handles control flow.
+
+A final-input policy registration must declare a nonzero timeout and a failure
+mode. Choose fail closed when an unavailable policy must stop provider
+execution, or fail open when Relay should continue after an operational worker
+failure. Fail-closed operational failures become caller-safe terminal
+rejections while the host retains the underlying error in its logs.
+Cancellation is cooperative. An explicit policy rejection is normal, terminal
+policy behavior and never fails open.
 
 Run `nemo-relay plugins add` and `nemo-relay plugins validate` to evaluate the
 configured host policy and artifact trust evidence. Refer to [Configure

--- a/docs/build-plugins/dynamic-plugins/grpc-worker/grpc-worker-protocol.mdx
+++ b/docs/build-plugins/dynamic-plugins/grpc-worker/grpc-worker-protocol.mdx
@@ -33,7 +33,7 @@ worker emit marks, manage scopes and isolated scope stacks, and call tool, LLM,
 or LLM-stream continuations during execution intercepts.
 
 This page summarizes the stable contract. Refer to the [canonical protocol
-definition](https://github.com/NVIDIA/NeMo-Relay/blob/0.5.0-alpha.20260706/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto)
+definition](https://github.com/NVIDIA/NeMo-Relay/blob/main/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto)
 for every message and RPC field required to implement another runtime.
 
 ## PluginWorker RPCs
@@ -57,8 +57,9 @@ and `Register` also carry the plugin ID and component configuration.
 ## Registration and Invocation
 
 On success, `RegisterResponse` contains `Registration` records with a local
-name, surface, priority, and `break_chain` value. A failed registration can
-return `WorkerError` without registrations. The supported surfaces are:
+name, surface, priority, and `break_chain` value. Final-input policy records
+also carry `timeout_ms` and a `failure_mode`. A failed registration can return
+`WorkerError` without registrations. The supported surfaces are:
 
 - `SUBSCRIBER`
 - `TOOL_SANITIZE_REQUEST_GUARDRAIL`, `TOOL_SANITIZE_RESPONSE_GUARDRAIL`,
@@ -66,13 +67,22 @@ return `WorkerError` without registrations. The supported surfaces are:
   `TOOL_EXECUTION_INTERCEPT`
 - `LLM_SANITIZE_REQUEST_GUARDRAIL`, `LLM_SANITIZE_RESPONSE_GUARDRAIL`,
   `LLM_CONDITIONAL_EXECUTION_GUARDRAIL`, `LLM_REQUEST_INTERCEPT`,
-  `LLM_EXECUTION_INTERCEPT`, and `LLM_STREAM_EXECUTION_INTERCEPT`
+  `LLM_FINAL_INPUT_POLICY`, `LLM_EXECUTION_INTERCEPT`, and
+  `LLM_STREAM_EXECUTION_INTERCEPT`
 
 `InvokeRequest` identifies the registration, surface, invocation, optional
 continuation, and scope context. Its payload is one of an event, tool
 invocation, or LLM invocation. `InvokeResponse` returns an empty result, JSON
-result, guardrail result, LLM request-intercept result, tool-execution result,
-or `WorkerError`. `InvokeStream` emits JSON chunks or `WorkerError` chunks.
+result, guardrail result, LLM request-intercept result, LLM final-input policy
+result, tool-execution result, or `WorkerError`. `InvokeStream` emits JSON
+chunks or `WorkerError` chunks.
+
+`LLM_FINAL_INPUT_POLICY` runs after LLM request intercepts and before managed
+scope creation, cache, routing, and provider execution. Its tagged
+`nemo.relay.LlmFinalInputPolicyOutcome@1` envelope selects allow, transform, or
+reject. Relay requires a nonzero timeout and either `FAIL_CLOSED` or
+`FAIL_OPEN`. Fail-open applies only to operational worker failures; it never
+overrides an explicit reject outcome.
 
 Every LLM sanitizer invocation includes a directional context with tagged codec
 identity: `none`, `builtin(id)`, `runtime(id)`, or `opaque`. Worker SDKs expose

--- a/python/plugin/README.md
+++ b/python/plugin/README.md
@@ -127,6 +127,41 @@ leave raw `request["content"]` unchanged, edit normalized fields or provider
 extensions through the annotation, and use `request["headers"]` for transport
 headers.
 
+## Final-Input Policies
+
+Use a final-input policy when a decision must see the request after every
+request intercept and must finish before Relay enters cache, routing, or
+provider execution:
+
+```python
+from nemo_relay_plugin import LlmFinalInputPolicyOutcome, PolicyFailureMode
+
+
+async def check_input(name, request, annotated):
+    del name, request, annotated
+    return LlmFinalInputPolicyOutcome.reject(
+        "unsafe_input",
+        "The request was rejected by policy.",
+    )
+
+
+ctx.register_llm_final_input_policy(
+    "check_input",
+    check_input,
+    timeout_ms=5_000,
+    failure_mode=PolicyFailureMode.FAIL_CLOSED,
+)
+```
+
+A policy returns `allow`, `transform`, or `reject`. An explicit rejection is
+always terminal. The failure mode applies only when the worker fails or misses
+its deadline: fail-closed aborts the request, while fail-open continues with
+redacted policy-bypass evidence. Relay sends `CancelInvocation` when the
+deadline expires. With an active codec, transformations must leave raw request
+content unchanged and return the transformed `annotated_request`. Fail-closed
+worker failures return a caller-safe terminal rejection while Relay keeps the
+operational error in host logs.
+
 ## Callback Concurrency
 
 The gRPC AsyncIO server can keep multiple RPCs in flight. Callback execution is

--- a/python/plugin/src/nemo_relay_plugin/__init__.py
+++ b/python/plugin/src/nemo_relay_plugin/__init__.py
@@ -36,6 +36,8 @@ Public data types:
     LlmOptimizationTokens: Explicit token evidence by category.
     LlmOptimizationTokenImpact: Baseline, effective, and saved token evidence.
     LlmRequestInterceptOutcome: Canonical LLM request-intercept result.
+    LlmFinalInputPolicyOutcome: Allow, transform, or reject a final LLM input.
+    PolicyFailureMode: Host behavior when the policy worker fails.
     ToolExecutionInterceptOutcome: Canonical tool execution-intercept result.
     DiagnosticLevel: Severity of a configuration diagnostic.
     ConfigDiagnostic: Structured configuration warning or error.
@@ -53,6 +55,7 @@ Public callback aliases:
     LlmSanitizeResponseCallback: LLM response sanitizer callback.
     LlmConditionalCallback: LLM execution guardrail callback.
     LlmRequestCallback: LLM request intercept callback.
+    LlmFinalInputPolicyCallback: Terminal final-input policy callback.
     LlmExecutionCallback: Unary LLM execution intercept callback.
     LlmStreamExecutionCallback: Streaming LLM execution intercept callback.
 
@@ -79,6 +82,8 @@ from ._api import (
     LlmCodecIdentity,
     LlmConditionalCallback,
     LlmExecutionCallback,
+    LlmFinalInputPolicyCallback,
+    LlmFinalInputPolicyOutcome,
     LlmNext,
     LlmOptimizationContribution,
     LlmOptimizationDataSchema,
@@ -99,6 +104,7 @@ from ._api import (
     PendingMarkSpec,
     PluginContext,
     PluginRuntime,
+    PolicyFailureMode,
     ScopeType,
     SubscriberCallback,
     ToolConditionalCallback,
@@ -125,6 +131,8 @@ __all__ = [
     "LlmConditionalCallback",
     "LlmCodecIdentity",
     "LlmExecutionCallback",
+    "LlmFinalInputPolicyCallback",
+    "LlmFinalInputPolicyOutcome",
     "LlmOptimizationContribution",
     "LlmOptimizationDataSchema",
     "LlmOptimizationEvidenceQuality",
@@ -144,6 +152,7 @@ __all__ = [
     "LlmStreamExecutionCallback",
     "PluginContext",
     "PluginRuntime",
+    "PolicyFailureMode",
     "PendingMarkSpec",
     "ScopeType",
     "SubscriberCallback",

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -25,6 +25,8 @@ Public data types:
     LlmOptimizationTokens: Explicit token evidence by category.
     LlmOptimizationTokenImpact: Baseline, effective, and saved token evidence.
     LlmRequestInterceptOutcome: Canonical LLM request-intercept result.
+    LlmFinalInputPolicyOutcome: Allow, transform, or reject a final LLM input.
+    PolicyFailureMode: Host behavior when the policy worker fails.
     DiagnosticLevel: Severity of a configuration diagnostic.
     ConfigDiagnostic: Structured configuration warning or error.
     ScopeType: Semantic category for a Relay execution scope.
@@ -48,6 +50,7 @@ Public callback aliases used in registration annotations:
     LlmSanitizeResponseCallback: LLM response sanitizer callback.
     LlmConditionalCallback: LLM execution guardrail callback.
     LlmRequestCallback: LLM request intercept callback.
+    LlmFinalInputPolicyCallback: Terminal final-input policy callback.
     LlmExecutionCallback: Unary LLM execution intercept callback.
     LlmStreamExecutionCallback: Streaming LLM execution intercept callback.
 
@@ -207,6 +210,7 @@ EVENT_SCHEMA = "nemo.relay.Event@1"
 LLM_REQUEST_SCHEMA = "nemo.relay.LlmRequest@1"
 ANNOTATED_LLM_REQUEST_SCHEMA = "nemo.relay.AnnotatedLlmRequest@2"
 LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA = "nemo.relay.LlmRequestInterceptOutcome@2"
+LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA = "nemo.relay.LlmFinalInputPolicyOutcome@1"
 TOOL_EXECUTION_INTERCEPT_OUTCOME_SCHEMA = "nemo.relay.ToolExecutionInterceptOutcome@1"
 PLUGIN_DIAGNOSTICS_SCHEMA = "nemo.relay.PluginDiagnostics@1"
 _OBJECT_SCHEMAS = frozenset(
@@ -215,6 +219,7 @@ _OBJECT_SCHEMAS = frozenset(
         LLM_REQUEST_SCHEMA,
         ANNOTATED_LLM_REQUEST_SCHEMA,
         LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA,
+        LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA,
         TOOL_EXECUTION_INTERCEPT_OUTCOME_SCHEMA,
     }
 )
@@ -651,6 +656,101 @@ class LlmRequestInterceptOutcome:
         }
 
 
+class PolicyFailureMode(str, Enum):
+    """Choose how Relay handles an unavailable final-input policy worker."""
+
+    FAIL_CLOSED = "fail_closed"
+    FAIL_OPEN = "fail_open"
+
+
+@dataclass(slots=True)
+class LlmFinalInputPolicyOutcome:
+    """Canonical decision returned by a final-input policy callback."""
+
+    decision: str
+    request: LlmRequest | None = None
+    annotated_request: AnnotatedLlmRequest | None = None
+    reason_code: str | None = None
+    safe_message: str | None = None
+    evidence: Json | None = None
+
+    @classmethod
+    def allow(cls, *, evidence: Json | None = None) -> LlmFinalInputPolicyOutcome:
+        """Allow the current request unchanged."""
+        return cls(decision="allow", evidence=evidence)
+
+    @classmethod
+    def transform(
+        cls,
+        request: LlmRequest,
+        annotated_request: AnnotatedLlmRequest | None = None,
+        *,
+        evidence: Json | None = None,
+    ) -> LlmFinalInputPolicyOutcome:
+        """Continue with a transformed request."""
+        return cls(
+            decision="transform",
+            request=request,
+            annotated_request=annotated_request,
+            evidence=evidence,
+        )
+
+    @classmethod
+    def reject(
+        cls,
+        reason_code: str,
+        safe_message: str,
+        *,
+        evidence: Json | None = None,
+    ) -> LlmFinalInputPolicyOutcome:
+        """Reject the request with caller-safe details."""
+        return cls(
+            decision="reject",
+            reason_code=reason_code,
+            safe_message=safe_message,
+            evidence=evidence,
+        )
+
+    def to_json(self) -> dict[str, Json]:
+        """Validate and convert this outcome to its tagged JSON payload."""
+        if self.decision == "allow":
+            if any(
+                value is not None
+                for value in (self.request, self.annotated_request, self.reason_code, self.safe_message)
+            ):
+                raise WorkerSdkError("allow outcome cannot include transform or rejection fields")
+            value: dict[str, Json] = {"decision": "allow"}
+        elif self.decision == "transform":
+            if not isinstance(self.request, dict):
+                raise WorkerSdkError("transform outcome request must be a JSON object")
+            if self.annotated_request is not None and not isinstance(self.annotated_request, dict):
+                raise WorkerSdkError("transform outcome annotated_request must be a JSON object or None")
+            if self.reason_code is not None or self.safe_message is not None:
+                raise WorkerSdkError("transform outcome cannot include rejection fields")
+            value = {
+                "decision": "transform",
+                "request": self.request,
+                "annotated_request": self.annotated_request,
+            }
+        elif self.decision == "reject":
+            if not isinstance(self.reason_code, str) or not self.reason_code.strip():
+                raise WorkerSdkError("reject outcome reason_code must be a non-empty string")
+            if not isinstance(self.safe_message, str) or not self.safe_message.strip():
+                raise WorkerSdkError("reject outcome safe_message must be a non-empty string")
+            if self.request is not None or self.annotated_request is not None:
+                raise WorkerSdkError("reject outcome cannot include transform fields")
+            value = {
+                "decision": "reject",
+                "reason_code": self.reason_code,
+                "safe_message": self.safe_message,
+            }
+        else:
+            raise WorkerSdkError("final-input policy decision must be allow, transform, or reject")
+        if self.evidence is not None:
+            value["evidence"] = self.evidence
+        return value
+
+
 @dataclass(slots=True)
 class ToolExecutionInterceptOutcome:
     """Canonical result returned by a Python worker tool execution intercept."""
@@ -840,6 +940,10 @@ LlmRequestCallback: TypeAlias = Callable[
     [str, LlmRequest, AnnotatedLlmRequest | None],
     LlmRequestInterceptOutcome | Awaitable[LlmRequestInterceptOutcome],
 ]
+LlmFinalInputPolicyCallback: TypeAlias = Callable[
+    [str, LlmRequest, AnnotatedLlmRequest | None],
+    LlmFinalInputPolicyOutcome | Awaitable[LlmFinalInputPolicyOutcome],
+]
 LlmExecutionCallback: TypeAlias = Callable[[str, LlmRequest, "LlmNext"], Json | Awaitable[Json]]
 LlmStreamExecutionCallback: TypeAlias = Callable[
     [str, LlmRequest, "LlmStreamNext"],
@@ -863,6 +967,7 @@ class _Handlers:
     llm_sanitize_responses: dict[str, LlmSanitizeResponseCallback]
     llm_conditionals: dict[str, LlmConditionalCallback]
     llm_requests: dict[str, LlmRequestCallback]
+    llm_final_input_policies: dict[str, LlmFinalInputPolicyCallback]
     llm_executions: dict[str, LlmExecutionCallback]
     llm_stream_executions: dict[str, LlmStreamExecutionCallback]
 
@@ -883,6 +988,7 @@ class _Handlers:
             llm_sanitize_responses={},
             llm_conditionals={},
             llm_requests={},
+            llm_final_input_policies={},
             llm_executions={},
             llm_stream_executions={},
         )
@@ -917,6 +1023,7 @@ class PluginContext:
             pb.LLM_SANITIZE_RESPONSE_GUARDRAIL,
             pb.LLM_CONDITIONAL_EXECUTION_GUARDRAIL,
             pb.LLM_REQUEST_INTERCEPT,
+            pb.LLM_FINAL_INPUT_POLICY,
             pb.LLM_EXECUTION_INTERCEPT,
         }
     )
@@ -1213,6 +1320,45 @@ class PluginContext:
         self._push_registration(name, pb.LLM_REQUEST_INTERCEPT, priority, break_chain)
         self._handlers.llm_requests[name] = callback
 
+    def register_llm_final_input_policy(
+        self,
+        name: str,
+        callback: LlmFinalInputPolicyCallback,
+        *,
+        priority: int = 0,
+        timeout_ms: int = 30_000,
+        failure_mode: PolicyFailureMode = PolicyFailureMode.FAIL_CLOSED,
+    ) -> None:
+        """Register a terminal async policy over the fully intercepted LLM input.
+
+        After all request intercepts and before cache, routing, or provider
+        execution, the callback receives ``(name, request,
+        annotated_request)``. ``name`` is Relay's logical LLM-call name.
+        Return :class:`LlmFinalInputPolicyOutcome` to allow, transform, or
+        reject the request. Relay cancels the worker invocation when
+        ``timeout_ms`` elapses. ``failure_mode`` applies only to worker failures
+        and timeouts; an explicit reject outcome is always terminal. Fail closed
+        returns a caller-safe terminal rejection after logging the underlying
+        error, while fail open continues with redacted bypass evidence.
+        """
+        if isinstance(timeout_ms, bool) or not isinstance(timeout_ms, int) or timeout_ms <= 0:
+            raise WorkerSdkError("final-input policy timeout_ms must be a positive integer")
+        if not isinstance(failure_mode, PolicyFailureMode):
+            raise WorkerSdkError("final-input policy failure_mode must be a PolicyFailureMode")
+        proto_failure_mode = {
+            PolicyFailureMode.FAIL_CLOSED: pb.FAIL_CLOSED,
+            PolicyFailureMode.FAIL_OPEN: pb.FAIL_OPEN,
+        }[failure_mode]
+        self._push_registration(
+            name,
+            pb.LLM_FINAL_INPUT_POLICY,
+            priority,
+            False,
+            timeout_ms=timeout_ms,
+            failure_mode=proto_failure_mode,
+        )
+        self._handlers.llm_final_input_policies[name] = callback
+
     def register_llm_execution_intercept(
         self,
         name: str,
@@ -1260,20 +1406,32 @@ class PluginContext:
         self._push_registration(name, pb.LLM_STREAM_EXECUTION_INTERCEPT, priority, False)
         self._handlers.llm_stream_executions[name] = callback
 
-    def _push_registration(self, name: str, surface: int, priority: int, break_chain: bool) -> None:
+    def _push_registration(
+        self,
+        name: str,
+        surface: int,
+        priority: int,
+        break_chain: bool,
+        *,
+        timeout_ms: int | None = None,
+        failure_mode: int | None = None,
+    ) -> None:
         if any(
             registration.local_name == name and registration.surface == surface
             for registration in self._handlers.registrations
         ):
             raise WorkerSdkError(f"handler {name!r} is already registered for surface {surface}")
-        self._handlers.registrations.append(
-            pb.Registration(
-                local_name=name,
-                surface=surface,
-                priority=priority,
-                break_chain=break_chain,
-            )
+        registration = pb.Registration(
+            local_name=name,
+            surface=surface,
+            priority=priority,
+            break_chain=break_chain,
         )
+        if timeout_ms is not None:
+            registration.timeout_ms = timeout_ms
+        if failure_mode is not None:
+            registration.failure_mode = failure_mode
+        self._handlers.registrations.append(registration)
 
 
 class PluginRuntime:
@@ -2118,6 +2276,35 @@ class _WorkerService(pb_grpc.PluginWorkerServicer):
                     ),
                 )
             )
+        if request.surface == pb.LLM_FINAL_INPUT_POLICY:
+            payload = request.llm
+            llm_request = _decode_required_envelope(payload.request, "llm request", LLM_REQUEST_SCHEMA)
+            annotated = (
+                _decode_required_envelope(
+                    payload.annotated_request,
+                    "annotated llm request",
+                    ANNOTATED_LLM_REQUEST_SCHEMA,
+                )
+                if payload.HasField("annotated_request")
+                else None
+            )
+            result = await _maybe_await(
+                self._handler(self._handlers.llm_final_input_policies, request.registration_name)(
+                    payload.model_name,
+                    llm_request,
+                    annotated,
+                )
+            )
+            if not isinstance(result, LlmFinalInputPolicyOutcome):
+                raise WorkerSdkError("LLM final-input policy must return LlmFinalInputPolicyOutcome")
+            return pb.InvokeResponse(
+                llm_final_input_policy=pb.LlmFinalInputPolicyResult(
+                    outcome=_json_envelope(
+                        LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA,
+                        result.to_json(),
+                    ),
+                )
+            )
         if request.surface == pb.LLM_EXECUTION_INTERCEPT:
             payload = request.llm
             result = await _maybe_await(
@@ -2206,6 +2393,7 @@ def _all_surfaces() -> list[int]:
         pb.LLM_REQUEST_INTERCEPT,
         pb.LLM_EXECUTION_INTERCEPT,
         pb.LLM_STREAM_EXECUTION_INTERCEPT,
+        pb.LLM_FINAL_INPUT_POLICY,
     ]
 
 

--- a/python/tests/plugin/test_public_api_docstrings.py
+++ b/python/tests/plugin/test_public_api_docstrings.py
@@ -33,6 +33,7 @@ _TYPE_ALIASES = {
     "LlmSanitizeResponseCallback",
     "LlmConditionalCallback",
     "LlmRequestCallback",
+    "LlmFinalInputPolicyCallback",
     "LlmExecutionCallback",
     "LlmStreamExecutionCallback",
 }

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -27,6 +27,7 @@ from nemo_relay_plugin import (  # noqa: E402
     ConfigDiagnostic,
     DiagnosticLevel,
     Json,
+    LlmFinalInputPolicyOutcome,
     LlmOptimizationContribution,
     LlmRequestInterceptOutcome,
     LlmSanitizeRequestContext,
@@ -34,6 +35,7 @@ from nemo_relay_plugin import (  # noqa: E402
     PendingMarkSpec,
     PluginContext,
     PluginRuntime,
+    PolicyFailureMode,
     ScopeType,
     ToolExecutionInterceptOutcome,
     ToolNext,
@@ -46,6 +48,7 @@ from nemo_relay_plugin._api import (  # noqa: E402
     ANNOTATED_LLM_REQUEST_SCHEMA,
     EVENT_SCHEMA,
     JSON_SCHEMA,
+    LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA,
     LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA,
     LLM_REQUEST_SCHEMA,
     TOOL_EXECUTION_INTERCEPT_OUTCOME_SCHEMA,
@@ -118,6 +121,42 @@ def test_optimization_contribution_omitted_applied_defaults_consistently():
     assert decoded.applied is False
     assert direct.to_json()["applied"] is False
     assert decoded.to_json()["applied"] is False
+
+
+def test_final_input_policy_outcomes_use_stable_tagged_json():
+    request = {"headers": {}, "content": {"prompt": "redacted"}}
+    annotated = {"messages": [], "extra": {}}
+
+    assert LlmFinalInputPolicyOutcome.allow(evidence={"policy": "ok"}).to_json() == {
+        "decision": "allow",
+        "evidence": {"policy": "ok"},
+    }
+    assert LlmFinalInputPolicyOutcome.transform(request, annotated).to_json() == {
+        "decision": "transform",
+        "request": request,
+        "annotated_request": annotated,
+    }
+    assert LlmFinalInputPolicyOutcome.reject("unsafe_input", "request rejected").to_json() == {
+        "decision": "reject",
+        "reason_code": "unsafe_input",
+        "safe_message": "request rejected",
+    }
+
+    with pytest.raises(WorkerSdkError, match="reason_code"):
+        LlmFinalInputPolicyOutcome.reject("", "request rejected").to_json()
+
+
+def test_final_input_policy_registration_requires_explicit_valid_resilience_options():
+    ctx = PluginContext()
+
+    async def policy(name: str, request: Json, annotated: Json | None) -> LlmFinalInputPolicyOutcome:
+        del name, request, annotated
+        return LlmFinalInputPolicyOutcome.allow()
+
+    with pytest.raises(WorkerSdkError, match="positive integer"):
+        ctx.register_llm_final_input_policy("zero_timeout", policy, timeout_ms=0)
+    with pytest.raises(WorkerSdkError, match="PolicyFailureMode"):
+        ctx.register_llm_final_input_policy("bad_failure", policy, failure_mode=cast(Any, "fail_open"))
 
 
 def test_optimization_contribution_preserves_future_quality_strings():
@@ -354,6 +393,16 @@ class AllSurfacesPlugin(WorkerPlugin):
                 pending_marks=[PendingMarkSpec("worker.pending", data={"source": "python"})],
             )
 
+        async def llm_final_input_policy(
+            name: str, request: Json, annotated: Json | None
+        ) -> LlmFinalInputPolicyOutcome:
+            del name, request, annotated
+            return LlmFinalInputPolicyOutcome.reject(
+                "unsafe_input",
+                "request rejected",
+                evidence={"source": "python"},
+            )
+
         async def llm_execution(name: str, request: Json, next_call: Any) -> Json:
             result = await next_call.call(_tag_llm_request(request, f"llm_execute_{name}"))
             return _tag(result, "llm_execution")
@@ -376,8 +425,15 @@ class AllSurfacesPlugin(WorkerPlugin):
         ctx.register_llm_sanitize_response_guardrail("llm_sanitize_response", llm_sanitize_response, priority=7)
         ctx.register_llm_conditional_execution_guardrail("llm_conditional", llm_block, priority=8)
         ctx.register_llm_request_intercept("llm_request", llm_request, priority=9, break_chain=True)
-        ctx.register_llm_execution_intercept("llm_execution", llm_execution, priority=10)
-        ctx.register_llm_stream_execution_intercept("llm_stream_execution", llm_stream_execution, priority=11)
+        ctx.register_llm_final_input_policy(
+            "llm_final_input_policy",
+            llm_final_input_policy,
+            priority=10,
+            timeout_ms=1_250,
+            failure_mode=PolicyFailureMode.FAIL_OPEN,
+        )
+        ctx.register_llm_execution_intercept("llm_execution", llm_execution, priority=11)
+        ctx.register_llm_stream_execution_intercept("llm_stream_execution", llm_stream_execution, priority=12)
 
 
 @pytest.fixture(name="host_stub")
@@ -408,6 +464,9 @@ def test_generated_proto_matches_worker_contract():
     assert pb.SUBSCRIBER == 1
     assert pb.TOOL_SANITIZE_REQUEST_GUARDRAIL == 10
     assert pb.LLM_STREAM_EXECUTION_INTERCEPT == 25
+    assert pb.LLM_FINAL_INPUT_POLICY == 26
+    assert pb.FAIL_CLOSED == 1
+    assert pb.FAIL_OPEN == 2
     assert pb.MARK_SANITIZE_GUARDRAIL == 30
     assert pb.SCOPE_SANITIZE_START_GUARDRAIL == 31
     assert pb.SCOPE_SANITIZE_END_GUARDRAIL == 32
@@ -461,9 +520,15 @@ async def test_health_handshake_validate_register_and_all_surfaces(service: _Wor
         ("llm_sanitize_response", pb.LLM_SANITIZE_RESPONSE_GUARDRAIL, 7, False),
         ("llm_conditional", pb.LLM_CONDITIONAL_EXECUTION_GUARDRAIL, 8, False),
         ("llm_request", pb.LLM_REQUEST_INTERCEPT, 9, True),
-        ("llm_execution", pb.LLM_EXECUTION_INTERCEPT, 10, False),
-        ("llm_stream_execution", pb.LLM_STREAM_EXECUTION_INTERCEPT, 11, False),
+        ("llm_final_input_policy", pb.LLM_FINAL_INPUT_POLICY, 10, False),
+        ("llm_execution", pb.LLM_EXECUTION_INTERCEPT, 11, False),
+        ("llm_stream_execution", pb.LLM_STREAM_EXECUTION_INTERCEPT, 12, False),
     ]
+    policy_registration = next(
+        registration for registration in register.registrations if registration.surface == pb.LLM_FINAL_INPUT_POLICY
+    )
+    assert policy_registration.timeout_ms == 1_250
+    assert policy_registration.failure_mode == pb.FAIL_OPEN
 
 
 def test_sdk_version_uses_package_metadata_and_source_tree_fallback(
@@ -1431,6 +1496,26 @@ async def test_unary_invoke_success_paths(service: _WorkerService, host_stub: Re
     assert request_only_outcome["request"]["content"]["llm_request"]
     assert request_only_outcome["annotated_request"] is None
     assert request_only_outcome["pending_marks"] == outcome["pending_marks"]
+
+    final_policy = await service.Invoke(
+        _invoke_request(
+            "llm_final_input_policy",
+            pb.LLM_FINAL_INPUT_POLICY,
+            llm=_llm_payload(
+                model_name="gpt-test",
+                request={"content": {"prompt": "hello"}},
+                annotated={"messages": []},
+            ),
+        ),
+        AbortContext(),
+    )
+    assert final_policy.llm_final_input_policy.outcome.schema == LLM_FINAL_INPUT_POLICY_OUTCOME_SCHEMA
+    assert _envelope_value(final_policy.llm_final_input_policy.outcome) == {
+        "decision": "reject",
+        "reason_code": "unsafe_input",
+        "safe_message": "request rejected",
+        "evidence": {"source": "python"},
+    }
 
     llm_execution = await _invoke_json_async(
         service,
@@ -2829,4 +2914,5 @@ def _all_expected_surfaces() -> list[int]:
         pb.LLM_REQUEST_INTERCEPT,
         pb.LLM_EXECUTION_INTERCEPT,
         pb.LLM_STREAM_EXECUTION_INTERCEPT,
+        pb.LLM_FINAL_INPUT_POLICY,
     ]


### PR DESCRIPTION
#### Overview

Adds an asynchronous LLM final-input policy stage that evaluates the fully intercepted provider request before managed scope creation, cache lookup, routing, and provider execution. This is the reusable Relay foundation for moving NeMo Guardrails into a dynamic Python worker in the next stack layer.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Introduces an allow, transform, or reject policy outcome for buffered and streaming LLM calls.
- Resolves global and scope-local policies sequentially by priority after request intercepts.
- Adds plugin registration support plus the `LLM_FINAL_INPUT_POLICY` gRPC worker surface.
- Requires worker policies to declare a nonzero timeout and fail-open or fail-closed behavior for operational failures. Explicit policy rejection always remains terminal.
- Converts fail-closed worker errors and timeouts into a caller-safe terminal rejection with redacted availability evidence while retaining the underlying error in host logs. Fail-open continues with redacted bypass evidence.
- Extends the Rust and Python worker SDKs and the stable worker protocol.
- Documents the middleware ordering, worker compatibility contract, and Relay 0.8 release highlight.
- Leaves the existing built-in NeMo Guardrails integration unchanged; its worker-based replacement is the dependent PR in this stack.

Validation:

- `uv run pre-commit run --all-files`
- `just docs-linkcheck`
- Python worker SDK and plugin suite: 126 tests passed with 96.52% coverage.
- Existing built-in NeMo Guardrails suite: 75 tests passed.
- Worker end-to-end timeout, cancellation, failure-mode, allow, transform, and reject coverage.
- Focused worker integration test verifies fail-closed callback errors and timeouts stop provider execution without surfacing the worker's error message.
- Live NVIDIA provider request using `meta/llama-3.1-8b-instruct` through request intercept, worker policy, execution intercept, and provider execution.
- Live failure injection with a valid downstream credential and invalid rail-model credential returned a caller-safe HTTP 403; the NIM 401 detail remained only in host logs and provider execution did not begin.

Breaking changes: None. The new policy and worker surface are additive.

#### Where should the reviewer start?

Start with `crates/types/src/api/llm.rs` for the public outcome contract and `crates/core/src/api/runtime/state.rs` for the exact lifecycle placement. Then review `crates/core/src/plugin/dynamic/worker.rs` and `crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto` for timeout, failure-mode, cancellation, and caller-safe fail-closed behavior.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to RELAY-681
