### PR TITLE
fix(node): route plugin validation to the JS thread

### DIFF
--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -1550,7 +1550,12 @@ impl NodePluginValidateCallback {
             plugin_config,
             ThreadsafeFunctionCallMode::Blocking,
             move |value: Option<Json>| {
-                let _ = tx.send(callback_json(value));
+                let result = callable::unwrap_middleware_result(
+                    callback_json(value),
+                    "JS plugin validate callback failed",
+                )
+                .map_err(|error| napi::Error::from_reason(error.to_string()));
+                let _ = tx.send(result);
                 Ok(())
             },
         );
@@ -1560,7 +1565,7 @@ impl NodePluginValidateCallback {
             )));
         }
         rx.recv()
-            .map_err(|_| napi::Error::from_reason("JS plugin validate completion channel closed"))
+            .map_err(|_| napi::Error::from_reason("JS plugin validate completion channel closed"))?
     }
 }
 
@@ -4782,7 +4787,8 @@ pub fn register_plugin(
     let validate_callback = match validate {
         Some(func) => {
             let direct = PersistentJsFunction::new(&env, &func)?;
-            let mut thread_safe = func.create_threadsafe_function(
+            let callback = callable::safe_middleware_callback(&env, &func)?;
+            let mut thread_safe = callback.create_threadsafe_function(
                 0,
                 |ctx: napi::threadsafe_function::ThreadSafeCallContext<Json>| Ok(vec![ctx.value]),
             )?;

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -1533,9 +1533,40 @@ impl Drop for PersistentJsFunction {
     }
 }
 
+struct NodePluginValidateCallback {
+    direct: PersistentJsFunction,
+    thread_safe: ThreadsafeFunction<Json, ErrorStrategy::Fatal>,
+    registration_thread: std::thread::ThreadId,
+}
+
+impl NodePluginValidateCallback {
+    fn call(&self, plugin_config: Json) -> napi::Result<Json> {
+        if std::thread::current().id() == self.registration_thread {
+            return self.direct.call_validate(&plugin_config);
+        }
+
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let status = self.thread_safe.call_with_return_value(
+            plugin_config,
+            ThreadsafeFunctionCallMode::Blocking,
+            move |value: Option<Json>| {
+                let _ = tx.send(callback_json(value));
+                Ok(())
+            },
+        );
+        if status != napi::Status::Ok {
+            return Err(napi::Error::from_reason(format!(
+                "failed to queue JS plugin validate callback: {status:?}"
+            )));
+        }
+        rx.recv()
+            .map_err(|_| napi::Error::from_reason("JS plugin validate completion channel closed"))
+    }
+}
+
 struct NodePlugin {
     plugin_kind: String,
-    validate: Option<PersistentJsFunction>,
+    validate: Option<NodePluginValidateCallback>,
     register: ThreadsafeFunction<NodePluginRegisterCall, ErrorStrategy::Fatal>,
 }
 
@@ -1551,7 +1582,7 @@ impl Plugin for NodePlugin {
         let Some(validate) = &self.validate else {
             return vec![];
         };
-        match validate.call_validate(&Json::Object(plugin_config.clone())) {
+        match validate.call(Json::Object(plugin_config.clone())) {
             Ok(Json::Null) => vec![],
             Ok(value) => {
                 serde_json::from_value::<Vec<ConfigDiagnostic>>(value).unwrap_or_else(|e| {
@@ -4748,8 +4779,20 @@ pub fn register_plugin(
     validate: Option<JsFunction>,
     register: JsFunction,
 ) -> napi::Result<()> {
-    let validate_tsfn = match validate {
-        Some(func) => Some(PersistentJsFunction::new(&env, &func)?),
+    let validate_callback = match validate {
+        Some(func) => {
+            let direct = PersistentJsFunction::new(&env, &func)?;
+            let mut thread_safe = func.create_threadsafe_function(
+                0,
+                |ctx: napi::threadsafe_function::ThreadSafeCallContext<Json>| Ok(vec![ctx.value]),
+            )?;
+            thread_safe.unref(&env)?;
+            Some(NodePluginValidateCallback {
+                direct,
+                thread_safe,
+                registration_thread: std::thread::current().id(),
+            })
+        }
         None => None,
     };
     let mut register_tsfn = register
@@ -4777,7 +4820,7 @@ pub fn register_plugin(
 
     register_plugin_impl(Arc::new(NodePlugin {
         plugin_kind,
-        validate: validate_tsfn,
+        validate: validate_callback,
         register: register_tsfn,
     }))
     .map_err(|e| napi::Error::from_reason(e.to_string()))

--- a/crates/node/tests/adaptive_tests.mjs
+++ b/crates/node/tests/adaptive_tests.mjs
@@ -141,6 +141,34 @@ describe('core plugins', () => {
     }
   });
 
+  it('reports throwing async plugin validation without terminating Node', async () => {
+    const pluginKind = `node.test.async_validate_throw.${Date.now()}`;
+    plugin.register(pluginKind, {
+      validate() {
+        throw new Error('plugin validation boom');
+      },
+      register() {
+        assert.fail('registration must not run after validation fails');
+      },
+    });
+
+    try {
+      const config = {
+        version: 1,
+        components: [plugin.ComponentSpec(pluginKind, {})],
+      };
+      await assert.rejects(() => plugin.initialize(config), /plugin validation boom/);
+      const report = plugin.validate(config);
+      assert.equal(report.diagnostics.length, 1);
+      assert.equal(report.diagnostics[0].code, 'plugin.validate_failed');
+      assert.match(report.diagnostics[0].message, /plugin validation boom/);
+      assert.deepEqual(await lib.toolCallExecute('validation_error_survives', {}, (args) => args), {});
+    } finally {
+      plugin.clear();
+      plugin.deregister(pluginKind);
+    }
+  });
+
   it('invokes top-level plugin registration during plugin configuration', async () => {
     const pluginKind = `node.test.register.${Date.now()}`;
     let registerCalls = 0;

--- a/crates/node/tests/adaptive_tests.mjs
+++ b/crates/node/tests/adaptive_tests.mjs
@@ -80,6 +80,48 @@ describe('core plugins', () => {
     }
   });
 
+  it('validates a registered JS plugin during asynchronous initialization', async () => {
+    const pluginKind = `node.test.async_validate.${Date.now()}`;
+    const config = {
+      version: 1,
+      components: [plugin.ComponentSpec(pluginKind, { marker: 'validated' })],
+    };
+    let validateCalls = 0;
+    let registerCalls = 0;
+
+    plugin.register(pluginKind, {
+      validate(pluginConfig) {
+        validateCalls += 1;
+        assert.equal(pluginConfig.marker, 'validated');
+        return [];
+      },
+      register(pluginConfig, context) {
+        registerCalls += 1;
+        context.registerToolRequestIntercept('marker', 1, false, (_name, args) => ({
+          ...args,
+          marker: pluginConfig.marker,
+        }));
+      },
+    });
+
+    try {
+      assert.deepEqual(plugin.validate(config).diagnostics, []);
+      assert.deepEqual((await plugin.initialize(config)).diagnostics, []);
+      assert.equal(validateCalls, 2);
+      assert.equal(registerCalls, 1);
+      assert.deepEqual(await lib.toolCallExecute('validated_plugin_tool', {}, (args) => args), {
+        marker: 'validated',
+      });
+
+      plugin.clear();
+      assert.equal(plugin.deregister(pluginKind), true);
+      assert.deepEqual(await lib.toolCallExecute('cleared_plugin_tool', {}, (args) => args), {});
+    } finally {
+      plugin.clear();
+      plugin.deregister(pluginKind);
+    }
+  });
+
   it('treats implicit undefined plugin validation as no diagnostics', () => {
     const pluginKind = `node.test.validate_undefined.${Date.now()}`;
 


### PR DESCRIPTION
#### Overview

Fix a Node.js binding crash when a language-binding plugin's JavaScript `validate` callback runs during asynchronous plugin initialization.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- **What:** Keep one registered Node plugin with both `validate` and `register` callbacks working through direct validation and asynchronous activation.
- **Why:** Initialization revalidates plugins on the dedicated plugin-host thread, but the Node adapter previously invoked the validator through raw N-API handles captured on the JavaScript thread. V8 aborted with `Cannot create a handle without a HandleScope`.
- **How:** Capture the JavaScript registration thread, retain direct invocation for validation on that thread, and route plugin-host validation through an unreferenced N-API threadsafe function. The plugin remains registered until normal deregistration.
- **Testing:** Added a regression that validates directly, initializes asynchronously, verifies validation and registration counts, executes a registered tool intercept, and verifies clear/deregister teardown. Ran the focused regression, `just test-node`, `cargo fmt --all -- --check`, `just test-rust`, `cargo clippy --workspace --all-targets -- -D warnings`, and `uv run pre-commit run --all-files`.
- **Breaking changes:** None.

#### Where should the reviewer start?

Start with `NodePluginValidateCallback` in `crates/node/src/api/mod.rs`, then the asynchronous initialization regression in `crates/node/tests/adaptive_tests.mjs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin validation reliability during explicit checks and asynchronous initialization.
  - Ensured validation works consistently regardless of when or where it is invoked.
  - Prevented validation errors from terminating the runtime or registering invalid plugins.
  - Fixed plugin-installed tool request interceptors so they remain active while enabled and are removed cleanly when plugin state is cleared.
- **Tests**
  - Added coverage for asynchronous validation, registration, interceptor behavior, error recovery, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->