### PR TITLE
ci: label skills and enhancements

### DIFF
--- a/.agents/skills/prepare-pr/SKILL.md
+++ b/.agents/skills/prepare-pr/SKILL.md
@@ -60,7 +60,9 @@ Common examples:
 
 - `ci: update codecov coverage reporting`
 - `docs: clarify release workflow`
+- `enhancement: improve scope configuration`
 - `chore: refresh generated attribution data`
+- `skills: add a plugin-authoring guide`
 - `test: add Python scope regression coverage`
 - `fix: preserve scope-local middleware cleanup`
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -33,6 +33,9 @@ changelog:
     - title: 📝 Documentation Updates
       labels:
         - Documentation
+    - title: 🧩 Skills Updates
+      labels:
+        - Skills
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -28,7 +28,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Apply size, breaking, type, and language labels
+      - name: Apply size, breaking, type, language, and skills labels
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -39,7 +39,7 @@ jobs:
 
           size_labels=("size:XS" "size:S" "size:M" "size:L" "size:XL" "size:XXL")
           classifier_labels=("build" "chore" "ci" "docs" "feat" "fix" "perf" "refactor" "revert" "style" "test")
-          type_labels=("Automation" "Bug" "Documentation" "Feature" "Improvement" "Maintenance" "Test")
+          type_labels=("Automation" "Bug" "Documentation" "Feature" "Improvement" "Maintenance" "Skills" "Test")
           lang_labels=("lang:go" "lang:js" "lang:python" "lang:rust")
           controlled_labels=("${size_labels[@]}" "${classifier_labels[@]}" "${type_labels[@]}" "${lang_labels[@]}")
 
@@ -113,14 +113,14 @@ jobs:
 
           title_lower="${PR_TITLE,,}"
           type_label=""
-          title_pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?(!)?:'
-          breaking_pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!:'
+          title_pattern='^(build|chore|ci|docs|enhancement|feat|fix|perf|refactor|revert|skills|style|test)(\([^)]+\))?(!)?:'
+          breaking_pattern='^(build|chore|ci|docs|enhancement|feat|fix|perf|refactor|revert|skills|style|test)(\([^)]+\))?!:'
           if [[ "$title_lower" =~ $title_pattern ]]; then
             case "${BASH_REMATCH[1]}" in
               feat)
                 type_label="Feature"
                 ;;
-              perf|refactor)
+              enhancement|perf|refactor)
                 type_label="Improvement"
                 ;;
               fix|revert)
@@ -131,6 +131,9 @@ jobs:
                 ;;
               docs)
                 type_label="Documentation"
+                ;;
+              skills)
+                type_label="Skills"
                 ;;
               build|chore|ci|style)
                 type_label="Maintenance"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ with repository expectations.
 - Update `README.md`, `fern/`, package READMEs, and binding-support notes when public behavior, package names, examples, or supported bindings change.
 - Keep release-process details in maintainer docs such as `RELEASING.md`. Do not move release-history policy into user-facing docs or `CHANGELOG.md`.
 - Keep stable public wrappers at the `scripts/` root in docs and examples. Reference namespaced helper paths only when documenting internal maintenance work.
-- Use branch prefixes from the contributor docs: `feat/`, `fix/`, `docs/`, `test/`, or `refactor/`.
+- Use branch prefixes from the contributor docs: `build/`, `chore/`, `ci/`, `feat/`, `fix/`, `enh/`, `perf/`, `refactor/`, `revert/`, `skills/`, `style/`, `docs/`, or `test/`.
 - Use signed-off commits for PR work: `git commit -s`.
 - Before creating, opening, publishing, or editing a pull request, read `.github/pull_request_template.md` and use it as the PR body skeleton. Preserve its visible headings, checklist items, and related-issue guidance; fill the sections instead of replacing them with a generic summary.
 - If repo-local PR guidance such as the `prepare-pr` skill conflicts with generic GitHub connector or plugin guidance, follow the repo-local PR guidance for PR body format and review handoff details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,16 @@ Use the following prefixes for branch names:
 
 | Prefix | Purpose |
 |--------|---------|
+| `build/` | Build or dependency configuration changes |
+| `chore/` | Routine maintenance changes |
+| `ci/` | Continuous integration changes |
 | `feat/` | New features or capabilities |
 | `fix/` | Bug fixes |
+| `enh/` | Product improvements |
+| `perf/` | Performance improvements |
+| `revert/` | Reverts of prior changes |
+| `skills/` | Agent skill changes |
+| `style/` | Non-functional formatting or style changes |
 | `docs/` | Documentation-only changes |
 | `test/` | Test additions or modifications |
 | `refactor/` | Code restructuring without behavior changes |

--- a/docs/contribute/development-setup.mdx
+++ b/docs/contribute/development-setup.mdx
@@ -61,8 +61,16 @@ cd ../..
 
 Use these prefixes:
 
+- `build/`
+- `chore/`
+- `ci/`
 - `feat/`
 - `fix/`
+- `enh/`
+- `perf/`
+- `revert/`
+- `skills/`
+- `style/`
 - `docs/`
 - `test/`
 - `refactor/`


### PR DESCRIPTION
#### Overview

Add automated labeling and release-note categorization for skills and enhancements.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Map `skills:` and `enhancement:` PR titles to `Skills` and `Improvement` labels.
- Add a Skills Updates GitHub release category.
- Align PR, branch, and contributor guidance with the supported prefixes.

#### Where should the reviewer start?

Review `.github/workflows/pr-labels.yaml` for the title-to-label mappings, then `.github/release.yml` for release grouping.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded branch naming guidance with prefixes for build, chores, CI, enhancements, performance, reverts, skills, and style changes.
  * Updated contribution guidance with additional Conventional Commit examples.

* **Chores**
  * Added a dedicated Skills category to changelog generation.
  * Updated pull request labeling to recognize Skills and Improvement changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->