### PR TITLE
feat(guardrails): deprecate built-in plugin

### DIFF
--- a/crates/cli/src/plugins/editor_model.rs
+++ b/crates/cli/src/plugins/editor_model.rs
@@ -2,19 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Testable plugin editor state helpers.
-#![allow(
-    deprecated,
-    reason = "the CLI must edit existing Guardrails configuration until the built-in plugin is removed"
-)]
 
 use std::path::Path;
 
 use nemo_relay::config_editor::{EditorConfig, EditorFieldKind, EditorFieldSpec};
 use nemo_relay::observability::plugin_component::{OBSERVABILITY_PLUGIN_KIND, ObservabilityConfig};
 use nemo_relay::plugin::{PluginComponentSpec, PluginConfig};
-use nemo_relay::plugins::nemo_guardrails::component::{
-    NEMO_GUARDRAILS_PLUGIN_KIND, NeMoGuardrailsConfig,
-};
 use nemo_relay_adaptive::AdaptiveConfig;
 use nemo_relay_adaptive::plugin_component::ADAPTIVE_PLUGIN_KIND;
 use nemo_relay_pii_redaction::component::{PII_REDACTION_PLUGIN_KIND, PiiRedactionConfig};
@@ -25,6 +18,20 @@ use serde::de::DeserializeOwned;
 use serde_json::{Map, Value, json};
 
 use crate::error::CliError;
+
+#[allow(
+    deprecated,
+    reason = "the CLI must edit existing Guardrails configuration until the built-in plugin is removed"
+)]
+mod guardrails_compat {
+    pub(super) type Config = nemo_relay::plugins::nemo_guardrails::component::NeMoGuardrailsConfig;
+    pub(super) const PLUGIN_KIND: &str =
+        nemo_relay::plugins::nemo_guardrails::component::NEMO_GUARDRAILS_PLUGIN_KIND;
+}
+
+use guardrails_compat::{
+    Config as NeMoGuardrailsConfig, PLUGIN_KIND as NEMO_GUARDRAILS_PLUGIN_KIND,
+};
 
 pub(super) const POLICY_SECTION: &str = "policy";
 

--- a/crates/cli/src/plugins/editor_model.rs
+++ b/crates/cli/src/plugins/editor_model.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Testable plugin editor state helpers.
+#![allow(
+    deprecated,
+    reason = "the CLI must edit existing Guardrails configuration until the built-in plugin is removed"
+)]
 
 use std::path::Path;
 
@@ -49,7 +53,7 @@ impl EditableComponent {
         match self {
             Self::Observability(_) => "Observability",
             Self::Adaptive(_) => "Adaptive",
-            Self::NemoGuardrails(_) => "NeMo Guardrails",
+            Self::NemoGuardrails(_) => "NeMo Guardrails (Deprecated)",
             Self::PiiRedaction(_) => "PII Redaction",
             #[cfg(feature = "switchyard")]
             Self::Switchyard(_) => "Switchyard Decision API",

--- a/crates/cli/tests/coverage/shared/plugins_tests.rs
+++ b/crates/cli/tests/coverage/shared/plugins_tests.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(
+    deprecated,
+    reason = "compatibility tests cover the built-in Guardrails editor until its scheduled removal"
+)]
+
 use super::*;
 use crate::configuration::{global_plugin_config_path, user_plugin_config_path};
 use crate::plugins::ConfigurationScope;
@@ -470,7 +475,7 @@ fn plugin_menu_builds_ordered_component_actions() {
     assert!(
         plain_labels
             .iter()
-            .any(|label| { label.starts_with("NeMo Guardrails [off] —") })
+            .any(|label| { label.starts_with("NeMo Guardrails (Deprecated) [off] —") })
     );
     assert_eq!(
         plain_labels[components.len()],

--- a/crates/cli/tests/coverage/shared/plugins_tests.rs
+++ b/crates/cli/tests/coverage/shared/plugins_tests.rs
@@ -1,11 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(
-    deprecated,
-    reason = "compatibility tests cover the built-in Guardrails editor until its scheduled removal"
-)]
-
 use super::*;
 use crate::configuration::{global_plugin_config_path, user_plugin_config_path};
 use crate::plugins::ConfigurationScope;
@@ -16,14 +11,30 @@ use nemo_relay::observability::plugin_component::{
     AtofSectionConfig, OBSERVABILITY_PLUGIN_KIND, ObservabilityConfig,
 };
 use nemo_relay::plugin::{ConfigPolicy, PluginComponentSpec, PluginConfig};
-use nemo_relay::plugins::nemo_guardrails::component::{
-    LocalBackendConfig, NEMO_GUARDRAILS_PLUGIN_KIND, NeMoGuardrailsConfig, RemoteBackendConfig,
-};
 use nemo_relay_adaptive::AdaptiveConfig;
 use nemo_relay_adaptive::plugin_component::ADAPTIVE_PLUGIN_KIND;
 use nemo_relay_pii_redaction::component::{PII_REDACTION_PLUGIN_KIND, PiiRedactionConfig};
 use serde_json::Map;
 use std::path::PathBuf;
+
+#[allow(
+    deprecated,
+    reason = "compatibility tests cover the built-in Guardrails editor until its scheduled removal"
+)]
+mod guardrails_compat {
+    pub(super) type Config = nemo_relay::plugins::nemo_guardrails::component::NeMoGuardrailsConfig;
+    pub(super) type LocalConfig =
+        nemo_relay::plugins::nemo_guardrails::component::LocalBackendConfig;
+    pub(super) type RemoteConfig =
+        nemo_relay::plugins::nemo_guardrails::component::RemoteBackendConfig;
+    pub(super) const PLUGIN_KIND: &str =
+        nemo_relay::plugins::nemo_guardrails::component::NEMO_GUARDRAILS_PLUGIN_KIND;
+}
+
+use guardrails_compat::{
+    Config as NeMoGuardrailsConfig, LocalConfig as LocalBackendConfig,
+    PLUGIN_KIND as NEMO_GUARDRAILS_PLUGIN_KIND, RemoteConfig as RemoteBackendConfig,
+};
 
 fn write_editor_dynamic_manifest(
     dir: &Path,
@@ -984,6 +995,10 @@ fn editor_model_adds_disabled_adaptive_component() {
 }
 
 #[test]
+#[allow(
+    deprecated,
+    reason = "this compatibility test inspects the built-in Guardrails config until its removal"
+)]
 fn editor_model_reads_missing_nemo_guardrails_component_as_disabled_default() {
     let config = PluginConfig::default();
 
@@ -2723,6 +2738,10 @@ fn validate_config_rejects_local_nemo_guardrails_colang_without_yaml() {
 }
 
 #[test]
+#[allow(
+    deprecated,
+    reason = "this compatibility test serializes the built-in Guardrails config until its removal"
+)]
 fn nemo_guardrails_config_map_prunes_default_version() {
     let map = nemo_guardrails_config_map(&NeMoGuardrailsConfig {
         codec: Some("openai_chat".into()),
@@ -2778,6 +2797,10 @@ fn write_plugin_config_round_trips_local_nemo_guardrails_component() {
 }
 
 #[test]
+#[allow(
+    deprecated,
+    reason = "this compatibility test serializes the built-in Guardrails config until its removal"
+)]
 fn nemo_guardrails_config_map_serializes_local_mode_fields() {
     let map = nemo_guardrails_config_map(&NeMoGuardrailsConfig {
         mode: "local".into(),

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,6 +26,7 @@ atof-streaming = [
     "tokio/time",
 ]
 schema = ["dep:schemars", "nemo-relay-types/schema"]
+# Deprecated with the built-in NeMo Guardrails integration; scheduled for removal in 0.9.
 guardrails-remote = []
 object-store = [
     "dep:object_store",

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -1025,6 +1025,10 @@ fn register_plugin_with_owner(
 ///
 /// Built-in plugins are available to validation and initialization without a
 /// binding or application-specific registration call.
+#[allow(
+    deprecated,
+    reason = "the host must register the built-in Guardrails plugin until its scheduled removal"
+)]
 pub fn ensure_builtin_plugins_registered() -> Result<()> {
     let all_registered = {
         let guard = PLUGIN_HANDLERS.read().map_err(|err| {

--- a/crates/core/src/plugins/nemo_guardrails/component.rs
+++ b/crates/core/src/plugins/nemo_guardrails/component.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! NeMo Guardrails plugin component contract.
+#![allow(
+    deprecated,
+    reason = "the built-in implementation remains supported until its scheduled removal"
+)]
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -27,8 +31,20 @@ use local::register_local_backend;
 #[cfg(feature = "guardrails-remote")]
 use remote::register_remote_backend;
 
-/// The plugin kind reserved for the planned first-party component.
+/// The built-in NeMo Guardrails plugin kind.
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 pub const NEMO_GUARDRAILS_PLUGIN_KIND: &str = "nemo_guardrails";
+
+/// Stable diagnostic code for the built-in plugin's deprecation warning.
+const NEMO_GUARDRAILS_DEPRECATION_CODE: &str = "nemo_guardrails.deprecated";
+
+/// NeMo Relay release in which the built-in plugin is scheduled for removal.
+const NEMO_GUARDRAILS_REMOVAL_VERSION: &str = "0.9";
+
+const NEMO_GUARDRAILS_DEPRECATION_MESSAGE: &str = "the built-in `nemo_guardrails` plugin is deprecated and scheduled for removal in NeMo Relay 0.9";
 
 #[cfg(not(feature = "guardrails-remote"))]
 fn register_remote_backend(
@@ -42,6 +58,10 @@ fn register_remote_backend(
 
 /// Top-level NeMo Guardrails component wrapper.
 #[derive(Debug, Clone)]
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 pub struct ComponentSpec {
     /// Whether the component should be activated.
     pub enabled: bool,
@@ -75,8 +95,12 @@ impl From<ComponentSpec> for PluginComponentSpec {
     }
 }
 
-/// Canonical config document for the planned NeMo Guardrails component.
+/// Canonical config document for the deprecated built-in NeMo Guardrails component.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct NeMoGuardrailsConfig {
     /// NeMo Guardrails config schema version.
@@ -155,6 +179,10 @@ impl Default for NeMoGuardrailsConfig {
 
 /// Remote-backend settings for a hosted NeMo Guardrails service.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct RemoteBackendConfig {
     /// Base URL for the remote Guardrails service.
@@ -188,6 +216,10 @@ impl Default for RemoteBackendConfig {
 
 /// Local-backend settings for the Python `nemoguardrails` runtime.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct LocalBackendConfig {
     /// Optional import path for the Python runtime module.
@@ -203,6 +235,10 @@ pub struct LocalBackendConfig {
 
 /// Default request semantics applied by the selected Guardrails backend.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct RequestDefaultsConfig {
     /// Default context object passed into Guardrails requests.
@@ -236,6 +272,10 @@ pub struct RequestDefaultsConfig {
 /// These are backend request options, not top-level NeMo Relay interception
 /// surfaces.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct RequestRailsConfig {
     /// Input rails selection.
@@ -261,6 +301,10 @@ pub struct RequestRailsConfig {
 /// Rail-selection shape used by Guardrails generation options.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum RailSelector {
     /// Enable or disable the whole rail family.
@@ -405,17 +449,29 @@ impl Plugin for NeMoGuardrailsPlugin {
 }
 
 /// Registers the `nemo_guardrails` component kind in the plugin registry.
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 pub fn register_nemo_guardrails_component() -> PluginResult<()> {
     register_builtin_plugin(Arc::new(NeMoGuardrailsPlugin))
 }
 
 /// Deregisters the `nemo_guardrails` component kind from the plugin registry.
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 pub fn deregister_nemo_guardrails_component() -> bool {
     deregister_plugin(NEMO_GUARDRAILS_PLUGIN_KIND)
 }
 
 /// Returns the JSON Schema for the NeMo Guardrails component configuration.
 #[cfg(feature = "schema")]
+#[deprecated(
+    since = "0.8.0",
+    note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
+)]
 pub fn nemo_guardrails_config_schema() -> serde_json::Value {
     serde_json::to_value(schemars::schema_for!(NeMoGuardrailsConfig))
         .expect("NeMo Guardrails config schema should serialize")
@@ -465,6 +521,14 @@ fn register_nemo_guardrails_backend(
     config: NeMoGuardrailsConfig,
     ctx: &mut PluginRegistrationContext,
 ) -> PluginResult<()> {
+    log::warn!(
+        target: "nemo_relay.plugin",
+        event = NEMO_GUARDRAILS_DEPRECATION_CODE,
+        plugin_kind = NEMO_GUARDRAILS_PLUGIN_KIND,
+        removal_version = NEMO_GUARDRAILS_REMOVAL_VERSION;
+        "The built-in NeMo Guardrails plugin is deprecated and scheduled for removal in NeMo Relay 0.9"
+    );
+
     match config.mode.as_str() {
         "remote" => register_remote_backend(config, ctx),
         "local" => register_local_backend(config, ctx),
@@ -492,23 +556,27 @@ fn validate_nemo_guardrails_plugin_config_with_policy(
     plugin_config: &Map<String, Json>,
     policy: Option<&ConfigPolicy>,
 ) -> Vec<ConfigDiagnostic> {
+    let deprecation = nemo_guardrails_deprecation_diagnostic();
     let mut config = match parse_nemo_guardrails_config(plugin_config) {
         Ok(config) => config,
         Err(err) => {
-            return vec![ConfigDiagnostic {
-                level: DiagnosticLevel::Error,
-                code: "nemo_guardrails.invalid_plugin_config".to_string(),
-                component: Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
-                field: None,
-                message: err.to_string(),
-            }];
+            return vec![
+                deprecation,
+                ConfigDiagnostic {
+                    level: DiagnosticLevel::Error,
+                    code: "nemo_guardrails.invalid_plugin_config".to_string(),
+                    component: Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
+                    field: None,
+                    message: err.to_string(),
+                },
+            ];
         }
     };
     if let Some(policy) = policy {
         config.policy = apply_global_config_policy(config.policy, policy);
     }
 
-    let mut diagnostics = vec![];
+    let mut diagnostics = vec![deprecation];
 
     validate_unknown_fields(
         &mut diagnostics,
@@ -597,6 +665,16 @@ fn validate_nemo_guardrails_plugin_config_with_policy(
     validate_request_defaults(&mut diagnostics, &config.policy, &config);
 
     diagnostics
+}
+
+fn nemo_guardrails_deprecation_diagnostic() -> ConfigDiagnostic {
+    ConfigDiagnostic {
+        level: DiagnosticLevel::Warning,
+        code: NEMO_GUARDRAILS_DEPRECATION_CODE.to_string(),
+        component: Some(NEMO_GUARDRAILS_PLUGIN_KIND.to_string()),
+        field: None,
+        message: NEMO_GUARDRAILS_DEPRECATION_MESSAGE.to_string(),
+    }
 }
 
 fn validate_version(diagnostics: &mut Vec<ConfigDiagnostic>, policy: &ConfigPolicy, version: u32) {

--- a/crates/core/src/plugins/nemo_guardrails/component.rs
+++ b/crates/core/src/plugins/nemo_guardrails/component.rs
@@ -523,7 +523,7 @@ fn register_nemo_guardrails_backend(
 ) -> PluginResult<()> {
     log::warn!(
         target: "nemo_relay.plugin",
-        event = NEMO_GUARDRAILS_DEPRECATION_CODE,
+        event = "nemo_guardrails_deprecated",
         plugin_kind = NEMO_GUARDRAILS_PLUGIN_KIND,
         removal_version = NEMO_GUARDRAILS_REMOVAL_VERSION;
         "The built-in NeMo Guardrails plugin is deprecated and scheduled for removal in NeMo Relay 0.9"

--- a/crates/core/src/plugins/nemo_guardrails/mod.rs
+++ b/crates/core/src/plugins/nemo_guardrails/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Planned NeMo Guardrails plugin integrations for NeMo Relay Core.
+//! Deprecated built-in NeMo Guardrails plugin integration for NeMo Relay Core.
 
 #[cfg(test)]
 use std::sync::Mutex;

--- a/crates/core/tests/unit/plugins/nemo_guardrails/component_tests.rs
+++ b/crates/core/tests/unit/plugins/nemo_guardrails/component_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Unit tests for the planned NeMo Guardrails plugin component contract.
+//! Unit tests for the built-in NeMo Guardrails plugin component contract.
 #![allow(clippy::await_holding_lock)]
 
 use super::*;
@@ -347,6 +347,20 @@ fn schema_property<'a>(schema: &'a Json, name: &str) -> Option<&'a Json> {
 #[test]
 fn schema_contains_every_supported_nemo_guardrails_option() {
     let schema = nemo_guardrails_config_schema();
+    assert_eq!(schema.get("deprecated"), Some(&json!(true)));
+    for definition in [
+        "LocalBackendConfig",
+        "RemoteBackendConfig",
+        "RequestDefaultsConfig",
+        "RequestRailsConfig",
+        "RailSelector",
+    ] {
+        assert_eq!(
+            schema.pointer(&format!("/definitions/{definition}/deprecated")),
+            Some(&json!(true)),
+            "schema definition `{definition}` is not marked deprecated"
+        );
+    }
     for field in [
         "version",
         "mode",
@@ -445,6 +459,38 @@ fn builtin_registration_is_automatic() {
 }
 
 #[test]
+fn configured_component_reports_deprecation_warning() {
+    let _guard = crate::plugins::nemo_guardrails::test_mutex()
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    reset_runtime();
+
+    for component in [
+        component(remote_valid_config()),
+        disabled_component(remote_valid_config()),
+    ] {
+        let report = validate_plugin_config(&PluginConfig {
+            version: 1,
+            components: vec![component],
+            policy: Default::default(),
+        });
+
+        assert!(!report.has_errors());
+        let diagnostic = report
+            .diagnostics
+            .iter()
+            .find(|diag| diag.code == NEMO_GUARDRAILS_DEPRECATION_CODE)
+            .expect("configured NeMo Guardrails component should report deprecation");
+        assert_eq!(diagnostic.level, DiagnosticLevel::Warning);
+        assert_eq!(
+            diagnostic.component.as_deref(),
+            Some(NEMO_GUARDRAILS_PLUGIN_KIND)
+        );
+        assert!(diagnostic.message.contains(NEMO_GUARDRAILS_REMOVAL_VERSION));
+    }
+}
+
+#[test]
 fn explicit_registration_helpers_are_idempotent_and_reversible() {
     let _guard = crate::plugins::nemo_guardrails::test_mutex()
         .lock()
@@ -471,7 +517,13 @@ fn disabled_component_validates_and_initializes_without_runtime_work() {
         policy: Default::default(),
     };
     assert!(!validate_plugin_config(&config).has_errors());
-    futures::executor::block_on(initialize_plugins(config)).unwrap();
+    let report = futures::executor::block_on(initialize_plugins(config)).unwrap();
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == NEMO_GUARDRAILS_DEPRECATION_CODE)
+    );
 }
 
 #[test]
@@ -1059,7 +1111,11 @@ fn unknown_fields_follow_policy() {
         "bogus": true
     })));
     assert!(!ignored.has_errors());
-    assert!(ignored.diagnostics.is_empty());
+    assert_eq!(ignored.diagnostics.len(), 1);
+    assert_eq!(
+        ignored.diagnostics[0].code,
+        NEMO_GUARDRAILS_DEPRECATION_CODE
+    );
 }
 
 #[test]

--- a/docs/about-nemo-relay/concepts/plugins.mdx
+++ b/docs/about-nemo-relay/concepts/plugins.mdx
@@ -225,9 +225,10 @@ Detailed observability plugin configuration belongs in
 
 ### NeMo Guardrails
 
-The core crate also ships a built-in `nemo_guardrails` plugin component. It is
-the first-party Guardrails integration point that NeMo Relay owns through the
-shared plugin system.
+The core crate also ships a built-in `nemo_guardrails` plugin component. The
+built-in integration is deprecated and scheduled for removal in NeMo Relay
+0.9. There is no replacement in NeMo Relay 0.8; any replacement will target 0.9
+or later. Do not use the built-in component for new deployments.
 
 The current shipped user-facing paths are:
 

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -109,9 +109,14 @@ for destination paths and explicit-file alternatives.
   authenticated ATOF HTTP stream sink. It is scheduled for removal in 0.8.
 - OpenClaw has public hook-backed telemetry. Its security and optimization
   coverage is partial because it does not own a managed execution path.
-- The NeMo Guardrails remote backend inherits its configured service's
-  availability, latency, and policy behavior. The local backend requires Python
-  3.11 or later and `nemoguardrails==0.22.0`.
+- The built-in `nemo_guardrails` plugin is deprecated and scheduled for removal
+  in NeMo Relay 0.9. It remains available in 0.8: the remote backend inherits
+  its configured service's availability, latency, and policy behavior, and the
+  local backend requires Python 3.11 or later and `nemoguardrails==0.22.0`. A
+  replacement is not included in 0.8 and will target 0.9 or later. Removal will
+  include the built-in component kind, the public
+  `nemo_relay::plugins::nemo_guardrails` Rust module, its CLI editor entry, and
+  the `guardrails-remote` Cargo feature.
 - The PII redaction plugin currently supports its deterministic local backend;
   local-model backend configuration is reserved for future work.
 - Pricing and optimization estimates depend on model names, token data, pricing

--- a/docs/configure-plugins/about.mdx
+++ b/docs/configure-plugins/about.mdx
@@ -29,8 +29,9 @@ entries in `plugins.toml`.
   or typed OpenTelemetry data.
 - [Adaptive](/configure-plugins/adaptive/about) configures adaptive runtime
   behavior.
-- [NeMo Guardrails](/configure-plugins/nemo-guardrails/about) installs
-  Guardrails-backed policy checks.
+- [NeMo Guardrails (Deprecated)](/configure-plugins/nemo-guardrails/about)
+  installs Guardrails-backed policy checks. The built-in plugin is scheduled
+  for removal in NeMo Relay 0.9 and should not be used for new deployments.
 - [PII Redaction](/configure-plugins/pii-redaction/about) sanitizes sensitive
   data in observability payloads.
 - [Switchyard (Deprecated)](/configure-plugins/switchyard/about) routes requests

--- a/docs/configure-plugins/nemo-guardrails/about.mdx
+++ b/docs/configure-plugins/nemo-guardrails/about.mdx
@@ -1,15 +1,21 @@
 ---
-title: "NeMo Guardrails Plugin"
+title: "NeMo Guardrails (Deprecated)"
 sidebar-title: "About"
-description: "Configure NeMo Guardrails policy around managed LLM and tool execution."
+description: "Review the deprecated built-in NeMo Guardrails plugin for managed LLM and tool execution."
 position: 1
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-Use the NeMo Guardrails plugin when you want first-party Guardrails policy
-around managed NeMo Relay LLM and tool execution through the shared plugin
-system.
+<Warning title="Deprecated">
+The built-in `nemo_guardrails` plugin is deprecated and scheduled for removal
+in NeMo Relay 0.9. It remains available in NeMo Relay 0.8. There is no
+replacement in NeMo Relay 0.8; any replacement will target 0.9 or later.
+
+</Warning>
+
+Do not start a new deployment on the built-in plugin. Use this documentation to
+maintain or remove an existing NeMo Relay 0.8 configuration.
 
 The built-in plugin component has kind `nemo_guardrails` and is available as a
 first-party NeMo Relay plugin.
@@ -23,9 +29,9 @@ The plugin supports these backend modes:
   - Calls `nemoguardrails` through a local `python3` worker subprocess instead
     of a separate Guardrails service.
 
-## Use This Plugin When
+## Existing Uses
 
-Start here when you need to:
+Existing NeMo Relay 0.8 deployments may use the built-in plugin to:
 
 - Apply Guardrails input and output checks around managed `llm.execute(...)`
   calls.

--- a/docs/configure-plugins/nemo-guardrails/configuration.mdx
+++ b/docs/configure-plugins/nemo-guardrails/configuration.mdx
@@ -1,14 +1,23 @@
 ---
 title: "NeMo Guardrails Configuration"
 sidebar-title: "Configuration"
-description: "Configure remote and local NeMo Guardrails backends for managed execution."
+description: "Configure the deprecated built-in remote and local NeMo Guardrails backends."
 position: 2
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-Use this page when you want to configure the built-in NeMo Guardrails plugin
-component. The component kind is `nemo_guardrails`.
+<Warning title="Deprecated">
+The built-in `nemo_guardrails` plugin is deprecated and scheduled for removal
+in NeMo Relay 0.9. Existing local and remote configurations continue to work in
+NeMo Relay 0.8. There is no replacement in NeMo Relay 0.8; any replacement
+will target 0.9 or later.
+
+</Warning>
+
+Use this page only to maintain or remove an existing NeMo Relay 0.8
+configuration. Do not start a new deployment on the built-in plugin. The
+component kind is `nemo_guardrails`.
 
 For plugin file discovery, precedence, merge behavior, editor controls, and
 gateway conflict rules, refer to

--- a/docs/configure-plugins/plugin-configuration-files.mdx
+++ b/docs/configure-plugins/plugin-configuration-files.mdx
@@ -259,9 +259,12 @@ Repository-local `.nemo-relay/plugins.toml` files are not discovered.
 
 ## Gateway Editing Files
 
-Use the interactive editor for Observability, Adaptive, NeMo Guardrails, and
-PII Redaction configuration. The editor also updates the configuration of
-manifest-backed dynamic plugins that `plugins add` has registered:
+Use the interactive editor for Observability, Adaptive, PII Redaction, and
+existing NeMo Guardrails configuration. The built-in `nemo_guardrails`
+component is deprecated and scheduled for removal in NeMo Relay 0.9; do not
+use the editor to start a new Guardrails deployment. The editor also updates
+the configuration of manifest-backed dynamic plugins that `plugins add` has
+registered:
 
 ```bash
 nemo-relay plugins edit
@@ -440,10 +443,11 @@ your `initialize` config applies.
 
 The editor writes explicit defaults for edited Observability and Adaptive
 sections. It writes NeMo Guardrails, PII Redaction, and dynamic-plugin fields
-only when readers configure them. In a layered config model, omitting a field
-means "inherit a lower precedence value"; it does not mean "delete that value."
-Use the dedicated `nemo-relay model-pricing` commands to manage model-pricing
-catalog sources.
+only when readers configure them. Use the NeMo Guardrails behavior only to
+maintain or remove an existing configuration. In a layered config model,
+omitting a field means "inherit a lower precedence value"; it does not mean
+"delete that value." Use the dedicated `nemo-relay model-pricing` commands to
+manage model-pricing catalog sources.
 
 For example, this system file disables ATOF even if an explicit or user file
 enables it:

--- a/docs/configure-plugins/plugin-configuration-files.mdx
+++ b/docs/configure-plugins/plugin-configuration-files.mdx
@@ -443,7 +443,7 @@ your `initialize` config applies.
 
 The editor writes explicit defaults for edited Observability and Adaptive
 sections. It writes NeMo Guardrails, PII Redaction, and dynamic-plugin fields
-only when readers configure them. Use the NeMo Guardrails behavior only to
+only when readers configure them. Use the NeMo Guardrails editor only to
 maintain or remove an existing configuration. In a layered config model,
 omitting a field means "inherit a lower precedence value"; it does not mean
 "delete that value." Use the dedicated `nemo-relay model-pricing` commands to

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -36,8 +36,10 @@ Plugins use a structured plugin configuration with:
 
 Start with [Language Binding Plugins](/build-plugins/language-binding/about) when you need reusable middleware, subscribers, or adaptive behavior.
 
-Use [NeMo Guardrails Configuration](/configure-plugins/nemo-guardrails/configuration) when
-you want the built-in first-party `nemo_guardrails` component.
+Use [NeMo Guardrails Configuration](/configure-plugins/nemo-guardrails/configuration)
+only to maintain or remove an existing NeMo Relay 0.8 `nemo_guardrails`
+component. The built-in plugin is deprecated and scheduled for removal in NeMo
+Relay 0.9; do not use it for a new deployment.
 
 The `nemo-relay` CLI gateway reads plugin files named `plugins.toml`. Refer to
 [Plugin Configuration Files](/configure-plugins/plugin-configuration-files)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -35,7 +35,7 @@ navigation:
         title: "Adaptive"
         title-source: frontmatter
       - folder: ./configure-plugins/nemo-guardrails
-        title: "NeMo Guardrails"
+        title: "NeMo Guardrails (Deprecated)"
         title-source: frontmatter
       - folder: ./configure-plugins/pii-redaction
         title: "PII Redaction"

--- a/docs/resources/glossary.mdx
+++ b/docs/resources/glossary.mdx
@@ -321,9 +321,10 @@ the rest of the documentation can use them consistently.
   Dynamic Plugins](/build-plugins/dynamic-plugins/native-dynamic/about).
 
 **NeMo Guardrails**
-: NeMo Guardrails is the built-in `nemo_guardrails` plugin component for
-  first-party guardrail policy around managed tool and LLM execution. It
-  supports remote Guardrails-service and Python-backed local backends.
+: NeMo Guardrails is the deprecated built-in `nemo_guardrails` plugin component
+  for first-party guardrail policy around managed tool and LLM execution. It
+  supports remote Guardrails-service and Python-backed local backends and is
+  scheduled for removal in NeMo Relay 0.9.
 
 **Next Function**
 : The next function is the continuation passed to an execution intercept. The


### PR DESCRIPTION
#### Overview

Deprecates the built-in `nemo_guardrails` plugin ahead of its planned removal in NeMo Relay 0.9.

The existing integration remains available in NeMo Relay 0.8 and continues to behave as before. This change adds clear runtime, configuration, API, CLI, and documentation warnings so users do not begin new deployments on an integration scheduled for removal. There is no replacement in NeMo Relay 0.8; replacement work is deferred to 0.9 or later.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Emit a stable `nemo_guardrails.deprecated` configuration diagnostic whenever the built-in component is configured, including when it is disabled.
- Emit a structured warning when the built-in plugin is activated.
- Mark the public Rust Guardrails registration, configuration, and component APIs as deprecated since Relay 0.8.0.
- Mark the generated Guardrails configuration schema, including its nested configuration definitions, as deprecated.
- Label the plugin as deprecated in the interactive CLI editor.
- Document that removal includes the component kind, public Rust module, CLI editor entry, and `guardrails-remote` Cargo feature.
- Add removal notices to the Guardrails documentation, plugin navigation, configuration guides, concepts, glossary, and release notes.
- Direct users to use the documentation only to maintain or remove existing NeMo Relay 0.8 configurations.
- Preserve the existing plugin ID, configuration format, execution behavior, and local and remote modes.

This is a non-breaking deprecation. It does not remove the plugin, change Guardrails behavior, upgrade the Guardrails dependency, or introduce a replacement worker integration.

Validation:

- `cargo fmt --all` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `just test-python` passed with 652 tests.
- `just test-go` passed for all packages through a no-space workspace alias. The direct invocation could not link because the local checkout path contains a space and the Go recipe supplies the absolute library path to Clang without quoting it.
- `just test-node` passed with 369 tests.
- `just test-rust` reached the CLI suite with all preceding suites passing, then one unrelated terminal-supervision test received `WouldBlock` because the test process did not own foreground stdin. The same test passed when rerun in isolation.
- `just docs` passed. Fern skipped its authenticated redirect check because no `FERN_TOKEN` was available locally.
- `uv run pre-commit run --all-files` passed.
- `git diff --check` passed.
- External Rust consumer smoke tests produced deprecation warnings for every public Guardrails API while an unrelated control consumer remained warning-free.

#### Where should the reviewer start?

Start with `crates/core/src/plugins/nemo_guardrails/component.rs` for the runtime, configuration, and public API deprecation behavior. Then review `docs/configure-plugins/nemo-guardrails/about.mdx` for the user-facing removal notice and `docs/about-nemo-relay/release-notes/index.mdx` for the complete removal boundary.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-681


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Deprecation**
  - Marked the built-in NeMo Guardrails integration and related configuration options as deprecated in version 0.8.
  - Added deprecation warnings during configuration validation and registration.
  - Scheduled removal for NeMo Relay 0.9.

- **Documentation**
  - Updated plugin menus, configuration guidance, glossary, and release notes with deprecation status.
  - Clarified that existing 0.8 deployments remain supported for maintenance or removal, while new deployments should not use the integration.
  - Documented that no replacement is currently available in 0.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->