### PR TITLE
feat: correlate managed tool calls by external ID

### DIFF
--- a/crates/core/src/api/tool.rs
+++ b/crates/core/src/api/tool.rs
@@ -191,6 +191,9 @@ pub struct ToolCallExecuteParams {
     /// Optional JSON metadata recorded on emitted events.
     #[builder(default)]
     pub metadata: Option<Json>,
+    /// Optional provider-specific correlation identifier.
+    #[builder(default, setter(into))]
+    pub tool_call_id: Option<String>,
 }
 
 /// Builder parameters for [`tool_call_end`].
@@ -721,6 +724,8 @@ impl Drop for ManagedToolCompletion {
 /// - `data`: Optional application payload stored on the managed tool handle.
 ///   It may be used on failure end events that have no output payload.
 /// - `metadata`: Optional JSON metadata recorded on emitted events.
+/// - `tool_call_id`: Optional provider-specific correlation identifier recorded
+///   on both managed lifecycle events.
 ///
 /// # Returns
 /// A [`Result`] containing the application result and optional opaque
@@ -743,6 +748,7 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<ToolExec
         attributes,
         data,
         metadata,
+        tool_call_id,
     } = params;
     ensure_runtime_owner()?;
     {
@@ -819,6 +825,7 @@ pub async fn tool_call_execute(params: ToolCallExecuteParams) -> Result<ToolExec
             .attributes(attributes)
             .data_opt(data.clone())
             .metadata_opt(metadata.clone())
+            .tool_call_id_opt(tool_call_id)
             .build(),
     )
     .await?;

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -171,6 +171,25 @@ fn captured_events_snapshot(events: &Arc<Mutex<Vec<Event>>>) -> Vec<Event> {
     events.lock().unwrap().clone()
 }
 
+fn assert_tool_lifecycle_correlation(
+    events: &[Event],
+    name: &str,
+    expected_tool_call_id: Option<&str>,
+) {
+    let lifecycle = events
+        .iter()
+        .filter(|event| event.name() == name && event.scope_type() == Some(ScopeType::Tool))
+        .collect::<Vec<_>>();
+    assert_eq!(lifecycle.len(), 2, "expected one managed Start/End pair");
+    let start = lifecycle[0];
+    let end = lifecycle[1];
+    assert_eq!(start.scope_category(), Some(ScopeCategory::Start));
+    assert_eq!(end.scope_category(), Some(ScopeCategory::End));
+    assert_eq!(start.uuid(), end.uuid());
+    assert_eq!(start.tool_call_id(), expected_tool_call_id);
+    assert_eq!(end.tool_call_id(), expected_tool_call_id);
+}
+
 fn assert_middleware_callback_locks_are_free() {
     let scope_stack = current_scope_stack();
     assert!(
@@ -522,6 +541,87 @@ async fn test_no_break_chain_runs_all_intercepts() {
 // =========================================================================
 // Execution Intercepts (Middleware Chain) Tests
 // =========================================================================
+
+#[tokio::test]
+async fn managed_tool_call_id_correlates_success_and_absent_lifecycles() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = events.clone();
+    register_subscriber(
+        "managed_tool_call_id_success_observer",
+        Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    let result = tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("managed-correlated-tool")
+            .args(json!({"value": 42}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(args.into()) })))
+            .tool_call_id("call-managed-42")
+            .build(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.result, json!({"value": 42}));
+
+    tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("managed-uncorrelated-tool")
+            .args(json!({}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(args.into()) })))
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    let captured = captured_events_snapshot(&events);
+    assert_tool_lifecycle_correlation(
+        &captured,
+        "managed-correlated-tool",
+        Some("call-managed-42"),
+    );
+    assert_tool_lifecycle_correlation(&captured, "managed-uncorrelated-tool", None);
+
+    deregister_subscriber("managed_tool_call_id_success_observer").unwrap();
+}
+
+#[tokio::test]
+async fn managed_tool_call_id_correlates_callback_error_lifecycle() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = events.clone();
+    register_subscriber(
+        "managed_tool_call_id_error_observer",
+        Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    let error = tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("managed-error-tool")
+            .args(json!({}))
+            .func(Arc::new(|_args| {
+                Box::pin(async { Err(FlowError::Internal("callback failed".into())) })
+            }))
+            .tool_call_id("call-managed-error")
+            .build(),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, FlowError::Internal(message) if message == "callback failed"));
+
+    let captured = captured_events_snapshot(&events);
+    assert_tool_lifecycle_correlation(&captured, "managed-error-tool", Some("call-managed-error"));
+
+    deregister_subscriber("managed_tool_call_id_error_observer").unwrap();
+}
 
 /// Register an execution intercept that calls next().
 /// Verify the original callable is invoked.
@@ -2376,6 +2476,7 @@ async fn dropping_pending_tool_execution_closes_the_managed_lifecycle() {
             .name("cancelled-tool")
             .args(json!({}))
             .func(Arc::new(|args| Box::pin(async move { Ok(args.into()) })))
+            .tool_call_id("call-managed-cancelled")
             .build(),
     ));
     tokio::select! {
@@ -2385,6 +2486,9 @@ async fn dropping_pending_tool_execution_closes_the_managed_lifecycle() {
 
     assert_flush_waits_for_pending_completion(|| drop(execution));
 
+    let captured = captured_events_snapshot(&events);
+    assert_tool_lifecycle_correlation(&captured, "cancelled-tool", Some("call-managed-cancelled"));
+
     let lifecycle = events
         .lock()
         .unwrap()
@@ -2393,8 +2497,8 @@ async fn dropping_pending_tool_execution_closes_the_managed_lifecycle() {
         .filter_map(Event::scope_category)
         .collect::<Vec<_>>();
     assert_eq!(lifecycle, [ScopeCategory::Start, ScopeCategory::End]);
-    let events = events.lock().unwrap();
-    let cancelled_end = events
+    let event_log = events.lock().unwrap();
+    let cancelled_end = event_log
         .iter()
         .find(|event| {
             event.name() == "cancelled-tool" && event.scope_category() == Some(ScopeCategory::End)
@@ -2406,7 +2510,7 @@ async fn dropping_pending_tool_execution_closes_the_managed_lifecycle() {
             .as_ref()
             .is_none_or(|value| value.is_null())
     }));
-    drop(events);
+    drop(event_log);
 
     deregister_tool_execution_intercept("pending_tool_execution").unwrap();
     deregister_subscriber("cancelled_tool_lifecycle").unwrap();
@@ -2714,6 +2818,14 @@ async fn test_conditional_guardrail_rejects() {
     reset_global();
     setup_isolated_thread();
 
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = events.clone();
+    register_subscriber(
+        "managed_tool_call_id_rejection_observer",
+        Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
     register_tool_conditional_execution_guardrail(
         "rejector",
         1,
@@ -2728,6 +2840,7 @@ async fn test_conditional_guardrail_rejects() {
             .name("tool")
             .args(json!({}))
             .func(func)
+            .tool_call_id("call-managed-rejected")
             .build(),
     )
     .await;
@@ -2740,8 +2853,16 @@ async fn test_conditional_guardrail_rejects() {
         other => panic!("Expected GuardrailRejected, got: {:?}", other),
     }
 
+    let captured = captured_events_snapshot(&events);
+    assert!(
+        captured
+            .iter()
+            .all(|event| { event.name() != "tool" || event.scope_type() != Some(ScopeType::Tool) })
+    );
+
     // Cleanup
     deregister_tool_conditional_execution_guardrail("rejector").unwrap();
+    deregister_subscriber("managed_tool_call_id_rejection_observer").unwrap();
 }
 
 /// Register a conditional guardrail that allows (returns None). Execution proceeds.

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -1340,6 +1340,123 @@ async fn test_tool_execution_outcome_marks_follow_end_with_tool_parentage() {
 }
 
 #[tokio::test]
+async fn managed_tool_call_id_projects_to_atif_and_otel() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    let agent = setup_isolated_scope("managed-tool-exporter-correlation");
+
+    let atif = AtifExporter::new(
+        "managed-tool-exporter-correlation".to_string(),
+        AtifAgentInfo {
+            name: "test-agent".to_string(),
+            version: "1.0.0".to_string(),
+            model_name: None,
+            tool_definitions: None,
+            extra: None,
+        },
+    );
+    register_subscriber("managed_tool_exporter_atif", atif.subscriber()).unwrap();
+
+    let otel_exporter = InMemorySpanExporterBuilder::new().build();
+    let otel_provider = SdkTracerProvider::builder()
+        .with_simple_exporter(otel_exporter.clone())
+        .build();
+    let otel =
+        OpenTelemetrySubscriber::from_tracer_provider(otel_provider, "managed-tool-exporter-otel");
+    register_subscriber("managed_tool_exporter_otel", otel.subscriber()).unwrap();
+
+    let tool_call_id = "call-managed-exporter-42";
+    llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("model-call")
+            .request(LlmRequest {
+                headers: serde_json::Map::new(),
+                content: json!({
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "weather in NYC"}],
+                }),
+            })
+            .func(Arc::new(move |_| {
+                Box::pin(async move {
+                    Ok(json!({
+                        "model": "test-model",
+                        "choices": [{
+                            "message": {
+                                "role": "assistant",
+                                "content": null,
+                                "tool_calls": [{
+                                    "id": tool_call_id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": "{\\\"city\\\":\\\"NYC\\\"}",
+                                    },
+                                }],
+                            },
+                        }],
+                    }))
+                })
+            }))
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    tool_call_execute(
+        nemo_relay::api::tool::ToolCallExecuteParams::builder()
+            .name("get_weather")
+            .args(json!({"city": "NYC"}))
+            .tool_call_id(tool_call_id)
+            .func(Arc::new(|args| {
+                Box::pin(async move { Ok(ToolExecutionResult::new(args)) })
+            }))
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    pop_scope(
+        nemo_relay::api::scope::PopScopeParams::builder()
+            .handle_uuid(&agent.uuid)
+            .build(),
+    )
+    .unwrap();
+    flush_subscribers().unwrap();
+
+    let trajectory = atif.export().unwrap();
+    let agent_step = trajectory
+        .steps
+        .iter()
+        .find(|step| step.source == "agent")
+        .expect("managed LLM event must create an agent step");
+    assert_eq!(
+        agent_step.tool_calls.as_ref().unwrap()[0].tool_call_id,
+        tool_call_id
+    );
+    assert_eq!(
+        agent_step.observation.as_ref().unwrap().results[0]
+            .source_call_id
+            .as_deref(),
+        Some(tool_call_id)
+    );
+
+    otel.force_flush().unwrap();
+    let tool_span = otel_exporter
+        .get_finished_spans()
+        .unwrap()
+        .into_iter()
+        .find(|span| span.name.as_ref() == "get_weather")
+        .expect("managed tool span must be exported");
+    assert!(tool_span.attributes.iter().any(|attribute| {
+        attribute.key.as_str() == "nemo_relay.tool_call_id"
+            && attribute.value.to_string() == tool_call_id
+    }));
+
+    deregister_subscriber("managed_tool_exporter_atif").unwrap();
+    deregister_subscriber("managed_tool_exporter_otel").unwrap();
+}
+
+#[tokio::test]
 async fn test_managed_tool_pending_marks_project_through_trace_exporters_only() {
     let _lock = TEST_MUTEX.lock().unwrap();
     reset_global();

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -2911,6 +2911,10 @@ NemoRelayStatus nemo_relay_tool_call_end(const struct FfiToolHandle *handle,
  * Start/End pair) and `GuardrailRejected` is returned. Blocks the calling
  * thread until completion.
  *
+ * This legacy entry point does not accept an external tool call ID. Use
+ * `nemo_relay_tool_call_execute_v2` to record one on the managed Start and End
+ * events.
+ *
  * # Parameters
  * - `name`: Null-terminated tool name.
  * - `args_json`: Tool arguments as a JSON C string.
@@ -2937,6 +2941,47 @@ NemoRelayStatus nemo_relay_tool_call_execute(const char *name,
                                              const char *data_json,
                                              const char *metadata_json,
                                              char **out);
+
+/**
+ * Execute a tool call end-to-end with an optional external tool call ID.
+ *
+ * This runs conditional-execution guardrails (on raw args), then request
+ * intercepts, sanitize-request guardrails, execution intercepts, the callback,
+ * and sanitize-response guardrails. On rejection, only a standalone Mark event
+ * is emitted (no Start/End pair) and `GuardrailRejected` is returned. Blocks
+ * the calling thread until completion.
+ *
+ * # Parameters
+ * - `name`: Null-terminated tool name.
+ * - `args_json`: Tool arguments as a JSON C string.
+ * - `func`: C callback that performs the actual tool execution.
+ * - `func_user_data`: Opaque pointer passed to `func`.
+ * - `func_free`: Optional destructor for `func_user_data`.
+ * - `parent`: Optional parent scope handle, or null.
+ * - `attributes`: Bitfield of tool attributes.
+ * - `data_json`: Optional JSON data, or null.
+ * - `metadata_json`: Optional JSON metadata, or null.
+ * - `tool_call_id`: Optional null-terminated external correlation ID recorded
+ *   on both managed lifecycle events, or null.
+ * - `out`: On success, receives the result as a JSON C string. Caller must free
+ *   with `nemo_relay_string_free`.
+ *
+ * # Safety
+ * `name`, `args_json`, and `out` must be valid, non-null pointers. Optional
+ * pointer arguments may be null; when non-null, they must be valid for reads
+ * for the duration of the call.
+ */
+NemoRelayStatus nemo_relay_tool_call_execute_v2(const char *name,
+                                                const char *args_json,
+                                                NemoRelayToolExecCb func,
+                                                void *func_user_data,
+                                                NemoRelayFreeFn func_free,
+                                                const struct FfiScopeHandle *parent,
+                                                uint32_t attributes,
+                                                const char *data_json,
+                                                const char *metadata_json,
+                                                const char *tool_call_id,
+                                                char **out);
 
 /**
  * Register a tool conditional execution guardrail. The callback decides whether

--- a/crates/ffi/src/api/tool_lifecycle.rs
+++ b/crates/ffi/src/api/tool_lifecycle.rs
@@ -202,6 +202,10 @@ pub unsafe extern "C" fn nemo_relay_tool_call_end(
 /// Start/End pair) and `GuardrailRejected` is returned. Blocks the calling
 /// thread until completion.
 ///
+/// This legacy entry point does not accept an external tool call ID. Use
+/// `nemo_relay_tool_call_execute_v2` to record one on the managed Start and End
+/// events.
+///
 /// # Parameters
 /// - `name`: Null-terminated tool name.
 /// - `args_json`: Tool arguments as a JSON C string.
@@ -228,6 +232,64 @@ pub unsafe extern "C" fn nemo_relay_tool_call_execute(
     attributes: u32,
     data_json: *const c_char,
     metadata_json: *const c_char,
+    out: *mut *mut c_char,
+) -> NemoRelayStatus {
+    unsafe {
+        nemo_relay_tool_call_execute_v2(
+            name,
+            args_json,
+            func,
+            func_user_data,
+            func_free,
+            parent,
+            attributes,
+            data_json,
+            metadata_json,
+            std::ptr::null(),
+            out,
+        )
+    }
+}
+
+/// Execute a tool call end-to-end with an optional external tool call ID.
+///
+/// This runs conditional-execution guardrails (on raw args), then request
+/// intercepts, sanitize-request guardrails, execution intercepts, the callback,
+/// and sanitize-response guardrails. On rejection, only a standalone Mark event
+/// is emitted (no Start/End pair) and `GuardrailRejected` is returned. Blocks
+/// the calling thread until completion.
+///
+/// # Parameters
+/// - `name`: Null-terminated tool name.
+/// - `args_json`: Tool arguments as a JSON C string.
+/// - `func`: C callback that performs the actual tool execution.
+/// - `func_user_data`: Opaque pointer passed to `func`.
+/// - `func_free`: Optional destructor for `func_user_data`.
+/// - `parent`: Optional parent scope handle, or null.
+/// - `attributes`: Bitfield of tool attributes.
+/// - `data_json`: Optional JSON data, or null.
+/// - `metadata_json`: Optional JSON metadata, or null.
+/// - `tool_call_id`: Optional null-terminated external correlation ID recorded
+///   on both managed lifecycle events, or null.
+/// - `out`: On success, receives the result as a JSON C string. Caller must free
+///   with `nemo_relay_string_free`.
+///
+/// # Safety
+/// `name`, `args_json`, and `out` must be valid, non-null pointers. Optional
+/// pointer arguments may be null; when non-null, they must be valid for reads
+/// for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_tool_call_execute_v2(
+    name: *const c_char,
+    args_json: *const c_char,
+    func: NemoRelayToolExecCb,
+    func_user_data: *mut libc::c_void,
+    func_free: NemoRelayFreeFn,
+    parent: *const FfiScopeHandle,
+    attributes: u32,
+    data_json: *const c_char,
+    metadata_json: *const c_char,
+    tool_call_id: *const c_char,
     out: *mut *mut c_char,
 ) -> NemoRelayStatus {
     clear_last_error();
@@ -257,6 +319,14 @@ pub unsafe extern "C" fn nemo_relay_tool_call_execute(
         Some(m) => m,
         None => return NemoRelayStatus::InvalidJson,
     };
+    let tool_call_id = if tool_call_id.is_null() {
+        None
+    } else {
+        match c_str_to_string(tool_call_id) {
+            Ok(id) => Some(id),
+            Err(status) => return status,
+        }
+    };
 
     let exec_fn = wrap_tool_exec_fn(func, func_user_data, func_free);
     let default_fn: ToolExecutionNextFn = Arc::new(move |args| exec_fn(args));
@@ -272,6 +342,7 @@ pub unsafe extern "C" fn nemo_relay_tool_call_execute(
                 .attributes(attrs)
                 .data_opt(data)
                 .metadata_opt(metadata)
+                .tool_call_id_opt(tool_call_id)
                 .build(),
         )
         .await

--- a/crates/ffi/tests/unit/api/execution_tests.rs
+++ b/crates/ffi/tests/unit/api/execution_tests.rs
@@ -84,6 +84,115 @@ fn test_ffi_tool_execute_parent_data_and_error_paths() {
 }
 
 #[test]
+fn test_ffi_tool_execute_v2_propagates_tool_call_id_and_legacy_omits_it() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let stack = fresh_scope_stack();
+        let subscriber_name = cstring(&unique_name("ffi_tool_execute_id_subscriber"));
+        assert_status!(
+            nemo_relay_register_subscriber(
+                subscriber_name.as_ptr(),
+                subscriber_cb,
+                ptr::null_mut(),
+                None,
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let args = cstring(r#"{"value":2}"#);
+        let managed_name = cstring("ffi_tool_execute_v2_id");
+        let legacy_name = cstring("ffi_tool_execute_legacy_id");
+        let tool_call_id = cstring("call_ffi_managed_123");
+        let mut out_json = ptr::null_mut();
+
+        assert_status!(
+            nemo_relay_tool_call_execute_v2(
+                managed_name.as_ptr(),
+                args.as_ptr(),
+                tool_exec_cb,
+                ptr::null_mut(),
+                None,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                tool_call_id.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let _ = returned_json(out_json);
+
+        assert_status!(
+            nemo_relay_tool_call_execute(
+                legacy_name.as_ptr(),
+                args.as_ptr(),
+                tool_exec_cb,
+                ptr::null_mut(),
+                None,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let _ = returned_json(out_json);
+
+        let invalid_utf8 = [0xff_u8, 0];
+        assert_status!(
+            nemo_relay_tool_call_execute_v2(
+                managed_name.as_ptr(),
+                args.as_ptr(),
+                tool_exec_cb,
+                ptr::null_mut(),
+                None,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                invalid_utf8.as_ptr().cast(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::InvalidUtf8
+        );
+
+        assert_status!(nemo_relay_flush_subscribers(), NemoRelayStatus::Ok);
+        let events = lock_unpoisoned(event_log()).clone();
+        for scope_category in ["start", "end"] {
+            let managed_event = events
+                .iter()
+                .find(|event| {
+                    event["json"]["kind"] == json!("scope")
+                        && event["json"]["name"] == json!("ffi_tool_execute_v2_id")
+                        && event["json"]["scope_category"] == json!(scope_category)
+                })
+                .unwrap_or_else(|| panic!("missing managed {scope_category} event"));
+            assert_eq!(managed_event["tool_call_id"], json!("call_ffi_managed_123"));
+
+            let legacy_event = events
+                .iter()
+                .find(|event| {
+                    event["json"]["kind"] == json!("scope")
+                        && event["json"]["name"] == json!("ffi_tool_execute_legacy_id")
+                        && event["json"]["scope_category"] == json!(scope_category)
+                })
+                .unwrap_or_else(|| panic!("missing legacy {scope_category} event"));
+            assert!(legacy_event["tool_call_id"].is_null());
+        }
+
+        assert_status!(
+            nemo_relay_deregister_subscriber(subscriber_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_scope_stack_free(stack);
+    }
+}
+
+#[test]
 fn test_ffi_llm_execute_codec_parent_and_error_paths() {
     let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     reset_globals();

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -2489,6 +2489,7 @@ pub fn tool_call_end(
 /// `End` event payload. On rejection, only a standalone Mark event is emitted
 /// (no Start/End pair) and `GuardrailRejected` is returned. Returns the final
 /// execution result; sanitize guardrails do not rewrite the caller-visible value.
+/// An optional trailing `toolCallId` is recorded in both lifecycle events.
 #[allow(clippy::too_many_arguments)]
 #[napi(ts_return_type = "Promise<ToolExecutionResult>")]
 pub fn tool_call_execute(
@@ -2500,6 +2501,7 @@ pub fn tool_call_execute(
     attributes: Option<u32>,
     data: Option<Json>,
     metadata: Option<Json>,
+    tool_call_id: Option<String>,
 ) -> Result<JsObject> {
     let attrs = ToolAttributes::from_bits_truncate(attributes.unwrap_or(0));
     let publication_context_id = callback_factory::event_sanitizer_callback_context_id(&env)?;
@@ -2528,6 +2530,7 @@ pub fn tool_call_execute(
                                     .attributes(attrs)
                                     .data_opt(opt_json(data))
                                     .metadata_opt(opt_json(metadata))
+                                    .tool_call_id_opt(tool_call_id)
                                     .build(),
                             )
                             .await
@@ -2548,6 +2551,7 @@ pub fn tool_call_execute(
 /// Same lifecycle as `toolCallExecute` (guardrails → intercepts → func → response processing),
 /// but transparently handles JS callbacks that return Promises. Uses `napi_is_promise` to detect
 /// Promise return values and resolves them before continuing the pipeline.
+/// An optional trailing `toolCallId` is recorded in both lifecycle events.
 ///
 /// Accepts a raw `JsFunction` instead of `ThreadsafeFunction` so it can create a
 /// promise-aware wrapper with access to `Env`.
@@ -2565,6 +2569,7 @@ pub fn tool_call_execute_async(
     attributes: Option<u32>,
     data: Option<Json>,
     metadata: Option<Json>,
+    tool_call_id: Option<String>,
 ) -> Result<JsObject> {
     let attrs = ToolAttributes::from_bits_truncate(attributes.unwrap_or(0));
     let publication_context_id = callback_factory::event_sanitizer_callback_context_id(&env)?;
@@ -2609,6 +2614,7 @@ pub fn tool_call_execute_async(
                                     .attributes(attrs)
                                     .data_opt(opt_json(data))
                                     .metadata_opt(opt_json(metadata))
+                                    .tool_call_id_opt(tool_call_id)
                                     .build(),
                             )
                             .await

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -3,6 +3,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -361,6 +362,7 @@ describe('Tool execute', () => {
         {
           caller: 'node-tool',
         },
+        'node-managed-success-123',
       );
       assert.deepEqual(result, {
         result: 2,
@@ -380,14 +382,29 @@ describe('Tool execute', () => {
             {
               caller: 'node-tool-error',
             },
+            'node-managed-error-123',
           ),
         /tool status failure/,
       );
 
       await flushSubscribers();
+      const okStart = events.find(
+        (e) =>
+          e.name === 'exec_status_ok_tool' &&
+          e.kind === 'scope' &&
+          e.category === 'tool' &&
+          e.scope_category === 'start',
+      );
       const okEnd = events.find(
         (e) =>
           e.name === 'exec_status_ok_tool' && e.kind === 'scope' && e.category === 'tool' && e.scope_category === 'end',
+      );
+      const errorStart = events.find(
+        (e) =>
+          e.name === 'exec_status_error_tool' &&
+          e.kind === 'scope' &&
+          e.category === 'tool' &&
+          e.scope_category === 'start',
       );
       const errorEnd = events.find(
         (e) =>
@@ -396,10 +413,16 @@ describe('Tool execute', () => {
           e.category === 'tool' &&
           e.scope_category === 'end',
       );
+      assert.ok(okStart, 'expected successful tool start event');
       assert.ok(okEnd, 'expected successful tool end event');
+      assert.equal(okStart.category_profile.tool_call_id, 'node-managed-success-123');
+      assert.equal(okEnd.category_profile.tool_call_id, 'node-managed-success-123');
       assert.equal(okEnd.metadata.caller, 'node-tool');
       assert.equal(okEnd.metadata['otel.status_code'], 'OK');
+      assert.ok(errorStart, 'expected failed tool start event');
       assert.ok(errorEnd, 'expected failed tool end event');
+      assert.equal(errorStart.category_profile.tool_call_id, 'node-managed-error-123');
+      assert.equal(errorEnd.category_profile.tool_call_id, 'node-managed-error-123');
       assert.equal(errorEnd.metadata.caller, 'node-tool-error');
       assert.equal(errorEnd.metadata['otel.status_code'], 'ERROR');
       assert.match(errorEnd.metadata['otel.status_description'], /tool status failure/);
@@ -410,27 +433,51 @@ describe('Tool execute', () => {
     }
   });
 
-  it('async execute awaits Promise-returning callbacks', async () => {
-    const result = await toolCallExecuteAsync(
-      'exec_async_tool',
-      {
-        x: 10,
-      },
-      async (args) => ({
-        result: args.x + 2,
-      }),
-      null,
-      TOOL_ATTR_LOCAL,
-      {
-        data: true,
-      },
-      {
-        meta: true,
-      },
-    );
-    assert.deepEqual(result, {
-      result: 12,
-    });
+  it('async execute awaits Promise-returning callbacks and records tool call IDs', async () => {
+    const events = [];
+    registerSubscriber('node_async_tool_call_id_sub', (event) => events.push(event));
+    try {
+      const result = await toolCallExecuteAsync(
+        'exec_async_tool',
+        {
+          x: 10,
+        },
+        async (args) => ({
+          result: args.x + 2,
+        }),
+        null,
+        TOOL_ATTR_LOCAL,
+        {
+          data: true,
+        },
+        {
+          meta: true,
+        },
+        'node-managed-async-123',
+      );
+      assert.deepEqual(result, {
+        result: 12,
+      });
+
+      await flushSubscribers();
+      const lifecycle = events.filter(
+        (event) => event.kind === 'scope' && event.category === 'tool' && event.name === 'exec_async_tool',
+      );
+      assert.deepEqual(
+        lifecycle.map((event) => event.scope_category),
+        ['start', 'end'],
+      );
+      assert.ok(lifecycle.every((event) => event.category_profile.tool_call_id === 'node-managed-async-123'));
+    } finally {
+      deregisterSubscriber('node_async_tool_call_id_sub');
+    }
+  });
+
+  it('generated execute declarations expose an additive trailing toolCallId', () => {
+    const declarations = readFileSync(new URL('../index.d.ts', import.meta.url), 'utf8');
+
+    assert.match(declarations, /toolCallExecute\([\s\S]*?metadata\?: Json[^,\n]*,[\s\S]*?toolCallId\?: string/);
+    assert.match(declarations, /toolCallExecuteAsync\([\s\S]*?metadata\?: Json[^,\n]*,[\s\S]*?toolCallId\?: string/);
   });
 
   it('async execute surfaces plain string rejections', async () => {

--- a/crates/node/tests/typed_tests.mjs
+++ b/crates/node/tests/typed_tests.mjs
@@ -399,6 +399,35 @@ describe('typedToolExecute', () => {
     });
   });
 
+  it('records toolCallId from typed options on managed lifecycle events', async () => {
+    const events = [];
+    registerSubscriber('typed_node_tool_call_id_sub', (event) => events.push(event));
+    try {
+      const passthrough = new JsonPassthrough();
+      const result = await typedToolExecute(
+        'typed_tool_call_id',
+        { value: 1 },
+        (args) => ({ result: args }),
+        passthrough,
+        passthrough,
+        { toolCallId: 'typed-node-call-123' },
+      );
+      assert.deepEqual(result, { result: { value: 1 } });
+
+      await flushSubscribers();
+      const lifecycle = events.filter(
+        (event) => event.kind === 'scope' && event.category === 'tool' && event.name === 'typed_tool_call_id',
+      );
+      assert.deepEqual(
+        lifecycle.map((event) => event.scope_category),
+        ['start', 'end'],
+      );
+      assert.ok(lifecycle.every((event) => event.category_profile.tool_call_id === 'typed-node-call-123'));
+    } finally {
+      deregisterSubscriber('typed_node_tool_call_id_sub');
+    }
+  });
+
   it('preserves falsy metadata/model options and uses non-null request data', async () => {
     const events = [];
     registerSubscriber('typed_node_falsy_opts', (event) => events.push(event));

--- a/crates/node/typed.d.ts
+++ b/crates/node/typed.d.ts
@@ -127,6 +127,7 @@ export interface TypedToolExecuteOptions {
   attributes?: number | null;
   data?: JsonValue;
   metadata?: JsonValue;
+  toolCallId?: string | null;
 }
 
 /** Options for `typedLlmExecute`. */
@@ -152,7 +153,7 @@ export interface TypedLlmExecuteOptions {
  * @param func - The tool implementation.
  * @param argsCodec - Codec for args serialization/deserialization.
  * @param resultCodec - Codec for result serialization/deserialization.
- * @param options - Optional scope handle, attributes, data, metadata.
+ * @param options - Optional scope handle, attributes, data, metadata, and toolCallId.
  * @returns A promise resolving to the decoded typed result and opaque annotation.
  * @remarks The wrapper accepts both synchronous and promise-returning tool
  * implementations; codec failures and native execution errors propagate to the

--- a/crates/node/typed.js
+++ b/crates/node/typed.js
@@ -102,6 +102,7 @@ function decodeResponseWithCodec(codec, response) {
  * @param {Codec<TArgs>} argsCodec - Codec used to serialize and deserialize tool args.
  * @param {Codec<TResult>} resultCodec - Codec used to serialize and deserialize tool results.
  * @param {object} [options] - Optional execution-scoping metadata.
+ * @param {string} [options.toolCallId] - Provider-specific tool call correlation ID.
  * @returns {Promise<{ result: TResult, annotation?: * }>} A promise resolving to the decoded typed tool result.
  * @remarks The wrapper accepts both synchronous and promise-returning tool
  * implementations; codec failures and native execution errors propagate to the
@@ -128,6 +129,7 @@ async function typedToolExecute(name, args, func, argsCodec, resultCodec, option
     opts.attributes ?? null,
     opts.data ?? null,
     opts.metadata ?? null,
+    opts.toolCallId ?? null,
   );
 
   return {

--- a/crates/python/src/py_api/mod.rs
+++ b/crates/python/src/py_api/mod.rs
@@ -874,6 +874,7 @@ fn tool_call_end(
 ///     metadata: Optional JSON-serializable metadata.
 ///         End events receive ``otel.status_code = "OK"`` on success, or
 ///         ``otel.status_code = "ERROR"`` and ``otel.status_description`` on error.
+///     tool_call_id: Optional provider-specific tool-call correlation ID.
 /// Returns:
 ///     An awaitable that resolves to the tool result after execution
 ///     intercepts. Sanitize guardrails do not rewrite the value returned to
@@ -887,8 +888,9 @@ fn tool_call_end(
     handle: "ScopeHandle | None"=None,
     attributes: "ToolAttributes | None"=None,
     data: "object | None"=None,
-    metadata: "object | None"=None
-) -> "object", text_signature = "(name: str, args: object, func: object, *, handle: ScopeHandle | None = None, attributes: ToolAttributes | None = None, data: object | None = None, metadata: object | None = None) -> object")]
+    metadata: "object | None"=None,
+    tool_call_id: "str | None"=None
+) -> "object", text_signature = "(name: str, args: object, func: object, *, handle: ScopeHandle | None = None, attributes: ToolAttributes | None = None, data: object | None = None, metadata: object | None = None, tool_call_id: str | None = None) -> object")]
 #[allow(clippy::too_many_arguments)]
 fn tool_call_execute<'py>(
     py: Python<'py>,
@@ -899,6 +901,7 @@ fn tool_call_execute<'py>(
     attributes: Option<PyToolAttributes>,
     data: Option<&Bound<'py, PyAny>>,
     metadata: Option<&Bound<'py, PyAny>>,
+    tool_call_id: Option<String>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let args_json = py_to_json(args)?;
     let attrs = attributes
@@ -928,6 +931,7 @@ fn tool_call_execute<'py>(
                             .attributes(attrs)
                             .data_opt(data_json)
                             .metadata_opt(metadata_json)
+                            .tool_call_id_opt(tool_call_id)
                             .build(),
                     )
                     .await

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -62,6 +62,9 @@ The following updates expand native Rust plugin capabilities:
 - ATOF, ATIF, and the `full` and `openinference` OpenTelemetry projections
   preserve sanitized tool result annotations without flattening their
   application-defined schemas.
+- Managed tool execution accepts an optional provider- or harness-supplied
+  tool-call ID and preserves it on the matching start and end events across
+  success, error, and cancellation paths.
 
 ### OpenTelemetry Logs and Metrics
 

--- a/docs/instrument-applications/instrument-tool-call.mdx
+++ b/docs/instrument-applications/instrument-tool-call.mdx
@@ -225,6 +225,8 @@ Use this checklist before running the pattern in production traffic.
 - Keep tool arguments, results, and annotations JSON-compatible.
 - Register temporary debugging subscribers only in development or test environments.
 - Pass the parent scope handle when the tool is part of a larger agent, request, or workflow.
+- Pass the provider or harness tool-call ID when the application already has a
+  stable identifier for the invocation.
 - Use middleware names that describe ownership, such as `search.redact_args` or `retrieval.timeout`.
 
 ## Common Issues

--- a/docs/integrate-into-frameworks/wrap-tool-calls.mdx
+++ b/docs/integrate-into-frameworks/wrap-tool-calls.mdx
@@ -33,8 +33,9 @@ Follow this sequence to keep framework work attached to the expected runtime con
 1. Enter or inherit the active framework scope.
 2. Capture the current scope handle at the tool boundary.
 3. Route the real tool callback through the managed tool execute helper.
-4. Keep framework-owned clients, callbacks, streams, and handles outside the emitted JSON payload.
-5. Return the tool result exactly as the framework expects.
+4. Forward the framework's stable tool-call ID when one is available.
+5. Keep framework-owned clients, callbacks, streams, and handles outside the emitted JSON payload.
+6. Return the tool result exactly as the framework expects.
 
 Managed wrappers are the first choice because NeMo Relay owns the full call boundary. That gives subscribers complete start and end events, lets execution intercepts wrap the real callback, and keeps guardrails and request intercepts in the normal middleware order.
 
@@ -126,6 +127,101 @@ async fn run_framework_tool() -> anyhow::Result<serde_json::Value> {
 
 </Tabs>
 
+## Preserve Tool-Call Identity
+
+Pass one stable invocation ID to the managed execute helper when the framework,
+model provider, or transport already assigned one. Relay places the exact value
+on both the tool start and tool end events, including error and cancellation end
+events, before the general event-sanitizer chain runs. An event sanitizer can
+redact or remove it with the rest of `category_profile`. Relay does not generate
+or infer an external ID when you omit it.
+
+<Tabs>
+<Tab title="Python" language="python">
+```python
+result = await nemo_relay.tools.execute(
+    tool_name,
+    raw_args,
+    invoke,
+    handle=parent,
+    tool_call_id=framework_call_id,
+)
+```
+</Tab>
+
+<Tab title="Node.js" language="node">
+```ts
+const result = await toolCallExecute(
+  toolName,
+  rawArgs,
+  invoke,
+  parent,
+  null,
+  null,
+  null,
+  frameworkCallId,
+);
+```
+</Tab>
+
+<Tab title="Rust" language="rust">
+```rust
+let result = tool_call_execute(
+    ToolCallExecuteParams::builder()
+        .name(tool_name)
+        .args(args)
+        .func(callback)
+        .parent(parent)
+        .tool_call_id(framework_call_id)
+        .build(),
+)
+.await?;
+```
+</Tab>
+</Tabs>
+
+Choose the ID at the application boundary:
+
+- For a model-originated tool invocation, use the model or harness tool-use ID
+  that correlates the request with its eventual result.
+- For direct JSON-RPC instrumentation, you can normalize the request ID to a
+  string and use it as the tool-call ID.
+- If both an execution ID and a transport request ID matter, use one stable
+  execution ID as `tool_call_id` and keep the transport ID in application-owned
+  metadata. Do not concatenate or infer identifiers in Relay middleware.
+
+The tool-call ID correlates records for one invocation; it does not establish
+cross-process parentage. Carry an authenticated Relay propagation context
+separately when work crosses a process boundary. See
+[Cross-Process Propagation](/about-nemo-relay/concepts/scopes#cross-process-propagation).
+
+Conditional guardrail rejection happens before Relay creates the managed tool
+span, so a rejected call emits no tool start/end pair. The standalone rejection
+mark is not assigned the managed tool-call ID.
+
+## Use the Same Contract for Local and Remote Tools
+
+Relay does not need a separate execution API for MCP-backed or other remote
+tools. Place the existing client callback behind the same managed tool boundary
+as a local callback, then preserve protocol data instead of translating it into
+Relay-specific fields.
+
+| Application or protocol value | Relay mapping |
+| --- | --- |
+| Tool name and arguments | Managed execute `name` and `args` |
+| Model or harness tool-use ID | Managed execute `tool_call_id` |
+| Complete MCP `CallToolResult` | Application-visible tool result, including `content`, `structuredContent`, `_meta`, and `isError` |
+| JSON-RPC request ID when it is not the chosen tool-call ID | Application-owned metadata |
+| Valid `isError: true` result | Successful callback result data; do not raise it as a transport failure |
+| Transport, protocol, or dispatch failure | Callback error path |
+| Authenticated cross-process Relay parent | Separately imported propagation context |
+
+This keeps local and remote tools in one middleware registry and one lifecycle
+path. The application still owns client construction, discovery, transport,
+authentication, request-ID selection, and validation of inbound propagation
+context. Relay does not infer that a callback is remote, inspect tool names to
+detect a protocol, or operate as a proxy.
+
 ## When to Use Fallback APIs
 
 Use explicit lifecycle APIs only when the framework owns the real tool invocation internally and exposes only start and finish hooks. In that case, the integration must preserve the returned handle and call the matching end helper on every success and failure path.
@@ -140,6 +236,7 @@ Run one framework tool path and check:
   receives the same tool result as before.
 - Subscribers see one tool start event and one matching tool end event.
 - Tool events share the same root scope UUID as the framework request.
+- Tool start and end events carry the same framework tool-call ID when supplied.
 - Global and scope-local tool middleware run exactly once.
 - Framework-owned objects do not appear in emitted JSON payloads.
 
@@ -148,6 +245,7 @@ Run one framework tool path and check:
 Check these symptoms first when the workflow does not behave as expected.
 
 - **Tool events appear without parentage**: Pass the active scope handle or ensure the framework tool runs inside a NeMo Relay scope.
+- **Tool events cannot be matched to the framework invocation**: Pass the framework's stable tool-call ID to the managed execute helper.
 - **Middleware does not run**: The framework still calls the real tool callback directly.
 - **Payload serialization fails**: Project framework objects into
   JSON-compatible tool arguments, results, and annotations before NeMo Relay

--- a/docs/reference/atof-event-format.mdx
+++ b/docs/reference/atof-event-format.mdx
@@ -324,11 +324,16 @@ The `category` `enum` is closed but `"custom"` + `category_profile.subtype` prov
 
 <Indent>
   <ParamField path="category_profile.model_name" type="string | null">
-    LLM model identifier when `category == "llm"`. It can be `null` when the model is unknown.
+    LLM model identifier when `category == "llm"`. Relay omits this key when
+    the model is unknown; consumers should also accept an explicit `null` from
+    other producers.
   </ParamField>
 
   <ParamField path="category_profile.tool_call_id" type="string | null">
-    Provider-, harness-, or transport-supplied correlation ID when `category == "tool"`. It is `null` when the producer did not supply an external tool-call ID.
+    Provider-, harness-, or transport-supplied correlation ID when `category ==
+    "tool"`. Relay omits this key when the producer does not supply an external
+    tool-call ID; consumers should also accept an explicit `null` from other
+    producers.
   </ParamField>
 
   <ParamField path="category_profile.tool_result_annotation" type="JSON value | null">
@@ -388,7 +393,7 @@ Each scope span receives a unique UUID at creation time. The `uuid` is stable ac
 Two distinct identifier namespaces appear in an ATOF stream:
 
 - **`uuid` / `parent_uuid`** — runtime identifiers attached to every event. Form the scope graph.
-- **`category_profile.tool_call_id`** (on `scope` or `mark` events when `category == "tool"`) — an external invocation identifier supplied by a provider, harness, or transport. Managed execution places the same supplied value on its tool start and end events before event sanitization; an event sanitizer can redact or remove it. Null when the producer did not supply an external tool-call ID.
+- **`category_profile.tool_call_id`** (on `scope` or `mark` events when `category == "tool"`) — an external invocation identifier supplied by a provider, harness, or transport. Managed execution places the same supplied value on its tool start and end events before event sanitization; an event sanitizer can redact or remove it. Relay omits this key when the producer did not supply an external tool-call ID; consumers should also accept an explicit `null` from other producers.
 
 ### 5.6 ATOF Version and Negotiation
 

--- a/docs/reference/atof-event-format.mdx
+++ b/docs/reference/atof-event-format.mdx
@@ -328,7 +328,7 @@ The `category` `enum` is closed but `"custom"` + `category_profile.subtype` prov
   </ParamField>
 
   <ParamField path="category_profile.tool_call_id" type="string | null">
-    LLM-provider correlation ID when `category == "tool"`. It can be `null` when the tool was not invoked through an LLM tool-use flow.
+    Provider-, harness-, or transport-supplied correlation ID when `category == "tool"`. It is `null` when the producer did not supply an external tool-call ID.
   </ParamField>
 
   <ParamField path="category_profile.tool_result_annotation" type="JSON value | null">
@@ -388,7 +388,7 @@ Each scope span receives a unique UUID at creation time. The `uuid` is stable ac
 Two distinct identifier namespaces appear in an ATOF stream:
 
 - **`uuid` / `parent_uuid`** — runtime identifiers attached to every event. Form the scope graph.
-- **`category_profile.tool_call_id`** (on `scope` or `mark` events when `category == "tool"`) — an LLM-provider identifier that bridges an LLM's tool-call response with the resulting tool execution. Null when the tool was not invoked via an LLM tool-use flow.
+- **`category_profile.tool_call_id`** (on `scope` or `mark` events when `category == "tool"`) — an external invocation identifier supplied by a provider, harness, or transport. Managed execution places the same supplied value on its tool start and end events before event sanitization; an event sanitizer can redact or remove it. Null when the producer did not supply an external tool-call ID.
 
 ### 5.6 ATOF Version and Negotiation
 

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -67,6 +67,12 @@ extern int32_t nemo_relay_tool_call_execute(
 	const FfiScopeHandle* parent, uint32_t attributes,
 	const char* data_json, const char* metadata_json,
 	char** out);
+extern int32_t nemo_relay_tool_call_execute_v2(
+	const char* name, const char* args_json,
+	NemoRelayToolExecFn func_cb, void* func_user_data, NemoRelayFreeFn func_free,
+	const FfiScopeHandle* parent, uint32_t attributes,
+	const char* data_json, const char* metadata_json,
+	const char* tool_call_id, char** out);
 
 // LLM lifecycle
 typedef void (*NemoRelayCollectorCb)(const char* chunk_json);
@@ -862,9 +868,10 @@ type toolCallOptions struct {
 // ToolCallOption is a functional option that configures optional parameters for
 // tool call functions ([ToolCall], [ToolCallEnd], [ToolCallExecute]). Available
 // options include [WithToolParent], [WithToolAttributes], [WithToolData],
-// [WithToolMetadata], [WithToolCallID], and [WithToolTimestamp]. Timestamp and
-// tool-call ID options affect manual [ToolCall] and [ToolCallEnd] spans only;
-// managed [ToolCallExecute] spans use runtime-generated timestamps.
+// [WithToolMetadata], [WithToolCallID], and [WithToolTimestamp]. Tool-call IDs
+// apply to both manual and managed spans. Explicit timestamps apply only to
+// manual [ToolCall] and [ToolCallEnd] spans; managed [ToolCallExecute] spans use
+// runtime-generated timestamps.
 type ToolCallOption func(*toolCallOptions)
 
 // WithToolParent sets the parent scope handle for a tool call. If not provided,
@@ -905,8 +912,9 @@ func WithToolMetadata(metadata json.RawMessage) ToolCallOption {
 
 // WithToolCallID sets an optional tool call ID for the tool call. This ID is
 // typically assigned by the LLM to correlate the tool invocation with the
-// original tool_call request in the conversation. Pass an empty string or omit
-// this option to leave the tool call ID unset.
+// original tool_call request in the conversation. It is recorded on both Start
+// and End events for manual and managed tool calls. Omit this option to leave
+// the tool call ID unset.
 func WithToolCallID(id string) ToolCallOption {
 	return func(o *toolCallOptions) {
 		o.toolCallID = C.CString(id)
@@ -1001,7 +1009,8 @@ func ToolCallEnd(handle *ToolHandle, result ToolExecutionResult, opts ...ToolCal
 // On rejection, only a standalone Mark event is emitted (no Start/End pair)
 // and GuardrailRejected is returned. This is the recommended high-level API
 // for tool invocations. Sanitize guardrails do not rewrite the value passed
-// into fn or the value returned to the caller.
+// into fn or the value returned to the caller. Use [WithToolCallID] to preserve
+// a provider-assigned correlation ID on both managed lifecycle events.
 func ToolCallExecute(name string, args json.RawMessage, fn ToolExecutionFunc, opts ...ToolCallOption) (ToolExecutionResult, error) {
 	o := &toolCallOptions{}
 	for _, opt := range opts {
@@ -1017,14 +1026,14 @@ func ToolCallExecute(name string, args json.RawMessage, fn ToolExecutionFunc, op
 	defer C.free(unsafe.Pointer(cArgs))
 
 	var out *C.char
-	status := C.nemo_relay_tool_call_execute(
+	status := C.nemo_relay_tool_call_execute_v2(
 		cName, cArgs,
 		C.NemoRelayToolExecFn(C.goToolExecTrampoline),
 		id,
 		C.NemoRelayFreeFn(C.goFreeTrampoline),
 		o.parent, C.uint32_t(o.attributes),
 		o.data, o.metadata,
-		&out,
+		o.toolCallID, &out,
 	)
 	if err := checkStatus(status); err != nil {
 		return ToolExecutionResult{}, err

--- a/go/nemo_relay/tools_test.go
+++ b/go/nemo_relay/tools_test.go
@@ -1064,6 +1064,66 @@ func TestToolCallWithToolCallID(t *testing.T) {
 	}
 }
 
+func TestToolCallExecutePropagatesToolCallIDToLifecycleEvents(t *testing.T) {
+	type lifecycleIDs struct {
+		start string
+		end   string
+	}
+
+	const (
+		managedTool = "managed_id_tool"
+		defaultTool = "managed_default_id_tool"
+		expectedID  = "call_go_managed_123"
+	)
+	captured := map[string]*lifecycleIDs{
+		managedTool: {},
+		defaultTool: {},
+	}
+	var mu sync.Mutex
+
+	RegisterSubscriber("go_tool_execute_id_sub", func(event Event) {
+		ids, tracked := captured[event.Name()]
+		if !tracked || event.Kind() != "scope" || event.Category() != "tool" {
+			return
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		switch event.ScopeCategory() {
+		case "start":
+			ids.start = event.ToolCallID()
+		case "end":
+			ids.end = event.ToolCallID()
+		}
+	})
+	defer func() { _ = DeregisterSubscriber("go_tool_execute_id_sub") }()
+
+	execute := func(name string, opts ...ToolCallOption) {
+		t.Helper()
+		_, err := ToolCallExecute(name, json.RawMessage(`{"value":1}`),
+			func(args json.RawMessage) (ToolExecutionResult, error) { return ToolExecutionResult{Result: args}, nil },
+			opts...,
+		)
+		if err != nil {
+			t.Fatalf(toolCallExecuteFailed, err)
+		}
+	}
+	execute(managedTool, WithToolCallID(expectedID))
+	execute(defaultTool)
+	if err := FlushSubscribers(); err != nil {
+		t.Fatalf(toolFlushSubscribersFailed, err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if *captured[managedTool] != (lifecycleIDs{start: expectedID, end: expectedID}) {
+		t.Fatalf("managed lifecycle tool call IDs = %+v, want %q on Start and End", *captured[managedTool], expectedID)
+	}
+	if *captured[defaultTool] != (lifecycleIDs{}) {
+		t.Fatalf("default managed lifecycle tool call IDs = %+v, want both unset", *captured[defaultTool])
+	}
+}
+
 func TestToolEventInputOutput(t *testing.T) {
 	var capturedInput, capturedOutput json.RawMessage
 	var mu sync.Mutex

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -1727,7 +1727,12 @@ def tool_call_execute(
     name: str,
     args: _Json,
     func: Callable[[_Json], ToolExecutionResult[_Json] | Awaitable[ToolExecutionResult[_Json]]],
-    **kwargs: object,
+    *,
+    handle: ScopeHandle | None = None,
+    attributes: ToolAttributes | None = None,
+    data: _Json | None = None,
+    metadata: _Json | None = None,
+    tool_call_id: str | None = None,
 ) -> Awaitable[ToolExecutionResult[_Json]]:
     """Execute a tool through the managed native middleware pipeline.
 
@@ -1736,7 +1741,11 @@ def tool_call_execute(
         args: Initial JSON-compatible tool arguments.
         func: Synchronous or asynchronous tool implementation called with final
             arguments. It must return ``ToolExecutionResult``.
-        **kwargs: Optional parent handle, attributes, data, and metadata.
+        handle: Optional parent scope handle.
+        attributes: Optional tool attribute bitflags.
+        data: Optional JSON application payload stored on the managed handle.
+        metadata: Optional JSON metadata recorded on emitted events.
+        tool_call_id: Optional provider-specific tool-call correlation ID.
 
     Returns:
         Awaitable that resolves to the canonical tool result.

--- a/python/nemo_relay/integrations/langchain/middleware.py
+++ b/python/nemo_relay/integrations/langchain/middleware.py
@@ -125,7 +125,8 @@ class NemoRelayMiddleware(AgentMiddleware):
         codec = nemo_relay.typed.BestEffortAnyCodec()
         tool_name = request.tool_call["name"]
         tool_args = request.tool_call.get("args") or {}
-        return (parent, codec, tool_name, tool_args)
+        tool_call_id = request.tool_call.get("id")
+        return (parent, codec, tool_name, tool_args, tool_call_id)
 
     def wrap_tool_call(
         self,
@@ -134,7 +135,7 @@ class NemoRelayMiddleware(AgentMiddleware):
     ) -> ToolMessage | Command[Any]:
         """Wrap a sync LangChain agent tool call in NeMo Relay tool execution."""
 
-        (parent, codec, tool_name, tool_args) = self._prepare_tool_call(request)
+        (parent, codec, tool_name, tool_args, tool_call_id) = self._prepare_tool_call(request)
 
         def _call(args: Any) -> nemo_relay.ToolExecutionResult[ToolMessage | Command[Any]]:
             return nemo_relay.ToolExecutionResult(
@@ -143,7 +144,13 @@ class NemoRelayMiddleware(AgentMiddleware):
 
         return run_sync(
             nemo_relay.typed.tool_execute(
-                name=tool_name, args=tool_args, func=_call, args_codec=codec, result_codec=codec, handle=parent
+                name=tool_name,
+                args=tool_args,
+                func=_call,
+                args_codec=codec,
+                result_codec=codec,
+                handle=parent,
+                tool_call_id=tool_call_id,
             )
         ).result
 
@@ -154,7 +161,7 @@ class NemoRelayMiddleware(AgentMiddleware):
     ) -> ToolMessage | Command[Any]:
         """Wrap an async LangChain agent tool call in NeMo Relay tool execution."""
 
-        (parent, codec, tool_name, tool_args) = self._prepare_tool_call(request)
+        (parent, codec, tool_name, tool_args, tool_call_id) = self._prepare_tool_call(request)
 
         async def _call(args: Any) -> nemo_relay.ToolExecutionResult[ToolMessage | Command[Any]]:
             return nemo_relay.ToolExecutionResult(
@@ -169,5 +176,6 @@ class NemoRelayMiddleware(AgentMiddleware):
                 args_codec=codec,
                 result_codec=codec,
                 handle=parent,
+                tool_call_id=tool_call_id,
             )
         ).result

--- a/python/nemo_relay/tools.py
+++ b/python/nemo_relay/tools.py
@@ -137,7 +137,7 @@ def call_end(handle, result, *, data=None, metadata=None, timestamp: datetime | 
     return _native_tool_call_end(handle, result, data=data, metadata=metadata, timestamp=timestamp)
 
 
-def execute(name, args, func, *, handle=None, attributes=None, data=None, metadata=None):
+def execute(name, args, func, *, handle=None, attributes=None, data=None, metadata=None, tool_call_id=None):
     """Run a tool through the managed middleware pipeline.
 
     Pipeline order:
@@ -159,6 +159,8 @@ def execute(name, args, func, *, handle=None, attributes=None, data=None, metada
         attributes: Optional native tool attributes attached to the start event.
         data: Optional JSON application payload stored on the managed tool handle.
         metadata: Optional JSON metadata recorded on the emitted start event.
+        tool_call_id: Optional provider-specific tool call identifier recorded
+            on the emitted start and end events.
 
     Returns:
         ToolExecutionResult: The canonical result returned by ``func`` or an
@@ -196,6 +198,7 @@ def execute(name, args, func, *, handle=None, attributes=None, data=None, metada
         attributes=attributes,
         data=data,
         metadata=metadata,
+        tool_call_id=tool_call_id,
     )
 
 

--- a/python/nemo_relay/typed.py
+++ b/python/nemo_relay/typed.py
@@ -475,6 +475,7 @@ async def tool_execute(
     attributes: int | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
+    tool_call_id: str | None = None,
 ) -> ToolExecutionResult[TResult]: ...
 
 
@@ -490,6 +491,7 @@ async def tool_execute(
     attributes: int | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
+    tool_call_id: str | None = None,
 ) -> ToolExecutionResult[TResult]: ...
 
 
@@ -504,6 +506,7 @@ async def tool_execute(
     attributes: int | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
+    tool_call_id: str | None = None,
 ) -> ToolExecutionResult[TResult]:
     """Run ``nemo_relay.tools.execute`` with typed arguments and results.
 
@@ -520,6 +523,8 @@ async def tool_execute(
         attributes: Optional native tool attributes attached to the start event.
         data: Optional JSON payload recorded on the emitted start event.
         metadata: Optional JSON metadata recorded on the emitted start event.
+        tool_call_id: Optional provider-specific tool call identifier recorded
+            on the emitted start and end events.
 
     Returns:
         ToolExecutionResult[TResult]: The decoded typed result and its opaque
@@ -574,6 +579,7 @@ async def tool_execute(
         attributes=attributes,
         data=data,
         metadata=metadata,
+        tool_call_id=tool_call_id,
     )
     return ToolExecutionResult(result_codec.from_json(json_result.result), json_result.annotation)
 

--- a/python/tests/integrations/deepagents_tests/test_deepagents_integration.py
+++ b/python/tests/integrations/deepagents_tests/test_deepagents_integration.py
@@ -327,6 +327,7 @@ def test_tool_call_routes_through_langchain_execution_middleware(
     assert kwargs["name"] == "lookup"
     assert kwargs["args"] == {"query": "original"}
     assert kwargs["handle"] is parent_handle
+    assert kwargs["tool_call_id"] == "call-1"
 
 
 def test_skill_load_mark_survives_deepagents_middleware(

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -435,6 +435,7 @@ def test_wrap_tool_call_routes_through_tool_execute(
     assert kwargs["name"] == "lookup"
     assert kwargs["args"] == {"query": "original"}
     assert kwargs["handle"] is parent_handle
+    assert kwargs["tool_call_id"] == "call-1"
     assert isinstance(kwargs["args_codec"], nemo_relay.typed.BestEffortAnyCodec)
     assert isinstance(kwargs["result_codec"], nemo_relay.typed.BestEffortAnyCodec)
 
@@ -462,6 +463,7 @@ def test_awrap_tool_call_routes_through_tool_execute(
     assert kwargs["name"] == "lookup"
     assert kwargs["args"] == {"query": "original"}
     assert kwargs["handle"] is parent_handle
+    assert kwargs["tool_call_id"] == "call-1"
     assert isinstance(kwargs["args_codec"], nemo_relay.typed.BestEffortAnyCodec)
     assert isinstance(kwargs["result_codec"], nemo_relay.typed.BestEffortAnyCodec)
 

--- a/python/tests/test_tools.py
+++ b/python/tests/test_tools.py
@@ -245,10 +245,10 @@ class TestToolsAsync:
             if isinstance(event, ScopeEvent) and event.name == "managed_tool_call_id"
         ]
         assert [event.scope_category for event in lifecycle] == ["start", "end"]
-        assert [event.category_profile for event in lifecycle] == [
-            {"tool_call_id": "managed-call-123"},
-            {"tool_call_id": "managed-call-123"},
-        ]
+        assert all(
+            event.category_profile is not None and event.category_profile.get("tool_call_id") == "managed-call-123"
+            for event in lifecycle
+        )
 
     async def test_execute_failure_emits_end_event(self):
         events = []
@@ -274,7 +274,10 @@ class TestToolsAsync:
         assert all(isinstance(event, ScopeEvent) for event in events)
         assert [e.scope_category for e in events] == ["start", "end"]
         assert all(e.category == "tool" for e in events)
-        assert all(e.category_profile == {"tool_call_id": "managed-failure-123"} for e in events)
+        assert all(
+            event.category_profile is not None and event.category_profile.get("tool_call_id") == "managed-failure-123"
+            for event in events
+        )
         assert events[0].uuid == events[1].uuid
         assert events[1].data is None
         assert events[1].metadata["error.type"] == "internal_error"
@@ -642,7 +645,10 @@ class TestToolInterceptsAsync:
         assert provider_calls == []
         lifecycle = [event for event in events if isinstance(event, ScopeEvent) and event.name == "cancel_tool"]
         assert [event.scope_category for event in lifecycle] == ["start", "end"]
-        assert all(event.category_profile == {"tool_call_id": "managed-cancel-123"} for event in lifecycle)
+        assert all(
+            event.category_profile is not None and event.category_profile.get("tool_call_id") == "managed-cancel-123"
+            for event in lifecycle
+        )
 
     async def test_sync_middleware_preserves_async_caller_context(self):
         request_id = contextvars.ContextVar("tool_middleware_request_id", default="registration")

--- a/python/tests/test_tools.py
+++ b/python/tests/test_tools.py
@@ -229,6 +229,27 @@ class TestToolsAsync:
         )
         assert result.result["key"] == "value"
 
+    async def test_execute_propagates_tool_call_id_to_lifecycle(self, subscribed_events: list[Event]):
+        result = await tools.execute(
+            "managed_tool_call_id",
+            {"value": 1},
+            lambda args: ToolExecutionResult(args),
+            tool_call_id="managed-call-123",
+        )
+        assert result.result == {"value": 1}
+
+        await subscribers.flush_async()
+        lifecycle = [
+            event
+            for event in subscribed_events
+            if isinstance(event, ScopeEvent) and event.name == "managed_tool_call_id"
+        ]
+        assert [event.scope_category for event in lifecycle] == ["start", "end"]
+        assert [event.category_profile for event in lifecycle] == [
+            {"tool_call_id": "managed-call-123"},
+            {"tool_call_id": "managed-call-123"},
+        ]
+
     async def test_execute_failure_emits_end_event(self):
         events = []
         subscribers.register("py_tool_exec_failure_sub", lambda e: events.append(e))
@@ -237,7 +258,12 @@ class TestToolsAsync:
             raise ValueError("boom")
 
         with pytest.raises(RuntimeError, match="boom"):
-            await tools.execute("failing_tool", {"x": 1}, failing)
+            await tools.execute(
+                "failing_tool",
+                {"x": 1},
+                failing,
+                tool_call_id="managed-failure-123",
+            )
 
         try:
             await subscribers.flush_async()
@@ -248,6 +274,7 @@ class TestToolsAsync:
         assert all(isinstance(event, ScopeEvent) for event in events)
         assert [e.scope_category for e in events] == ["start", "end"]
         assert all(e.category == "tool" for e in events)
+        assert all(e.category_profile == {"tool_call_id": "managed-failure-123"} for e in events)
         assert events[0].uuid == events[1].uuid
         assert events[1].data is None
         assert events[1].metadata["error.type"] == "internal_error"
@@ -593,7 +620,14 @@ class TestToolInterceptsAsync:
         intercepts.register_tool_execution("py_tool_cancel_intercept", 1, middleware)
         subscribers.register("py_tool_cancel_events", events.append)
         try:
-            execution = asyncio.ensure_future(tools.execute("cancel_tool", {"ok": True}, provider))
+            execution = asyncio.ensure_future(
+                tools.execute(
+                    "cancel_tool",
+                    {"ok": True},
+                    provider,
+                    tool_call_id="managed-cancel-123",
+                )
+            )
             await asyncio.wait_for(started.wait(), timeout=1)
             execution.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -606,10 +640,9 @@ class TestToolInterceptsAsync:
             subscribers.deregister("py_tool_cancel_events")
 
         assert provider_calls == []
-        lifecycle = [
-            event.scope_category for event in events if isinstance(event, ScopeEvent) and event.name == "cancel_tool"
-        ]
-        assert lifecycle == ["start", "end"]
+        lifecycle = [event for event in events if isinstance(event, ScopeEvent) and event.name == "cancel_tool"]
+        assert [event.scope_category for event in lifecycle] == ["start", "end"]
+        assert all(event.category_profile == {"tool_call_id": "managed-cancel-123"} for event in lifecycle)
 
     async def test_sync_middleware_preserves_async_caller_context(self):
         request_id = contextvars.ContextVar("tool_middleware_request_id", default="registration")

--- a/python/tests/test_typed.py
+++ b/python/tests/test_typed.py
@@ -320,7 +320,10 @@ class TestTypedToolExecute:
             event for event in subscribed_events if isinstance(event, ScopeEvent) and event.name == "typed_tool_call_id"
         ]
         assert [event.scope_category for event in lifecycle] == ["start", "end"]
-        assert all(event.category_profile == {"tool_call_id": "typed-call-123"} for event in lifecycle)
+        assert all(
+            event.category_profile is not None and event.category_profile.get("tool_call_id") == "typed-call-123"
+            for event in lifecycle
+        )
 
     async def test_dataclass_add(self):
         async def add(args: DcArgs) -> ToolExecutionResult[DcResult]:

--- a/python/tests/test_typed.py
+++ b/python/tests/test_typed.py
@@ -14,9 +14,11 @@ import pytest
 from nemo_relay import (
     JsonObject,
     LLMRequest,
+    ScopeEvent,
     ToolExecutionInterceptOutcome,
     ToolExecutionResult,
     intercepts,
+    subscribers,
     typed,
 )
 from nemo_relay.typed import BestEffortAnyCodec, Codec, DataclassCodec, JsonPassthrough
@@ -301,6 +303,24 @@ class TestTypedToolExecute:
                     search_args_codec,
                     search_result_codec,
                 )
+
+    async def test_tool_call_id_reaches_managed_lifecycle(self, subscribed_events):
+        result = await typed.tool_execute(
+            "typed_tool_call_id",
+            SearchArgs(query="hello"),
+            lambda args: ToolExecutionResult(SearchResult(items=[args.query], total=1)),
+            search_args_codec,
+            search_result_codec,
+            tool_call_id="typed-call-123",
+        )
+        assert result.result == SearchResult(items=["hello"], total=1)
+
+        await subscribers.flush_async()
+        lifecycle = [
+            event for event in subscribed_events if isinstance(event, ScopeEvent) and event.name == "typed_tool_call_id"
+        ]
+        assert [event.scope_category for event in lifecycle] == ["start", "end"]
+        assert all(event.category_profile == {"tool_call_id": "typed-call-123"} for event in lifecycle)
 
     async def test_dataclass_add(self):
         async def add(args: DcArgs) -> ToolExecutionResult[DcResult]:


### PR DESCRIPTION
#### Overview

Manual tool-call lifecycle APIs can carry a provider-assigned `tool_call_id`, but managed execution could not accept one. Consequently, a framework, harness, or transport could not preserve an upstream invocation ID into Relay's managed tool Start and End lifecycle events. On current `main`, Python `tools.execute(..., tool_call_id="…")` raises `TypeError` because that parameter is absent.

This PR adds an optional external tool-call correlation ID to managed execution across Rust, Python, Node.js, C FFI, and Go. A provider, harness, or transport can now supply one stable ID at the managed execution boundary, and Relay places that ID on the matching tool Start and End events across success, callback error, and cancellation.

This closes the remaining managed-execution runtime gap in the tool-provenance direction described by #446:

- #444 supplies explicit cross-process Relay parent context.
- #575 supplies the canonical application-visible tool result and annotation contract.
- This PR supplies the external invocation ID at the managed execution boundary and forwards it through supported framework middleware.

This PR is rebased on current `main` and builds on #575. Relay continues to expose transport-neutral primitives rather than owning MCP transport or adding a protocol-specific proxy.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds optional `tool_call_id` / `toolCallId` support to managed execution in Rust, Python, and Node.js, including typed wrappers.
- Preserves the exact supplied ID on matching managed tool Start and End lifecycle events. General event sanitizers can still redact or remove it from published `category_profile` data.
- Covers success, callback failure, and cancellation with the same lifecycle UUID and external ID. Omitted IDs remain absent.
- Keeps conditional guardrail rejection before lifecycle creation, so rejected calls still emit no managed tool Start/End pair.
- Updates LangChain sync and async middleware to forward `ToolCallRequest.tool_call["id"]`; the Deep Agents integration inherits the same behavior.
- Preserves the existing C ABI entry point and adds `nemo_relay_tool_call_execute_v2(..., tool_call_id, out)` instead of changing the legacy signature.
- Makes the existing Go `WithToolCallID` option apply to `ToolCallExecute` as well as manual lifecycle calls.
- Dynamic-plugin support is intentionally unchanged: plugins do not originate managed execution, and existing subscriber event payloads already expose `category_profile.tool_call_id`. Passing or overriding it in middleware callback arguments would require a separate native ABI and `grpc-v1` protocol change.
- Documents the transport-neutral mapping for local, MCP-backed, and other remote tools: keep full result data intact, distinguish callback failures from valid error-status results, carry external Relay parent context separately, and leave transport/authentication ownership with the application.

Validation completed after rebasing:

- `just test-rust`, including the focused managed `tool_call_id` propagation regressions
- `just test-python`: 684 passed
- Focused Python tool, typed, and LangChain integration tests: 130 passed, 14 skipped
- `just test-node`: 388 passed
- Focused Node tool and typed tests: 97 passed
- `just test-go`: all packages passed
- `just docs`
- Full pre-commit validation, including Ruff, `ty`, docs links, FFI header sync, Cargo checks, Go formatting/vet, and Node formatting/docstrings. Ruff reordered one test import; the follow-up Ruff validation passed.
- `git diff --check`

#### Where should the reviewer start?

Start with `crates/core/src/api/tool.rs` and the managed lifecycle regressions in `crates/core/tests/integration/middleware_tests.rs`. They show the central behavior for success, failure, cancellation, omission, and guardrail rejection.

Then review `crates/ffi/src/api/tool_lifecycle.rs` with `crates/ffi/nemo_relay.h` for the additive C ABI decision, and `python/nemo_relay/integrations/langchain/middleware.py` for framework ID forwarding. The application/protocol responsibility boundary is documented in `docs/integrate-into-frameworks/wrap-tool-calls.mdx`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #446
- Relates to #444
- Relates to #575
- Relates to #742


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional tool-call IDs to managed tool execution across Python, Node.js, Go, and Rust integrations.
  - IDs are preserved on matching start and end events across successful, failed, rejected, and cancelled executions.
  - Added a v2 execution API for external tool-call IDs.
  - Added support for typed APIs and framework integrations.

- **Bug Fixes**
  - Preserved legacy behavior when no tool-call ID is supplied.

- **Documentation**
  - Expanded guidance for correlating provider- and framework-supplied tool calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
