### PR TITLE
test: stabilize process supervision coverage

### DIFF
--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -4067,7 +4067,8 @@ delay_after_continue = False
 
 def handle_continue(_signal, _frame):
     if delay_after_continue:
-        os.write(sys.stdout.fileno(), b"AGENT_BG_DELAY\n")
+        with open(os.environ["NEMO_RELAY_TEST_DELAY_MARKER"], "w") as marker:
+            marker.write("AGENT_BG_DELAY\n")
         time.sleep(1.5)
 
 signal.signal(signal.SIGCONT, handle_continue)
@@ -4112,6 +4113,7 @@ import termios
 import time
 
 relay, config, home, xdg, runtime = sys.argv[1:]
+delay_marker = os.path.join(runtime, "agent-bg-delay")
 pid, master = pty.fork()
 if pid == 0:
     env = os.environ.copy()
@@ -4120,6 +4122,7 @@ if pid == 0:
         "XDG_CONFIG_HOME": xdg,
         "XDG_RUNTIME_DIR": runtime,
         "NEMO_RELAY_PLUGIN_IDLE_TIMEOUT_SECS": "1",
+        "NEMO_RELAY_TEST_DELAY_MARKER": delay_marker,
         "PS1": "RELAY_SHELL> ",
         "ENV": "/dev/null",
         "BASH_ENV": "/dev/null",
@@ -4162,20 +4165,13 @@ def read_until(token, timeout=10):
         buffer.extend(chunk)
     raise AssertionError(f"did not observe {token!r}; output={buffer.decode(errors='replace')!r}")
 
-def wait_until_present(token, timeout=10):
+def wait_until_path(path, timeout=10):
     deadline = time.monotonic() + timeout
-    expected = token.encode()
     while time.monotonic() < deadline:
-        if expected in buffer:
+        if os.path.exists(path):
             return
-        ready, _, _ = select.select([master], [], [], 0.1)
-        if not ready:
-            continue
-        chunk = os.read(master, 4096)
-        if not chunk:
-            break
-        buffer.extend(chunk)
-    raise AssertionError(f"did not observe {token!r}; output={buffer.decode(errors='replace')!r}")
+        time.sleep(0.1)
+    raise AssertionError(f"did not observe marker {path!r}; output={buffer.decode(errors='replace')!r}")
 
 def safe_kill_group(process_group):
     if process_group is None or process_group <= 0 or process_group == pid:
@@ -4234,7 +4230,7 @@ try:
     os.write(master, b"\x1a")
     read_until("RELAY_SHELL> ")
     os.killpg(relay_group, signal.SIGCONT)
-    wait_until_present("AGENT_BG_DELAY")
+    wait_until_path(delay_marker)
     assert os.tcgetpgrp(master) == pid, (os.tcgetpgrp(master), pid, buffer)
     os.write(master, b"fg\n")
     os.write(master, b"third-line\n")

--- a/crates/cli/tests/coverage/shared/agent_process_tests.rs
+++ b/crates/cli/tests/coverage/shared/agent_process_tests.rs
@@ -193,7 +193,7 @@ while (-not (Test-Path -LiteralPath $args[1])) {
         .stderr(std::process::Stdio::null());
     let mut child = SupervisedChild::spawn(&mut command).await.unwrap();
 
-    let publish_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let publish_deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
     let descendant_pid = loop {
         if let Some(process_id) = read_windows_process_id(&descendant_pid_path) {
             break process_id;


### PR DESCRIPTION
#### Overview

Stabilize process-supervision coverage on Windows and Unix under loaded CI runners.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Increase the Windows PID-publication wait from 5 to 15 seconds, matching the wrapper's existing 15-second startup deadline.
- Record the Unix job-control test's background-agent delay marker in a temporary file rather than writing it to the background PTY, where terminal settings can stop the agent before the test observes the marker.

#### Where should the reviewer start?

Review the Windows-only `windows_supervision_assigns_before_a_wrapper_can_spawn_a_descendant` coverage test and the Unix-only `cli_transparent_run_preserves_interactive_terminal_job_control` test.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

#### Testing

- `cargo test -p nemo-relay-cli --test cli_tests cli_transparent_run_preserves_interactive_terminal_job_control -- --exact --nocapture`
- `cargo fmt --all`
- `just test-rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the Windows supervision test timeout to improve reliability when waiting for process information.
  * Improved Unix interactive terminal test reliability by detecting delayed process continuation through a filesystem marker rather than terminal output.
  * Enhanced test synchronization to better accommodate platform-specific timing differences and reduce intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->