### PR TITLE
chore: reduce Sonar complexity findings

### DIFF
--- a/go/nemo_relay/adaptive/optimizer_test.go
+++ b/go/nemo_relay/adaptive/optimizer_test.go
@@ -9,6 +9,8 @@ import (
 	nemo_relay "github.com/NVIDIA/NeMo-Relay/go/nemo_relay"
 )
 
+const redisURL = "redis://127.0.0.1:6379"
+
 func TestConfigBuilders(t *testing.T) {
 	config := NewConfig()
 	if config.Version != 1 {
@@ -39,11 +41,11 @@ func TestConfigBuilders(t *testing.T) {
 }
 
 func TestRedisBackendAndComponentSpecBuilders(t *testing.T) {
-	backend := NewRedisBackend("redis://127.0.0.1:6379", "adaptive:")
+	backend := NewRedisBackend(redisURL, "adaptive:")
 	if backend.Kind != "redis" {
 		t.Fatalf("expected redis backend kind, got %q", backend.Kind)
 	}
-	if backend.Config["url"] != "redis://127.0.0.1:6379" {
+	if backend.Config["url"] != redisURL {
 		t.Fatalf("expected backend url to round-trip, got %#v", backend.Config["url"])
 	}
 	if backend.Config["key_prefix"] != "adaptive:" {
@@ -115,7 +117,7 @@ func TestResponseCacheBuilders(t *testing.T) {
 	if NewInMemoryResponseCacheBackend().Kind != "in_memory" {
 		t.Fatal("expected in-memory response cache backend")
 	}
-	backend := NewRedisResponseCacheBackend("redis://127.0.0.1:6379", "responses:")
+	backend := NewRedisResponseCacheBackend(redisURL, "responses:")
 	if backend.Kind != "redis" || backend.Config["key_prefix"] != "responses:" {
 		t.Fatalf("unexpected redis response cache backend: %#v", backend)
 	}

--- a/python/nemo_relay/plugin.py
+++ b/python/nemo_relay/plugin.py
@@ -459,67 +459,65 @@ def load_dynamic_plugin_activation_specs(
     specs: list[DynamicPluginActivationSpec] = []
     seen_plugin_ids: set[str] = set()
     for index, entry in enumerate(dynamic_plugins):
-        if not isinstance(entry, dict):
-            raise ValueError(f"invalid dynamic plugin config in {source}: plugins.dynamic[{index}] must be a table")
-        entry = cast(dict[str, object], entry)
-        unknown_fields = sorted(set(entry) - {"manifest", "config"})
-        if unknown_fields:
-            raise ValueError(
-                f"invalid dynamic plugin config in {source}: plugins.dynamic[{index}] has unknown fields: "
-                + ", ".join(unknown_fields)
-            )
-        manifest_ref = entry.get("manifest")
-        if not isinstance(manifest_ref, str) or not manifest_ref.strip():
-            raise ValueError(
-                f"invalid dynamic plugin config in {source}: "
-                f"plugins.dynamic[{index}].manifest must be a non-empty string"
-            )
-        manifest_path = Path(manifest_ref)
-        if not manifest_path.is_absolute():
-            manifest_path = source.parent / manifest_path
-        manifest_path = manifest_path.resolve()
-
-        manifest = _load_plugin_toml(manifest_path, "dynamic plugin manifest")
-        identity = manifest.get("plugin")
-        if not isinstance(identity, dict):
-            raise ValueError(f"invalid dynamic plugin manifest in {manifest_path}: 'plugin' must be a table")
-        identity = cast(dict[str, object], identity)
-        plugin_id = identity.get("id")
-        if not isinstance(plugin_id, str) or not plugin_id.strip():
-            raise ValueError(
-                f"invalid dynamic plugin manifest in {manifest_path}: 'plugin.id' must be a non-empty string"
-            )
-        plugin_id = plugin_id.strip()
-        kind = identity.get("kind")
-        if kind not in ("rust_dynamic", "worker"):
-            raise ValueError(
-                f"invalid dynamic plugin manifest in {manifest_path}: 'plugin.kind' must be 'rust_dynamic' or 'worker'"
-            )
-        if plugin_id in seen_plugin_ids:
-            raise ValueError(f"duplicate dynamic plugin id {plugin_id!r} in {source}")
-        seen_plugin_ids.add(plugin_id)
-
-        config = entry.get("config", {})
-        if not isinstance(config, dict):
-            raise ValueError(
-                f"invalid dynamic plugin config in {source}: plugins.dynamic[{index}].config must be a table"
-            )
-        try:
-            normalized_config = cast(JsonObject, json.loads(json.dumps(config, allow_nan=False)))
-        except (TypeError, ValueError) as error:
-            raise ValueError(
-                f"invalid dynamic plugin config in {source}: "
-                f"plugins.dynamic[{index}].config must contain JSON values: {error}"
-            ) from error
-        specs.append(
-            DynamicPluginActivationSpec(
-                plugin_id=plugin_id,
-                kind=cast(DynamicPluginKind, kind),
-                manifest_ref=str(manifest_path),
-                config=normalized_config,
-            )
-        )
+        spec = _dynamic_plugin_spec(source, index, entry)
+        if spec.plugin_id in seen_plugin_ids:
+            raise ValueError(f"duplicate dynamic plugin id {spec.plugin_id!r} in {source}")
+        seen_plugin_ids.add(spec.plugin_id)
+        specs.append(spec)
     return specs
+
+
+def _dynamic_plugin_spec(source: Path, index: int, entry: object) -> DynamicPluginActivationSpec:
+    if not isinstance(entry, dict):
+        raise ValueError(f"invalid dynamic plugin config in {source}: plugins.dynamic[{index}] must be a table")
+    entry = cast(dict[str, object], entry)
+    unknown_fields = sorted(set(entry) - {"manifest", "config"})
+    if unknown_fields:
+        raise ValueError(
+            f"invalid dynamic plugin config in {source}: plugins.dynamic[{index}] has unknown fields: "
+            + ", ".join(unknown_fields)
+        )
+    manifest_path = _dynamic_manifest_path(source, index, entry.get("manifest"))
+    plugin_id, kind = _dynamic_manifest_identity(manifest_path)
+    config = _dynamic_plugin_config(source, index, entry.get("config", {}))
+    return DynamicPluginActivationSpec(plugin_id=plugin_id, kind=kind, manifest_ref=str(manifest_path), config=config)
+
+
+def _dynamic_manifest_path(source: Path, index: int, manifest_ref: object) -> Path:
+    if not isinstance(manifest_ref, str) or not manifest_ref.strip():
+        raise ValueError(
+            f"invalid dynamic plugin config in {source}: plugins.dynamic[{index}].manifest must be a non-empty string"
+        )
+    path = Path(manifest_ref)
+    return (path if path.is_absolute() else source.parent / path).resolve()
+
+
+def _dynamic_manifest_identity(manifest_path: Path) -> tuple[str, DynamicPluginKind]:
+    identity = _load_plugin_toml(manifest_path, "dynamic plugin manifest").get("plugin")
+    if not isinstance(identity, dict):
+        raise ValueError(f"invalid dynamic plugin manifest in {manifest_path}: 'plugin' must be a table")
+    identity = cast(dict[str, object], identity)
+    plugin_id = identity.get("id")
+    if not isinstance(plugin_id, str) or not plugin_id.strip():
+        raise ValueError(f"invalid dynamic plugin manifest in {manifest_path}: 'plugin.id' must be a non-empty string")
+    kind = identity.get("kind")
+    if kind not in ("rust_dynamic", "worker"):
+        raise ValueError(
+            f"invalid dynamic plugin manifest in {manifest_path}: 'plugin.kind' must be 'rust_dynamic' or 'worker'"
+        )
+    return plugin_id.strip(), cast(DynamicPluginKind, kind)
+
+
+def _dynamic_plugin_config(source: Path, index: int, config: object) -> JsonObject:
+    if not isinstance(config, dict):
+        raise ValueError(f"invalid dynamic plugin config in {source}: plugins.dynamic[{index}].config must be a table")
+    try:
+        return cast(JsonObject, json.loads(json.dumps(config, allow_nan=False)))
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"invalid dynamic plugin config in {source}: "
+            f"plugins.dynamic[{index}].config must contain JSON values: {error}"
+        ) from error
 
 
 def _load_plugin_toml(path: Path, description: str) -> dict[str, object]:

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -185,15 +185,17 @@ def _llm_codec_identity(invocation: pb.LlmInvocation) -> LlmCodecIdentity:
     proto_codec = context.codec if context is not None and context.HasField("codec") else None
     codec_id = proto_codec.id if proto_codec is not None and proto_codec.HasField("id") else None
     codec_kind = proto_codec.kind if proto_codec is not None else pb.LLM_CODEC_KIND_UNSPECIFIED
+    return _codec_identity(codec_kind, codec_id)
+
+
+def _codec_identity(codec_kind: int, codec_id: str | None) -> LlmCodecIdentity:
     if codec_kind == pb.LLM_CODEC_KIND_UNSPECIFIED:
-        identity = LlmCodecIdentity("none")
-    elif codec_kind == pb.LLM_CODEC_KIND_BUILTIN and codec_id:
-        identity = LlmCodecIdentity("builtin", codec_id)
-    elif codec_kind == pb.LLM_CODEC_KIND_RUNTIME and codec_id:
-        identity = LlmCodecIdentity("runtime", codec_id)
-    else:
-        identity = LlmCodecIdentity("opaque")
-    return identity
+        return LlmCodecIdentity("none")
+    if codec_kind == pb.LLM_CODEC_KIND_BUILTIN and codec_id:
+        return LlmCodecIdentity("builtin", codec_id)
+    if codec_kind == pb.LLM_CODEC_KIND_RUNTIME and codec_id:
+        return LlmCodecIdentity("runtime", codec_id)
+    return LlmCodecIdentity("opaque")
 
 
 def _llm_codec_capability(invocation: pb.LlmInvocation) -> str | None:

--- a/scripts/docs/generate_python_library_reference.py
+++ b/scripts/docs/generate_python_library_reference.py
@@ -256,25 +256,28 @@ def _collect_module(
     )
 
     for node in api_tree.body:
-        if isinstance(node, ast.ClassDef) and _is_public(node.name):
-            impl_node = impl_nodes.get(node.name)
-            module.classes.append(_class_doc(node, impl_node if isinstance(impl_node, ast.ClassDef) else None))
-        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and _is_public(node.name):
-            impl_node = impl_nodes.get(node.name)
-            module.functions.append(
-                _function_doc(
-                    node,
-                    impl_node=impl_node if isinstance(impl_node, (ast.FunctionDef, ast.AsyncFunctionDef)) else None,
-                )
-            )
-        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
-            module.aliases.extend(_assignment_names(node))
-        elif module_path.stem == "__init__" and isinstance(node, ast.ImportFrom):
-            module.reexports.extend(_reexport_names(node))
+        _collect_module_node(module, module_path, node, impl_nodes)
 
     module.aliases = sorted(set(module.aliases))
     module.reexports = sorted(set(module.reexports) - set(module.aliases))
     return module
+
+
+def _collect_module_node(module: ModuleDoc, module_path: Path, node: ast.AST, impl_nodes: dict[str, ast.AST]) -> None:
+    if isinstance(node, ast.ClassDef) and _is_public(node.name):
+        impl_node = impl_nodes.get(node.name)
+        module.classes.append(_class_doc(node, impl_node if isinstance(impl_node, ast.ClassDef) else None))
+    elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and _is_public(node.name):
+        impl_node = impl_nodes.get(node.name)
+        module.functions.append(
+            _function_doc(
+                node, impl_node=impl_node if isinstance(impl_node, (ast.FunctionDef, ast.AsyncFunctionDef)) else None
+            )
+        )
+    elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+        module.aliases.extend(_assignment_names(node))
+    elif module_path.stem == "__init__" and isinstance(node, ast.ImportFrom):
+        module.reexports.extend(_reexport_names(node))
 
 
 def _discover_modules(package: Package, package_root: Path) -> list[ModuleDoc]:

--- a/scripts/latency_benchmark/src/reporting.py
+++ b/scripts/latency_benchmark/src/reporting.py
@@ -34,39 +34,45 @@ def environment_record(binary: Path) -> dict[str, Any]:
     }
 
 
+def _print_gateway_results(gateway: list[dict[str, Any]]) -> None:
+    print("\nGateway incremental latency (milliseconds; negative values are measurement noise)")
+    headers = ("provider", "mode", "bytes", "c", "comparison", "metric", "p50", "p95", "p99")
+    print("  ".join(f"{header:>12}" for header in headers))
+    for scenario in gateway:
+        for comparison, metrics in scenario["comparisons"].items():
+            if not comparison.endswith("_vs_direct"):
+                continue
+            for metric, summary in metrics.items():
+                values = (
+                    scenario["provider"],
+                    scenario["mode"],
+                    str(scenario["payload_bytes"]),
+                    str(scenario["concurrency"]),
+                    comparison.replace("relay-", "").replace("_vs_direct", ""),
+                    metric,
+                    f"{summary['p50_ms']:.3f}",
+                    f"{summary['p95_ms']:.3f}",
+                    f"{summary['p99_ms']:.3f}",
+                )
+                print("  ".join(f"{value:>12}" for value in values))
+
+
+def _print_absolute_results(title: str, results: dict[str, Any]) -> None:
+    print(title)
+    for name, summary in results["absolute"].items():
+        print(f"  {name:<24} {summary['p50_ms']:>9.3f}")
+
+
 def print_results(results: dict[str, Any]) -> None:
     """Print only the result sections produced by selected test suites."""
     if "gateway" in results:
-        print("\nGateway incremental latency (milliseconds; negative values are measurement noise)")
-        headers = ("provider", "mode", "bytes", "c", "comparison", "metric", "p50", "p95", "p99")
-        print("  ".join(f"{header:>12}" for header in headers))
-        for scenario in results["gateway"]:
-            for comparison, metrics in scenario["comparisons"].items():
-                if not comparison.endswith("_vs_direct"):
-                    continue
-                for metric, summary in metrics.items():
-                    values = (
-                        scenario["provider"],
-                        scenario["mode"],
-                        str(scenario["payload_bytes"]),
-                        str(scenario["concurrency"]),
-                        comparison.replace("relay-", "").replace("_vs_direct", ""),
-                        metric,
-                        f"{summary['p50_ms']:.3f}",
-                        f"{summary['p95_ms']:.3f}",
-                        f"{summary['p99_ms']:.3f}",
-                    )
-                    print("  ".join(f"{value:>12}" for value in values))
+        _print_gateway_results(results["gateway"])
 
     if "hooks" in results:
-        print("\nHook subprocess wall time (p50 milliseconds)")
-        for name, summary in results["hooks"]["absolute"].items():
-            print(f"  {name:<24} {summary['p50_ms']:>9.3f}")
+        _print_absolute_results("\nHook subprocess wall time (p50 milliseconds)", results["hooks"])
 
     if "startup" in results:
-        print("\nCold process/readiness time (p50 milliseconds)")
-        for name, summary in results["startup"]["absolute"].items():
-            print(f"  {name:<24} {summary['p50_ms']:>9.3f}")
+        _print_absolute_results("\nCold process/readiness time (p50 milliseconds)", results["startup"])
 
     if "exporter_delivery" in results:
         delivery = results["exporter_delivery"]


### PR DESCRIPTION
#### Overview

Reduce Sonar-reported complexity in Python support code and remove a duplicated Go test literal.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Extract focused helpers from dynamic-plugin configuration loading, codec identity handling, benchmark reporting, and Python API-reference collection.
- Reuse the Redis test URL constant across Go adaptive builder tests.

#### Where should the reviewer start?

Start with `python/nemo_relay/plugin.py`; the helper extraction keeps its validation behavior and error messages intact.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of plugin loading, codec identification, documentation generation, and benchmark reporting without changing existing behavior.
  * Preserved validation, error handling, output formatting, and activation results.
* **Tests**
  * Standardized Redis test configuration across state and response-cache backend coverage, improving consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->