### PR TITLE
ci: remove untrusted Homebrew tap on macOS

### DIFF
--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -69,6 +69,13 @@ jobs:
       contents: read
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ci_go.yml
+++ b/.github/workflows/ci_go.yml
@@ -43,6 +43,13 @@ jobs:
             runner: windows-11-arm
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/ci_node.yml
+++ b/.github/workflows/ci_node.yml
@@ -67,6 +67,13 @@ jobs:
             runner: windows-11-arm
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -144,6 +151,13 @@ jobs:
             package_name: nemo-relay-node-linux-arm64-musl
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -350,6 +364,13 @@ jobs:
           - *package-linux-musl-amd64
           - *package-linux-musl-arm64
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         if: ${{ !contains(matrix.platform, 'musl') }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -67,6 +67,13 @@ jobs:
             runner: windows-11-arm
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -194,6 +201,13 @@ jobs:
             container_image: quay.io/pypa/musllinux_1_2_aarch64@sha256:274a947b4d5d745b56b868b0d052641e0798a652e3e65755987edf60547d1268
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -428,6 +442,13 @@ jobs:
             runner: ubuntu-latest
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         if: ${{ !contains(matrix.platform, 'musl') }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -90,6 +90,13 @@ jobs:
             run_s3_tests: false
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -238,6 +245,13 @@ jobs:
             runtime_image: ''
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -396,6 +410,13 @@ jobs:
           - *package-windows-arm64
 
     steps:
+      - name: Remove untrusted Homebrew tap
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          if [ -d "$(brew --repository aws/tap)" ]; then
+            brew untap aws/tap
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
#### Overview

Remove the untrusted `aws/tap` Homebrew tap before CI actions run on macOS. This prevents Homebrew 6 from adding a tap-trust warning annotation when setup actions install packages on GitHub-hosted macOS runners, as seen in [this Node.js CI job](https://github.com/NVIDIA/NeMo-Relay/actions/runs/31273690715/job/93143803703#step:4:31).

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add a first step to each macOS-capable check, Rust, Python, Node.js, and Go CI job.
- Run the step only when `runner.os == 'macOS'`.
- Check whether the tap directory exists before calling `brew untap aws/tap`, so the workaround remains safe after runner images stop preinstalling the tap.
- Leave Linux and Windows execution unchanged.

There are no breaking changes.

Validation:

- `uv run pre-commit run --files .github/workflows/ci_check.yml .github/workflows/ci_go.yml .github/workflows/ci_node.yml .github/workflows/ci_python.yml .github/workflows/ci_rust.yml`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start with the first step in `.github/workflows/ci_node.yml`, which covers the job where the warning was observed. The same macOS-only step is applied to the other reusable workflows with macOS matrices.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to actions/runner-images#14232


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build and packaging reliability by automatically removing a conflicting Homebrew tap when present.
  * Applied the fix consistently across installer, Go, Node.js, Python, and Rust validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->