### PR TITLE
fix(observability): project OpenInference tool results

### DIFF
--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -301,40 +301,123 @@ fn push_annotated_input_messages(
     messages: &[Message],
     start_index: usize,
 ) {
-    for (offset, message) in messages.iter().enumerate() {
-        let index = start_index + offset;
-        let role = match message {
-            Message::System { .. } => "system",
-            Message::Developer { .. } => "developer",
-            Message::User { .. } => "user",
-            Message::Assistant { .. } => "assistant",
-            Message::Tool { .. } => "tool",
-            Message::Function { .. } => "function",
-            Message::ToolCallItem { .. } => "assistant",
-            Message::ToolResultItem { .. } => "tool",
-            Message::ProviderNative { value, .. } => value
-                .get("role")
-                .and_then(Json::as_str)
-                .unwrap_or("provider_native"),
+    let mut next_index = start_index;
+    for message in messages {
+        if let Message::User { content, .. } = message
+            && let Some(parts) = exclusive_tool_result_parts(content)
+        {
+            for part in parts {
+                let ContentPart::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } = part
+                else {
+                    continue;
+                };
+                push_tool_result_input_message(attributes, next_index, tool_use_id, content);
+                next_index += 1;
+            }
+            continue;
+        }
+
+        let index = next_index;
+        next_index += 1;
+        let (role, content, tool_call_id) = match message {
+            Message::System { content, .. } => ("system", message_content_text(content), None),
+            Message::Developer { content, .. } => {
+                ("developer", message_content_text(content), None)
+            }
+            Message::User { content, .. } => ("user", message_content_text(content), None),
+            Message::Assistant { content, .. } => (
+                "assistant",
+                content.as_ref().and_then(message_content_text),
+                None,
+            ),
+            Message::Tool {
+                content,
+                tool_call_id,
+            } => (
+                "tool",
+                tool_message_content(content),
+                Some(tool_call_id.as_str()),
+            ),
+            Message::Function { content, .. } => (
+                "function",
+                content.as_deref().and_then(display_text_from_string),
+                None,
+            ),
+            Message::ToolCallItem { .. } => ("assistant", None, None),
+            Message::ToolResultItem {
+                call_id, output, ..
+            } => (
+                "tool",
+                Some(tool_result_content(output)),
+                Some(call_id.as_str()),
+            ),
+            Message::ProviderNative { value, .. } => (
+                value
+                    .get("role")
+                    .and_then(Json::as_str)
+                    .unwrap_or("provider_native"),
+                value.get("content").and_then(display_text_from_json),
+                None,
+            ),
         };
         push_message_role(attributes, "llm.input_messages", index, role);
-        let content = match message {
-            Message::System { content, .. }
-            | Message::Developer { content, .. }
-            | Message::User { content, .. }
-            | Message::Tool { content, .. } => message_content_text(content),
-            Message::Assistant { content, .. } => content.as_ref().and_then(message_content_text),
-            Message::Function { content, .. } => {
-                content.as_deref().and_then(display_text_from_string)
-            }
-            Message::ProviderNative { value, .. } => {
-                value.get("content").and_then(display_text_from_json)
-            }
-            Message::ToolCallItem { .. } | Message::ToolResultItem { .. } => None,
-        };
         if let Some(content) = content {
             push_message_text_value(attributes, "llm.input_messages", index, content);
         }
+        if let Some(tool_call_id) = tool_call_id {
+            attributes.push(KeyValue::new(
+                format!("llm.input_messages.{index}.message.tool_call_id"),
+                tool_call_id.to_string(),
+            ));
+        }
+    }
+}
+
+fn exclusive_tool_result_parts(content: &MessageContent) -> Option<&[ContentPart]> {
+    let MessageContent::Parts(parts) = content else {
+        return None;
+    };
+    (!parts.is_empty()
+        && parts
+            .iter()
+            .all(|part| matches!(part, ContentPart::ToolResult { .. })))
+    .then_some(parts)
+}
+
+fn push_tool_result_input_message(
+    attributes: &mut Vec<KeyValue>,
+    index: usize,
+    tool_call_id: &str,
+    content: &Json,
+) {
+    push_message_role(attributes, "llm.input_messages", index, "tool");
+    push_message_text_value(
+        attributes,
+        "llm.input_messages",
+        index,
+        tool_result_content(content),
+    );
+    attributes.push(KeyValue::new(
+        format!("llm.input_messages.{index}.message.tool_call_id"),
+        tool_call_id.to_string(),
+    ));
+}
+
+fn tool_message_content(content: &MessageContent) -> Option<String> {
+    match content {
+        MessageContent::Text(text) => Some(text.clone()),
+        MessageContent::Parts(parts) => to_json_string(parts),
+    }
+}
+
+fn tool_result_content(content: &Json) -> String {
+    match content {
+        Json::String(text) => text.clone(),
+        value => value.to_string(),
     }
 }
 

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -4640,6 +4640,89 @@ fn annotated_input_projection_covers_extended_roles_and_native_text() {
 }
 
 #[test]
+fn annotated_input_projection_normalizes_tool_result_messages() {
+    let messages = vec![
+        Message::User {
+            content: MessageContent::Parts(vec![
+                ContentPart::ToolResult {
+                    tool_use_id: "call_1".into(),
+                    content: json!("first result"),
+                    is_error: None,
+                    extra: serde_json::Map::new(),
+                },
+                ContentPart::ToolResult {
+                    tool_use_id: "call_2".into(),
+                    content: json!({"status": "ok"}),
+                    is_error: Some(false),
+                    extra: serde_json::Map::new(),
+                },
+            ]),
+            name: None,
+        },
+        Message::User {
+            content: MessageContent::Parts(vec![
+                ContentPart::ToolResult {
+                    tool_use_id: "call_3".into(),
+                    content: json!("mixed result"),
+                    is_error: None,
+                    extra: serde_json::Map::new(),
+                },
+                ContentPart::Text {
+                    text: "follow-up".into(),
+                    extra: serde_json::Map::new(),
+                },
+            ]),
+            name: None,
+        },
+        Message::Tool {
+            content: MessageContent::Text("openai result".into()),
+            tool_call_id: "call_4".into(),
+        },
+        Message::ToolResultItem {
+            id: None,
+            call_id: "call_5".into(),
+            output: json!(["first", 2]),
+            extra: serde_json::Map::new(),
+        },
+    ];
+
+    let mut attributes = Vec::new();
+    push_annotated_input_messages(&mut attributes, &messages, 0);
+    let attributes = attr_map(&attributes);
+
+    for (index, call_id, content) in [
+        (0, "call_1", "first result"),
+        (1, "call_2", r#"{"status":"ok"}"#),
+        (3, "call_4", "openai result"),
+        (4, "call_5", r#"["first",2]"#),
+    ] {
+        assert_attr(
+            &attributes,
+            &format!("llm.input_messages.{index}.message.role"),
+            "tool",
+        );
+        assert_attr(
+            &attributes,
+            &format!("llm.input_messages.{index}.message.tool_call_id"),
+            call_id,
+        );
+        assert_attr(
+            &attributes,
+            &format!("llm.input_messages.{index}.message.content"),
+            content,
+        );
+    }
+    assert_attr(&attributes, "llm.input_messages.2.message.role", "user");
+    assert_attr(
+        &attributes,
+        "llm.input_messages.2.message.content",
+        "follow-up",
+    );
+    assert!(!attributes.contains_key("llm.input_messages.2.message.tool_call_id"));
+    assert!(!attributes.contains_key("llm.input_messages.5.message.role"));
+}
+
+#[test]
 fn annotated_llm_instructions_emit_leading_system_input_message() {
     let (provider, exporter) = make_provider();
     let mut processor = crate::observability::otel::OtelEventProcessor::new_openinference(

--- a/docs/configure-plugins/observability/openinference.mdx
+++ b/docs/configure-plugins/observability/openinference.mdx
@@ -41,6 +41,12 @@ projection. It supports the `mark_projection`, `mark_exclude_names`, and
 `attribute_mappings` controls on the typed endpoint, retaining the legacy
 behavior.
 
+Normalized tool results emit one `llm.input_messages` entry per result with
+`message.role = "tool"`, `message.tool_call_id`, and `message.content`.
+Anthropic user messages that contain only `tool_result` blocks expand into
+separate entries so parallel tool results retain their original order and
+correlation IDs.
+
 Set `OTEL_AUTHORIZATION` to the complete authorization header value before
 activation. NeMo Relay snapshots the value when the plugin
 activates. The variable must be set and nonblank. A header name cannot appear


### PR DESCRIPTION
#### Overview

Project normalized tool results into OpenInference input-message attributes. This is a focused follow-up to #768 for `release/0.7`; the general/full OpenTelemetry projection remains unchanged.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Expand user messages containing only Anthropic `tool_result` blocks into one OpenInference `tool` message per result.
- Emit `message.tool_call_id` and `message.content` for normalized OpenAI Chat and Responses tool-result messages.
- Keep mixed tool-result/text messages as user messages so ambiguous content is not reclassified.
- Document the projection and add regression coverage for parallel and mixed results.
- Breaking changes: None.

Validation:

- `cargo test -p nemo-relay --lib observability::openinference::tests` (74 passed)
- Rust workspace tests passed. The FFI stage inherited a local `~/.nemo-relay/plugins.toml`; its seed failure passed when rerun from an isolated config-discovery directory.
- Python suite from an isolated config-discovery directory (639 passed)
- `just test-go`
- Node suite from an isolated config-discovery directory (355 passed)
- `just docs`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start with `push_annotated_input_messages` in `crates/core/src/observability/openinference.rs`, then review `annotated_input_projection_normalizes_tool_result_messages`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [NVIDIA/NeMo-Relay#768](https://github.com/NVIDIA/NeMo-Relay/pull/768)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenInference tracing for tool calls and results.
  - Preserved tool-result content, call IDs, and serialized result details in input messages.
  - Improved handling of mixed message types while retaining ordinary text correctly.

- **Documentation**
  - Documented how tool results are represented and correlated in OpenInference input messages.

- **Tests**
  - Added regression coverage for tool-result normalization and message ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->