### PR TITLE
fix(observability): project Claude tool results as tool messages

### DIFF
--- a/crates/core/src/observability/otel_genai.rs
+++ b/crates/core/src/observability/otel_genai.rs
@@ -349,7 +349,15 @@ fn input_message(message: &Message) -> Json {
         Message::Developer { content, name } => {
             ("developer", name.as_ref(), content_parts(content))
         }
-        Message::User { content, name } => ("user", name.as_ref(), content_parts(content)),
+        Message::User { content, name } => (
+            if is_tool_result_message(content) {
+                "tool"
+            } else {
+                "user"
+            },
+            name.as_ref(),
+            content_parts(content),
+        ),
         Message::Assistant {
             content,
             tool_calls,
@@ -433,6 +441,17 @@ fn input_message(message: &Message) -> Json {
         object.insert("name".to_string(), Json::String(name.clone()));
     }
     Json::Object(object)
+}
+
+fn is_tool_result_message(content: &MessageContent) -> bool {
+    matches!(
+        content,
+        MessageContent::Parts(parts)
+            if !parts.is_empty()
+                && parts
+                    .iter()
+                    .all(|part| matches!(part, ContentPart::ToolResult { .. }))
+    )
 }
 
 fn output_messages_json(response: &AnnotatedLlmResponse) -> Option<String> {

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -2227,6 +2227,24 @@ fn gen_ai_projection_covers_message_variants_and_empty_input() {
                 "role": "user",
                 "content": [
                     {
+                        "type": "tool_result",
+                        "tool_use_id": "call-3",
+                        "content": "mixed result"
+                    },
+                    {
+                        "type": "text",
+                        "text": "continue"
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": []
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
                         "type": "provider_native",
                         "provider": "example",
                         "kind": "reasoning",
@@ -2286,6 +2304,24 @@ fn gen_ai_projection_covers_message_variants_and_empty_input() {
                     "id": "call-2",
                     "response": "claude result"
                 }]
+            },
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "type": "tool_call_response",
+                        "id": "call-3",
+                        "response": "mixed result"
+                    },
+                    {
+                        "type": "text",
+                        "content": "continue"
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "parts": []
             },
             {
                 "role": "user",

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -2217,6 +2217,14 @@ fn gen_ai_projection_covers_message_variants_and_empty_input() {
             },
             {
                 "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "call-2",
+                    "content": "claude result"
+                }]
+            },
+            {
+                "role": "user",
                 "content": [
                     {
                         "type": "provider_native",
@@ -2269,6 +2277,14 @@ fn gen_ai_projection_covers_message_variants_and_empty_input() {
                     "type": "tool_call_response",
                     "id": "call-1",
                     "response": "result"
+                }]
+            },
+            {
+                "role": "tool",
+                "parts": [{
+                    "type": "tool_call_response",
+                    "id": "call-2",
+                    "response": "claude result"
                 }]
             },
             {


### PR DESCRIPTION
Normalize Anthropic user-role tool_result blocks to OTel tool messages so Agent Observability can correlate and display their tool_call_response payloads. Preserve response as the payload key required by the OTel input-message JSON schema.

#### Overview

<!-- Describe your pull request here -->

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Correct Claude tool-result projection in GenAI OpenTelemetry spans. Claude represents tool results as user messages containing only tool_result parts; NeMo Relay now projects these as role: "tool" messages so backends such as Datadog LLM Observability can associate tool calls with their results.

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected serialization of messages containing only tool results so they use the `tool` role instead of `user`.
  - Preserved tool call response details, including IDs and returned results, in GenAI telemetry.
  - Improved handling of messages with mixed tool-result and text content, as well as empty content arrays.

- **Tests**
  - Added coverage for Claude-style tool-result messages and their normalized telemetry output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->