### PR TITLE
Forward-merge release/0.7 into main

### DIFF
--- a/crates/cli/tests/coverage/shared/session_tests.rs
+++ b/crates/cli/tests/coverage/shared/session_tests.rs
@@ -3733,7 +3733,7 @@ async fn hermes_routed_provider_payloads_write_exact_atif_trajectory() {
     assert_eq!(steps[0]["message"], json!("Find the file."));
     assert_eq!(steps[1]["message"], json!("I will search."));
     assert_eq!(steps[1]["tool_calls"][0]["tool_call_id"], json!("toolu_01"));
-    assert_eq!(steps[1]["metrics"]["prompt_tokens"], json!(11));
+    assert_eq!(steps[1]["metrics"]["prompt_tokens"], json!(14));
     assert_eq!(steps[1]["metrics"]["cached_tokens"], json!(3));
     assert_eq!(steps[1]["metrics"]["cost_usd"], json!(0.0042));
 
@@ -3757,7 +3757,7 @@ async fn hermes_routed_provider_payloads_write_exact_atif_trajectory() {
     assert_eq!(steps[5]["metrics"]["cached_tokens"], json!(2));
     assert_eq!(steps[5]["metrics"]["cost_usd"], json!(0.001));
 
-    assert_eq!(atif["final_metrics"]["total_prompt_tokens"], json!(89));
+    assert_eq!(atif["final_metrics"]["total_prompt_tokens"], json!(92));
     assert_eq!(atif["final_metrics"]["total_completion_tokens"], json!(31));
     assert_eq!(atif["final_metrics"]["total_cached_tokens"], json!(15));
     assert_eq!(atif["final_metrics"]["total_cost_usd"], json!(0.0102));
@@ -3825,11 +3825,15 @@ async fn hermes_routed_provider_payloads_emit_openinference_text_usage_and_cost(
     );
     assert_eq!(
         anthropic.get("llm.token_count.prompt"),
-        Some(&"11".to_string())
+        Some(&"14".to_string())
     );
     assert_eq!(
         anthropic.get("llm.token_count.completion"),
         Some(&"7".to_string())
+    );
+    assert_eq!(
+        anthropic.get("llm.token_count.total"),
+        Some(&"21".to_string())
     );
     assert_eq!(
         anthropic.get("llm.token_count.prompt_details.cache_read"),

--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -43,7 +43,10 @@ use crate::codec::response::AnnotatedLlmResponse;
 use crate::error::Result;
 use crate::json::Json;
 
-use super::{estimate_cost_for_response_or_model, manual, merge_usage, model_name_for_llm_event};
+use super::{
+    estimate_cost_for_response_or_model, input_tokens_including_cache, manual, merge_usage,
+    model_name_for_llm_event,
+};
 
 /// The ATIF schema version string embedded in all exported trajectories.
 ///
@@ -723,7 +726,9 @@ fn extract_metrics(
     let fallback_usage = manual::usage_from_manual_llm_output(Some(output));
     let normalized_usage = normalized_response.and_then(|response| response.usage.as_ref());
     let merged_usage = merge_usage(normalized_usage, fallback_usage.as_ref());
-    let prompt = merged_usage.as_ref().and_then(|usage| usage.prompt_tokens);
+    let prompt = merged_usage
+        .as_ref()
+        .and_then(|usage| input_tokens_including_cache(provider, normalized_response, usage));
     let completion = merged_usage
         .as_ref()
         .and_then(|usage| usage.completion_tokens);

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -4,6 +4,7 @@
 //! Optional observability integrations for NeMo Relay Core.
 
 use crate::api::event::EventNormalizationExt;
+use crate::codec::response::{AnnotatedLlmResponse, ApiSpecificResponse, Usage};
 use serde::{Deserialize, Serialize};
 
 /// Copies a projected OTLP attribute to a second attribute name.
@@ -44,6 +45,59 @@ pub(crate) mod openinference;
 pub mod otel;
 mod otel_genai;
 pub mod plugin_component;
+
+/// Return the provider-independent input total used by semantic observability
+/// projections. Anthropic reports uncached, cache-read, and cache-creation
+/// input tokens separately, while providers such as OpenAI include cache reads
+/// in their prompt count.
+pub(crate) fn input_tokens_including_cache(
+    provider: Option<&str>,
+    response: Option<&AnnotatedLlmResponse>,
+    usage: &Usage,
+) -> Option<u64> {
+    let prompt_tokens = usage.prompt_tokens?;
+    if !uses_separate_anthropic_cache_tokens(provider, response) {
+        return Some(prompt_tokens);
+    }
+    [usage.cache_read_tokens, usage.cache_write_tokens]
+        .into_iter()
+        .flatten()
+        .try_fold(prompt_tokens, u64::checked_add)
+}
+
+/// Return the provider-independent prompt-plus-completion total used by
+/// semantic observability projections.
+pub(crate) fn total_tokens_including_cache(
+    provider: Option<&str>,
+    response: Option<&AnnotatedLlmResponse>,
+    usage: &Usage,
+) -> Option<u64> {
+    if !uses_separate_anthropic_cache_tokens(provider, response) {
+        return usage.total_tokens;
+    }
+    match (
+        input_tokens_including_cache(provider, response, usage),
+        usage.completion_tokens,
+    ) {
+        (Some(input), Some(output)) => input.checked_add(output),
+        _ => usage.total_tokens,
+    }
+}
+
+fn uses_separate_anthropic_cache_tokens(
+    provider: Option<&str>,
+    response: Option<&AnnotatedLlmResponse>,
+) -> bool {
+    response.is_some_and(|response| {
+        matches!(
+            response.api_specific.as_ref(),
+            Some(ApiSpecificResponse::AnthropicMessages { .. })
+        )
+    }) || provider.is_some_and(|provider| {
+        let provider = provider.to_ascii_lowercase();
+        provider.starts_with("anthropic") || provider.starts_with("claude")
+    })
+}
 
 /// Export representation for point-in-time mark events.
 ///

--- a/crates/core/src/observability/openinference.rs
+++ b/crates/core/src/observability/openinference.rs
@@ -6,9 +6,10 @@
 //! Projection functions used by the unified OpenTelemetry subscriber.
 
 use super::{
-    estimate_cost_for_response_or_model, estimate_cost_for_response_or_requested_model, manual,
-    merge_usage, model_name_for_llm_event, push_serialized_top_level_attributes,
-    push_top_level_json_attributes,
+    estimate_cost_for_response_or_model, estimate_cost_for_response_or_requested_model,
+    input_tokens_including_cache, manual, merge_usage, model_name_for_llm_event,
+    push_serialized_top_level_attributes, push_top_level_json_attributes,
+    total_tokens_including_cache,
 };
 use crate::api::event::{Event, EventNormalizationExt};
 use crate::api::scope::ScopeType;
@@ -150,7 +151,12 @@ pub(super) fn end_attributes(event: &Event) -> Vec<KeyValue> {
         fallback_usage.as_ref(),
     );
     if is_llm {
-        push_llm_usage_attributes(&mut attributes, usage.as_ref());
+        push_llm_usage_attributes(
+            &mut attributes,
+            Some(event.name()),
+            normalized.as_deref(),
+            usage.as_ref(),
+        );
     }
     if is_llm
         && let Some(cost_total) =
@@ -164,17 +170,22 @@ pub(super) fn end_attributes(event: &Event) -> Vec<KeyValue> {
     attributes
 }
 
-fn push_llm_usage_attributes(attributes: &mut Vec<KeyValue>, usage: Option<&Usage>) {
+fn push_llm_usage_attributes(
+    attributes: &mut Vec<KeyValue>,
+    provider: Option<&str>,
+    response: Option<&AnnotatedLlmResponse>,
+    usage: Option<&Usage>,
+) {
     let Some(usage) = usage else {
         return;
     };
-    if let Some(v) = usage.prompt_tokens {
+    if let Some(v) = input_tokens_including_cache(provider, response, usage) {
         attributes.push(KeyValue::new("llm.token_count.prompt", v as i64));
     }
     if let Some(v) = usage.completion_tokens {
         attributes.push(KeyValue::new("llm.token_count.completion", v as i64));
     }
-    if let Some(v) = usage.total_tokens {
+    if let Some(v) = total_tokens_including_cache(provider, response, usage) {
         attributes.push(KeyValue::new("llm.token_count.total", v as i64));
     }
     if let Some(v) = usage.cache_read_tokens {

--- a/crates/core/src/observability/otel_genai.rs
+++ b/crates/core/src/observability/otel_genai.rs
@@ -303,10 +303,10 @@ fn push_llm_response_attributes(attributes: &mut Vec<KeyValue>, event: &Event) {
         attributes.push(KeyValue::new(GEN_AI_OUTPUT_MESSAGES, messages));
     }
     if let Some(usage) = response.usage.as_ref() {
-        // `prompt_tokens` is the canonical input count. Cache counts remain
-        // separate diagnostic attributes; adding them here would double-count
-        // providers such as OpenAI that include cache reads in prompt tokens.
-        if let Some(input_tokens) = usage.prompt_tokens.and_then(to_i64) {
+        // Anthropic reports uncached, cache-read, and cache-creation input
+        // tokens separately. Other providers such as OpenAI include cache
+        // reads in their prompt count, so only combine known Anthropic usage.
+        if let Some(input_tokens) = gen_ai_input_tokens(event, response) {
             attributes.push(KeyValue::new(
                 semconv::GEN_AI_USAGE_INPUT_TOKENS,
                 input_tokens,
@@ -325,6 +325,12 @@ fn push_llm_response_attributes(attributes: &mut Vec<KeyValue>, event: &Event) {
             ));
         }
     }
+}
+
+fn gen_ai_input_tokens(event: &Event, response: &AnnotatedLlmResponse) -> Option<i64> {
+    let usage = response.usage.as_ref()?;
+    let provider = provider_name(event);
+    super::input_tokens_including_cache(provider.as_deref(), Some(response), usage).and_then(to_i64)
 }
 
 fn input_messages_json(messages: &[Message]) -> Option<String> {

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -1946,7 +1946,7 @@ fn test_exporter_anthropic_messages_lifecycle_promotes_tool_use_blocks() {
     assert_eq!(agent_step.message, json!("I will search for it."));
     assert_eq!(agent_step.model_name, Some("claude-sonnet-4".to_string()));
     let metrics = agent_step.metrics.as_ref().unwrap();
-    assert_eq!(metrics.prompt_tokens, Some(11));
+    assert_eq!(metrics.prompt_tokens, Some(19));
     assert_eq!(metrics.completion_tokens, Some(7));
     assert_eq!(metrics.cached_tokens, Some(8));
     let tool_call = &agent_step.tool_calls.as_ref().unwrap()[0];

--- a/crates/core/tests/unit/observability/exporter_parity_tests.rs
+++ b/crates/core/tests/unit/observability/exporter_parity_tests.rs
@@ -467,7 +467,7 @@ fn test_usage_facts_parity_for_anthropic_payload_with_cache_write() {
     );
 
     let metrics = exports.agent_step().metrics.as_ref().unwrap();
-    assert_eq!(metrics.prompt_tokens, Some(1000));
+    assert_eq!(metrics.prompt_tokens, Some(1264));
     assert_eq!(metrics.completion_tokens, Some(500));
     // ATIF folds cache reads and writes into a single cached_tokens sum
     // (200 + 64).
@@ -476,16 +476,17 @@ fn test_usage_facts_parity_for_anthropic_payload_with_cache_write() {
     let openinference = exports.openinference_attrs("model-call");
     assert_eq!(
         openinference.get("llm.token_count.prompt"),
-        Some(&"1000".to_string())
+        Some(&"1264".to_string())
     );
     assert_eq!(
         openinference.get("llm.token_count.completion"),
         Some(&"500".to_string())
     );
-    // Anthropic reports no total; the shared codec computes 1000 + 500.
+    // Anthropic reports each cache type separately, so the semantic prompt
+    // and total counts include both cache reads and cache writes.
     assert_eq!(
         openinference.get("llm.token_count.total"),
-        Some(&"1500".to_string())
+        Some(&"1764".to_string())
     );
     assert_eq!(
         openinference.get("llm.token_count.prompt_details.cache_read"),

--- a/crates/core/tests/unit/observability/openinference_tests.rs
+++ b/crates/core/tests/unit/observability/openinference_tests.rs
@@ -4438,11 +4438,15 @@ fn anthropic_messages_output_emits_openinference_text_tool_and_usage_attributes(
     );
     assert_eq!(
         attributes.get("llm.token_count.prompt"),
-        Some(&"11".to_string())
+        Some(&"19".to_string())
     );
     assert_eq!(
         attributes.get("llm.token_count.completion"),
         Some(&"7".to_string())
+    );
+    assert_eq!(
+        attributes.get("llm.token_count.total"),
+        Some(&"26".to_string())
     );
     assert_eq!(
         attributes.get("llm.token_count.prompt_details.cache_read"),

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -1600,6 +1600,44 @@ fn gen_ai_projection_emits_normalized_response_attributes() {
 }
 
 #[test]
+fn gen_ai_projection_includes_anthropic_cache_tokens_in_input_total() {
+    let event = make_end_event(
+        Uuid::now_v7(),
+        None,
+        "anthropic.messages",
+        ScopeType::Llm,
+        Some(json!({
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4",
+            "content": [{"type": "text", "text": "ok"}],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 2,
+                "output_tokens": 1,
+                "cache_read_input_tokens": 17_980,
+                "cache_creation_input_tokens": 9_421
+            }
+        })),
+    );
+
+    let attributes = attr_map(&crate::observability::otel_genai::end_attributes(&event));
+    assert_eq!(
+        attributes.get("gen_ai.usage.input_tokens"),
+        Some(&"27403".to_string())
+    );
+    assert_eq!(
+        attributes.get("gen_ai.usage.cache_read.input_tokens"),
+        Some(&"17980".to_string())
+    );
+    assert_eq!(
+        attributes.get("gen_ai.usage.cache_creation.input_tokens"),
+        Some(&"9421".to_string())
+    );
+}
+
+#[test]
 fn gen_ai_end_projection_preserves_explicit_error_type() {
     let event = Event::Scope(ScopeEvent::new(
         BaseEvent::builder()


### PR DESCRIPTION
#### Overview

Forward-merge `release/0.7` into `main` after the automated forward merge reported a conflict.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Created a local merge commit from `upstream/release/0.7` into `upstream/main` and resolved the session-test conflict without restoring retired Hermes CLI support.

#### Where should the reviewer start?

Review merge commit `7e835041a` and its parent relationship; the conflict resolution preserves the current `main` version of `crates/cli/tests/coverage/shared/session_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Anthropic usage metrics now include cached input tokens in prompt and total token counts.
  * Cache-read and cache-write tokens remain available as separate details while contributing to aggregate input usage.
  * Token reporting is now consistent across supported observability exporters.

* **Tests**
  * Added and updated coverage for cached-token calculations, aggregate totals, and exporter consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->