### PR TITLE
fix: validate doctor install directory target

### DIFF
--- a/crates/cli/src/commands/diagnostics.rs
+++ b/crates/cli/src/commands/diagnostics.rs
@@ -17,7 +17,7 @@ pub(crate) struct DoctorCommand {
     pub(crate) agent: Option<AgentArg>,
     #[arg(long, value_enum)]
     pub(crate) plugin: Option<InstallTarget>,
-    #[arg(long)]
+    #[arg(long, requires = "plugin")]
     pub(crate) install_dir: Option<PathBuf>,
     #[arg(long)]
     pub(crate) json: bool,

--- a/crates/cli/tests/coverage/commands/main_tests.rs
+++ b/crates/cli/tests/coverage/commands/main_tests.rs
@@ -337,6 +337,17 @@ fn doctor_rejects_conflicting_agent_and_plugin_targets() {
 }
 
 #[test]
+fn doctor_rejects_install_dir_without_plugin_target() {
+    let error =
+        Cli::try_parse_from(["nemo-relay", "doctor", "--install-dir", "/tmp/plugins"]).unwrap_err();
+    assert_eq!(
+        error.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument
+    );
+    assert!(error.to_string().contains("--plugin"));
+}
+
+#[test]
 fn doctor_accepts_offline_flag() {
     let cli = Cli::try_parse_from(["nemo-relay", "doctor", "--offline"]).unwrap();
     match cli.command {


### PR DESCRIPTION
#### Overview

Reject `nemo-relay doctor --install-dir <path>` unless a plugin target is provided, preventing the path from being silently ignored by gateway diagnostics.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add a Clap `requires = "plugin"` constraint to the doctor command's `--install-dir` argument.
- Add parser regression coverage for the invalid invocation.

#### Where should the reviewer start?

Start with `crates/cli/src/commands/diagnostics.rs` and the parser test in `crates/cli/tests/coverage/commands/main_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #756
- Relates to RELAY-717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `doctor --install-dir` command now requires a plugin selection, preventing incomplete diagnostic requests.
  * Added validation to provide a clear error when no plugin is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->