### PR TITLE
fix(langchain): close finished scopes from the top of the stack down

### DIFF
--- a/python/nemo_relay/integrations/langchain/callbacks.py
+++ b/python/nemo_relay/integrations/langchain/callbacks.py
@@ -204,6 +204,13 @@ class NemoRelayCallbackHandler(BaseCallbackHandler):
             completed = self._completed.get(top.uuid)
             if completed is None:
                 return
+            if top.name != completed.handle.name:
+                # Same uuid, different scope. ``create_scope_stack_from_propagation``
+                # rebuilds a parent from a captured context, so our uuid can appear on
+                # another stack as a stand-in. Closing it would discard the completion
+                # and strand the real scope. Handles cannot be told apart by identity --
+                # reading the current one returns a fresh wrapper even on its own stack.
+                return
             try:
                 nemo_relay.scope.pop(
                     completed.handle,

--- a/python/nemo_relay/integrations/langchain/callbacks.py
+++ b/python/nemo_relay/integrations/langchain/callbacks.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
+import threading
 import typing
 
 from langchain_core.callbacks.base import BaseCallbackHandler
@@ -19,6 +21,54 @@ if typing.TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
+class _CompletedScope(typing.NamedTuple):
+    """A run that has ended, waiting for its scope to reach the top of the stack.
+
+    A scope stack closes strictly LIFO, but concurrent sibling runs finish in the order
+    the graph chooses, so a run can end while scopes opened after it are still open.
+    Recording the completion and closing it once it reaches the top preserves the stack's
+    ordering without ever attempting a close the stack would reject.
+
+    A completion is only ever closed when its scope is the top of the active stack, so
+    ownership needs no separate check: a scope sits on exactly one stack, and its handle
+    uuid can only be the current top on that stack. Comparing ``ScopeStack`` objects
+    would not work anyway -- propagating a stack to a worker thread yields a different
+    Python wrapper for the same stack, with no way to correlate the two.
+
+    ``output`` is already serialized: callers own the mapping they hand to the callback
+    and may mutate it afterwards, so it is snapshotted when the callback fires, for the
+    same reason ``ended_at`` is.
+
+    Entries are removed as their scopes reach the top, so the set is bounded by the runs
+    a handler has open at once. The exception is a scope closed by something other than
+    this handler: it can never return to the top, so its entry is retained for the life
+    of the handler, holding the serialized output.
+    """
+
+    handle: nemo_relay.ScopeHandle
+    output: nemo_relay.Json | None
+    metadata: nemo_relay.Json | None
+    ended_at: datetime.datetime
+
+
+def _current_scope_handle() -> nemo_relay.ScopeHandle | None:
+    """Return the scope on top of the active stack, or ``None`` if there is not one.
+
+    ``get_handle`` creates a stack for the current context when it has none, so it is
+    guarded by a status check: a run completing somewhere without a stack has nothing
+    this handler could close, and should not leave one behind for having asked. The
+    check consults the thread binding as well as the context, so a stack propagated to
+    a worker thread still counts as active.
+    """
+    try:
+        if not nemo_relay.scope_stack_active():
+            return None
+        return nemo_relay.scope.get_handle()
+    except Exception:
+        _logger.debug("NeMo Relay: reading the current scope failed", exc_info=True)
+        return None
+
+
 class NemoRelayCallbackHandler(BaseCallbackHandler):
     """Bridge LangChain chain run IDs to NeMo Relay Agent scopes."""
 
@@ -27,7 +77,14 @@ class NemoRelayCallbackHandler(BaseCallbackHandler):
 
     def __init__(self) -> None:
         super().__init__()
-        self._scope_handles: dict[UUID, typing.Any] = {}
+        # Start, completion, top-check and pop are multi-step transitions over the maps
+        # below. A handler can be reused by callbacks delivered on worker threads, so the
+        # transitions are serialized: a top-check is only meaningful if the pop it
+        # authorizes cannot be overtaken by another thread pushing onto the same stack.
+        # Reentrant because completing a run drains, and both take the lock.
+        self._lock = threading.RLock()
+        self._scope_handles: dict[UUID, nemo_relay.ScopeHandle] = {}
+        self._completed: dict[str, _CompletedScope] = {}
 
     def on_chain_start(
         self,
@@ -68,7 +125,8 @@ class NemoRelayCallbackHandler(BaseCallbackHandler):
                 input=prepared_inputs,
                 metadata=scope_metadata,
             )
-            self._scope_handles[run_id] = handle
+            with self._lock:
+                self._scope_handles[run_id] = handle
         except Exception:
             _logger.error("NeMo Relay: on_chain_start failed", exc_info=True)
 
@@ -101,12 +159,79 @@ class NemoRelayCallbackHandler(BaseCallbackHandler):
     def _pop_scope(
         self, run_id: UUID, *, output: dict[str, typing.Any] | None = None, metadata: nemo_relay.Json | None = None
     ) -> None:
-        handle = self._scope_handles.pop(run_id, None)
-        if handle is None:
-            return
+        # Serialized before the run mappings are touched. Serialization walks
+        # caller-supplied data and can fail on its own -- a cyclic output raises
+        # ``RecursionError`` -- and a run dropped from the maps with no completion
+        # recorded is a scope nothing can ever close.
+        prepared_output = _prepare_output(output)
 
-        try:
-            prepared_outputs = _prepare_lc_payloads(output) if output is not None else None
-            nemo_relay.scope.pop(handle, output=prepared_outputs, metadata=metadata)
-        except Exception:
-            _logger.error("NeMo Relay: scope.pop failed", exc_info=True)
+        with self._lock:
+            handle = self._scope_handles.pop(run_id, None)
+            if handle is None:
+                return
+
+            self._completed[handle.uuid] = _CompletedScope(
+                handle=handle,
+                output=prepared_output,
+                metadata=metadata,
+                ended_at=datetime.datetime.now(datetime.timezone.utc),
+            )
+            self._close_completed_scopes_locked()
+
+    def _close_completed_scopes(self) -> None:
+        """Close finished scopes from the top of the active stack down."""
+        with self._lock:
+            self._close_completed_scopes_locked()
+
+    def _close_completed_scopes_locked(self) -> None:
+        """Close finished scopes from the top of ``stack`` down.
+
+        Only the scope currently on top is ever closed, so the stack is never asked to
+        accept a close it would reject. Draining stops as soon as the top is a run that
+        is still going, or a scope this handler does not own; anything completed
+        underneath it waits, which is what keeps the ordering intact.
+
+        This is also what confines a shared handler to one stack at a time: a completion
+        belonging to another stack cannot be the top here, so it is left alone.
+
+        The caller must hold ``self._lock``: a top-check is only meaningful if the pop it
+        authorizes cannot be overtaken by another thread pushing onto the same stack.
+        """
+        while self._completed:
+            top = _current_scope_handle()
+            if top is None:
+                return
+            completed = self._completed.get(top.uuid)
+            if completed is None:
+                return
+            try:
+                nemo_relay.scope.pop(
+                    completed.handle,
+                    output=completed.output,
+                    metadata=completed.metadata,
+                    timestamp=completed.ended_at,
+                )
+            except Exception:
+                # The runtime can refuse before it mutates the stack, so the scope
+                # may still be live and closable later. Keep the completion -- it is
+                # the only record able to close it -- and stop rather than spin.
+                _logger.error("NeMo Relay: scope.pop failed", exc_info=True)
+                return
+            # Only once the stack has actually accepted the close.
+            del self._completed[top.uuid]
+
+
+def _prepare_output(output: dict[str, typing.Any] | None) -> nemo_relay.Json | None:
+    """Serialize a callback output, degrading to ``None`` if it cannot be serialized.
+
+    Losing an output payload costs one scope's telemetry detail. Letting the failure
+    escape would cost the scope itself, since the run has ended and nothing else will
+    close it.
+    """
+    if output is None:
+        return None
+    try:
+        return _prepare_lc_payloads(output)
+    except Exception:
+        _logger.error("NeMo Relay: preparing scope output failed", exc_info=True)
+        return None

--- a/python/tests/integrations/langchain_tests/test_callbacks.py
+++ b/python/tests/integrations/langchain_tests/test_callbacks.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import types
 import typing
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -17,21 +17,40 @@ if typing.TYPE_CHECKING:
 
 
 def _make_mock_nemo_relay() -> MagicMock:
-    """Build a minimal mock of the ``nemo_relay`` module."""
+    """Build a minimal mock of the ``nemo_relay`` module.
+
+    The mock models the runtime's LIFO scope stack rather than accepting any call in any
+    order. The handler closes whichever scope is on top, so a mock that cannot answer
+    "what is on top?" would report no closes at all.
+    """
     mock_nemo_relay = MagicMock(name="nemo_relay")
     mock_nemo_relay.ScopeType = types.SimpleNamespace(Agent="Agent")
 
-    scope = types.SimpleNamespace()
-    scope.push = MagicMock(
-        side_effect=lambda name, scope_type, **kwargs: types.SimpleNamespace(
+    stack = [types.SimpleNamespace(uuid=str(uuid4()), name="root")]
+
+    def push(name, scope_type, **kwargs):
+        handle = types.SimpleNamespace(
             uuid=str(uuid4()),
             name=name,
             scope_type=scope_type,
             kwargs=kwargs,
         )
-    )
-    scope.pop = MagicMock()
+        stack.append(handle)
+        return handle
+
+    def pop(handle, **kwargs):
+        # Closing anything but the top is what the real stack rejects, so the mock has to
+        # reject it too; otherwise a handler that closed the wrong scope would pass.
+        assert handle is stack[-1], "closed a scope that was not on top"
+        stack.pop()
+
+    scope = types.SimpleNamespace()
+    scope.push = MagicMock(side_effect=push)
+    scope.pop = MagicMock(side_effect=pop)
+    scope.get_handle = MagicMock(side_effect=lambda: stack[-1])
     mock_nemo_relay.scope = scope
+    # A stable object so the handler can tell one stack from another by identity.
+    mock_nemo_relay.get_scope_stack = MagicMock(side_effect=lambda: stack)
     return mock_nemo_relay
 
 
@@ -113,6 +132,7 @@ class TestScopeLifecycle:
             handle,
             output={"output": "result"},
             metadata={"otel.status_code": "OK"},
+            timestamp=ANY,
         )
         assert run_id not in handler._scope_handles
 
@@ -134,6 +154,7 @@ class TestScopeLifecycle:
             handle,
             output={"error": "RuntimeError('boom')"},
             metadata={"otel.status_code": "ERROR", "otel.status_description": "boom"},
+            timestamp=ANY,
         )
         assert run_id not in handler._scope_handles
 
@@ -192,6 +213,7 @@ class TestScopeLifecycle:
                 }
             },
             metadata={"otel.status_code": "OK"},
+            timestamp=ANY,
         )
 
     def test_parent_scope_passed_to_push(self, handler: NemoRelayCallbackHandler, mock_nemo_relay: MagicMock):

--- a/python/tests/integrations/langchain_tests/test_callbacks_scope_stack.py
+++ b/python/tests/integrations/langchain_tests/test_callbacks_scope_stack.py
@@ -1,0 +1,688 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the callback handler against a real NeMo Relay scope stack.
+
+``test_callbacks.py`` drives the handler with a ``MagicMock`` of ``nemo_relay``. That is
+the right tool for asserting which calls the handler makes, but a mocked ``scope.pop``
+accepts any handle in any order, so it cannot observe the stack's LIFO rule at all. The
+failure covered here is exactly that rule being violated, so these tests use the real
+stack.
+
+The shape under test is two sibling chain runs that finish out of LIFO order: A starts,
+B starts, A ends, B ends. That ordering is what LangGraph produces when it schedules
+sibling nodes as concurrent asyncio tasks sharing one scope stack. These tests drive the
+handler's callbacks directly rather than through a callback manager, so they reproduce
+the stack-level consequence deterministically; they do not attempt to prove how LangGraph
+dispatches callbacks, which belongs in the langgraph integration tests.
+
+Two things make a test here easy to get wrong, so each test guards against them:
+
+* ``on_chain_start`` logs and swallows every exception, so a handler that pushed nothing
+  would satisfy "no scope was stranded" and "the stack is unchanged" while exercising
+  nothing. Each test asserts the scopes were genuinely open before reading the end state.
+* ``scope.push`` parents a new scope to the current top of stack unless an explicit
+  parent handle is given, so callbacks that omit ``parent_run_id`` produce a nested
+  chain, not siblings. The sibling runs here declare a common tracked parent run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import datetime
+import threading
+import typing
+from uuid import UUID, uuid4
+
+import pytest
+
+import nemo_relay
+
+if typing.TYPE_CHECKING:
+    from nemo_relay.integrations.langchain.callbacks import NemoRelayCallbackHandler
+
+# Handles the handler tracks while both siblings are open: the parent run plus A and B.
+_OPEN_AT_OVERLAP = 3
+
+
+@pytest.fixture(name="isolated_scope_stack", autouse=True)
+def isolated_scope_stack_fixture():
+    """Run each test on its own stack so a stranded scope cannot leak into the next."""
+
+    with nemo_relay.use_scope_stack(nemo_relay.create_scope_stack()):
+        yield
+
+
+@pytest.fixture(name="handler")
+def handler_fixture() -> NemoRelayCallbackHandler:
+    from nemo_relay.integrations.langchain.callbacks import NemoRelayCallbackHandler
+
+    return NemoRelayCallbackHandler()
+
+
+def _start(
+    handler: NemoRelayCallbackHandler,
+    run_id: UUID,
+    name: str,
+    parent_run_id: UUID | None = None,
+) -> None:
+    handler.on_chain_start({}, {"task": name}, run_id=run_id, parent_run_id=parent_run_id, name=name)
+
+
+def _end(handler: NemoRelayCallbackHandler, run_id: UUID, name: str) -> None:
+    handler.on_chain_end({"done": name}, run_id=run_id)
+
+
+async def _overlapping_sibling_runs(handler: NemoRelayCallbackHandler) -> int:
+    """Interleave two sibling chain runs so they close out of LIFO order.
+
+    A and B both declare ``parent`` as their parent run, so they are siblings rather than
+    a nested chain. They then close as A, B — valid for the graph, rejected by the stack.
+
+    Returns the number of scopes the handler had open while both siblings were running,
+    so a caller can tell a real overlap from a handler that pushed nothing.
+    """
+
+    parent_run, run_a, run_b = uuid4(), uuid4(), uuid4()
+    a_started, b_started, allow_b_end = (asyncio.Event() for _ in range(3))
+    open_at_overlap = 0
+
+    _start(handler, parent_run, "parent")
+
+    async def drive_a() -> None:
+        _start(handler, run_a, "A", parent_run_id=parent_run)
+        a_started.set()
+        await b_started.wait()
+        _end(handler, run_a, "A")
+        allow_b_end.set()
+
+    async def drive_b() -> None:
+        nonlocal open_at_overlap
+        await a_started.wait()
+        _start(handler, run_b, "B", parent_run_id=parent_run)
+        open_at_overlap = len(handler._scope_handles)
+        b_started.set()
+        await allow_b_end.wait()
+        _end(handler, run_b, "B")
+
+    await asyncio.gather(asyncio.create_task(drive_a()), asyncio.create_task(drive_b()))
+    _end(handler, parent_run, "parent")
+    return open_at_overlap
+
+
+async def test_strictly_nested_runs_close_cleanly(handler: NemoRelayCallbackHandler):
+    """Control: the harness itself is sound when the runs nest properly."""
+
+    baseline = nemo_relay.scope.get_handle()
+    run_a, run_b = uuid4(), uuid4()
+
+    with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
+        _start(handler, run_a, "A")
+        _start(handler, run_b, "B", parent_run_id=run_a)
+        assert len(handler._scope_handles) == 2, "the handler did not open both scopes"
+        _end(handler, run_b, "B")
+        _end(handler, run_a, "A")
+
+    assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+    assert handler._scope_handles == {}
+
+
+async def test_sibling_runs_are_parented_to_a_common_run(
+    handler: NemoRelayCallbackHandler,
+    subscribed_events: list[nemo_relay.Event],
+):
+    """Pin the topology the regression tests below depend on.
+
+    ``scope.push`` parents to the current top of stack when no explicit handle is given,
+    so callbacks that omit ``parent_run_id`` yield a nested chain that reaches the stack
+    the same way but is not the sibling shape LangGraph produces. Without this, a fix
+    that only handled true siblings would still look covered.
+    """
+
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+    await _overlapping_sibling_runs(handler)
+    # This test is about parentage, not the close, which is asserted elsewhere.
+    with contextlib.suppress(RuntimeError):
+        nemo_relay.scope.pop(request)
+    await nemo_relay.subscribers.flush_async()
+
+    scopes = {}
+    for event in subscribed_events:
+        payload = event.to_dict()
+        if payload.get("kind") == "scope":
+            scopes[payload["name"]] = payload
+
+    assert {"parent", "A", "B"} <= scopes.keys(), "the sibling runs did not open scopes"
+    assert scopes["A"]["parent_uuid"] == scopes["parent"]["uuid"]
+    assert scopes["B"]["parent_uuid"] == scopes["parent"]["uuid"]
+    assert scopes["B"]["parent_uuid"] != scopes["A"]["uuid"], "B is nested under A"
+
+
+async def test_a_deferred_close_records_when_the_run_actually_ended(
+    handler: NemoRelayCallbackHandler,
+    subscribed_events: list[nemo_relay.Event],
+):
+    """A close held back for ordering must not be dated to when it was replayed.
+
+    A ends before B but can only be closed after it, so recording the replay time would
+    inflate A's duration by however long B ran.
+
+    Driven step by step so the moment A ended can be marked. Comparing A's close against
+    B's would depend on the two callbacks landing in different clock ticks, which is not
+    true on every platform.
+    """
+
+    parent_run, run_a, run_b = uuid4(), uuid4(), uuid4()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    _start(handler, parent_run, "parent")
+    _start(handler, run_a, "A", parent_run_id=parent_run)
+    _start(handler, run_b, "B", parent_run_id=parent_run)
+
+    _end(handler, run_a, "A")
+    assert len(handler._completed) == 1, "A should be waiting on B"
+    a_ended_by = datetime.datetime.now(datetime.timezone.utc)
+
+    _end(handler, run_b, "B")
+    _end(handler, parent_run, "parent")
+    nemo_relay.scope.pop(request)
+    await nemo_relay.subscribers.flush_async()
+
+    stamps: dict[str, list[str]] = {}
+    for event in subscribed_events:
+        payload = event.to_dict()
+        if payload.get("kind") == "scope":
+            stamps.setdefault(str(payload["name"]), []).append(str(payload["timestamp"]))
+
+    # Two events per scope, start then end; the second is the close.
+    assert len(stamps.get("A", [])) == 2, "A did not open and close"
+    assert len(stamps.get("B", [])) == 2, "B did not open and close"
+
+    a_closed_at = datetime.datetime.fromisoformat(stamps["A"][1])
+    b_closed_at = datetime.datetime.fromisoformat(stamps["B"][1])
+    assert a_closed_at <= a_ended_by, "A's close was dated to its replay, not its end"
+    assert a_closed_at <= b_closed_at, "A was recorded as outliving the run it waited on"
+
+
+async def test_overlapping_sibling_runs_leave_the_outer_scope_closable(
+    handler: NemoRelayCallbackHandler,
+):
+    """A sibling closing out of order must not break the enclosing scope.
+
+    The out-of-order pop is the handler's problem to absorb. Today it is swallowed and
+    the scope stays on the stack, so the caller's own scope raises on exit and an
+    operation that fully succeeded is reported as failed.
+    """
+
+    # Pushed and popped explicitly so only the close is guarded: an error raised by the
+    # scenario itself must fail the test rather than be mistaken for a teardown failure.
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+    open_at_overlap = await _overlapping_sibling_runs(handler)
+
+    teardown_error: BaseException | None = None
+    try:
+        nemo_relay.scope.pop(request)
+    except RuntimeError as exc:
+        teardown_error = exc
+
+    assert open_at_overlap == _OPEN_AT_OVERLAP, "the sibling runs never actually overlapped"
+    assert teardown_error is None
+
+
+async def test_overlapping_sibling_runs_do_not_strand_a_scope(
+    handler: NemoRelayCallbackHandler,
+):
+    """Every scope the handler opened must be closed by the time its runs have ended.
+
+    ``_pop_scope`` drops the handle from ``_scope_handles`` before attempting the pop, so
+    a rejected pop leaves a scope that is live on the stack and untracked by the handler:
+    nothing can close it afterwards, and it stays current for everything that follows.
+    """
+
+    baseline = nemo_relay.scope.get_handle()
+
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+    open_at_overlap = await _overlapping_sibling_runs(handler)
+    # Closing the enclosing scope is asserted by the test above; this one is about the
+    # stack that was left behind, which is why only the close is tolerated here.
+    with contextlib.suppress(RuntimeError):
+        nemo_relay.scope.pop(request)
+
+    assert open_at_overlap == _OPEN_AT_OVERLAP, "the sibling runs never actually overlapped"
+    assert handler._scope_handles == {}
+    assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+
+
+async def test_a_close_is_queued_only_until_the_scopes_above_it_go(
+    handler: NemoRelayCallbackHandler,
+):
+    """Observe the queue itself, rather than inferring it from the end state.
+
+    Driven step by step so the state between callbacks is visible: an implementation that
+    simply delayed every close would satisfy the end-state assertions elsewhere.
+    """
+
+    parent_run, run_a, run_b = uuid4(), uuid4(), uuid4()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    _start(handler, parent_run, "parent")
+    _start(handler, run_a, "A", parent_run_id=parent_run)
+    _start(handler, run_b, "B", parent_run_id=parent_run)
+
+    _end(handler, run_a, "A")
+    # A cannot close while B sits above it, so it must be held rather than abandoned.
+    assert len(handler._completed) == 1
+
+    _end(handler, run_b, "B")
+    # Closing B exposes A, so both leave the queue on this one callback.
+    assert handler._completed == {}
+
+    _end(handler, parent_run, "parent")
+    nemo_relay.scope.pop(request)
+    assert handler._scope_handles == {}
+
+
+async def test_a_scope_closed_out_of_band_does_not_block_other_closes(
+    handler: NemoRelayCallbackHandler,
+):
+    """A completion whose scope is gone waits forever, but holds nothing else up.
+
+    Closing only what is on top means there is no failed attempt to classify, and so no
+    way to notice that a scope was closed by someone else and can never come back to the
+    top. Its completion is retained. That is the trade for never guessing at an error
+    message: the entry is inert, and everything around it still closes normally.
+
+    Retention is therefore bounded by open runs plus any scope closed out of band, and
+    an out-of-band close is not something the handler can cause on its own.
+    """
+
+    run_a, run_b = uuid4(), uuid4()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    _start(handler, run_a, "A")
+    # Close A behind the handler's back, so its scope leaves the stack.
+    nemo_relay.scope.pop(handler._scope_handles[run_a])
+    _end(handler, run_a, "A")
+    assert len(handler._completed) == 1, "A's completion should be retained"
+
+    # A later run on the same stack is unaffected.
+    _start(handler, run_b, "B")
+    _end(handler, run_b, "B")
+
+    # And the enclosing scope still closes, which is what actually matters.
+    nemo_relay.scope.pop(request)
+    assert handler._scope_handles == {}
+
+
+async def test_a_queued_close_is_not_discarded_by_another_stacks_drain(
+    handler: NemoRelayCallbackHandler,
+):
+    """A completion is only closed when its scope is the top of the active stack.
+
+    That is what confines a shared handler to one stack at a time: draining while another
+    stack is active cannot match this completion's handle, so it is left alone rather
+    than consumed or discarded.
+    """
+
+    parent_run, run_a, run_b = uuid4(), uuid4(), uuid4()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    _start(handler, parent_run, "parent")
+    _start(handler, run_a, "A", parent_run_id=parent_run)
+    _start(handler, run_b, "B", parent_run_id=parent_run)
+    _end(handler, run_a, "A")
+    assert len(handler._completed) == 1, "A should be waiting on B"
+
+    # A drain driven by an unrelated stack must leave A alone.
+    with nemo_relay.use_scope_stack(nemo_relay.create_scope_stack()):
+        handler._close_completed_scopes()
+    assert len(handler._completed) == 1, "another stack's drain discarded A"
+
+    # Back on its own stack, A still closes normally.
+    _end(handler, run_b, "B")
+    assert handler._completed == {}
+    _end(handler, parent_run, "parent")
+    nemo_relay.scope.pop(request)
+
+
+async def test_one_handler_shared_across_two_scope_stacks(
+    handler: NemoRelayCallbackHandler,
+):
+    """The reported failure: two concurrent invocations sharing one handler.
+
+    Invocation 1 queues A behind B. Invocation 2 then closes a run of its own, and its
+    drain must not touch A. If it does, A is dropped as terminal and invocation 1's
+    request scope cannot close.
+    """
+
+    first_parent, first_a, first_b = uuid4(), uuid4(), uuid4()
+    second_run = uuid4()
+    first_stack = nemo_relay.create_scope_stack()
+    second_stack = nemo_relay.create_scope_stack()
+
+    with nemo_relay.use_scope_stack(first_stack):
+        first_request = nemo_relay.scope.push("request-1", nemo_relay.ScopeType.Agent)
+        _start(handler, first_parent, "parent-1")
+        _start(handler, first_a, "A", parent_run_id=first_parent)
+        _start(handler, first_b, "B", parent_run_id=first_parent)
+        _end(handler, first_a, "A")
+        assert len(handler._completed) == 1
+
+    with nemo_relay.use_scope_stack(second_stack):
+        second_request = nemo_relay.scope.push("request-2", nemo_relay.ScopeType.Agent)
+        _start(handler, second_run, "X")
+        _end(handler, second_run, "X")
+        nemo_relay.scope.pop(second_request)
+
+    with nemo_relay.use_scope_stack(first_stack):
+        _end(handler, first_b, "B")
+        _end(handler, first_parent, "parent-1")
+        # The whole point: invocation 1 can still close its own request scope.
+        nemo_relay.scope.pop(first_request)
+
+    assert handler._completed == {}
+    assert handler._scope_handles == {}
+
+
+async def test_the_output_is_snapshotted_when_the_callback_fires(
+    handler: NemoRelayCallbackHandler,
+    subscribed_events: list[nemo_relay.Event],
+):
+    """A deferred close must report the output as it was when the run ended.
+
+    The caller owns the mapping passed to the callback and may reuse or mutate it, so
+    serializing at replay time would let telemetry depend on when the queue happened to
+    drain.
+    """
+
+    parent_run, run_a, run_b = uuid4(), uuid4(), uuid4()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    _start(handler, parent_run, "parent")
+    _start(handler, run_a, "A", parent_run_id=parent_run)
+    _start(handler, run_b, "B", parent_run_id=parent_run)
+
+    outputs = {"done": "A-at-callback"}
+    handler.on_chain_end(outputs, run_id=run_a)
+    assert len(handler._completed) == 1, "A should be waiting on B"
+
+    outputs["done"] = "A-mutated-after-callback"
+
+    _end(handler, run_b, "B")
+    _end(handler, parent_run, "parent")
+    nemo_relay.scope.pop(request)
+    await nemo_relay.subscribers.flush_async()
+
+    payloads = [event.to_dict() for event in subscribed_events]
+    a_events = [p for p in payloads if p.get("name") == "A" and p.get("data")]
+    assert a_events, "A emitted no event carrying output data"
+    rendered = str(a_events[-1]["data"])
+    assert "A-at-callback" in rendered
+    assert "A-mutated-after-callback" not in rendered
+
+
+def test_a_run_completed_on_a_worker_thread_still_closes(
+    handler: NemoRelayCallbackHandler,
+):
+    """A handler reused by worker-thread callbacks must still close its scopes.
+
+    Propagating a stack to a thread hands back a different ``ScopeStack`` wrapper for the
+    same stack, and the two cannot be correlated through the public API. Anything that
+    identified the owning stack by object would stop draining here and strand every
+    scope. Ownership is established by handle uuid instead, which crosses threads.
+    """
+
+    run_id = uuid4()
+    stack = nemo_relay.get_scope_stack()
+    baseline = nemo_relay.scope.get_handle()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    # Start on this context, finish on a worker thread bound to the same stack.
+    _start(handler, run_id, "A")
+
+    failures: list[BaseException] = []
+
+    def finish_on_thread() -> None:
+        try:
+            nemo_relay.set_thread_scope_stack(stack)
+            _end(handler, run_id, "A")
+        except BaseException as exc:  # noqa: BLE001 - surfaced through ``failures``
+            failures.append(exc)
+
+    worker = threading.Thread(target=finish_on_thread)
+    worker.start()
+    worker.join(timeout=10)
+
+    assert not worker.is_alive(), "the worker thread did not finish"
+    assert failures == []
+    assert handler._completed == {}, "the run's scope was never closed"
+    nemo_relay.scope.pop(request)
+    assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+
+
+def test_completing_a_run_without_a_stack_does_not_create_one(
+    handler: NemoRelayCallbackHandler,
+):
+    """Reading the top scope must not leave a stack behind in a context that had none.
+
+    ``get_handle`` creates one on demand, so an unguarded read would materialise an empty
+    stack in every context that happens to complete a run it does not own.
+    """
+
+    run_id = uuid4()
+    _start(handler, run_id, "A")
+
+    created: list[bool] = []
+
+    def finish_without_a_stack() -> None:
+        # A worker thread with no stack bound: nothing here can be closed.
+        _end(handler, run_id, "A")
+        created.append(nemo_relay.scope_stack_active())
+
+    worker = threading.Thread(target=finish_without_a_stack)
+    worker.start()
+    worker.join(timeout=10)
+
+    assert not worker.is_alive(), "the worker thread did not finish"
+    assert created == [False], "completing a run created a scope stack out of nothing"
+
+
+async def test_two_handlers_on_one_stack_only_close_their_own_scopes(
+    handler: NemoRelayCallbackHandler,
+):
+    """Ownership is per handler, not per stack.
+
+    Applications can attach more than one callback handler. Each closes only the runs it
+    opened; a scope on top that belongs to the other handler must stop the drain rather
+    than be closed by whoever happens to be draining.
+    """
+
+    from nemo_relay.integrations.langchain.callbacks import NemoRelayCallbackHandler
+
+    other = NemoRelayCallbackHandler()
+    mine, theirs = uuid4(), uuid4()
+    baseline = nemo_relay.scope.get_handle()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    _start(handler, mine, "mine")
+    _start(other, theirs, "theirs")
+
+    # ``mine`` sits under ``theirs``; my drain must not close a scope I do not own.
+    _end(handler, mine, "mine")
+    assert len(handler._completed) == 1, "my completion should be waiting"
+    assert other._completed == {}
+    assert nemo_relay.scope.get_handle().name == "theirs", "someone closed another's scope"
+
+    _end(other, theirs, "theirs")
+    assert other._completed == {}
+    # Closing theirs exposes mine, but only my own handler can close it.
+    handler._close_completed_scopes()
+    assert handler._completed == {}
+
+    nemo_relay.scope.pop(request)
+    assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+
+
+def test_the_handler_lock_is_reentrant(handler: NemoRelayCallbackHandler):
+    """Closing a scope can re-enter the handler, so the lock has to be reentrant.
+
+    A subscriber or middleware reacting to a scope end may issue another callback on the
+    same thread while the lock is held. Probed with a timed acquire rather than by
+    actually re-entering, so a non-reentrant lock fails the test instead of deadlocking
+    the suite.
+    """
+
+    with handler._lock:
+        reacquired = handler._lock.acquire(timeout=1)
+        if reacquired:
+            handler._lock.release()
+
+    assert reacquired, "handler lock is not reentrant; a re-entrant close would deadlock"
+
+
+async def test_a_transient_pop_failure_keeps_the_completion_for_a_later_close(
+    handler: NemoRelayCallbackHandler,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """The runtime can refuse a close before it mutates the stack.
+
+    The completion is the only record able to close that scope, so dropping it on the
+    first refusal would strand the scope exactly as the original bug did.
+    """
+
+    run_id = uuid4()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+    _start(handler, run_id, "A")
+
+    real_pop = nemo_relay.scope.pop
+    attempts = {"count": 0}
+
+    def flaky_pop(handle: nemo_relay.ScopeHandle, **kwargs: typing.Any) -> None:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("runtime busy")
+        real_pop(handle, **kwargs)
+
+    monkeypatch.setattr(nemo_relay.scope, "pop", flaky_pop)
+
+    with caplog.at_level("ERROR"):
+        _end(handler, run_id, "A")
+
+    assert len(handler._completed) == 1, "a refused close discarded its only record"
+    assert any(record.levelname == "ERROR" for record in caplog.records)
+
+    # The next drain closes it, and the enclosing scope is closable again.
+    handler._close_completed_scopes()
+    assert handler._completed == {}
+    nemo_relay.scope.pop(request)
+
+
+async def test_an_unserializable_output_does_not_strand_the_scope(
+    handler: NemoRelayCallbackHandler,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Serializing the output walks caller data and can fail on its own.
+
+    A cyclic output raises ``RecursionError``. If that escaped after the run had been
+    dropped from the handler's maps, nothing would be left able to close the scope.
+    """
+
+    run_id = uuid4()
+    baseline = nemo_relay.scope.get_handle()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+    _start(handler, run_id, "A")
+
+    cyclic: dict[str, object] = {}
+    cyclic["self"] = cyclic
+
+    with caplog.at_level("ERROR"):
+        handler.on_chain_end(cyclic, run_id=run_id)
+
+    # The scope closed; only the output payload was lost.
+    assert handler._completed == {}
+    assert any(record.levelname == "ERROR" for record in caplog.records)
+    nemo_relay.scope.pop(request)
+    assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+
+
+async def test_a_failed_run_completes_its_scope_the_same_way(
+    handler: NemoRelayCallbackHandler,
+):
+    """``on_chain_error`` completes a run exactly as ``on_chain_end`` does.
+
+    A failed sibling that finished out of order strands its scope just as readily as a
+    successful one, so the error path needs the same treatment.
+    """
+
+    parent_run, run_a, run_b = uuid4(), uuid4(), uuid4()
+    baseline = nemo_relay.scope.get_handle()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    _start(handler, parent_run, "parent")
+    _start(handler, run_a, "A", parent_run_id=parent_run)
+    _start(handler, run_b, "B", parent_run_id=parent_run)
+
+    handler.on_chain_error(RuntimeError("boom"), run_id=run_a)
+    assert len(handler._completed) == 1, "a failed run should wait for B like any other"
+
+    _end(handler, run_b, "B")
+    _end(handler, parent_run, "parent")
+    nemo_relay.scope.pop(request)
+
+    assert handler._completed == {}
+    assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+
+
+async def test_two_concurrent_invocations_share_one_handler(
+    handler: NemoRelayCallbackHandler,
+):
+    """Two asyncio tasks, each on its own stack, interleaved through one handler.
+
+    Invocation 2 is active while invocation 1 has a completion waiting, so anything that
+    drained without regard to which scope is on top would consume it.
+    """
+
+    one_parked, two_done = asyncio.Event(), asyncio.Event()
+    outcomes: dict[str, BaseException | None] = {}
+
+    async def invocation_one() -> None:
+        parent_run, run_a, run_b = uuid4(), uuid4(), uuid4()
+        with nemo_relay.use_scope_stack(nemo_relay.create_scope_stack()):
+            request = nemo_relay.scope.push("request-1", nemo_relay.ScopeType.Agent)
+            _start(handler, parent_run, "parent-1")
+            _start(handler, run_a, "A", parent_run_id=parent_run)
+            _start(handler, run_b, "B", parent_run_id=parent_run)
+            _end(handler, run_a, "A")
+            one_parked.set()
+            await two_done.wait()
+            _end(handler, run_b, "B")
+            _end(handler, parent_run, "parent-1")
+            try:
+                nemo_relay.scope.pop(request)
+            except RuntimeError as exc:
+                outcomes["one"] = exc
+            else:
+                outcomes["one"] = None
+
+    async def invocation_two() -> None:
+        run_x = uuid4()
+        await one_parked.wait()
+        with nemo_relay.use_scope_stack(nemo_relay.create_scope_stack()):
+            request = nemo_relay.scope.push("request-2", nemo_relay.ScopeType.Agent)
+            _start(handler, run_x, "X")
+            _end(handler, run_x, "X")
+            try:
+                nemo_relay.scope.pop(request)
+            except RuntimeError as exc:
+                outcomes["two"] = exc
+            else:
+                outcomes["two"] = None
+        two_done.set()
+
+    await asyncio.gather(asyncio.create_task(invocation_one()), asyncio.create_task(invocation_two()))
+
+    assert outcomes == {"one": None, "two": None}
+    assert handler._completed == {}
+    assert handler._scope_handles == {}

--- a/python/tests/integrations/langchain_tests/test_callbacks_scope_stack.py
+++ b/python/tests/integrations/langchain_tests/test_callbacks_scope_stack.py
@@ -686,3 +686,92 @@ async def test_two_concurrent_invocations_share_one_handler(
     assert outcomes == {"one": None, "two": None}
     assert handler._completed == {}
     assert handler._scope_handles == {}
+
+
+async def test_a_propagated_stack_does_not_consume_another_stacks_completion(
+    handler: NemoRelayCallbackHandler,
+):
+    """A propagated stack seeds a scope carrying an existing scope's uuid.
+
+    ``create_scope_stack_from_propagation`` rebuilds a parent scope from a captured
+    context, so the same uuid legitimately appears on a second stack. Matching a
+    completion on uuid alone closes that stand-in, discards the record, and strands the
+    real scope — the original defect, reached through propagation instead of ordering.
+    """
+
+    import uuid as uuid_module
+
+    parent_run, run_a, run_b = uuid4(), uuid4(), uuid4()
+    baseline = nemo_relay.scope.get_handle()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+
+    _start(handler, parent_run, "parent")
+    _start(handler, run_a, "A", parent_run_id=parent_run)
+    # Captured while A is on top, so the propagated stack's parent carries A's uuid.
+    context = nemo_relay.capture_propagation_context_with_root(str(uuid_module.uuid4()))
+    _start(handler, run_b, "B", parent_run_id=parent_run)
+
+    _end(handler, run_a, "A")
+    assert len(handler._completed) == 1, "A should be waiting on B"
+
+    propagated = nemo_relay.create_scope_stack_from_propagation(context)
+    with nemo_relay.use_scope_stack(propagated):
+        assert nemo_relay.scope.get_handle().uuid == context.parent_uuid
+        handler._close_completed_scopes()
+
+    assert len(handler._completed) == 1, "a propagated stack consumed another stack's completion"
+
+    # The real scope is still closable, and the enclosing scope with it.
+    _end(handler, run_b, "B")
+    _end(handler, parent_run, "parent")
+    assert handler._completed == {}
+    nemo_relay.scope.pop(request)
+    assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+
+
+async def test_propagated_stand_ins_keep_their_reserved_names(
+    handler: NemoRelayCallbackHandler,
+):
+    """Pin the naming the uuid+name check depends on.
+
+    A propagated stack rebuilds scopes carrying an existing uuid, so the name is what
+    separates a stand-in from the scope it represents. Those names are fixed in the
+    runtime (``propagated-parent``/``propagated-root`` in
+    ``crates/core/src/api/runtime/scope_stack.rs``); if either changes, matching silently
+    starts closing the wrong scope, so fail here instead.
+
+    Propagating an already-propagated stack yields stand-ins identical in both uuid and
+    name, which still cannot be confused with a run this handler opened.
+    """
+
+    import uuid as uuid_module
+
+    run_id = uuid4()
+    request = nemo_relay.scope.push("request", nemo_relay.ScopeType.Agent)
+    _start(handler, run_id, "A")
+    opened = handler._scope_handles[run_id]
+
+    with_root = nemo_relay.capture_propagation_context_with_root(str(uuid_module.uuid4()))
+    first = nemo_relay.create_scope_stack_from_propagation(with_root)
+    with nemo_relay.use_scope_stack(first):
+        stand_in = nemo_relay.scope.get_handle()
+        assert stand_in.uuid == opened.uuid, "the stand-in should carry the same uuid"
+        assert stand_in.name == "propagated-parent"
+        again = nemo_relay.capture_propagation_context_with_root(str(uuid_module.uuid4()))
+
+    # Propagating the propagation: identical uuid and name, still not our scope.
+    second = nemo_relay.create_scope_stack_from_propagation(again)
+    with nemo_relay.use_scope_stack(second):
+        repeated = nemo_relay.scope.get_handle()
+        assert (repeated.uuid, repeated.name) == (stand_in.uuid, stand_in.name)
+        assert (repeated.uuid, repeated.name) != (opened.uuid, opened.name)
+
+    # And the branch where the propagated parent is the root.
+    as_root = nemo_relay.create_scope_stack_from_propagation(nemo_relay.PropagationContext(opened.uuid, opened.uuid))
+    with nemo_relay.use_scope_stack(as_root):
+        root_stand_in = nemo_relay.scope.get_handle()
+        assert root_stand_in.name == "propagated-root"
+        assert (root_stand_in.uuid, root_stand_in.name) != (opened.uuid, opened.name)
+
+    _end(handler, run_id, "A")
+    nemo_relay.scope.pop(request)

--- a/python/tests/integrations/langgraph_tests/test_langgraph_integration.py
+++ b/python/tests/integrations/langgraph_tests/test_langgraph_integration.py
@@ -6,7 +6,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, cast
+import operator
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import uuid4
 
 import pytest
@@ -207,3 +208,175 @@ def test_graph_lifecycle_callbacks_emit_marks(
     resume_data = cast(dict[str, Any], resume_event.data)
     assert resume_data["checkpoint_ns"] == ["parent", "child"]
     assert resume_event.metadata == {"integration": "langgraph"}
+
+
+class FanOutState(TypedDict):
+    branches: Annotated[list[str], operator.add]
+
+
+def _build_fan_out_graph() -> CompiledStateGraph:
+    """A graph whose two branches finish in a different order than they started.
+
+    LangGraph runs the branches as concurrent tasks sharing one scope stack, so the
+    slower branch's scope is still open when the faster one closes. That is the ordering
+    Relay's stack rejects, and reproducing it here needs no stubbing at all.
+    """
+    from langgraph.graph import END, START, StateGraph
+
+    async def slow(state: FanOutState) -> FanOutState:
+        await asyncio.sleep(0.05)
+        return {"branches": ["slow"]}
+
+    async def fast(state: FanOutState) -> FanOutState:
+        await asyncio.sleep(0)
+        return {"branches": ["fast"]}
+
+    builder = StateGraph(cast(Any, FanOutState))
+    builder.add_node("slow", slow)
+    builder.add_node("fast", fast)
+    builder.add_edge(START, "slow")
+    builder.add_edge(START, "fast")
+    builder.add_edge("slow", END)
+    builder.add_edge("fast", END)
+    return builder.compile()
+
+
+async def test_parallel_fan_out_leaves_the_enclosing_scope_closable(
+    callback_handler: NemoRelayCallbackHandler,
+    subscribed_events: list[nemo_relay.Event],
+):
+    """The reported failure, driven by a real graph rather than synthesized callbacks.
+
+    Before the ordering fix, the branch that finished first was abandoned on the stack
+    and the enclosing ``request`` scope raised on exit, turning a graph that ran to
+    completion into a reported failure.
+    """
+
+    graph = _build_fan_out_graph()
+
+    with nemo_relay.use_scope_stack(nemo_relay.create_scope_stack()):
+        baseline = nemo_relay.scope.get_handle()
+        with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
+            result = await graph.ainvoke({"branches": []}, config={"callbacks": [callback_handler]})
+
+        # The graph really did fan out, and the stack is back where it started.
+        assert sorted(result["branches"]) == ["fast", "slow"]
+        assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+
+    # ``on_chain_start`` swallows its exceptions, so a handler that pushed nothing would
+    # satisfy everything above. Pin that both branches actually opened and closed scopes.
+    await nemo_relay.subscribers.flush_async()
+    emitted = _events_to_strings(subscribed_events)
+    for branch in ("slow", "fast"):
+        assert f"scope.start.{branch}" in emitted
+        assert f"scope.end.{branch}" in emitted
+
+
+def _build_nested_fan_out_graph() -> CompiledStateGraph:
+    """Three branches of differing durations, one of which fans out again.
+
+    A two-branch graph only ever has one completion waiting. This leaves several
+    waiting at once, at more than one depth, so a drain has to close a run of them in
+    the right order rather than one scope at a time.
+    """
+    from langgraph.graph import END, START, StateGraph
+
+    async def slowest(state: FanOutState) -> FanOutState:
+        await asyncio.sleep(0.06)
+        return {"branches": ["slowest"]}
+
+    async def middle(state: FanOutState) -> FanOutState:
+        await asyncio.sleep(0.03)
+        return {"branches": ["middle"]}
+
+    async def quickest(state: FanOutState) -> FanOutState:
+        await asyncio.sleep(0)
+        return {"branches": ["quickest"]}
+
+    inner = StateGraph(cast(Any, FanOutState))
+    inner.add_node("middle", middle)
+    inner.add_node("quickest", quickest)
+    inner.add_edge(START, "middle")
+    inner.add_edge(START, "quickest")
+    inner.add_edge("middle", END)
+    inner.add_edge("quickest", END)
+
+    builder = StateGraph(cast(Any, FanOutState))
+    builder.add_node("slowest", slowest)
+    builder.add_node("inner", inner.compile())
+    builder.add_edge(START, "slowest")
+    builder.add_edge(START, "inner")
+    builder.add_edge("slowest", END)
+    builder.add_edge("inner", END)
+    return builder.compile()
+
+
+async def test_nested_fan_out_closes_every_scope(
+    callback_handler: NemoRelayCallbackHandler,
+    subscribed_events: list[nemo_relay.Event],
+):
+    """Several completions waiting at once, at two depths, must all close in order."""
+
+    graph = _build_nested_fan_out_graph()
+
+    with nemo_relay.use_scope_stack(nemo_relay.create_scope_stack()):
+        baseline = nemo_relay.scope.get_handle()
+        with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
+            result = await graph.ainvoke({"branches": []}, config={"callbacks": [callback_handler]})
+
+        assert sorted(result["branches"]) == ["middle", "quickest", "slowest"]
+        assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+        assert callback_handler._completed == {}
+
+    await nemo_relay.subscribers.flush_async()
+    emitted = _events_to_strings(subscribed_events)
+    for node in ("slowest", "middle", "quickest"):
+        assert f"scope.start.{node}" in emitted
+        assert f"scope.end.{node}" in emitted
+
+
+async def test_a_failing_node_still_closes_its_siblings(
+    callback_handler: NemoRelayCallbackHandler,
+    subscribed_events: list[nemo_relay.Event],
+):
+    """A node raising mid-fan-out completes through ``on_chain_error``.
+
+    The failed run's scope has to be closed like any other, or it strands its siblings
+    and the enclosing scope underneath it.
+    """
+    from langgraph.graph import END, START, StateGraph
+
+    async def boom(state: FanOutState) -> FanOutState:
+        await asyncio.sleep(0)
+        raise ValueError("node failed")
+
+    async def survivor(state: FanOutState) -> FanOutState:
+        await asyncio.sleep(0.05)
+        return {"branches": ["survivor"]}
+
+    builder = StateGraph(cast(Any, FanOutState))
+    builder.add_node("boom", boom)
+    builder.add_node("survivor", survivor)
+    builder.add_edge(START, "boom")
+    builder.add_edge(START, "survivor")
+    builder.add_edge("boom", END)
+    builder.add_edge("survivor", END)
+    graph = builder.compile()
+
+    with nemo_relay.use_scope_stack(nemo_relay.create_scope_stack()):
+        baseline = nemo_relay.scope.get_handle()
+        with nemo_relay.scope.scope("request", nemo_relay.ScopeType.Agent):
+            with pytest.raises(ValueError, match="node failed"):
+                await graph.ainvoke({"branches": []}, config={"callbacks": [callback_handler]})
+
+        # The graph failed, but the telemetry did not leave the stack dirty.
+        assert nemo_relay.scope.get_handle().uuid == baseline.uuid
+        assert callback_handler._completed == {}
+
+    # ``on_chain_start`` swallows its exceptions, so a handler that opened no branch
+    # scopes would satisfy everything above. Pin that both branches ran and closed.
+    await nemo_relay.subscribers.flush_async()
+    emitted = _events_to_strings(subscribed_events)
+    for node in ("boom", "survivor"):
+        assert f"scope.start.{node}" in emitted
+        assert f"scope.end.{node}" in emitted


### PR DESCRIPTION
#### Overview

> Targets `release/0.7` so this can go into a 0.7.3 cut for Fabric 0.2

**What.** When a LangChain chain run ends, the handler records it as completed and closes finished scopes from the top of the stack down, instead of attempting a close that the stack may reject and then abandoning the scope.

**Why.** Relay closes scopes strictly LIFO, but LangGraph schedules sibling chain runs as concurrent asyncio tasks that share one scope stack, so two siblings can finish in an order the stack rejects: A starts, B starts, A ends, B ends. `_pop_scope` removed the handle from `_scope_handles` *before* attempting the pop and then swallowed the rejection, so the scope stayed live on the stack with nothing left able to close it. It remained current for everything that followed, and the caller's own enclosing scope raised on exit:

```
RuntimeError: invalid argument: scope handle is not at the top of the stack
```

Downstream this reported fully successful agent work as failed (NVBug 6562846). The enclosing scope belonged to a NeMo Fabric Deep Agents invocation, whose adapter turned a teardown error into an invocation failure (since contained separately in NVIDIA/NeMo-Fabric#191) — 31 otherwise-successful agent-eval trials were scored as adapter failures in one regression run, including at parallelism 1.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Each run's handle is tracked from `on_chain_start`. When a run ends, its prepared output, metadata and end timestamp are recorded as completed state, and finished scopes are closed from the top of the active stack down: read `scope.get_handle()`, close it when its uuid belongs to a completed run of ours, stop as soon as the top is a run still going or a scope this handler does not own.

Only the current top is ever closed, so the stack is never asked to accept a close it would reject. There is no speculative pop, hence no failure to classify and no dependency on the runtime's error text.

**On "drain only the owning stack".** Implemented, then removed, with evidence. A stack-identity check *cannot* be written against the public API: `set_thread_scope_stack` genuinely shares the stack (a push in the thread is visible outside it) but returns a **different Python wrapper**, and `ScopeStack` exposes no id and only identity equality. A handler completing a run on a worker thread would therefore park every completion and strand every scope — the original bug, reintroduced by the guard. Dropping it also removes a strong reference to a `ScopeStack` per retained completion. Covered by `test_a_run_completed_on_a_worker_thread_still_closes`.

Cross-stack safety is therefore structural, not an ownership guard: a completion is matched on the top scope's uuid **and** name. uuid alone is not sufficient — a stack rebuilt from a `PropagationContext` re-creates a scope carrying an existing uuid, so a uuid-only match pops the stand-in, discards the completion and strands the real scope on its own stack (`test_a_propagated_stack_does_not_consume_another_stacks_completion`). The two are distinguishable because the runtime names rebuilt scopes `propagated-parent` and `propagated-root` (`scope_stack.rs`), which `test_propagated_stand_ins_keep_their_reserved_names` pins so a rename fails loudly rather than silently closing the wrong scope. Residual: a chain run named exactly one of those two reserved names would still collide.

**@AjayThorve's findings.** Output is prepared when the callback fires, so later mutation cannot change emitted telemetry. Cross-stack loss is structural rather than guarded, per above.

**@willkill07's second review.** Output is prepared *before* the run is dropped from the handler's map and degrades to `None` on failure — serializing walks caller data and a cyclic output raises `RecursionError`; a run removed with no completion recorded is a scope nothing can close. A completion is deleted only once the stack accepts the close, since the runtime can refuse before mutating the stack. Handler state transitions are serialized under a lock.

Reading the current handle is guarded by `scope_stack_active()`, which does not create a stack, so completing a run in a context without one no longer materialises an empty stack there.

#### Where should the reviewer start?

`_close_completed_scopes_locked` in `python/nemo_relay/integrations/langchain/callbacks.py` — the loop that reads the top and stops as soon as it is not a completed run of ours. Note the locked/unlocked split: `_pop_scope` holds the lock and calls the locked form, so the lock is never re-acquired on the normal path. That was a real fragility — an earlier revision nested the acquisition and only worked because the lock was reentrant.

Then the tests, which use a real scope stack. `test_callbacks.py` mocks `nemo_relay`, and its mock accepted any pop in any order, so it could not observe the LIFO rule this fix turns on; it now models the stack and rejects closing anything but the top.

The LangGraph tests drive real compiled graphs with no stubbing: a two-branch fan-out, a nested three-branch fan-out with a subgraph, and a failing node completing through `on_chain_error`.

#### Testing

- `python/tests/integrations` — 64 passed, 2 skipped.
- `python/tests` (excluding `plugin/` and `test_dynamic_plugin_host.py`, which need `just build-test-plugin-fixtures`) — 545 passed, 2 skipped.
- Pre-commit on the changed files: copyright, ruff, ruff-format, ty all pass.
- Mutation checks, each caught by a named test: closing the top regardless of ownership (13 tests fail); a non-reentrant lock; serializing output at close time; letting output serialization escape; deleting a completion before the pop succeeds; dropping the `scope_stack_active` guard; and a handler that pushes no scopes at all.
- Every new test was run against the unpatched upstream handler: 19 of 21 fail, and the 2 that pass are the ones that should — the harness control and the topology test, neither of which depends on this change. Of the 19, nine fail behaviourally (the scope-stack error, or its absence); the rest reference internals that do not exist upstream, so they guard against regressions in this implementation rather than detecting the original defect.
- End to end against the original symptom: built this branch as a wheel and installed it into a NeMo Fabric checkout. Fabric's own tests that assert the leak *exists* flip to failing, and its Deep Agents mitigation for this bug never engages because there is nothing left to mitigate. A wheel built from unpatched `release/0.7` was used as the control, and confirms the flip is caused by this change rather than by version skew.

#### Remaining limitations

- **A scope closed out of band** can never return to the top, so its completion is retained for the life of the handler. That is the trade for never guessing at error text; the entry is inert and everything around it still closes. Documented on the type and in a test.
- **A sibling that never ends at all** — a cancelled task with no `on_chain_error` — still leaves its parent waiting. Unchanged by this PR, and better than an abandoned scope since the state is visible.
- Untested: runs that never end retaining their `_scope_handles` entry, sync (non-async) LangGraph execution, and very wide fan-out as a performance question.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to internal NVBug


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved reliability when concurrent workflow steps complete out of order.
- Preserved outputs, metadata, and completion timestamps during deferred processing.
- Prevented lingering workflow state after concurrent or nested executions.
- Improved handling of failed workflow steps and branch cleanup.
- Increased reliability for concurrent LangGraph branch execution.

## Tests
- Added coverage for nested, overlapping, and out-of-order workflow lifecycles.
- Added regression coverage for concurrent branches, shared handlers, worker-thread completion, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



