### PR TITLE
feat(plugins): add typed marks and runtime diagnostics

### DIFF
--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -1763,9 +1763,10 @@ async fn restore_previous_plugin_configuration(
     .await
     {
         Ok(registrations) => {
-            store_active_plugin_configuration(
+            store_active_plugin_configuration_with_runtime_diagnostics(
                 previous_state.config,
                 previous_state.report,
+                previous_state.runtime_diagnostics,
                 registrations,
             )?;
             log::warn!(
@@ -2697,13 +2698,27 @@ fn store_active_plugin_configuration(
     report: ConfigReport,
     registrations: Vec<PluginRegistration>,
 ) -> Result<()> {
+    store_active_plugin_configuration_with_runtime_diagnostics(
+        config,
+        report,
+        BTreeMap::new(),
+        registrations,
+    )
+}
+
+fn store_active_plugin_configuration_with_runtime_diagnostics(
+    config: PluginConfig,
+    report: ConfigReport,
+    runtime_diagnostics: BTreeMap<String, RuntimeDiagnosticsSnapshotEntry>,
+    registrations: Vec<PluginRegistration>,
+) -> Result<()> {
     let mut guard = ACTIVE_PLUGIN_CONFIGURATION.lock().map_err(|err| {
         PluginError::Internal(format!("active plugin configuration lock poisoned: {err}"))
     })?;
     *guard = Some(ActivePluginConfiguration {
         config,
         report,
-        runtime_diagnostics: BTreeMap::new(),
+        runtime_diagnostics,
         registrations,
     });
     if let Ok(mut guard) = LAST_FAILED_RUNTIME_DIAGNOSTICS_REPORT.lock() {

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -10,7 +10,7 @@
 //! - rollback bookkeeping for registrations created during plugin setup
 
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::future::Future;
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -218,6 +218,16 @@ pub struct RuntimeDiagnostic {
     /// Number of failures aggregated into this entry.
     pub count: u64,
 }
+
+/// Read-only projection of runtime diagnostics exposed to dynamic plugins.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RuntimeDiagnosticsSnapshotEntry {
+    pub(crate) code: String,
+    pub(crate) message: String,
+    pub(crate) count: u64,
+}
+
+const MAX_DYNAMIC_PLUGIN_RUNTIME_DIAGNOSTICS: usize = 32;
 
 impl ConfigReport {
     /// Returns `true` when the report contains at least one error diagnostic.
@@ -1684,6 +1694,7 @@ fn install_previous_configuration_for_teardown(
     *guard = Some(ActivePluginConfiguration {
         config: previous_state.config.clone(),
         report: previous_state.report.clone(),
+        runtime_diagnostics: previous_state.runtime_diagnostics.clone(),
         registrations: Vec::new(),
     });
     Ok(())
@@ -2451,6 +2462,19 @@ pub fn record_active_plugin_runtime_diagnostic(diagnostic: RuntimeDiagnostic) {
     let Some(state) = guard.as_mut() else {
         return;
     };
+    if let Some(existing) = state.runtime_diagnostics.get_mut(&diagnostic.code) {
+        existing.message = diagnostic.message.clone();
+        existing.count = existing.count.saturating_add(diagnostic.count);
+    } else if state.runtime_diagnostics.len() < MAX_DYNAMIC_PLUGIN_RUNTIME_DIAGNOSTICS {
+        state.runtime_diagnostics.insert(
+            diagnostic.code.clone(),
+            RuntimeDiagnosticsSnapshotEntry {
+                code: diagnostic.code.clone(),
+                message: diagnostic.message.clone(),
+                count: diagnostic.count,
+            },
+        );
+    }
     if let Some(existing) = state
         .report
         .runtime_diagnostics
@@ -2467,6 +2491,19 @@ pub fn record_active_plugin_runtime_diagnostic(diagnostic: RuntimeDiagnostic) {
     } else {
         state.report.runtime_diagnostics.push(diagnostic);
     }
+}
+
+/// Return a bounded, active-only runtime-diagnostics snapshot for dynamic plugins.
+pub(crate) fn active_runtime_diagnostics_snapshot() -> Vec<RuntimeDiagnosticsSnapshotEntry> {
+    ACTIVE_PLUGIN_CONFIGURATION
+        .lock()
+        .ok()
+        .and_then(|guard| {
+            guard
+                .as_ref()
+                .map(|state| state.runtime_diagnostics.values().cloned().collect())
+        })
+        .unwrap_or_default()
 }
 
 /// Rolls back registrations in reverse order, ignoring rollback failures.
@@ -2537,6 +2574,7 @@ fn panic_payload_message(payload: Box<dyn std::any::Any + Send>) -> String {
 struct ActivePluginConfiguration {
     config: PluginConfig,
     report: ConfigReport,
+    runtime_diagnostics: BTreeMap<String, RuntimeDiagnosticsSnapshotEntry>,
     registrations: Vec<PluginRegistration>,
 }
 
@@ -2665,6 +2703,7 @@ fn store_active_plugin_configuration(
     *guard = Some(ActivePluginConfiguration {
         config,
         report,
+        runtime_diagnostics: BTreeMap::new(),
         registrations,
     });
     if let Ok(mut guard) = LAST_FAILED_RUNTIME_DIAGNOSTICS_REPORT.lock() {

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -21,7 +21,7 @@ use std::task::{Context, Poll};
 
 use futures_util::FutureExt;
 
-use crate::api::event::{Event, EventSanitizeFields};
+use crate::api::event::{DataSchema, Event, EventSanitizeFields, LogSeverity};
 use crate::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 use crate::api::runtime::{
     EventSanitizeFn, EventSubscriberFn, LlmCodecIdentity, LlmConditionalFn, LlmExecutionFn,
@@ -68,6 +68,10 @@ use nemo_relay_plugin::{
     NemoRelayNativeScopeStackBinding, NemoRelayNativeScopeType, NemoRelayNativeString,
     NemoRelayNativeToolConditionalCb, NemoRelayNativeToolExecutionCb, NemoRelayNativeToolJsonCb,
     NemoRelayNativeWithScopeStackCb, NemoRelayStatus,
+};
+#[cfg(test)]
+use nemo_relay_plugin::{
+    NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS, NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
 };
 use serde_json::{Map, Value as Json};
 use sha2::{Digest, Sha256};
@@ -399,9 +403,9 @@ fn load_one_native_plugin(
                 ))
             })?;
         let mut status = entry(native_host_api(), &mut plugin);
-        // Older SDKs reject newer tables. Negotiate through separately frozen
-        // v4, v3, and v2 tables so their struct sizes and function pointers do
-        // not change as the current ABI grows.
+        // Older SDKs reject newer tables. Negotiate from the current v4 table
+        // through separately frozen v3 and v2 tables so their struct sizes and
+        // function pointers do not change as the current ABI grows.
         if status == NemoRelayStatus::InvalidArg {
             drop_native_plugin_descriptor(&mut plugin);
             status = entry(native_host_api_v3(), &mut plugin);
@@ -919,6 +923,7 @@ fn build_native_host_api_v4() -> NemoRelayNativeHostApiV4 {
         async_llm_stream_release: native_async_llm_stream_release,
         async_completion_retain: native_async_completion_retain,
         async_stream_is_backpressured: native_async_stream_is_backpressured,
+        emit_mark_v2: native_emit_mark_v2,
     }
 }
 
@@ -1002,6 +1007,38 @@ fn optional_json_from_native_string(
         set_native_last_error(format!("{field} is not valid JSON: {err}"));
         NemoRelayStatus::InvalidJson
     })
+}
+
+fn optional_typed_json_from_native_string<T: serde::de::DeserializeOwned>(
+    value: *const NemoRelayNativeString,
+    field: &str,
+) -> Result<Option<T>, NemoRelayStatus> {
+    optional_json_from_native_string(value, field)?
+        .map(|value| {
+            serde_json::from_value(value).map_err(|err| {
+                set_native_last_error(format!("{field} has an invalid shape: {err}"));
+                NemoRelayStatus::InvalidArg
+            })
+        })
+        .transpose()
+}
+
+fn optional_severity_from_native_string(
+    value: *const NemoRelayNativeString,
+) -> Result<Option<LogSeverity>, NemoRelayStatus> {
+    if value.is_null() {
+        return Ok(None);
+    }
+    let value = read_native_string(value).map_err(|err| {
+        set_native_last_error(err.to_string());
+        NemoRelayStatus::InvalidUtf8
+    })?;
+    serde_json::from_value(Json::String(value))
+        .map(Some)
+        .map_err(|err| {
+            set_native_last_error(format!("mark severity is invalid: {err}"));
+            NemoRelayStatus::InvalidArg
+        })
 }
 
 fn optional_timestamp_from_native(
@@ -1191,6 +1228,61 @@ unsafe extern "C" fn native_emit_mark(
             .parent_opt(parent_ref)
             .data_opt(data)
             .metadata_opt(metadata)
+            .timestamp_opt(timestamp)
+            .build(),
+    ) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(err) => status_from_flow_error(err),
+    }
+}
+
+#[allow(clippy::too_many_arguments)] // Mirrors the append-only native ABI function.
+unsafe extern "C" fn native_emit_mark_v2(
+    name: *const NemoRelayNativeString,
+    parent: *const NemoRelayNativeScopeHandle,
+    data_json: *const NemoRelayNativeString,
+    metadata_json: *const NemoRelayNativeString,
+    data_schema_json: *const NemoRelayNativeString,
+    severity: *const NemoRelayNativeString,
+    timestamp_unix_micros: *const i64,
+) -> NemoRelayStatus {
+    clear_native_last_error();
+    let name = match read_name(name) {
+        Ok(name) => name,
+        Err(status) => return status,
+    };
+    let data = match optional_json_from_native_string(data_json, "mark data") {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let metadata = match optional_json_from_native_string(metadata_json, "mark metadata") {
+        Ok(metadata) => metadata,
+        Err(status) => return status,
+    };
+    let data_schema = match optional_typed_json_from_native_string::<DataSchema>(
+        data_schema_json,
+        "mark data schema",
+    ) {
+        Ok(data_schema) => data_schema,
+        Err(status) => return status,
+    };
+    let severity = match optional_severity_from_native_string(severity) {
+        Ok(severity) => severity,
+        Err(status) => return status,
+    };
+    let timestamp = match optional_timestamp_from_native(timestamp_unix_micros) {
+        Ok(timestamp) => timestamp,
+        Err(status) => return status,
+    };
+    let parent_ref = native_scope_ref(parent);
+    match emit_scope_mark(
+        EmitMarkEventParams::builder()
+            .name(&name)
+            .parent_opt(parent_ref)
+            .data_opt(data)
+            .metadata_opt(metadata)
+            .data_schema_opt(data_schema)
+            .severity_opt(severity)
             .timestamp_opt(timestamp)
             .build(),
     ) {

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -1294,8 +1294,11 @@ unsafe extern "C" fn native_get_runtime_diagnostics(
 ) -> NemoRelayStatus {
     clear_native_last_error();
     let diagnostics = active_runtime_diagnostics_snapshot();
-    match serde_json::to_value(serde_json::json!({"entries": diagnostics})) {
-        Ok(value) => write_native_json(&value, out_json),
+    match serde_json::to_value(diagnostics) {
+        Ok(entries) => {
+            let value = Json::Object(Map::from_iter([("entries".into(), entries)]));
+            write_native_json(&value, out_json)
+        }
         Err(error) => {
             set_native_last_error(format!("failed to serialize runtime diagnostics: {error}"));
             NemoRelayStatus::Internal

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -70,11 +70,6 @@ use nemo_relay_plugin::{
     NemoRelayNativeToolConditionalCb, NemoRelayNativeToolExecutionCb, NemoRelayNativeToolJsonCb,
     NemoRelayNativeWithScopeStackCb, NemoRelayStatus,
 };
-#[cfg(test)]
-use nemo_relay_plugin::{
-    NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS, NEMO_RELAY_NATIVE_ABI_VERSION_RUNTIME_DIAGNOSTICS,
-    NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
-};
 use serde_json::{Map, Value as Json};
 use sha2::{Digest, Sha256};
 use tokio::runtime::Runtime;

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -45,7 +45,8 @@ use crate::codec::traits::{LlmCodec, LlmResponseCodec};
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
     ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
-    deregister_plugin_registration_checked, register_plugin_tracked,
+    active_runtime_diagnostics_snapshot, deregister_plugin_registration_checked,
+    register_plugin_tracked,
 };
 use chrono::{DateTime, Utc};
 use libloading::{Library, Symbol};
@@ -71,7 +72,8 @@ use nemo_relay_plugin::{
 };
 #[cfg(test)]
 use nemo_relay_plugin::{
-    NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS, NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
+    NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS, NEMO_RELAY_NATIVE_ABI_VERSION_RUNTIME_DIAGNOSTICS,
+    NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
 };
 use serde_json::{Map, Value as Json};
 use sha2::{Digest, Sha256};
@@ -924,6 +926,7 @@ fn build_native_host_api_v4() -> NemoRelayNativeHostApiV4 {
         async_completion_retain: native_async_completion_retain,
         async_stream_is_backpressured: native_async_stream_is_backpressured,
         emit_mark_v2: native_emit_mark_v2,
+        get_runtime_diagnostics: native_get_runtime_diagnostics,
     }
 }
 
@@ -1288,6 +1291,20 @@ unsafe extern "C" fn native_emit_mark_v2(
     ) {
         Ok(()) => NemoRelayStatus::Ok,
         Err(err) => status_from_flow_error(err),
+    }
+}
+
+unsafe extern "C" fn native_get_runtime_diagnostics(
+    out_json: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    clear_native_last_error();
+    let diagnostics = active_runtime_diagnostics_snapshot();
+    match serde_json::to_value(serde_json::json!({"entries": diagnostics})) {
+        Ok(value) => write_native_json(&value, out_json),
+        Err(error) => {
+            set_native_last_error(format!("failed to serialize runtime diagnostics: {error}"));
+            NemoRelayStatus::Internal
+        }
     }
 }
 

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -61,7 +61,7 @@ use tokio_stream::wrappers::UnixListenerStream;
 #[cfg(unix)]
 use tower::service_fn;
 
-use crate::api::event::{Event, EventSanitizeFields};
+use crate::api::event::{DataSchema, Event, EventSanitizeFields, LogSeverity};
 use crate::api::llm::{LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA, LlmRequest};
 use crate::api::runtime::subscriber_dispatcher::{
     PublicationBuffer, capture_nested_publication_buffer, with_nested_publication_buffer,
@@ -91,6 +91,7 @@ use super::{
 };
 
 const JSON_SCHEMA: &str = "nemo.relay.Json@1";
+const DATA_SCHEMA_SCHEMA: &str = "nemo.relay.DataSchema@1";
 const EVENT_SCHEMA: &str = "nemo.relay.Event@1";
 const LLM_REQUEST_SCHEMA: &str = "nemo.relay.LlmRequest@1";
 const WORKER_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
@@ -2473,15 +2474,31 @@ impl RelayHostRuntime for WorkerHostRuntimeService {
         &self,
         request: Request<EmitMarkRequest>,
     ) -> Result<Response<HostAck>, Status> {
-        let request = request.into_inner();
-        self.state
-            .authorize(&request.activation_id, &request.auth_token)?;
-        let result = self.with_stack(request.scope.as_ref(), || {
+        let EmitMarkRequest {
+            activation_id,
+            auth_token,
+            scope,
+            name,
+            data,
+            metadata,
+            data_schema,
+            severity,
+        } = request.into_inner();
+        self.state.authorize(&activation_id, &auth_token)?;
+        let data_schema = optional_typed_envelope::<DataSchema>(
+            data_schema,
+            "mark data_schema",
+            DATA_SCHEMA_SCHEMA,
+        );
+        let severity = optional_log_severity(&severity);
+        let result = self.with_stack(scope.as_ref(), || {
             emit_scope_mark(
                 EmitMarkEventParams::builder()
-                    .name(&request.name)
-                    .data_opt(optional_envelope_to_json(request.data)?)
-                    .metadata_opt(optional_envelope_to_json(request.metadata)?)
+                    .name(&name)
+                    .data_opt(optional_envelope_to_json(data)?)
+                    .metadata_opt(optional_envelope_to_json(metadata)?)
+                    .data_schema_opt(data_schema?)
+                    .severity_opt(severity?)
                     .build(),
             )
         });
@@ -3031,6 +3048,35 @@ fn optional_envelope_to_json(value: Option<JsonEnvelope>) -> FlowResult<Option<J
                 .map_err(|err| FlowError::Internal(format!("invalid JSON envelope: {err}")))
         })
         .transpose()
+}
+
+fn optional_typed_envelope<T: serde::de::DeserializeOwned>(
+    value: Option<JsonEnvelope>,
+    field: &str,
+    expected_schema: &str,
+) -> FlowResult<Option<T>> {
+    value
+        .map(|value| {
+            if value.schema != expected_schema {
+                return Err(FlowError::InvalidArgument(format!(
+                    "{field} has schema {:?}; expected {expected_schema:?}",
+                    value.schema
+                )));
+            }
+            decode_json_envelope::<T>(&value).map_err(|err| {
+                FlowError::InvalidArgument(format!("{field} has an invalid value: {err}"))
+            })
+        })
+        .transpose()
+}
+
+fn optional_log_severity(value: &str) -> FlowResult<Option<LogSeverity>> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_value(Json::String(value.to_owned()))
+        .map(Some)
+        .map_err(|err| FlowError::InvalidArgument(format!("mark severity is invalid: {err}")))
 }
 
 fn host_ack(result: FlowResult<()>) -> HostAck {

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -20,14 +20,16 @@ use nemo_relay_worker_proto::v1::relay_host_runtime_server::{
 };
 use nemo_relay_worker_proto::v1::{
     CancelInvocationRequest, CreateScopeStackRequest, CreateScopeStackResponse,
-    DropScopeStackRequest, EmitMarkRequest, GuardrailResult, HandshakeRequest, HandshakeResponse,
+    DropScopeStackRequest, EmitMarkRequest, GetRuntimeDiagnosticsRequest,
+    GetRuntimeDiagnosticsResponse, GuardrailResult, HandshakeRequest, HandshakeResponse,
     HealthRequest, HostAck, InvokeRequest, InvokeResponse, JsonEnvelope, JsonResult,
     LlmCodecDecodeRequest, LlmCodecDecodeResponse, LlmCodecEncodeRequest,
     LlmCodecIdentity as ProtoLlmCodecIdentity, LlmCodecKind, LlmInvocation, LlmNextRequest,
     LlmSanitizeRequestContext as ProtoLlmSanitizeRequestContext,
     LlmSanitizeResponseContext as ProtoLlmSanitizeResponseContext, LlmStreamNextRequest,
     PopScopeRequest, PushScopeRequest, PushScopeResponse, RegisterRequest, RegisterResponse,
-    Registration, RegistrationSurface, ScopeContext, ShutdownRequest, StreamChunk,
+    Registration, RegistrationSurface, RuntimeDiagnostic as ProtoRuntimeDiagnostic, ScopeContext,
+    ShutdownRequest, StreamChunk,
     ToolExecutionInterceptOutcome as ProtoToolExecutionInterceptOutcome,
     ToolExecutionResult as ProtoToolExecutionResult, ToolExecutionResultResponse, ToolInvocation,
     ToolNextRequest, ValidateRequest, WorkerError,
@@ -81,7 +83,8 @@ use crate::codec::traits::{LlmCodec, LlmResponseCodec};
 use crate::error::{FlowError, Result as FlowResult};
 use crate::plugin::{
     ConfigDiagnostic, DiagnosticLevel, Plugin, PluginError, PluginRegistrationContext,
-    deregister_plugin_registration_checked, register_plugin_tracked,
+    active_runtime_diagnostics_snapshot, deregister_plugin_registration_checked,
+    register_plugin_tracked,
 };
 
 use super::{
@@ -2503,6 +2506,25 @@ impl RelayHostRuntime for WorkerHostRuntimeService {
             )
         });
         Ok(Response::new(host_ack(result)))
+    }
+
+    async fn get_runtime_diagnostics(
+        &self,
+        request: Request<GetRuntimeDiagnosticsRequest>,
+    ) -> Result<Response<GetRuntimeDiagnosticsResponse>, Status> {
+        let request = request.into_inner();
+        self.state
+            .authorize(&request.activation_id, &request.auth_token)?;
+        Ok(Response::new(GetRuntimeDiagnosticsResponse {
+            entries: active_runtime_diagnostics_snapshot()
+                .into_iter()
+                .map(|diagnostic| ProtoRuntimeDiagnostic {
+                    code: diagnostic.code,
+                    message: diagnostic.message,
+                    count: diagnostic.count,
+                })
+                .collect(),
+        }))
     }
 
     async fn push_scope(

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -8,15 +8,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use futures::StreamExt;
 use nemo_relay_plugin::{
     CategoryProfile, ConfigDiagnostic, DiagnosticLevel, Event, EventCategory, EventSanitizeFields,
-    Json, LlmJsonAsyncStream, LlmRequest, LlmRequestInterceptOutcome, NativeExecutorConfig,
-    NativePlugin,
-    NemoRelayNativeAsyncCallbackState, NemoRelayNativeAsyncMiddlewareCb,
-    NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeAsyncNext, NemoRelayNativeAsyncStream,
-    NemoRelayNativeHostApiV1, NemoRelayNativeHostApiV3, NemoRelayNativePluginContext,
-    NemoRelayNativePluginV1, NemoRelayNativeString, NemoRelayNativeToolNextFn, NemoRelayStatus,
-    NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY, PendingMarkSpec, PluginContext, PluginRuntime,
-    ScopeCategory, ScopeType,
-    ToolExecutionInterceptOutcome,
+    Json, LlmJsonAsyncStream, LlmRequest, LlmRequestInterceptOutcome, MetricKind,
+    MetricMeasurement, MetricValueType, NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE,
+    NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY, NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
+    NativeExecutorConfig, NativePlugin, NemoRelayNativeAsyncCallbackState,
+    NemoRelayNativeAsyncMiddlewareCb, NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeAsyncNext,
+    NemoRelayNativeAsyncStream, NemoRelayNativeHostApiV1, NemoRelayNativeHostApiV3,
+    NemoRelayNativeHostApiV4, NemoRelayNativePluginContext, NemoRelayNativePluginV1,
+    NemoRelayNativeString, NemoRelayNativeToolNextFn, NemoRelayStatus, PendingMarkSpec,
+    PluginContext, PluginRuntime, ScopeCategory, ScopeType, ToolExecutionInterceptOutcome,
 };
 use serde_json::{Map, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -155,10 +155,8 @@ impl NativePlugin for FixtureNativePlugin {
                         .unwrap_or(false)
                     {
                         let first_next = next.clone();
-                        let (first, second) = tokio::join!(
-                            first_next.call(args.clone()),
-                            next.call(args),
-                        );
+                        let (first, second) =
+                            tokio::join!(first_next.call(args.clone()), next.call(args),);
                         let result = first?;
                         second?;
                         result
@@ -304,6 +302,18 @@ fn emit_runtime_events(runtime: &PluginRuntime) -> nemo_relay_plugin::Result<()>
         Some(&Json::String("current".into())),
         None,
     )?;
+    runtime.emit_metric(
+        "fixture.native.metric",
+        vec![
+            MetricMeasurement::builder()
+                .name("fixture.native.count")
+                .kind(MetricKind::Counter)
+                .value_type(MetricValueType::U64)
+                .value(json!(1))
+                .build(),
+        ],
+        None,
+    )?;
     let scope = runtime.push_scope(
         "fixture.native.scope",
         ScopeType::Custom,
@@ -367,6 +377,114 @@ fn mark_json(mut value: Json, key: &str) -> Json {
 }
 
 nemo_relay_plugin::nemo_relay_plugin!(nemo_relay_fixture_native_plugin, || FixtureNativePlugin);
+
+unsafe extern "C" fn fixture_compat_register(
+    _user_data: *mut c_void,
+    _plugin_config_json: *const NemoRelayNativeString,
+    _ctx: *mut NemoRelayNativePluginContext,
+) -> NemoRelayStatus {
+    NemoRelayStatus::Ok
+}
+
+/// Raw ABI-v3 entry used to verify host fallback for already-built plugins.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_fixture_native_plugin_v3(
+    host: *const NemoRelayNativeHostApiV1,
+    out: *mut NemoRelayNativePluginV1,
+) -> NemoRelayStatus {
+    if host.is_null() || out.is_null() {
+        return NemoRelayStatus::NullPointer;
+    }
+    let host = unsafe { &*host };
+    if host.abi_version != NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE {
+        return NemoRelayStatus::InvalidArg;
+    }
+    let kind = b"fixture_native_v3";
+    let mut plugin_kind = ptr::null_mut();
+    let status = unsafe { (host.string_new)(kind.as_ptr(), kind.len(), &mut plugin_kind) };
+    if status != NemoRelayStatus::Ok {
+        return status;
+    }
+    unsafe {
+        *out = NemoRelayNativePluginV1 {
+            struct_size: std::mem::size_of::<NemoRelayNativePluginV1>(),
+            plugin_kind,
+            allows_multiple_components: false,
+            user_data: ptr::null_mut(),
+            validate: None,
+            register: Some(fixture_compat_register),
+            drop: None,
+        };
+    }
+    NemoRelayStatus::Ok
+}
+
+/// Raw ABI-v2 entry used to verify host fallback for already-built plugins.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_fixture_native_plugin_v2(
+    host: *const NemoRelayNativeHostApiV1,
+    out: *mut NemoRelayNativePluginV1,
+) -> NemoRelayStatus {
+    unsafe {
+        fixture_compat_entry(
+            host,
+            out,
+            NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY,
+            std::mem::size_of::<NemoRelayNativeHostApiV1>(),
+            b"fixture_native_v2",
+        )
+    }
+}
+
+/// Raw ABI-v4 entry used to verify the current table is append-only.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_fixture_native_plugin_v4(
+    host: *const NemoRelayNativeHostApiV1,
+    out: *mut NemoRelayNativePluginV1,
+) -> NemoRelayStatus {
+    unsafe {
+        fixture_compat_entry(
+            host,
+            out,
+            NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
+            std::mem::offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2),
+            b"fixture_native_v4",
+        )
+    }
+}
+
+unsafe fn fixture_compat_entry(
+    host: *const NemoRelayNativeHostApiV1,
+    out: *mut NemoRelayNativePluginV1,
+    expected_version: u32,
+    minimum_size: usize,
+    kind: &[u8],
+) -> NemoRelayStatus {
+    if host.is_null() || out.is_null() {
+        return NemoRelayStatus::NullPointer;
+    }
+    let host = unsafe { &*host };
+    if host.abi_version != expected_version || host.struct_size < minimum_size {
+        return NemoRelayStatus::InvalidArg;
+    }
+    let mut plugin_kind = ptr::null_mut();
+    let status = unsafe { (host.string_new)(kind.as_ptr(), kind.len(), &mut plugin_kind) };
+    if status != NemoRelayStatus::Ok {
+        return status;
+    }
+    unsafe {
+        *out = NemoRelayNativePluginV1 {
+            struct_size: std::mem::size_of::<NemoRelayNativePluginV1>(),
+            plugin_kind,
+            allows_multiple_components: false,
+            user_data: ptr::null_mut(),
+            validate: None,
+            register: Some(fixture_compat_register),
+            drop: None,
+        };
+    }
+    NemoRelayStatus::Ok
+}
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nemo_relay_fixture_async_entry(

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -9,8 +9,8 @@ use futures::StreamExt;
 use nemo_relay_plugin::{
     CategoryProfile, ConfigDiagnostic, DiagnosticLevel, Event, EventCategory, EventSanitizeFields,
     Json, LlmJsonAsyncStream, LlmRequest, LlmRequestInterceptOutcome, MetricKind,
-    MetricMeasurement, MetricValueType, NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE,
-    NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY, NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
+    MetricMeasurement, MetricValueType, NEMO_RELAY_NATIVE_ABI_VERSION,
+    NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE, NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY,
     NativeExecutorConfig, NativePlugin, NemoRelayNativeAsyncCallbackState,
     NemoRelayNativeAsyncMiddlewareCb, NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeAsyncNext,
     NemoRelayNativeAsyncStream, NemoRelayNativeHostApiV1, NemoRelayNativeHostApiV3,
@@ -436,7 +436,7 @@ pub unsafe extern "C" fn nemo_relay_fixture_native_plugin_v2(
     }
 }
 
-/// Raw ABI-v4 entry used to verify the current table is append-only.
+/// Raw ABI-v4 entry used to verify the final current table.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nemo_relay_fixture_native_plugin_v4(
     host: *const NemoRelayNativeHostApiV1,
@@ -446,8 +446,8 @@ pub unsafe extern "C" fn nemo_relay_fixture_native_plugin_v4(
         fixture_compat_entry(
             host,
             out,
-            NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
-            std::mem::offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2),
+            NEMO_RELAY_NATIVE_ABI_VERSION,
+            std::mem::size_of::<NemoRelayNativeHostApiV4>(),
             b"fixture_native_v4",
         )
     }

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -392,31 +392,15 @@ pub unsafe extern "C" fn nemo_relay_fixture_native_plugin_v3(
     host: *const NemoRelayNativeHostApiV1,
     out: *mut NemoRelayNativePluginV1,
 ) -> NemoRelayStatus {
-    if host.is_null() || out.is_null() {
-        return NemoRelayStatus::NullPointer;
-    }
-    let host = unsafe { &*host };
-    if host.abi_version != NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE {
-        return NemoRelayStatus::InvalidArg;
-    }
-    let kind = b"fixture_native_v3";
-    let mut plugin_kind = ptr::null_mut();
-    let status = unsafe { (host.string_new)(kind.as_ptr(), kind.len(), &mut plugin_kind) };
-    if status != NemoRelayStatus::Ok {
-        return status;
-    }
     unsafe {
-        *out = NemoRelayNativePluginV1 {
-            struct_size: std::mem::size_of::<NemoRelayNativePluginV1>(),
-            plugin_kind,
-            allows_multiple_components: false,
-            user_data: ptr::null_mut(),
-            validate: None,
-            register: Some(fixture_compat_register),
-            drop: None,
-        };
+        fixture_compat_entry(
+            host,
+            out,
+            NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE,
+            std::mem::size_of::<NemoRelayNativeHostApiV3>(),
+            b"fixture_native_v3",
+        )
     }
-    NemoRelayStatus::Ok
 }
 
 /// Raw ABI-v2 entry used to verify host fallback for already-built plugins.

--- a/crates/core/tests/fixtures/worker_plugin/src/main.rs
+++ b/crates/core/tests/fixtures/worker_plugin/src/main.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nemo_relay_worker::{
-    ConfigDiagnostic, DiagnosticLevel, EventSanitizeFields, Json, LlmRequest, PendingMarkSpec,
+    ConfigDiagnostic, DiagnosticLevel, EventSanitizeFields, Json, LlmRequest,
+    METRIC_DATA_SCHEMA_NAME, MetricKind, MetricMeasurement, MetricValueType, PendingMarkSpec,
 };
 use nemo_relay_worker::{
     JsonStream, LlmNext, LlmStreamNext, PluginContext, ScopeType, ToolExecutionInterceptOutcome,
@@ -67,9 +68,16 @@ impl WorkerPlugin for FixtureWorkerPlugin {
         ctx.register_mark_sanitize_guardrail(
             "fixture_mark_sanitize_data",
             1,
-            |_, mut fields| async move {
-                fields.data = Some(json!({"worker_plugin_mark_data": true}));
-                Ok(fields)
+            |event, mut fields| {
+                let is_metric = event
+                    .data_schema()
+                    .is_some_and(|schema| schema.name == METRIC_DATA_SCHEMA_NAME);
+                async move {
+                    if !is_metric {
+                        fields.data = Some(json!({"worker_plugin_mark_data": true}));
+                    }
+                    Ok(fields)
+                }
             },
         );
         let nested_publication_runtime = runtime.clone();
@@ -107,6 +115,7 @@ impl WorkerPlugin for FixtureWorkerPlugin {
             fixture_flag(config, "block_tool"),
             fixture_flag(config, "tool_request_error"),
             fixture_flag(config, "exit_in_tool_request"),
+            fixture_flag(config, "emit_tokenomics_metric"),
         );
         register_fixture_llm_hooks(
             ctx,
@@ -153,6 +162,7 @@ fn register_fixture_tool_hooks(
     block_tool: bool,
     tool_request_error: bool,
     exit_in_tool_request: bool,
+    emit_tokenomics_metric: bool,
 ) {
     ctx.register_tool_sanitize_request_guardrail(
         "fixture_tool_sanitize_request",
@@ -188,7 +198,26 @@ fn register_fixture_tool_hooks(
                     "fixture tool request error requested".into(),
                 ));
             }
-            emit_runtime_events(runtime).await?;
+            if emit_tokenomics_metric {
+                runtime
+                    .emit_metric(
+                        "tokenomics.measurements",
+                        vec![MetricMeasurement {
+                            name: "example.tokens.saved".into(),
+                            kind: MetricKind::Counter,
+                            value_type: MetricValueType::U64,
+                            value: json!(42),
+                            unit: Some("{token}".into()),
+                            description: Some("Tokens avoided".into()),
+                            attributes: Some(json!({"model": "example-model"})),
+                            boundaries: None,
+                        }],
+                        None,
+                    )
+                    .await?;
+            } else {
+                emit_runtime_events(runtime).await?;
+            }
             Ok(mark_json(args, "worker_plugin"))
         }
     });

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -293,6 +293,16 @@ async fn sdk_cdylib_registers_tool_request_intercept() {
             .unwrap()["native_plugin_mark"],
         true
     );
+    let metric = find_event(&first_events, "fixture.native.metric", None);
+    assert_eq!(
+        metric.data_schema().expect("native metric schema").name,
+        "nemo.relay.metric_measurements"
+    );
+    assert_eq!(
+        metric.data_schema().expect("native metric schema").version,
+        "1"
+    );
+    assert_eq!(metric.data().unwrap()["measurements"][0]["value"], 1);
     assert_parent(
         &first_events,
         "fixture.native.scope",
@@ -1129,6 +1139,48 @@ fn native_loader_resolves_manifest_directory_and_relative_library_paths() {
     }])
     .expect("native plugin should load from manifest directory");
     activation.clear();
+}
+
+#[test]
+fn native_loader_falls_back_to_abi_v3_plugins() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.blocking_lock();
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest_text(ManifestOptions {
+        manifest_dir: fixture.manifest_dir.path(),
+        plugin_id: "fixture_native_v3",
+        relay: &format!("={}", env!("CARGO_PKG_VERSION")),
+        library: &fixture.library_path.to_string_lossy(),
+        symbol: "nemo_relay_fixture_native_plugin_v3",
+        integrity: None,
+    });
+
+    let activation = load_native_plugins([load_spec("fixture_native_v3", &manifest_ref)])
+        .expect("ABI-v3 fixture should load through compatibility fallback");
+    activation.clear();
+}
+
+#[test]
+fn native_loader_supports_current_v4_and_legacy_v2_plugins() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.blocking_lock();
+    let fixture = build_fixture_plugin();
+
+    for (plugin_id, symbol) in [
+        ("fixture_native_v4", "nemo_relay_fixture_native_plugin_v4"),
+        ("fixture_native_v2", "nemo_relay_fixture_native_plugin_v2"),
+    ] {
+        let manifest_ref = write_manifest_text(ManifestOptions {
+            manifest_dir: fixture.manifest_dir.path(),
+            plugin_id,
+            relay: &format!("={}", env!("CARGO_PKG_VERSION")),
+            library: &fixture.library_path.to_string_lossy(),
+            symbol,
+            integrity: None,
+        });
+
+        let activation = load_native_plugins([load_spec(plugin_id, &manifest_ref)])
+            .unwrap_or_else(|error| panic!("ABI compatibility fixture should load: {error}"));
+        activation.clear();
+    }
 }
 
 #[test]

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -302,7 +302,11 @@ async fn sdk_cdylib_registers_tool_request_intercept() {
         metric.data_schema().expect("native metric schema").version,
         "1"
     );
-    assert_eq!(metric.data().unwrap()["measurements"][0]["value"], 1);
+    let measurement = &metric.data().unwrap()["measurements"][0];
+    assert_eq!(measurement["name"], "fixture.native.count");
+    assert_eq!(measurement["kind"], "counter");
+    assert_eq!(measurement["value_type"], "u64");
+    assert_eq!(measurement["value"], 1);
     assert_parent(
         &first_events,
         "fixture.native.scope",

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -23,6 +23,10 @@ use nemo_relay::api::tool::{
 use nemo_relay::codec::request::AnnotatedLlmRequest;
 use nemo_relay::codec::traits::LlmCodec;
 use nemo_relay::error::Result as FlowResult;
+use nemo_relay::observability::otel_logs::{OpenTelemetryLogConfig, OpenTelemetryLogSubscriber};
+use nemo_relay::observability::otel_metrics::{
+    OpenTelemetryMetricConfig, OpenTelemetryMetricSubscriber,
+};
 use nemo_relay::plugin::dynamic::{
     DynamicPluginActivationSpec, DynamicPluginKind, PluginHostActivation, WorkerPluginActivation,
     WorkerPluginLoadSpec, load_worker_plugins,
@@ -31,6 +35,8 @@ use nemo_relay::plugin::{
     PluginComponentSpec, PluginConfig, clear_plugin_configuration, initialize_plugins_exact,
     list_plugin_kinds,
 };
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use prost::Message;
 use serde_json::{Map, Value as Json, json};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
@@ -41,6 +47,67 @@ static WORKER_PLUGIN_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::con
 fn enable_operational_logs() {
     let _ = spdlog::init_log_crate_proxy();
     log::set_max_level(log::LevelFilter::Info);
+}
+
+struct CapturedOtlpRequest {
+    path: String,
+    body: Vec<u8>,
+}
+
+fn capture_one_otlp_request(
+    listener: std::net::TcpListener,
+) -> std::sync::mpsc::Receiver<CapturedOtlpRequest> {
+    use std::io::{Read, Write};
+
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("collector should accept request");
+        let mut bytes = Vec::new();
+        let mut buffer = [0_u8; 4_096];
+        let (header_end, content_length) = loop {
+            let count = stream.read(&mut buffer).expect("collector should read");
+            assert!(count > 0, "collector closed before request headers");
+            bytes.extend_from_slice(&buffer[..count]);
+            if let Some(offset) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                let header_end = offset + 4;
+                let headers = String::from_utf8_lossy(&bytes[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                break (header_end, content_length);
+            }
+        };
+        while bytes.len() < header_end + content_length {
+            let count = stream
+                .read(&mut buffer)
+                .expect("collector should read body");
+            assert!(count > 0, "collector closed before request body");
+            bytes.extend_from_slice(&buffer[..count]);
+        }
+        let headers = String::from_utf8_lossy(&bytes[..header_end]);
+        let path = headers
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .expect("request path")
+            .to_string();
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            .expect("collector should respond");
+        sender
+            .send(CapturedOtlpRequest {
+                path,
+                body: bytes[header_end..header_end + content_length].to_vec(),
+            })
+            .expect("capture receiver should remain available");
+    });
+    receiver
 }
 
 #[test]
@@ -375,6 +442,63 @@ async fn rust_worker_registers_and_invokes_all_current_surfaces() {
         stream_value["request"]["worker_plugin_llm_stream_execution_request"],
         true
     );
+
+    loaded.clear();
+}
+
+#[tokio::test]
+async fn rust_worker_tokenomics_metric_reaches_metrics_only() {
+    let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
+    let loaded = load_and_initialize_fixture(Map::from_iter([(
+        "emit_tokenomics_metric".into(),
+        json!(true),
+    )]))
+    .await;
+
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("metric capture listener should bind");
+    let metric_endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let metric_request = capture_one_otlp_request(listener);
+    let metric_subscriber = OpenTelemetryMetricSubscriber::new(
+        OpenTelemetryMetricConfig::new(metric_endpoint)
+            .with_instrumentation_scope("worker-tokenomics-metric-test"),
+    )
+    .expect("metric subscriber should build");
+    let log_subscriber =
+        OpenTelemetryLogSubscriber::new(OpenTelemetryLogConfig::new("http://127.0.0.1:9/v1/logs"))
+            .expect("log subscriber should build without connecting");
+    let metric_name = "worker_tokenomics_metric_metrics";
+    let log_name = "worker_tokenomics_metric_logs";
+    metric_subscriber.register(metric_name).unwrap();
+    log_subscriber.register(log_name).unwrap();
+
+    let rewritten = tool_request_intercepts("tokenomics_meter", json!({"input": true}))
+        .await
+        .expect("worker metric callback should complete");
+    assert_eq!(rewritten["worker_plugin"], true);
+
+    metric_subscriber.deregister(metric_name).unwrap();
+    log_subscriber.deregister(log_name).unwrap();
+    log_subscriber
+        .shutdown()
+        .expect("metric mark must not be reinterpreted as an OTLP log");
+    metric_subscriber
+        .shutdown()
+        .expect("metric provider should export its final collection");
+
+    let request = metric_request
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("worker metric should reach the local OTLP collector");
+    assert_eq!(request.path, "/v1/metrics");
+    let metrics = ExportMetricsServiceRequest::decode(request.body.as_slice()).unwrap();
+    let names = metrics
+        .resource_metrics
+        .iter()
+        .flat_map(|resource| &resource.scope_metrics)
+        .flat_map(|scope| &scope.metrics)
+        .map(|metric| metric.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["example.tokens.saved"]);
 
     loaded.clear();
 }

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -1926,6 +1926,8 @@ async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
             scope: None,
             data: None,
             metadata: None,
+            data_schema: None,
+            severity: String::new(),
         }))
         .await
         .expect_err("bad activation id should fail auth");
@@ -1942,6 +1944,8 @@ async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
             }),
             data: None,
             metadata: None,
+            data_schema: None,
+            severity: String::new(),
         }))
         .await
         .expect("missing stack should return host ack")
@@ -1962,11 +1966,74 @@ async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
             scope: None,
             data: None,
             metadata: None,
+            data_schema: None,
+            severity: String::new(),
         }))
         .await
         .expect("no-scope mark should succeed")
         .into_inner();
     assert!(ack.ok);
+
+    let ack = service
+        .emit_mark(Request::new(EmitMarkRequest {
+            activation_id: ACTIVATION_ID.into(),
+            auth_token: AUTH_TOKEN.into(),
+            name: "telemetry-options".into(),
+            scope: None,
+            data: Some(json_envelope("nemo.relay.Json@1", &json!({"measurements": []})).unwrap()),
+            metadata: None,
+            data_schema: Some(
+                json_envelope(
+                    "nemo.relay.DataSchema@1",
+                    &json!({
+                        "name": "nemo.relay.metric_measurements",
+                        "version": "1"
+                    }),
+                )
+                .unwrap(),
+            ),
+            severity: "warning".into(),
+        }))
+        .await
+        .expect("typed mark options should return host ack")
+        .into_inner();
+    assert!(ack.ok, "{:?}", ack.error);
+
+    for request in [
+        EmitMarkRequest {
+            activation_id: ACTIVATION_ID.into(),
+            auth_token: AUTH_TOKEN.into(),
+            name: "bad-schema".into(),
+            data_schema: Some(
+                json_envelope(
+                    "nemo.relay.DataSchema@1",
+                    &json!({"name": 7, "version": "1"}),
+                )
+                .unwrap(),
+            ),
+            ..EmitMarkRequest::default()
+        },
+        EmitMarkRequest {
+            activation_id: ACTIVATION_ID.into(),
+            auth_token: AUTH_TOKEN.into(),
+            name: "bad-severity".into(),
+            severity: "fatal".into(),
+            ..EmitMarkRequest::default()
+        },
+    ] {
+        let ack = service
+            .emit_mark(Request::new(request))
+            .await
+            .expect("invalid mark options should return host ack")
+            .into_inner();
+        assert!(!ack.ok);
+        assert!(
+            ack.error
+                .expect("invalid mark error")
+                .message
+                .contains("invalid argument")
+        );
+    }
 
     let push = service
         .push_scope(Request::new(PushScopeRequest {

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -23,11 +23,11 @@ use nemo_relay_worker_proto::v1::plugin_worker_server::{PluginWorker, PluginWork
 use nemo_relay_worker_proto::v1::stream_chunk::Item as StreamItem;
 use nemo_relay_worker_proto::v1::{
     CancelInvocationRequest, CreateScopeStackRequest, DropScopeStackRequest, EmitMarkRequest,
-    EmptyResult, GuardrailResult, HandshakeRequest, HandshakeResponse, HealthRequest,
-    HealthResponse, JsonEnvelope, JsonResult, JsonValue, LlmCodecDecodeRequest,
-    LlmCodecDecodeResponse, LlmCodecEncodeRequest, LlmNextRequest, LlmRequestInterceptResult,
-    LlmStreamNextRequest, PopScopeRequest, PushScopeRequest, Registration, ScopeContext,
-    ScopeType as ProtoScopeType, ShutdownRequest, StreamChunk,
+    EmptyResult, GetRuntimeDiagnosticsRequest, GuardrailResult, HandshakeRequest,
+    HandshakeResponse, HealthRequest, HealthResponse, JsonEnvelope, JsonResult, JsonValue,
+    LlmCodecDecodeRequest, LlmCodecDecodeResponse, LlmCodecEncodeRequest, LlmNextRequest,
+    LlmRequestInterceptResult, LlmStreamNextRequest, PopScopeRequest, PushScopeRequest,
+    Registration, ScopeContext, ScopeType as ProtoScopeType, ShutdownRequest, StreamChunk,
     ToolExecutionInterceptOutcome as ProtoToolExecutionInterceptOutcome,
     ToolExecutionInterceptResult, ToolExecutionResultResponse, ToolNextRequest, ValidateRequest,
     ValidateResponse, WorkerAck,
@@ -1917,6 +1917,24 @@ async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
     let service = WorkerHostRuntimeService {
         state: state.clone(),
     };
+
+    let diagnostics_auth_error = service
+        .get_runtime_diagnostics(Request::new(GetRuntimeDiagnosticsRequest {
+            activation_id: "wrong".into(),
+            auth_token: AUTH_TOKEN.into(),
+        }))
+        .await
+        .expect_err("bad activation id should fail diagnostics auth");
+    assert_eq!(diagnostics_auth_error.code(), tonic::Code::PermissionDenied);
+    let diagnostics = service
+        .get_runtime_diagnostics(Request::new(GetRuntimeDiagnosticsRequest {
+            activation_id: ACTIVATION_ID.into(),
+            auth_token: AUTH_TOKEN.into(),
+        }))
+        .await
+        .expect("diagnostics request should succeed")
+        .into_inner();
+    assert!(diagnostics.entries.len() <= 32);
 
     let auth_error = service
         .emit_mark(Request::new(EmitMarkRequest {

--- a/crates/core/tests/unit/native_plugin_tests.rs
+++ b/crates/core/tests/unit/native_plugin_tests.rs
@@ -642,18 +642,6 @@ fn assert_native_host_api_versions() {
         unsafe { (*current).abi_version },
         NEMO_RELAY_NATIVE_ABI_VERSION
     );
-    assert_eq!(
-        unsafe { (*current).abi_version },
-        NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC
-    );
-    assert_eq!(
-        unsafe { (*current).abi_version },
-        NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS
-    );
-    assert_eq!(
-        unsafe { (*current).abi_version },
-        NEMO_RELAY_NATIVE_ABI_VERSION_RUNTIME_DIAGNOSTICS
-    );
     assert_eq!(unsafe { (*frozen_v3).abi_version }, 3);
     assert_eq!(
         unsafe { (*legacy).abi_version },

--- a/crates/core/tests/unit/native_plugin_tests.rs
+++ b/crates/core/tests/unit/native_plugin_tests.rs
@@ -650,6 +650,10 @@ fn assert_native_host_api_versions() {
         unsafe { (*current).abi_version },
         NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS
     );
+    assert_eq!(
+        unsafe { (*current).abi_version },
+        NEMO_RELAY_NATIVE_ABI_VERSION_RUNTIME_DIAGNOSTICS
+    );
     assert_eq!(unsafe { (*frozen_v3).abi_version }, 3);
     assert_eq!(
         unsafe { (*legacy).abi_version },
@@ -670,21 +674,29 @@ fn assert_native_host_api_versions() {
     #[cfg(target_pointer_width = "64")]
     {
         assert_eq!(std::mem::align_of::<NemoRelayNativeHostApiV4>(), 8);
-        assert_eq!(std::mem::size_of::<NemoRelayNativeHostApiV4>(), 520);
+        assert_eq!(std::mem::size_of::<NemoRelayNativeHostApiV4>(), 528);
         assert_eq!(std::mem::offset_of!(NemoRelayNativeHostApiV4, v3), 0);
         assert_eq!(
             std::mem::offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2),
             512
         );
+        assert_eq!(
+            std::mem::offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics),
+            520
+        );
     }
     #[cfg(target_pointer_width = "32")]
     {
         assert_eq!(std::mem::align_of::<NemoRelayNativeHostApiV4>(), 4);
-        assert_eq!(std::mem::size_of::<NemoRelayNativeHostApiV4>(), 256);
+        assert_eq!(std::mem::size_of::<NemoRelayNativeHostApiV4>(), 260);
         assert_eq!(std::mem::offset_of!(NemoRelayNativeHostApiV4, v3), 0);
         assert_eq!(
             std::mem::offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2),
             252
+        );
+        assert_eq!(
+            std::mem::offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics),
+            256
         );
     }
 }

--- a/crates/core/tests/unit/native_plugin_tests.rs
+++ b/crates/core/tests/unit/native_plugin_tests.rs
@@ -638,12 +638,55 @@ fn assert_native_host_api_versions() {
     assert!(!current.is_null());
     assert!(!frozen_v3.is_null());
     assert!(!legacy.is_null());
-    assert_eq!(unsafe { (*current).abi_version }, 4);
+    assert_eq!(
+        unsafe { (*current).abi_version },
+        NEMO_RELAY_NATIVE_ABI_VERSION
+    );
+    assert_eq!(
+        unsafe { (*current).abi_version },
+        NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC
+    );
+    assert_eq!(
+        unsafe { (*current).abi_version },
+        NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS
+    );
     assert_eq!(unsafe { (*frozen_v3).abi_version }, 3);
     assert_eq!(
         unsafe { (*legacy).abi_version },
         NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY
     );
+    assert_eq!(
+        unsafe { (*current).struct_size },
+        std::mem::size_of::<NemoRelayNativeHostApiV4>()
+    );
+    assert_eq!(
+        unsafe { (*frozen_v3).struct_size },
+        std::mem::size_of::<NemoRelayNativeHostApiV3>()
+    );
+    assert_eq!(
+        unsafe { (*legacy).struct_size },
+        std::mem::size_of::<NemoRelayNativeHostApiV1>()
+    );
+    #[cfg(target_pointer_width = "64")]
+    {
+        assert_eq!(std::mem::align_of::<NemoRelayNativeHostApiV4>(), 8);
+        assert_eq!(std::mem::size_of::<NemoRelayNativeHostApiV4>(), 520);
+        assert_eq!(std::mem::offset_of!(NemoRelayNativeHostApiV4, v3), 0);
+        assert_eq!(
+            std::mem::offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2),
+            512
+        );
+    }
+    #[cfg(target_pointer_width = "32")]
+    {
+        assert_eq!(std::mem::align_of::<NemoRelayNativeHostApiV4>(), 4);
+        assert_eq!(std::mem::size_of::<NemoRelayNativeHostApiV4>(), 256);
+        assert_eq!(std::mem::offset_of!(NemoRelayNativeHostApiV4, v3), 0);
+        assert_eq!(
+            std::mem::offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2),
+            252
+        );
+    }
 }
 
 #[tokio::test]
@@ -4315,6 +4358,38 @@ fn assert_native_scope_pop_and_mark_validation(
         },
         NemoRelayStatus::InvalidArg
     );
+    let malformed_schema = native_string(r#"{"name":7,"version":"1"}"#);
+    assert_eq!(
+        unsafe {
+            native_emit_mark_v2(
+                strings.mark_name,
+                scope,
+                ptr::null(),
+                ptr::null(),
+                malformed_schema,
+                ptr::null(),
+                ptr::null(),
+            )
+        },
+        NemoRelayStatus::InvalidArg
+    );
+    unsafe { native_string_free(malformed_schema) };
+    let invalid_severity = native_string("fatal");
+    assert_eq!(
+        unsafe {
+            native_emit_mark_v2(
+                strings.mark_name,
+                scope,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                invalid_severity,
+                ptr::null(),
+            )
+        },
+        NemoRelayStatus::InvalidArg
+    );
+    unsafe { native_string_free(invalid_severity) };
     assert_eq!(
         unsafe { native_scope_pop(ptr::null(), ptr::null(), ptr::null(), ptr::null()) },
         NemoRelayStatus::NullPointer

--- a/crates/core/tests/unit/native_plugin_tests.rs
+++ b/crates/core/tests/unit/native_plugin_tests.rs
@@ -4396,6 +4396,20 @@ fn assert_native_scope_pop_and_mark_validation(
     );
 }
 
+#[test]
+fn native_runtime_diagnostics_callback_returns_owned_json() {
+    let mut out = std::ptr::null_mut();
+    assert_eq!(
+        unsafe { native_get_runtime_diagnostics(&mut out) },
+        NemoRelayStatus::Ok
+    );
+    assert!(!out.is_null());
+
+    let value: Json = serde_json::from_str(&read_native_string(out).unwrap()).unwrap();
+    assert!(value["entries"].is_array());
+    unsafe { native_string_free(out) };
+}
+
 fn assert_native_scope_stack_binding_lifecycle() {
     let mut binding = ptr::null_mut();
     assert_eq!(

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -1735,6 +1735,96 @@ fn test_teardown_runtime_diagnostics_remain_in_the_plugin_report() {
 }
 
 #[test]
+fn dynamic_plugin_runtime_diagnostics_are_active_only_and_aggregated_by_code() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    store_active_plugin_configuration(PluginConfig::default(), ConfigReport::default(), vec![])
+        .unwrap();
+
+    for diagnostic in [
+        RuntimeDiagnostic {
+            code: "zeta".into(),
+            component: "observability".into(),
+            field: None,
+            message: "first zeta".into(),
+            session_id: None,
+            count: 2,
+        },
+        RuntimeDiagnostic {
+            code: "alpha".into(),
+            component: "observability".into(),
+            field: Some("logs[0]".into()),
+            message: "alpha".into(),
+            session_id: None,
+            count: 1,
+        },
+        RuntimeDiagnostic {
+            code: "zeta".into(),
+            component: "observability".into(),
+            field: Some("metrics[0]".into()),
+            message: "latest zeta".into(),
+            session_id: None,
+            count: u64::MAX,
+        },
+    ] {
+        record_active_plugin_runtime_diagnostic(diagnostic);
+    }
+
+    let diagnostics = active_runtime_diagnostics_snapshot();
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| (
+                diagnostic.code.as_str(),
+                diagnostic.message.as_str(),
+                diagnostic.count
+            ))
+            .collect::<Vec<_>>(),
+        vec![("alpha", "alpha", 1), ("zeta", "latest zeta", u64::MAX)]
+    );
+
+    clear_plugin_configuration_inner();
+    assert!(active_runtime_diagnostics_snapshot().is_empty());
+    reset_global();
+}
+
+#[test]
+fn dynamic_plugin_runtime_diagnostics_snapshot_is_bounded() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    store_active_plugin_configuration(PluginConfig::default(), ConfigReport::default(), vec![])
+        .unwrap();
+
+    for index in 0..=MAX_DYNAMIC_PLUGIN_RUNTIME_DIAGNOSTICS {
+        record_active_plugin_runtime_diagnostic(RuntimeDiagnostic {
+            code: format!("diagnostic.{index:02}"),
+            component: "observability".into(),
+            field: None,
+            message: "runtime diagnostic".into(),
+            session_id: None,
+            count: 1,
+        });
+    }
+
+    let diagnostics = active_runtime_diagnostics_snapshot();
+    assert_eq!(diagnostics.len(), MAX_DYNAMIC_PLUGIN_RUNTIME_DIAGNOSTICS);
+    assert_eq!(
+        diagnostics
+            .first()
+            .map(|diagnostic| diagnostic.code.as_str()),
+        Some("diagnostic.00")
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "diagnostic.32")
+    );
+
+    clear_plugin_configuration_inner();
+    reset_global();
+}
+
+#[test]
 fn test_opentelemetry_delivery_failure_allows_later_plugin_configuration() {
     let _guard = lock_runtime_owner();
     reset_global();

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -1406,6 +1406,13 @@ fn test_initialize_plugins_restores_previous_configuration_after_failed_replacem
     let restored_report = active_plugin_report().expect("previous config should be restored");
     assert!(restored_report.diagnostics.is_empty());
     assert_eq!(restored_report.runtime_diagnostics.len(), 1);
+    let restored = &restored_report.runtime_diagnostics[0];
+    assert_eq!(restored.code, "atif.remote_delivery_failed");
+    assert_eq!(restored.component, "observability");
+    assert_eq!(restored.field.as_deref(), Some("storage[0]"));
+    assert_eq!(restored.message, "HTTP 500");
+    assert_eq!(restored.session_id.as_deref(), Some("session-123"));
+    assert_eq!(restored.count, 1);
     let diagnostics = active_runtime_diagnostics_snapshot();
     assert_eq!(diagnostics.len(), 1);
     assert_eq!(diagnostics[0].code, "atif.remote_delivery_failed");

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -1380,6 +1380,14 @@ fn test_initialize_plugins_restores_previous_configuration_after_failed_replacem
             ..PluginConfig::default()
         }))
         .unwrap();
+    record_active_plugin_runtime_diagnostic(RuntimeDiagnostic {
+        code: "atif.remote_delivery_failed".into(),
+        component: "observability".into(),
+        field: Some("storage[0]".into()),
+        message: "HTTP 500".into(),
+        session_id: Some("session-123".into()),
+        count: 1,
+    });
 
     let err = runtime
         .block_on(initialize_plugins_exact(PluginConfig {
@@ -1397,6 +1405,12 @@ fn test_initialize_plugins_restores_previous_configuration_after_failed_replacem
     assert_eq!(RESTORE_FAIL_REGISTRATIONS.load(Ordering::SeqCst), 1);
     let restored_report = active_plugin_report().expect("previous config should be restored");
     assert!(restored_report.diagnostics.is_empty());
+    assert_eq!(restored_report.runtime_diagnostics.len(), 1);
+    let diagnostics = active_runtime_diagnostics_snapshot();
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, "atif.remote_delivery_failed");
+    assert_eq!(diagnostics[0].message, "HTTP 500");
+    assert_eq!(diagnostics[0].count, 1);
     let names = recorded_names().lock().unwrap().clone();
     assert_eq!(
         names,

--- a/crates/plugin/src/async_sdk.rs
+++ b/crates/plugin/src/async_sdk.rs
@@ -147,7 +147,7 @@ impl Drop for NativeExecutor {
 }
 
 #[derive(Clone, Copy)]
-struct HostV4(NemoRelayNativeHostApiV4);
+struct HostV4(NemoRelayNativeHostApiV4TypedAsync);
 
 unsafe impl Send for HostV4 {}
 unsafe impl Sync for HostV4 {}
@@ -1053,12 +1053,12 @@ impl CodecIdentityInvocation {
 impl PluginContext<'_> {
     fn host_v4(&self) -> Result<HostV4> {
         if self.host.abi_version < NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC
-            || self.host.struct_size < std::mem::size_of::<NemoRelayNativeHostApiV4>()
+            || self.host.struct_size < NEMO_RELAY_NATIVE_HOST_API_V4_TYPED_ASYNC_SIZE
         {
             return Err("typed async native middleware requires Relay ABI v4".into());
         }
         Ok(HostV4(unsafe {
-            *(self.host as *const _ as *const NemoRelayNativeHostApiV4)
+            *(self.host as *const _ as *const NemoRelayNativeHostApiV4TypedAsync)
         }))
     }
 

--- a/crates/plugin/src/async_sdk.rs
+++ b/crates/plugin/src/async_sdk.rs
@@ -147,7 +147,7 @@ impl Drop for NativeExecutor {
 }
 
 #[derive(Clone, Copy)]
-struct HostV4(NemoRelayNativeHostApiV4TypedAsync);
+struct HostV4(NemoRelayNativeHostApiV4);
 
 unsafe impl Send for HostV4 {}
 unsafe impl Sync for HostV4 {}
@@ -1052,13 +1052,13 @@ impl CodecIdentityInvocation {
 
 impl PluginContext<'_> {
     fn host_v4(&self) -> Result<HostV4> {
-        if self.host.abi_version < NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC
-            || self.host.struct_size < NEMO_RELAY_NATIVE_HOST_API_V4_TYPED_ASYNC_SIZE
+        if self.host.abi_version < NEMO_RELAY_NATIVE_ABI_VERSION
+            || self.host.struct_size < std::mem::size_of::<NemoRelayNativeHostApiV4>()
         {
             return Err("typed async native middleware requires Relay ABI v4".into());
         }
         Ok(HostV4(unsafe {
-            *(self.host as *const _ as *const NemoRelayNativeHostApiV4TypedAsync)
+            *(self.host as *const _ as *const NemoRelayNativeHostApiV4)
         }))
     }
 

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -21,8 +21,9 @@ use std::sync::{Arc, Mutex};
 
 pub use nemo_relay_types::Json;
 pub use nemo_relay_types::api::event::{
-    CategoryProfile, DataSchema, Event, EventCategory, EventSanitizeFields, PendingMarkSpec,
-    ScopeCategory,
+    CategoryProfile, DataSchema, Event, EventCategory, EventSanitizeFields, LogSeverity,
+    METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION, MetricEnvelope, MetricKind,
+    MetricMeasurement, MetricValueType, PendingMarkSpec, ScopeCategory,
 };
 pub use nemo_relay_types::api::llm::{LlmAttributes, LlmRequest, LlmRequestInterceptOutcome};
 pub use nemo_relay_types::api::scope::{HandleAttributes, ScopeAttributes, ScopeType};
@@ -45,14 +46,16 @@ use serde_json::Map;
 
 /// Native plugin ABI version supported by this crate.
 ///
-/// Version 4 adds completion-scoped codecs and pull-based LLM streams. Hosts
-/// retain frozen version-3 and version-2 tables for Relay 0.8-built plugins
-/// that target those layouts.
+/// Version 4 adds completion-scoped codecs, pull-based LLM streams, and
+/// extended mark emission. Hosts retain frozen version-3 and version-2 tables
+/// for already-built plugins that target those layouts.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION: u32 = 4;
 /// ABI version that introduced completion-based asynchronous middleware.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE: u32 = 3;
 /// ABI version that introduced typed async middleware capabilities.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC: u32 = 4;
+/// ABI version that introduced data schemas and severities for emitted marks.
+pub const NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS: u32 = 4;
 
 /// Legacy native plugin ABI accepted by Relay hosts for compatibility.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY: u32 = 2;
@@ -1124,7 +1127,18 @@ pub struct NemoRelayNativeHostApiV3 {
     ) -> NemoRelayStatus,
 }
 
-/// ABI-v4 host extension for typed asynchronous native middleware.
+/// Extended native mark-emission function introduced in ABI v4.
+pub type NemoRelayNativeEmitMarkV2Fn = unsafe extern "C" fn(
+    name: *const NemoRelayNativeString,
+    parent: *const NemoRelayNativeScopeHandle,
+    data_json: *const NemoRelayNativeString,
+    metadata_json: *const NemoRelayNativeString,
+    data_schema_json: *const NemoRelayNativeString,
+    severity: *const NemoRelayNativeString,
+    timestamp_unix_micros: *const i64,
+) -> NemoRelayStatus;
+
+/// ABI-v4 host extension for typed asynchronous middleware and mark options.
 ///
 /// The complete ABI-v3 table is the prefix, preserving layout compatibility.
 #[repr(C)]
@@ -1180,6 +1194,8 @@ pub struct NemoRelayNativeHostApiV4 {
     /// rejection operation to decide whether that operation must be retried.
     pub async_stream_is_backpressured:
         unsafe extern "C" fn(stream: *const NemoRelayNativeAsyncStream) -> bool,
+    /// Emits a mark with optional data-schema and telemetry-severity fields.
+    pub emit_mark_v2: NemoRelayNativeEmitMarkV2Fn,
 }
 
 unsafe impl Send for NemoRelayNativeHostApiV3 {}
@@ -1241,12 +1257,23 @@ pub type LlmJsonStream = Box<dyn Iterator<Item = Result<Json>> + Send>;
 #[derive(Clone)]
 pub struct PluginRuntime {
     host: NemoRelayNativeHostApiV1,
+    emit_mark_v2: Option<NemoRelayNativeEmitMarkV2Fn>,
 }
 
 impl PluginRuntime {
     /// Creates a runtime handle from the host ABI table.
     pub fn new(host: &NemoRelayNativeHostApiV1) -> Self {
-        Self { host: *host }
+        let emit_mark_v2 = if host.abi_version >= NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS
+            && host.struct_size >= std::mem::size_of::<NemoRelayNativeHostApiV4>()
+        {
+            Some(unsafe { &*(host as *const _ as *const NemoRelayNativeHostApiV4) }.emit_mark_v2)
+        } else {
+            None
+        };
+        Self {
+            host: *host,
+            emit_mark_v2,
+        }
     }
 
     /// Returns the underlying host ABI table.
@@ -1305,6 +1332,53 @@ impl PluginRuntime {
         metadata: Option<&Json>,
     ) -> Result<()> {
         emit_mark(&self.host, name, data, metadata)
+    }
+
+    /// Emits a mark event with an optional data schema and telemetry severity.
+    ///
+    /// Hosts without the ABI-v4 mark extension accept this call only when both
+    /// new options are absent, in which case the legacy function is used.
+    pub fn emit_mark_with_options(
+        &self,
+        name: &str,
+        data: Option<&Json>,
+        metadata: Option<&Json>,
+        data_schema: Option<&DataSchema>,
+        severity: Option<LogSeverity>,
+    ) -> Result<()> {
+        match self.emit_mark_v2 {
+            Some(emit_mark_v2) => emit_mark_v2_call(
+                &self.host,
+                emit_mark_v2,
+                name,
+                data,
+                metadata,
+                data_schema,
+                severity,
+            ),
+            None if data_schema.is_none() && severity.is_none() => {
+                emit_mark(&self.host, name, data, metadata)
+            }
+            None => Err("mark data_schema and severity require native host ABI v4".into()),
+        }
+    }
+
+    /// Emits a validated Relay metric-measurement mark under the current scope.
+    pub fn emit_metric(
+        &self,
+        name: &str,
+        measurements: Vec<MetricMeasurement>,
+        metadata: Option<&Json>,
+    ) -> Result<()> {
+        let envelope = MetricEnvelope { measurements };
+        envelope.validate().map_err(|err| err.to_string())?;
+        let data = serde_json::to_value(envelope)
+            .map_err(|err| format!("failed to serialize metric mark: {err}"))?;
+        let data_schema = DataSchema::builder()
+            .name(METRIC_DATA_SCHEMA_NAME)
+            .version(METRIC_DATA_SCHEMA_VERSION)
+            .build();
+        self.emit_mark_with_options(name, Some(&data), metadata, Some(&data_schema), None)
     }
 
     /// Creates a new independent scope stack.
@@ -1777,6 +1851,65 @@ pub fn emit_mark(
         Ok(())
     } else {
         Err(format!("emit_mark failed: {status:?}"))
+    }
+}
+
+#[allow(clippy::too_many_arguments)] // Mirrors the append-only native ABI function.
+fn emit_mark_v2_call(
+    host: &NemoRelayNativeHostApiV1,
+    emit_mark_v2: NemoRelayNativeEmitMarkV2Fn,
+    name: &str,
+    data: Option<&Json>,
+    metadata: Option<&Json>,
+    data_schema: Option<&DataSchema>,
+    severity: Option<LogSeverity>,
+) -> Result<()> {
+    let name =
+        HostString::new(host, name).ok_or_else(|| "failed to allocate mark name".to_string())?;
+    let data = OptionalHostJson::new(host, data)?;
+    let metadata = OptionalHostJson::new(host, metadata)?;
+    let data_schema = data_schema
+        .map(|value| {
+            HostString::from_json(host, value)
+                .ok_or_else(|| "failed to serialize mark data schema".to_string())
+        })
+        .transpose()?;
+    let severity = severity
+        .map(|value| {
+            serde_json::to_value(value)
+                .map_err(|err| format!("failed to serialize mark severity: {err}"))
+                .and_then(|value| {
+                    value
+                        .as_str()
+                        .ok_or_else(|| "mark severity did not serialize as a string".to_string())
+                        .and_then(|value| {
+                            HostString::new(host, value)
+                                .ok_or_else(|| "failed to allocate mark severity".to_string())
+                        })
+                })
+        })
+        .transpose()?;
+    let status = unsafe {
+        emit_mark_v2(
+            name.as_ptr(),
+            ptr::null(),
+            data.as_ptr(),
+            metadata.as_ptr(),
+            data_schema
+                .as_ref()
+                .map(HostString::as_ptr)
+                .unwrap_or(ptr::null()),
+            severity
+                .as_ref()
+                .map(HostString::as_ptr)
+                .unwrap_or(ptr::null()),
+            ptr::null(),
+        )
+    };
+    if status == NemoRelayStatus::Ok {
+        Ok(())
+    } else {
+        Err(format!("emit_mark_v2 failed: {status:?}"))
     }
 }
 
@@ -2791,7 +2924,9 @@ where
     P: NativePlugin,
     F: FnOnce() -> P,
 {
-    if host_ref.abi_version != NEMO_RELAY_NATIVE_ABI_VERSION {
+    let supported_abi = (NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY..=NEMO_RELAY_NATIVE_ABI_VERSION)
+        .contains(&host_ref.abi_version);
+    if !supported_abi {
         return NemoRelayStatus::InvalidArg;
     }
     if host_ref.struct_size < std::mem::size_of::<NemoRelayNativeHostApiV1>() {

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -56,6 +56,8 @@ pub const NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE: u32 = 3;
 pub const NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC: u32 = 4;
 /// ABI version that introduced data schemas and severities for emitted marks.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS: u32 = 4;
+/// ABI version that introduced runtime diagnostics for dynamic plugins.
+pub const NEMO_RELAY_NATIVE_ABI_VERSION_RUNTIME_DIAGNOSTICS: u32 = 4;
 
 /// Legacy native plugin ABI accepted by Relay hosts for compatibility.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY: u32 = 2;
@@ -176,7 +178,7 @@ pub struct NemoRelayNativeLlmSanitizeResponseContext {
 
 /// Safe completion-backed request codec facade for typed native plugins.
 pub struct LlmSanitizeRequestCodec<'a> {
-    async_host: NemoRelayNativeHostApiV4,
+    async_host: NemoRelayNativeHostApiV4TypedAsync,
     completion: *const NemoRelayNativeAsyncCompletion,
     completion_release: unsafe extern "C" fn(*const NemoRelayNativeAsyncCompletion),
     _lifetime: PhantomData<&'a NemoRelayNativeLlmRequestCodec>,
@@ -233,7 +235,7 @@ impl LlmSanitizeRequestCodec<'_> {
 
 /// Safe completion-backed response codec facade for typed native plugins.
 pub struct LlmSanitizeResponseCodec<'a> {
-    async_host: NemoRelayNativeHostApiV4,
+    async_host: NemoRelayNativeHostApiV4TypedAsync,
     completion: *const NemoRelayNativeAsyncCompletion,
     completion_release: unsafe extern "C" fn(*const NemoRelayNativeAsyncCompletion),
     _lifetime: PhantomData<&'a NemoRelayNativeLlmResponseCodec>,
@@ -1138,7 +1140,11 @@ pub type NemoRelayNativeEmitMarkV2Fn = unsafe extern "C" fn(
     timestamp_unix_micros: *const i64,
 ) -> NemoRelayStatus;
 
-/// ABI-v4 host extension for typed asynchronous middleware and mark options.
+/// Reads the active host runtime-diagnostics snapshot as canonical JSON.
+pub type NemoRelayNativeGetRuntimeDiagnosticsFn =
+    unsafe extern "C" fn(out_json: *mut *mut NemoRelayNativeString) -> NemoRelayStatus;
+
+/// ABI-v4 host extension for typed asynchronous middleware, mark options, and diagnostics.
 ///
 /// The complete ABI-v3 table is the prefix, preserving layout compatibility.
 #[repr(C)]
@@ -1196,12 +1202,74 @@ pub struct NemoRelayNativeHostApiV4 {
         unsafe extern "C" fn(stream: *const NemoRelayNativeAsyncStream) -> bool,
     /// Emits a mark with optional data-schema and telemetry-severity fields.
     pub emit_mark_v2: NemoRelayNativeEmitMarkV2Fn,
+    /// Returns a bounded snapshot of active host runtime diagnostics.
+    pub get_runtime_diagnostics: NemoRelayNativeGetRuntimeDiagnosticsFn,
 }
+
+/// Frozen ABI-v4 prefix required by typed asynchronous middleware.
+///
+/// This private prefix lets newly built plugins copy the pre-diagnostics ABI-v4
+/// fields from an older v4 host without reading the appended diagnostics field.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub(crate) struct NemoRelayNativeHostApiV4TypedAsync {
+    pub(crate) v3: NemoRelayNativeHostApiV3,
+    pub(crate) async_completion_llm_request_codec_decode: unsafe extern "C" fn(
+        completion: *const NemoRelayNativeAsyncCompletion,
+        request_json: *const NemoRelayNativeString,
+        out: *mut *mut NemoRelayNativeString,
+    )
+        -> NemoRelayStatus,
+    pub(crate) async_completion_llm_request_codec_encode: unsafe extern "C" fn(
+        completion: *const NemoRelayNativeAsyncCompletion,
+        annotated_json: *const NemoRelayNativeString,
+        original_json: *const NemoRelayNativeString,
+        out: *mut *mut NemoRelayNativeString,
+    )
+        -> NemoRelayStatus,
+    pub(crate) async_completion_llm_response_codec_decode: unsafe extern "C" fn(
+        completion: *const NemoRelayNativeAsyncCompletion,
+        response_json: *const NemoRelayNativeString,
+        out: *mut *mut NemoRelayNativeString,
+    )
+        -> NemoRelayStatus,
+    pub(crate) async_next_open_llm_stream: unsafe extern "C" fn(
+        next: *const NemoRelayNativeAsyncNext,
+        request_json: *const NemoRelayNativeString,
+        cb: NemoRelayNativeAsyncLlmStreamOpenCb,
+        user_data: *mut c_void,
+    ) -> NemoRelayStatus,
+    pub(crate) async_llm_stream_pull: unsafe extern "C" fn(
+        stream: *const NemoRelayNativeLlmAsyncStream,
+        cb: NemoRelayNativeAsyncLlmStreamPullCb,
+        user_data: *mut c_void,
+    ) -> NemoRelayStatus,
+    pub(crate) async_llm_stream_cancel:
+        unsafe extern "C" fn(stream: *const NemoRelayNativeLlmAsyncStream) -> NemoRelayStatus,
+    pub(crate) async_llm_stream_release:
+        unsafe extern "C" fn(stream: *const NemoRelayNativeLlmAsyncStream),
+    pub(crate) async_completion_retain:
+        unsafe extern "C" fn(completion: *const NemoRelayNativeAsyncCompletion) -> NemoRelayStatus,
+    pub(crate) async_stream_is_backpressured:
+        unsafe extern "C" fn(stream: *const NemoRelayNativeAsyncStream) -> bool,
+}
+
+/// Bytes required for the typed asynchronous middleware portion of ABI v4.
+pub const NEMO_RELAY_NATIVE_HOST_API_V4_TYPED_ASYNC_SIZE: usize =
+    std::mem::size_of::<NemoRelayNativeHostApiV4TypedAsync>();
+/// Bytes required for the mark-options portion of ABI v4.
+pub const NEMO_RELAY_NATIVE_HOST_API_V4_MARK_OPTIONS_SIZE: usize =
+    std::mem::offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics);
+/// Bytes required for the runtime-diagnostics portion of ABI v4.
+pub const NEMO_RELAY_NATIVE_HOST_API_V4_RUNTIME_DIAGNOSTICS_SIZE: usize =
+    std::mem::size_of::<NemoRelayNativeHostApiV4>();
 
 unsafe impl Send for NemoRelayNativeHostApiV3 {}
 unsafe impl Sync for NemoRelayNativeHostApiV3 {}
 unsafe impl Send for NemoRelayNativeHostApiV4 {}
 unsafe impl Sync for NemoRelayNativeHostApiV4 {}
+unsafe impl Send for NemoRelayNativeHostApiV4TypedAsync {}
+unsafe impl Sync for NemoRelayNativeHostApiV4TypedAsync {}
 
 // The host API table is immutable after construction. Function pointers and
 // the null-terminated version string pointer are safe to share across threads.
@@ -1250,6 +1318,37 @@ pub type NemoRelayNativePluginEntry = unsafe extern "C" fn(
 /// Result type used by the Rust native plugin SDK.
 pub type Result<T> = std::result::Result<T, String>;
 
+/// One bounded runtime diagnostic reported by the Relay host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+pub struct RuntimeDiagnostic {
+    /// Stable identifier for the diagnostic condition.
+    pub code: String,
+    /// Most recently recorded message for this condition.
+    pub message: String,
+    /// Total number of occurrences recorded for this condition.
+    pub count: u64,
+}
+
+/// Bounded snapshot of active host runtime diagnostics.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, serde::Deserialize)]
+pub struct RuntimeDiagnostics {
+    entries: Vec<RuntimeDiagnostic>,
+}
+
+impl RuntimeDiagnostics {
+    /// Return diagnostics in stable code order.
+    pub fn entries(&self) -> &[RuntimeDiagnostic] {
+        &self.entries
+    }
+
+    /// Return a diagnostic by its stable code.
+    pub fn get(&self, code: &str) -> Option<&RuntimeDiagnostic> {
+        self.entries
+            .iter()
+            .find(|diagnostic| diagnostic.code == code)
+    }
+}
+
 /// Synchronous JSON chunk stream used by native LLM stream intercept helpers.
 pub type LlmJsonStream = Box<dyn Iterator<Item = Result<Json>> + Send>;
 
@@ -1258,21 +1357,34 @@ pub type LlmJsonStream = Box<dyn Iterator<Item = Result<Json>> + Send>;
 pub struct PluginRuntime {
     host: NemoRelayNativeHostApiV1,
     emit_mark_v2: Option<NemoRelayNativeEmitMarkV2Fn>,
+    get_runtime_diagnostics: Option<NemoRelayNativeGetRuntimeDiagnosticsFn>,
 }
 
 impl PluginRuntime {
     /// Creates a runtime handle from the host ABI table.
     pub fn new(host: &NemoRelayNativeHostApiV1) -> Self {
         let emit_mark_v2 = if host.abi_version >= NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS
-            && host.struct_size >= std::mem::size_of::<NemoRelayNativeHostApiV4>()
+            && host.struct_size >= NEMO_RELAY_NATIVE_HOST_API_V4_MARK_OPTIONS_SIZE
         {
             Some(unsafe { &*(host as *const _ as *const NemoRelayNativeHostApiV4) }.emit_mark_v2)
+        } else {
+            None
+        };
+        let get_runtime_diagnostics = if host.abi_version
+            >= NEMO_RELAY_NATIVE_ABI_VERSION_RUNTIME_DIAGNOSTICS
+            && host.struct_size >= NEMO_RELAY_NATIVE_HOST_API_V4_RUNTIME_DIAGNOSTICS_SIZE
+        {
+            Some(
+                unsafe { &*(host as *const _ as *const NemoRelayNativeHostApiV4) }
+                    .get_runtime_diagnostics,
+            )
         } else {
             None
         };
         Self {
             host: *host,
             emit_mark_v2,
+            get_runtime_diagnostics,
         }
     }
 
@@ -1379,6 +1491,19 @@ impl PluginRuntime {
             .version(METRIC_DATA_SCHEMA_VERSION)
             .build();
         self.emit_mark_with_options(name, Some(&data), metadata, Some(&data_schema), None)
+    }
+
+    /// Return a bounded snapshot of active host runtime diagnostics.
+    pub fn runtime_diagnostics(&self) -> Result<RuntimeDiagnostics> {
+        let Some(get_runtime_diagnostics) = self.get_runtime_diagnostics else {
+            return Err(
+                "runtime diagnostics require the native host ABI v4 diagnostics extension".into(),
+            );
+        };
+        native_json_call(&self.host, "runtime diagnostics", |out| {
+            let status = unsafe { get_runtime_diagnostics(out) };
+            codec_status(&self.host, status)
+        })
     }
 
     /// Creates a new independent scope stack.
@@ -2607,15 +2732,23 @@ fn native_codec_call<T: DeserializeOwned>(
     host: &NemoRelayNativeHostApiV1,
     call: impl FnOnce(*mut *mut NemoRelayNativeString) -> Result<()>,
 ) -> Result<T> {
+    native_json_call(host, "LLM codec operation", call)
+}
+
+fn native_json_call<T: DeserializeOwned>(
+    host: &NemoRelayNativeHostApiV1,
+    operation: &str,
+    call: impl FnOnce(*mut *mut NemoRelayNativeString) -> Result<()>,
+) -> Result<T> {
     let mut out = ptr::null_mut();
     call(&mut out)?;
     if out.is_null() {
-        return Err("LLM codec operation returned null".into());
+        return Err(format!("{operation} returned null"));
     }
     let out = HostString { host, ptr: out };
     let text = read_host_string(host, out.as_ptr())
-        .map_err(|_| "LLM codec operation returned invalid UTF-8".to_string())?;
-    serde_json::from_str(&text).map_err(|error| format!("invalid LLM codec result: {error}"))
+        .map_err(|_| format!("{operation} returned invalid UTF-8"))?;
+    serde_json::from_str(&text).map_err(|error| format!("invalid {operation} result: {error}"))
 }
 
 struct OptionalHostJson<'a>(Option<HostString<'a>>);

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -46,18 +46,12 @@ use serde_json::Map;
 
 /// Native plugin ABI version supported by this crate.
 ///
-/// Version 4 adds completion-scoped codecs, pull-based LLM streams, and
-/// extended mark emission. Hosts retain frozen version-3 and version-2 tables
-/// for already-built plugins that target those layouts.
+/// Version 4 adds completion-scoped codecs, pull-based LLM streams, extended
+/// mark emission, and runtime diagnostics. Hosts retain frozen version-3 and
+/// version-2 tables for already-built plugins that target those layouts.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION: u32 = 4;
 /// ABI version that introduced completion-based asynchronous middleware.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE: u32 = 3;
-/// ABI version that introduced typed async middleware capabilities.
-pub const NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC: u32 = 4;
-/// ABI version that introduced data schemas and severities for emitted marks.
-pub const NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS: u32 = 4;
-/// ABI version that introduced runtime diagnostics for dynamic plugins.
-pub const NEMO_RELAY_NATIVE_ABI_VERSION_RUNTIME_DIAGNOSTICS: u32 = 4;
 
 /// Legacy native plugin ABI accepted by Relay hosts for compatibility.
 pub const NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY: u32 = 2;
@@ -178,7 +172,7 @@ pub struct NemoRelayNativeLlmSanitizeResponseContext {
 
 /// Safe completion-backed request codec facade for typed native plugins.
 pub struct LlmSanitizeRequestCodec<'a> {
-    async_host: NemoRelayNativeHostApiV4TypedAsync,
+    async_host: NemoRelayNativeHostApiV4,
     completion: *const NemoRelayNativeAsyncCompletion,
     completion_release: unsafe extern "C" fn(*const NemoRelayNativeAsyncCompletion),
     _lifetime: PhantomData<&'a NemoRelayNativeLlmRequestCodec>,
@@ -235,7 +229,7 @@ impl LlmSanitizeRequestCodec<'_> {
 
 /// Safe completion-backed response codec facade for typed native plugins.
 pub struct LlmSanitizeResponseCodec<'a> {
-    async_host: NemoRelayNativeHostApiV4TypedAsync,
+    async_host: NemoRelayNativeHostApiV4,
     completion: *const NemoRelayNativeAsyncCompletion,
     completion_release: unsafe extern "C" fn(*const NemoRelayNativeAsyncCompletion),
     _lifetime: PhantomData<&'a NemoRelayNativeLlmResponseCodec>,
@@ -1206,70 +1200,10 @@ pub struct NemoRelayNativeHostApiV4 {
     pub get_runtime_diagnostics: NemoRelayNativeGetRuntimeDiagnosticsFn,
 }
 
-/// Frozen ABI-v4 prefix required by typed asynchronous middleware.
-///
-/// This private prefix lets newly built plugins copy the pre-diagnostics ABI-v4
-/// fields from an older v4 host without reading the appended diagnostics field.
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub(crate) struct NemoRelayNativeHostApiV4TypedAsync {
-    pub(crate) v3: NemoRelayNativeHostApiV3,
-    pub(crate) async_completion_llm_request_codec_decode: unsafe extern "C" fn(
-        completion: *const NemoRelayNativeAsyncCompletion,
-        request_json: *const NemoRelayNativeString,
-        out: *mut *mut NemoRelayNativeString,
-    )
-        -> NemoRelayStatus,
-    pub(crate) async_completion_llm_request_codec_encode: unsafe extern "C" fn(
-        completion: *const NemoRelayNativeAsyncCompletion,
-        annotated_json: *const NemoRelayNativeString,
-        original_json: *const NemoRelayNativeString,
-        out: *mut *mut NemoRelayNativeString,
-    )
-        -> NemoRelayStatus,
-    pub(crate) async_completion_llm_response_codec_decode: unsafe extern "C" fn(
-        completion: *const NemoRelayNativeAsyncCompletion,
-        response_json: *const NemoRelayNativeString,
-        out: *mut *mut NemoRelayNativeString,
-    )
-        -> NemoRelayStatus,
-    pub(crate) async_next_open_llm_stream: unsafe extern "C" fn(
-        next: *const NemoRelayNativeAsyncNext,
-        request_json: *const NemoRelayNativeString,
-        cb: NemoRelayNativeAsyncLlmStreamOpenCb,
-        user_data: *mut c_void,
-    ) -> NemoRelayStatus,
-    pub(crate) async_llm_stream_pull: unsafe extern "C" fn(
-        stream: *const NemoRelayNativeLlmAsyncStream,
-        cb: NemoRelayNativeAsyncLlmStreamPullCb,
-        user_data: *mut c_void,
-    ) -> NemoRelayStatus,
-    pub(crate) async_llm_stream_cancel:
-        unsafe extern "C" fn(stream: *const NemoRelayNativeLlmAsyncStream) -> NemoRelayStatus,
-    pub(crate) async_llm_stream_release:
-        unsafe extern "C" fn(stream: *const NemoRelayNativeLlmAsyncStream),
-    pub(crate) async_completion_retain:
-        unsafe extern "C" fn(completion: *const NemoRelayNativeAsyncCompletion) -> NemoRelayStatus,
-    pub(crate) async_stream_is_backpressured:
-        unsafe extern "C" fn(stream: *const NemoRelayNativeAsyncStream) -> bool,
-}
-
-/// Bytes required for the typed asynchronous middleware portion of ABI v4.
-pub const NEMO_RELAY_NATIVE_HOST_API_V4_TYPED_ASYNC_SIZE: usize =
-    std::mem::size_of::<NemoRelayNativeHostApiV4TypedAsync>();
-/// Bytes required for the mark-options portion of ABI v4.
-pub const NEMO_RELAY_NATIVE_HOST_API_V4_MARK_OPTIONS_SIZE: usize =
-    std::mem::offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics);
-/// Bytes required for the runtime-diagnostics portion of ABI v4.
-pub const NEMO_RELAY_NATIVE_HOST_API_V4_RUNTIME_DIAGNOSTICS_SIZE: usize =
-    std::mem::size_of::<NemoRelayNativeHostApiV4>();
-
 unsafe impl Send for NemoRelayNativeHostApiV3 {}
 unsafe impl Sync for NemoRelayNativeHostApiV3 {}
 unsafe impl Send for NemoRelayNativeHostApiV4 {}
 unsafe impl Sync for NemoRelayNativeHostApiV4 {}
-unsafe impl Send for NemoRelayNativeHostApiV4TypedAsync {}
-unsafe impl Sync for NemoRelayNativeHostApiV4TypedAsync {}
 
 // The host API table is immutable after construction. Function pointers and
 // the null-terminated version string pointer are safe to share across threads.
@@ -1363,28 +1297,13 @@ pub struct PluginRuntime {
 impl PluginRuntime {
     /// Creates a runtime handle from the host ABI table.
     pub fn new(host: &NemoRelayNativeHostApiV1) -> Self {
-        let emit_mark_v2 = if host.abi_version >= NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS
-            && host.struct_size >= NEMO_RELAY_NATIVE_HOST_API_V4_MARK_OPTIONS_SIZE
-        {
-            Some(unsafe { &*(host as *const _ as *const NemoRelayNativeHostApiV4) }.emit_mark_v2)
-        } else {
-            None
-        };
-        let get_runtime_diagnostics = if host.abi_version
-            >= NEMO_RELAY_NATIVE_ABI_VERSION_RUNTIME_DIAGNOSTICS
-            && host.struct_size >= NEMO_RELAY_NATIVE_HOST_API_V4_RUNTIME_DIAGNOSTICS_SIZE
-        {
-            Some(
-                unsafe { &*(host as *const _ as *const NemoRelayNativeHostApiV4) }
-                    .get_runtime_diagnostics,
-            )
-        } else {
-            None
-        };
+        let v4 = (host.abi_version >= NEMO_RELAY_NATIVE_ABI_VERSION
+            && host.struct_size >= std::mem::size_of::<NemoRelayNativeHostApiV4>())
+        .then(|| unsafe { &*(host as *const _ as *const NemoRelayNativeHostApiV4) });
         Self {
             host: *host,
-            emit_mark_v2,
-            get_runtime_diagnostics,
+            emit_mark_v2: v4.map(|host| host.emit_mark_v2),
+            get_runtime_diagnostics: v4.map(|host| host.get_runtime_diagnostics),
         }
     }
 
@@ -2779,7 +2698,7 @@ enum OwnedHostApi {
 
 impl OwnedHostApi {
     unsafe fn copy_from(host: &NemoRelayNativeHostApiV1) -> Self {
-        if host.abi_version >= NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC
+        if host.abi_version >= NEMO_RELAY_NATIVE_ABI_VERSION
             && host.struct_size >= std::mem::size_of::<NemoRelayNativeHostApiV4>()
         {
             Self::V4(unsafe { *(host as *const _ as *const NemoRelayNativeHostApiV4) })

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -461,9 +461,13 @@ fn assert_native_abi_platform_layout() {
             0, 320, 328, 336, 344, 352, 360, 368, 376, 384, 392, 400, 408, 416, 424, 432
         ]
     );
-    assert_type_layout::<NemoRelayNativeHostApiV4>(8, 520);
+    assert_type_layout::<NemoRelayNativeHostApiV4>(8, 528);
     assert_eq!(offset_of!(NemoRelayNativeHostApiV4, v3), 0);
     assert_eq!(offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2), 512);
+    assert_eq!(
+        offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics),
+        520
+    );
     assert_type_layout::<NemoRelayNativePluginV1>(8, 56);
     assert_eq!(plugin_offsets(), [0, 8, 16, 24, 32, 40, 48]);
     assert_type_layout::<NemoRelayNativeLlmStreamV1>(8, 40);
@@ -487,9 +491,13 @@ fn assert_native_abi_platform_layout() {
             0, 160, 164, 168, 172, 176, 180, 184, 188, 192, 196, 200, 204, 208, 212
         ]
     );
-    assert_type_layout::<NemoRelayNativeHostApiV4>(4, 256);
+    assert_type_layout::<NemoRelayNativeHostApiV4>(4, 260);
     assert_eq!(offset_of!(NemoRelayNativeHostApiV4, v3), 0);
     assert_eq!(offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2), 252);
+    assert_eq!(
+        offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics),
+        256
+    );
     assert_type_layout::<NemoRelayNativePluginV1>(4, 28);
     assert_eq!(plugin_offsets(), [0, 4, 8, 12, 16, 20, 24]);
     assert_type_layout::<NemoRelayNativeLlmStreamV1>(4, 20);
@@ -506,22 +514,23 @@ fn native_abi_v4_extension_is_append_only() {
     #[cfg(target_pointer_width = "64")]
     {
         assert_eq!(align_of::<NemoRelayNativeHostApiV4>(), 8);
-        assert_eq!(size_of::<NemoRelayNativeHostApiV4>(), 520);
-        assert_eq!(host_api_v4_offsets(), [0, 512]);
+        assert_eq!(size_of::<NemoRelayNativeHostApiV4>(), 528);
+        assert_eq!(host_api_v4_offsets(), [0, 512, 520]);
     }
 
     #[cfg(target_pointer_width = "32")]
     {
         assert_eq!(align_of::<NemoRelayNativeHostApiV4>(), 4);
-        assert_eq!(size_of::<NemoRelayNativeHostApiV4>(), 256);
-        assert_eq!(host_api_v4_offsets(), [0, 252]);
+        assert_eq!(size_of::<NemoRelayNativeHostApiV4>(), 260);
+        assert_eq!(host_api_v4_offsets(), [0, 252, 256]);
     }
 }
 
-fn host_api_v4_offsets() -> [usize; 2] {
+fn host_api_v4_offsets() -> [usize; 3] {
     [
         offset_of!(NemoRelayNativeHostApiV4, v3),
         offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2),
+        offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics),
     ]
 }
 
@@ -1325,6 +1334,21 @@ unsafe extern "C" fn capture_emit_mark_v2(
         !parent.is_null()
     ));
     NemoRelayStatus::Ok
+}
+
+unsafe extern "C" fn capture_runtime_diagnostics(
+    out: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    let value =
+        c"{\"entries\":[{\"code\":\"otel.example\",\"message\":\"example failure\",\"count\":3}]}";
+    unsafe { test_string_new(value.as_ptr().cast(), value.to_bytes().len(), out) }
+}
+
+unsafe extern "C" fn capture_malformed_runtime_diagnostics(
+    out: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    let value = c"{not-json";
+    unsafe { test_string_new(value.as_ptr().cast(), value.to_bytes().len(), out) }
 }
 
 unsafe extern "C" fn capture_scope_stack_create(
@@ -2133,6 +2157,7 @@ fn test_host_v4() -> NemoRelayNativeHostApiV4 {
         async_completion_retain: capture_async_completion_retain,
         async_stream_is_backpressured: capture_async_stream_backpressured,
         emit_mark_v2: capture_emit_mark_v2,
+        get_runtime_diagnostics: capture_runtime_diagnostics,
     }
 }
 
@@ -2604,6 +2629,58 @@ fn plugin_runtime_uses_v4_mark_options_extension() {
             && call.contains(r#""name":"example.mark""#)
             && call.contains("severity=warn")
     }));
+}
+
+#[test]
+fn plugin_runtime_reads_v4_runtime_diagnostics_extension() {
+    let _guard = begin_test();
+    let host = test_host_v4();
+    let diagnostics = PluginRuntime::new(&host.v3.v1)
+        .runtime_diagnostics()
+        .unwrap();
+
+    assert_eq!(diagnostics.entries().len(), 1);
+    assert_eq!(diagnostics.entries()[0].code, "otel.example");
+    assert_eq!(diagnostics.entries()[0].count, 3);
+    assert_eq!(
+        diagnostics
+            .get("otel.example")
+            .map(|diagnostic| diagnostic.message.as_str()),
+        Some("example failure")
+    );
+    assert_eq!(STRING_LIVE_COUNT.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn plugin_runtime_rejects_malformed_runtime_diagnostics_json() {
+    let _guard = begin_test();
+    let mut host = test_host_v4();
+    host.get_runtime_diagnostics = capture_malformed_runtime_diagnostics;
+
+    let error = PluginRuntime::new(&host.v3.v1)
+        .runtime_diagnostics()
+        .unwrap_err();
+    assert!(
+        error.contains("invalid runtime diagnostics result"),
+        "{error}"
+    );
+    assert_eq!(STRING_LIVE_COUNT.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn plugin_runtime_keeps_mark_options_on_a_pre_diagnostics_v4_host() {
+    let _guard = begin_test();
+    let mut host = test_host_v4();
+    host.v3.v1.struct_size = offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics);
+    let runtime = PluginRuntime::new(&host.v3.v1);
+
+    runtime
+        .emit_mark_with_options("current-v4", None, None, None, Some(LogSeverity::Info))
+        .unwrap();
+    assert_eq!(
+        runtime.runtime_diagnostics().unwrap_err(),
+        "runtime diagnostics require the native host ABI v4 diagnostics extension"
+    );
 }
 
 #[test]

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -24,13 +24,13 @@ use nemo_relay_plugin::{
     AnnotatedLlmRequest, BuiltinLlmCodec, CategoryProfile, ConfigDiagnostic, DataSchema,
     DiagnosticLevel, Event, EventCategory, EventSanitizeFields, Json, LlmCodecIdentity,
     LlmJsonAsyncStream, LlmJsonStream, LlmNext, LlmRequest, LlmRequestInterceptOutcome, LlmStream,
-    LlmStreamNext, LogSeverity, NEMO_RELAY_NATIVE_ABI_VERSION,
-    NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE, NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY,
-    NativeExecutorConfig, NativePlugin, NemoRelayNativeAsyncCallbackState,
-    NemoRelayNativeAsyncCompletion, NemoRelayNativeAsyncLlmStreamOpenCb,
-    NemoRelayNativeAsyncLlmStreamPullCb, NemoRelayNativeAsyncMiddlewareCb,
-    NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeAsyncNext, NemoRelayNativeAsyncNextResultCb,
-    NemoRelayNativeAsyncNextStreamCb, NemoRelayNativeAsyncStream,
+    LlmStreamNext, LogSeverity, MetricKind, MetricMeasurement, MetricValueType,
+    NEMO_RELAY_NATIVE_ABI_VERSION, NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE,
+    NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY, NativeExecutorConfig, NativePlugin,
+    NemoRelayNativeAsyncCallbackState, NemoRelayNativeAsyncCompletion,
+    NemoRelayNativeAsyncLlmStreamOpenCb, NemoRelayNativeAsyncLlmStreamPullCb,
+    NemoRelayNativeAsyncMiddlewareCb, NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeAsyncNext,
+    NemoRelayNativeAsyncNextResultCb, NemoRelayNativeAsyncNextStreamCb, NemoRelayNativeAsyncStream,
     NemoRelayNativeAsyncStreamMiddlewareCb, NemoRelayNativeEventSanitizeCb,
     NemoRelayNativeEventSubscriberCb, NemoRelayNativeFreeFn, NemoRelayNativeHostApiV1,
     NemoRelayNativeHostApiV3, NemoRelayNativeHostApiV4, NemoRelayNativeLlmAsyncStream,
@@ -2627,6 +2627,41 @@ fn plugin_runtime_uses_v4_mark_options_extension() {
             && call.contains("severity=warn")
     }));
     assert_eq!(STRING_LIVE_COUNT.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn plugin_runtime_emits_metrics_and_requires_v4_diagnostics() {
+    let _guard = begin_test();
+    let host = test_host_v4();
+    PluginRuntime::new(&host.v3.v1)
+        .emit_metric(
+            "example.requests",
+            vec![MetricMeasurement {
+                name: "example.requests".into(),
+                kind: MetricKind::Counter,
+                value_type: MetricValueType::U64,
+                value: json!(1),
+                unit: Some("{request}".into()),
+                description: None,
+                attributes: Some(json!({"region": "test"})),
+                boundaries: None,
+            }],
+            Some(&json!({"source": "sdk-test"})),
+        )
+        .unwrap();
+
+    assert!(RUNTIME_CALLS.lock().unwrap().iter().any(|call| {
+        call.starts_with("mark_v2:example.requests:parent=false")
+            && call.contains(r#""name":"nemo.relay.metric_measurements""#)
+            && call.contains(r#""measurements":[{"attributes":{"region":"test"}"#)
+    }));
+    assert_eq!(STRING_LIVE_COUNT.load(Ordering::SeqCst), 0);
+
+    let legacy_host = test_host();
+    let error = PluginRuntime::new(&legacy_host)
+        .runtime_diagnostics()
+        .unwrap_err();
+    assert!(error.contains("runtime diagnostics require the native host ABI v4"));
 }
 
 #[test]

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -2626,6 +2626,7 @@ fn plugin_runtime_uses_v4_mark_options_extension() {
             && call.contains(r#""name":"example.mark""#)
             && call.contains("severity=warn")
     }));
+    assert_eq!(STRING_LIVE_COUNT.load(Ordering::SeqCst), 0);
 }
 
 #[test]

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -26,7 +26,6 @@ use nemo_relay_plugin::{
     LlmJsonAsyncStream, LlmJsonStream, LlmNext, LlmRequest, LlmRequestInterceptOutcome, LlmStream,
     LlmStreamNext, LogSeverity, NEMO_RELAY_NATIVE_ABI_VERSION,
     NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE, NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY,
-    NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS, NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
     NativeExecutorConfig, NativePlugin, NemoRelayNativeAsyncCallbackState,
     NemoRelayNativeAsyncCompletion, NemoRelayNativeAsyncLlmStreamOpenCb,
     NemoRelayNativeAsyncLlmStreamPullCb, NemoRelayNativeAsyncMiddlewareCb,
@@ -425,8 +424,6 @@ static ASYNC_TOOL_NEXT_RESULT: AtomicBool = AtomicBool::new(false);
 #[test]
 fn native_abi_struct_sizes_are_self_describing() {
     assert_eq!(NEMO_RELAY_NATIVE_ABI_VERSION, 4);
-    assert_eq!(NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC, 4);
-    assert_eq!(NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS, 4);
     assert_eq!(
         size_of::<NemoRelayNativeHostApiV1>(),
         test_host().struct_size
@@ -2665,52 +2662,6 @@ fn plugin_runtime_rejects_malformed_runtime_diagnostics_json() {
         "{error}"
     );
     assert_eq!(STRING_LIVE_COUNT.load(Ordering::SeqCst), 0);
-}
-
-#[test]
-fn plugin_runtime_keeps_mark_options_on_a_pre_diagnostics_v4_host() {
-    let _guard = begin_test();
-    let mut host = test_host_v4();
-    host.v3.v1.struct_size = offset_of!(NemoRelayNativeHostApiV4, get_runtime_diagnostics);
-    let runtime = PluginRuntime::new(&host.v3.v1);
-
-    runtime
-        .emit_mark_with_options("current-v4", None, None, None, Some(LogSeverity::Info))
-        .unwrap();
-    assert_eq!(
-        runtime.runtime_diagnostics().unwrap_err(),
-        "runtime diagnostics require the native host ABI v4 diagnostics extension"
-    );
-}
-
-#[test]
-fn plugin_runtime_does_not_read_mark_options_past_v4_struct_size() {
-    let _guard = begin_test();
-    let mut host = test_host_v4();
-    host.v3.v1.struct_size = offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2);
-    let runtime = PluginRuntime::new(&host.v3.v1);
-
-    runtime
-        .emit_mark_with_options("legacy", None, None, None, None)
-        .unwrap();
-    let schema = DataSchema::builder()
-        .name("example.mark")
-        .version("1")
-        .build();
-    assert_eq!(
-        runtime
-            .emit_mark_with_options("extended", None, None, Some(&schema), None)
-            .unwrap_err(),
-        "mark data_schema and severity require native host ABI v4"
-    );
-
-    let calls = RUNTIME_CALLS.lock().unwrap();
-    assert!(
-        calls
-            .iter()
-            .any(|call| call.starts_with("mark:legacy:parent=false"))
-    );
-    assert!(!calls.iter().any(|call| call.starts_with("mark_v2:")));
 }
 
 fn assert_scope_runtime_calls(calls: &[String]) {
@@ -5237,7 +5188,7 @@ fn exported_entry_symbol_accepts_supported_prior_host_versions() {
     for abi_version in [
         NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY,
         NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE,
-        NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
+        NEMO_RELAY_NATIVE_ABI_VERSION,
     ] {
         let mut host = test_host();
         host.abi_version = abi_version;

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -21,14 +21,17 @@ use std::time::{Duration, Instant};
 
 use futures::StreamExt;
 use nemo_relay_plugin::{
-    AnnotatedLlmRequest, BuiltinLlmCodec, CategoryProfile, ConfigDiagnostic, DiagnosticLevel,
-    Event, EventCategory, EventSanitizeFields, Json, LlmCodecIdentity, LlmJsonAsyncStream,
-    LlmJsonStream, LlmNext, LlmRequest, LlmRequestInterceptOutcome, LlmStream, LlmStreamNext,
-    NEMO_RELAY_NATIVE_ABI_VERSION, NativeExecutorConfig, NativePlugin,
-    NemoRelayNativeAsyncCallbackState, NemoRelayNativeAsyncCompletion,
-    NemoRelayNativeAsyncLlmStreamOpenCb, NemoRelayNativeAsyncLlmStreamPullCb,
-    NemoRelayNativeAsyncMiddlewareCb, NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeAsyncNext,
-    NemoRelayNativeAsyncNextResultCb, NemoRelayNativeAsyncNextStreamCb, NemoRelayNativeAsyncStream,
+    AnnotatedLlmRequest, BuiltinLlmCodec, CategoryProfile, ConfigDiagnostic, DataSchema,
+    DiagnosticLevel, Event, EventCategory, EventSanitizeFields, Json, LlmCodecIdentity,
+    LlmJsonAsyncStream, LlmJsonStream, LlmNext, LlmRequest, LlmRequestInterceptOutcome, LlmStream,
+    LlmStreamNext, LogSeverity, NEMO_RELAY_NATIVE_ABI_VERSION,
+    NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE, NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY,
+    NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS, NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
+    NativeExecutorConfig, NativePlugin, NemoRelayNativeAsyncCallbackState,
+    NemoRelayNativeAsyncCompletion, NemoRelayNativeAsyncLlmStreamOpenCb,
+    NemoRelayNativeAsyncLlmStreamPullCb, NemoRelayNativeAsyncMiddlewareCb,
+    NemoRelayNativeAsyncMiddlewareKind, NemoRelayNativeAsyncNext, NemoRelayNativeAsyncNextResultCb,
+    NemoRelayNativeAsyncNextStreamCb, NemoRelayNativeAsyncStream,
     NemoRelayNativeAsyncStreamMiddlewareCb, NemoRelayNativeEventSanitizeCb,
     NemoRelayNativeEventSubscriberCb, NemoRelayNativeFreeFn, NemoRelayNativeHostApiV1,
     NemoRelayNativeHostApiV3, NemoRelayNativeHostApiV4, NemoRelayNativeLlmAsyncStream,
@@ -422,6 +425,8 @@ static ASYNC_TOOL_NEXT_RESULT: AtomicBool = AtomicBool::new(false);
 #[test]
 fn native_abi_struct_sizes_are_self_describing() {
     assert_eq!(NEMO_RELAY_NATIVE_ABI_VERSION, 4);
+    assert_eq!(NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC, 4);
+    assert_eq!(NEMO_RELAY_NATIVE_ABI_VERSION_MARK_OPTIONS, 4);
     assert_eq!(
         size_of::<NemoRelayNativeHostApiV1>(),
         test_host().struct_size
@@ -440,8 +445,7 @@ fn native_abi_struct_sizes_are_self_describing() {
 
 #[cfg(target_pointer_width = "64")]
 fn assert_native_abi_platform_layout() {
-    assert_eq!(align_of::<NemoRelayNativeHostApiV1>(), 8);
-    assert_eq!(size_of::<NemoRelayNativeHostApiV1>(), 320);
+    assert_type_layout::<NemoRelayNativeHostApiV1>(8, 320);
     assert_eq!(
         host_api_offsets(),
         [
@@ -450,29 +454,25 @@ fn assert_native_abi_platform_layout() {
             296, 304, 312,
         ]
     );
-    assert_eq!(align_of::<NemoRelayNativeHostApiV3>(), 8);
-    assert_eq!(size_of::<NemoRelayNativeHostApiV3>(), 440);
+    assert_type_layout::<NemoRelayNativeHostApiV3>(8, 440);
     assert_eq!(
         host_api_v3_offsets(),
         [
             0, 320, 328, 336, 344, 352, 360, 368, 376, 384, 392, 400, 408, 416, 424, 432
         ]
     );
-    assert_eq!(align_of::<NemoRelayNativeHostApiV4>(), 8);
-    assert_eq!(size_of::<NemoRelayNativeHostApiV4>(), 512);
+    assert_type_layout::<NemoRelayNativeHostApiV4>(8, 520);
     assert_eq!(offset_of!(NemoRelayNativeHostApiV4, v3), 0);
-    assert_eq!(align_of::<NemoRelayNativePluginV1>(), 8);
-    assert_eq!(size_of::<NemoRelayNativePluginV1>(), 56);
+    assert_eq!(offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2), 512);
+    assert_type_layout::<NemoRelayNativePluginV1>(8, 56);
     assert_eq!(plugin_offsets(), [0, 8, 16, 24, 32, 40, 48]);
-    assert_eq!(align_of::<NemoRelayNativeLlmStreamV1>(), 8);
-    assert_eq!(size_of::<NemoRelayNativeLlmStreamV1>(), 40);
+    assert_type_layout::<NemoRelayNativeLlmStreamV1>(8, 40);
     assert_eq!(stream_offsets(), [0, 8, 16, 24, 32]);
 }
 
 #[cfg(target_pointer_width = "32")]
 fn assert_native_abi_platform_layout() {
-    assert_eq!(align_of::<NemoRelayNativeHostApiV1>(), 4);
-    assert_eq!(size_of::<NemoRelayNativeHostApiV1>(), 160);
+    assert_type_layout::<NemoRelayNativeHostApiV1>(4, 160);
     assert_eq!(
         host_api_offsets(),
         [
@@ -480,23 +480,49 @@ fn assert_native_abi_platform_layout() {
             88, 92, 96, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 148, 152, 156,
         ]
     );
-    assert_eq!(align_of::<NemoRelayNativeHostApiV3>(), 4);
-    assert_eq!(size_of::<NemoRelayNativeHostApiV3>(), 216);
+    assert_type_layout::<NemoRelayNativeHostApiV3>(4, 216);
     assert_eq!(
         host_api_v3_offsets(),
         [
             0, 160, 164, 168, 172, 176, 180, 184, 188, 192, 196, 200, 204, 208, 212
         ]
     );
-    assert_eq!(align_of::<NemoRelayNativeHostApiV4>(), 4);
-    assert_eq!(size_of::<NemoRelayNativeHostApiV4>(), 252);
+    assert_type_layout::<NemoRelayNativeHostApiV4>(4, 256);
     assert_eq!(offset_of!(NemoRelayNativeHostApiV4, v3), 0);
-    assert_eq!(align_of::<NemoRelayNativePluginV1>(), 4);
-    assert_eq!(size_of::<NemoRelayNativePluginV1>(), 28);
+    assert_eq!(offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2), 252);
+    assert_type_layout::<NemoRelayNativePluginV1>(4, 28);
     assert_eq!(plugin_offsets(), [0, 4, 8, 12, 16, 20, 24]);
-    assert_eq!(align_of::<NemoRelayNativeLlmStreamV1>(), 4);
-    assert_eq!(size_of::<NemoRelayNativeLlmStreamV1>(), 20);
+    assert_type_layout::<NemoRelayNativeLlmStreamV1>(4, 20);
     assert_eq!(stream_offsets(), [0, 4, 8, 12, 16]);
+}
+
+fn assert_type_layout<T>(expected_alignment: usize, expected_size: usize) {
+    assert_eq!(align_of::<T>(), expected_alignment);
+    assert_eq!(size_of::<T>(), expected_size);
+}
+
+#[test]
+fn native_abi_v4_extension_is_append_only() {
+    #[cfg(target_pointer_width = "64")]
+    {
+        assert_eq!(align_of::<NemoRelayNativeHostApiV4>(), 8);
+        assert_eq!(size_of::<NemoRelayNativeHostApiV4>(), 520);
+        assert_eq!(host_api_v4_offsets(), [0, 512]);
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    {
+        assert_eq!(align_of::<NemoRelayNativeHostApiV4>(), 4);
+        assert_eq!(size_of::<NemoRelayNativeHostApiV4>(), 256);
+        assert_eq!(host_api_v4_offsets(), [0, 252]);
+    }
+}
+
+fn host_api_v4_offsets() -> [usize; 2] {
+    [
+        offset_of!(NemoRelayNativeHostApiV4, v3),
+        offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2),
+    ]
 }
 
 fn host_api_v3_offsets() -> [usize; 16] {
@@ -1259,6 +1285,43 @@ unsafe extern "C" fn capture_emit_mark(
     };
     RUNTIME_CALLS.lock().unwrap().push(format!(
         "mark:{name}:parent={}:data={data}:metadata={metadata}",
+        !parent.is_null()
+    ));
+    NemoRelayStatus::Ok
+}
+
+unsafe extern "C" fn capture_emit_mark_v2(
+    name: *const NemoRelayNativeString,
+    parent: *const NemoRelayNativeScopeHandle,
+    data_json: *const NemoRelayNativeString,
+    metadata_json: *const NemoRelayNativeString,
+    data_schema_json: *const NemoRelayNativeString,
+    severity: *const NemoRelayNativeString,
+    _timestamp_unix_micros: *const i64,
+) -> NemoRelayStatus {
+    let host = test_host();
+    let name = match required_host_string(&host, name) {
+        Ok(name) => name,
+        Err(status) => return status,
+    };
+    let data = match optional_host_string(&host, data_json) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let metadata = match optional_host_string(&host, metadata_json) {
+        Ok(metadata) => metadata,
+        Err(status) => return status,
+    };
+    let data_schema = match optional_host_string(&host, data_schema_json) {
+        Ok(data_schema) => data_schema,
+        Err(status) => return status,
+    };
+    let severity = match optional_host_string(&host, severity) {
+        Ok(severity) => severity,
+        Err(status) => return status,
+    };
+    RUNTIME_CALLS.lock().unwrap().push(format!(
+        "mark_v2:{name}:parent={}:data={data}:metadata={metadata}:data_schema={data_schema}:severity={severity}",
         !parent.is_null()
     ));
     NemoRelayStatus::Ok
@@ -2069,6 +2132,7 @@ fn test_host_v4() -> NemoRelayNativeHostApiV4 {
         async_llm_stream_release: capture_async_release_pull_stream,
         async_completion_retain: capture_async_completion_retain,
         async_stream_is_backpressured: capture_async_stream_backpressured,
+        emit_mark_v2: capture_emit_mark_v2,
     }
 }
 
@@ -2511,6 +2575,65 @@ fn plugin_runtime_scope_mark_and_stack_helpers_call_host() {
     assert_eq!(SCOPE_STACK_FREES.load(Ordering::SeqCst), 1);
     assert_eq!(SCOPE_STACK_BINDING_RESTORES.load(Ordering::SeqCst), 1);
     assert_eq!(SCOPE_STACK_BINDING_FREES.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn plugin_runtime_uses_v4_mark_options_extension() {
+    let _guard = begin_test();
+    let host = test_host_v4();
+    let runtime = PluginRuntime::new(&host.v3.v1);
+    let data_schema = DataSchema::builder()
+        .name("example.mark")
+        .version("1")
+        .build();
+
+    runtime
+        .emit_mark_with_options(
+            "checkpoint",
+            Some(&json!({ "mark": true })),
+            Some(&json!({ "meta": true })),
+            Some(&data_schema),
+            Some(LogSeverity::Warn),
+        )
+        .unwrap();
+
+    assert!(RUNTIME_CALLS.lock().unwrap().iter().any(|call| {
+        call.starts_with("mark_v2:checkpoint:parent=false")
+            && call.contains(r#""mark":true"#)
+            && call.contains(r#""meta":true"#)
+            && call.contains(r#""name":"example.mark""#)
+            && call.contains("severity=warn")
+    }));
+}
+
+#[test]
+fn plugin_runtime_does_not_read_mark_options_past_v4_struct_size() {
+    let _guard = begin_test();
+    let mut host = test_host_v4();
+    host.v3.v1.struct_size = offset_of!(NemoRelayNativeHostApiV4, emit_mark_v2);
+    let runtime = PluginRuntime::new(&host.v3.v1);
+
+    runtime
+        .emit_mark_with_options("legacy", None, None, None, None)
+        .unwrap();
+    let schema = DataSchema::builder()
+        .name("example.mark")
+        .version("1")
+        .build();
+    assert_eq!(
+        runtime
+            .emit_mark_with_options("extended", None, None, Some(&schema), None)
+            .unwrap_err(),
+        "mark data_schema and severity require native host ABI v4"
+    );
+
+    let calls = RUNTIME_CALLS.lock().unwrap();
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.starts_with("mark:legacy:parent=false"))
+    );
+    assert!(!calls.iter().any(|call| call.starts_with("mark_v2:")));
 }
 
 fn assert_scope_runtime_calls(calls: &[String]) {
@@ -5027,6 +5150,30 @@ fn exported_entry_symbol_validates_args_before_constructor() {
         NemoRelayStatus::InvalidArg
     );
     assert_eq!(CONSTRUCTOR_CALLS.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn exported_entry_symbol_accepts_supported_prior_host_versions() {
+    let _guard = begin_test();
+    CONSTRUCTOR_CALLS.store(0, Ordering::SeqCst);
+
+    for abi_version in [
+        NEMO_RELAY_NATIVE_ABI_VERSION_LEGACY,
+        NEMO_RELAY_NATIVE_ABI_VERSION_ASYNC_MIDDLEWARE,
+        NEMO_RELAY_NATIVE_ABI_VERSION_TYPED_ASYNC,
+    ] {
+        let mut host = test_host();
+        host.abi_version = abi_version;
+        let mut plugin = NemoRelayNativePluginV1::default();
+
+        assert_eq!(
+            unsafe { constructor_counting_entry(&host, &mut plugin) },
+            NemoRelayStatus::Ok
+        );
+        unsafe { drop_exported_plugin(&host, plugin) };
+    }
+
+    assert_eq!(CONSTRUCTOR_CALLS.load(Ordering::SeqCst), 3);
 }
 
 #[test]

--- a/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
+++ b/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
@@ -18,6 +18,7 @@ service PluginWorker {
 
 service RelayHostRuntime {
   rpc EmitMark(EmitMarkRequest) returns (HostAck);
+  rpc GetRuntimeDiagnostics(GetRuntimeDiagnosticsRequest) returns (GetRuntimeDiagnosticsResponse);
   rpc PushScope(PushScopeRequest) returns (PushScopeResponse);
   rpc PopScope(PopScopeRequest) returns (HostAck);
   rpc CreateScopeStack(CreateScopeStackRequest) returns (CreateScopeStackResponse);
@@ -280,6 +281,21 @@ message WorkerAck {
 message HostAck {
   bool ok = 1;
   WorkerError error = 2;
+}
+
+message GetRuntimeDiagnosticsRequest {
+  string activation_id = 1;
+  string auth_token = 2;
+}
+
+message RuntimeDiagnostic {
+  string code = 1;
+  string message = 2;
+  uint64 count = 3;
+}
+
+message GetRuntimeDiagnosticsResponse {
+  repeated RuntimeDiagnostic entries = 1;
 }
 
 message WorkerError {

--- a/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
+++ b/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
@@ -300,6 +300,8 @@ message EmitMarkRequest {
   string name = 4;
   JsonEnvelope data = 5;
   JsonEnvelope metadata = 6;
+  JsonEnvelope data_schema = 7;
+  string severity = 8;
 }
 
 message PushScopeRequest {

--- a/crates/worker-proto/tests/proto_tests.rs
+++ b/crates/worker-proto/tests/proto_tests.rs
@@ -4,8 +4,9 @@
 //! Tests for stable worker protocol helpers, structural tool results, and enum values.
 
 use nemo_relay_worker_proto::v1::{
-    EmitMarkRequest, HandshakeRequest, HealthRequest, InvokeRequest, JsonEnvelope, JsonValue,
-    RegistrationSurface, ScopeType, ToolExecutionResult as ProtoToolExecutionResult,
+    EmitMarkRequest, GetRuntimeDiagnosticsRequest, GetRuntimeDiagnosticsResponse, HandshakeRequest,
+    HealthRequest, InvokeRequest, JsonEnvelope, JsonValue, RegistrationSurface, RuntimeDiagnostic,
+    ScopeType, ToolExecutionResult as ProtoToolExecutionResult,
 };
 use nemo_relay_worker_proto::{
     WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, decode_json_value, json_envelope, json_value,
@@ -112,6 +113,28 @@ fn request_field_numbers_are_stable() {
         InvokeRequest::decode(encoded.as_slice()).expect("decode invoke"),
         invoke
     );
+}
+
+#[test]
+fn runtime_diagnostics_messages_are_stable() {
+    let request = GetRuntimeDiagnosticsRequest {
+        activation_id: "act".into(),
+        auth_token: "token".into(),
+    };
+    assert_eq!(
+        request.encode_to_vec(),
+        b"\x0a\x03act\x12\x05token".to_vec()
+    );
+
+    let response = GetRuntimeDiagnosticsResponse {
+        entries: vec![RuntimeDiagnostic {
+            code: "otel.metric_mark_invalid".into(),
+            message: "unsupported metric schema version".into(),
+            count: 3,
+        }],
+    };
+    assert_eq!(response.entries[0].count, 3);
+    assert_eq!(response.entries[0].code, "otel.metric_mark_invalid");
 }
 
 #[test]

--- a/crates/worker-proto/tests/proto_tests.rs
+++ b/crates/worker-proto/tests/proto_tests.rs
@@ -4,8 +4,8 @@
 //! Tests for stable worker protocol helpers, structural tool results, and enum values.
 
 use nemo_relay_worker_proto::v1::{
-    HandshakeRequest, HealthRequest, InvokeRequest, JsonEnvelope, JsonValue, RegistrationSurface,
-    ScopeType, ToolExecutionResult as ProtoToolExecutionResult,
+    EmitMarkRequest, HandshakeRequest, HealthRequest, InvokeRequest, JsonEnvelope, JsonValue,
+    RegistrationSurface, ScopeType, ToolExecutionResult as ProtoToolExecutionResult,
 };
 use nemo_relay_worker_proto::{
     WORKER_PROTOCOL_GRPC_V1, decode_json_envelope, decode_json_value, json_envelope, json_value,
@@ -180,4 +180,27 @@ fn tool_execution_result_tolerates_unknown_protobuf_fields() {
         decode_json_value::<serde_json::Value>(decoded_proto.result.as_ref().unwrap()).unwrap(),
         json!({"ok": true})
     );
+}
+
+#[test]
+fn emit_mark_additive_fields_preserve_legacy_wire_compatibility() {
+    let legacy = EmitMarkRequest::decode(b"\x22\x04mark".as_slice()).expect("decode legacy mark");
+    assert_eq!(legacy.name, "mark");
+    assert!(legacy.data_schema.is_none());
+    assert!(legacy.severity.is_empty());
+
+    let request = EmitMarkRequest {
+        name: "mark".into(),
+        data_schema: Some(
+            json_envelope(
+                "nemo.relay.DataSchema@1",
+                &json!({"name": "nemo.relay.metric_measurements", "version": "1"}),
+            )
+            .unwrap(),
+        ),
+        severity: "warn".into(),
+        ..EmitMarkRequest::default()
+    };
+    let round_trip = EmitMarkRequest::decode(request.encode_to_vec().as_slice()).unwrap();
+    assert_eq!(round_trip, request);
 }

--- a/crates/worker-proto/tests/proto_tests.rs
+++ b/crates/worker-proto/tests/proto_tests.rs
@@ -133,6 +133,11 @@ fn runtime_diagnostics_messages_are_stable() {
             count: 3,
         }],
     };
+    assert_eq!(
+        response.encode_to_vec(),
+        b"\x0a\x3f\x0a\x18otel.metric_mark_invalid\x12\x21unsupported metric schema version\x18\x03"
+            .to_vec()
+    );
     assert_eq!(response.entries[0].count, 3);
     assert_eq!(response.entries[0].code, "otel.metric_mark_invalid");
 }
@@ -224,6 +229,12 @@ fn emit_mark_additive_fields_preserve_legacy_wire_compatibility() {
         severity: "warn".into(),
         ..EmitMarkRequest::default()
     };
-    let round_trip = EmitMarkRequest::decode(request.encode_to_vec().as_slice()).unwrap();
+    let encoded = request.encode_to_vec();
+    assert_eq!(
+        encoded,
+        b"\x22\x04mark\x3a\x52\x0a\x17nemo.relay.DataSchema@1\x12\x37{\"name\":\"nemo.relay.metric_measurements\",\"version\":\"1\"}\x42\x04warn"
+            .to_vec()
+    );
+    let round_trip = EmitMarkRequest::decode(encoded.as_slice()).unwrap();
     assert_eq!(round_trip, request);
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -34,7 +34,11 @@ use futures_util::{Stream, StreamExt};
 #[cfg(unix)]
 use hyper_util::rt::TokioIo;
 pub use nemo_relay_types::Json;
-pub use nemo_relay_types::api::event::{DataSchema, Event, EventSanitizeFields, PendingMarkSpec};
+pub use nemo_relay_types::api::event::{
+    DataSchema, Event, EventSanitizeFields, LogSeverity, METRIC_DATA_SCHEMA_NAME,
+    METRIC_DATA_SCHEMA_VERSION, MetricEnvelope, MetricKind, MetricMeasurement, MetricValueType,
+    PendingMarkSpec,
+};
 pub use nemo_relay_types::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 pub use nemo_relay_types::api::scope::ScopeType;
 pub use nemo_relay_types::api::tool::{ToolExecutionInterceptOutcome, ToolExecutionResult};
@@ -88,6 +92,7 @@ pub type BoxFutureResult<T> = Pin<Box<dyn Future<Output = Result<T>> + Send>>;
 pub type JsonStream = Pin<Box<dyn tokio_stream::Stream<Item = Result<Json>> + Send>>;
 
 const JSON_SCHEMA: &str = "nemo.relay.Json@1";
+const DATA_SCHEMA_SCHEMA: &str = "nemo.relay.DataSchema@1";
 const LLM_REQUEST_SCHEMA: &str = "nemo.relay.LlmRequest@1";
 
 tokio::task_local! {
@@ -113,6 +118,15 @@ pub enum WorkerSdkError {
     /// JSON serialization failed.
     #[error("serialization failed: {0}")]
     Serialization(#[from] serde_json::Error),
+}
+
+/// Optional fields supported by the additive `grpc-v1` mark-emission request.
+#[derive(Debug, Clone, Default)]
+pub struct EmitMarkOptions {
+    /// Schema identifier for the mark's opaque data payload.
+    pub data_schema: Option<DataSchema>,
+    /// Telemetry severity for OTLP log projection.
+    pub severity: Option<LogSeverity>,
 }
 
 /// Trait implemented by Rust out-of-process worker plugins.
@@ -762,6 +776,18 @@ impl PluginRuntime {
         data: Option<Json>,
         metadata: Option<Json>,
     ) -> Result<()> {
+        self.emit_mark_with_options(name, data, metadata, EmitMarkOptions::default())
+            .await
+    }
+
+    /// Emits a mark event through the host runtime with optional schema and severity fields.
+    pub async fn emit_mark_with_options(
+        &self,
+        name: &str,
+        data: Option<Json>,
+        metadata: Option<Json>,
+        options: EmitMarkOptions,
+    ) -> Result<()> {
         let scope = self.current_scope_context();
         let mut client = self.host_client().await?;
         let response = client
@@ -772,11 +798,49 @@ impl PluginRuntime {
                 name: name.into(),
                 data: optional_json_envelope(data)?,
                 metadata: optional_json_envelope(metadata)?,
+                data_schema: optional_typed_json_envelope(
+                    DATA_SCHEMA_SCHEMA,
+                    options.data_schema.as_ref(),
+                )?,
+                severity: options
+                    .severity
+                    .as_ref()
+                    .map(severity_wire_value)
+                    .transpose()?
+                    .unwrap_or_default(),
             }))
             .await
             .map_err(|err| WorkerSdkError::Transport(err.to_string()))?
             .into_inner();
         ack_to_result(response.ok, response.error)
+    }
+
+    /// Emits a validated Relay metric-measurement mark through the host runtime.
+    pub async fn emit_metric(
+        &self,
+        name: &str,
+        measurements: Vec<MetricMeasurement>,
+        metadata: Option<Json>,
+    ) -> Result<()> {
+        let envelope = MetricEnvelope { measurements };
+        envelope
+            .validate()
+            .map_err(|err| WorkerSdkError::InvalidInput(err.to_string()))?;
+        self.emit_mark_with_options(
+            name,
+            Some(serde_json::to_value(envelope)?),
+            metadata,
+            EmitMarkOptions {
+                data_schema: Some(
+                    DataSchema::builder()
+                        .name(METRIC_DATA_SCHEMA_NAME)
+                        .version(METRIC_DATA_SCHEMA_VERSION)
+                        .build(),
+                ),
+                severity: None,
+            },
+        )
+        .await
     }
 
     /// Creates an isolated host-owned scope stack.
@@ -2349,6 +2413,24 @@ fn optional_json_envelope(value: Option<Json>) -> Result<Option<JsonEnvelope>> {
         .as_ref()
         .map(|value| json_envelope(JSON_SCHEMA, value).map_err(WorkerSdkError::from))
         .transpose()
+}
+
+fn optional_typed_json_envelope<T: serde::Serialize>(
+    schema: &str,
+    value: Option<&T>,
+) -> Result<Option<JsonEnvelope>> {
+    value
+        .map(|value| json_envelope(schema, value).map_err(WorkerSdkError::from))
+        .transpose()
+}
+
+fn severity_wire_value(value: &LogSeverity) -> Result<String> {
+    serde_json::to_value(value)?
+        .as_str()
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            WorkerSdkError::InvalidInput("LogSeverity did not serialize as a string".into())
+        })
 }
 
 fn infallible_json_envelope<T: serde::Serialize>(schema: &str, value: &T) -> JsonEnvelope {

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -56,12 +56,12 @@ use nemo_relay_worker_proto::v1::plugin_worker_server::{PluginWorker, PluginWork
 use nemo_relay_worker_proto::v1::relay_host_runtime_client::RelayHostRuntimeClient;
 use nemo_relay_worker_proto::v1::{
     CancelInvocationRequest, CreateScopeStackRequest, DropScopeStackRequest, EmitMarkRequest,
-    EmptyResult, GuardrailResult, HandshakeRequest, HandshakeResponse, HealthRequest,
-    HealthResponse, InvokeRequest, InvokeResponse, JsonEnvelope, JsonResult, LlmCodecDecodeRequest,
-    LlmCodecDecodeResponse, LlmCodecEncodeRequest, LlmCodecKind, LlmNextRequest,
-    LlmRequestInterceptResult, LlmStreamNextRequest, PopScopeRequest, PushScopeRequest,
-    RegisterRequest, RegisterResponse, Registration, RegistrationSurface, ScopeContext,
-    ShutdownRequest, StreamChunk,
+    EmptyResult, GetRuntimeDiagnosticsRequest, GuardrailResult, HandshakeRequest,
+    HandshakeResponse, HealthRequest, HealthResponse, InvokeRequest, InvokeResponse, JsonEnvelope,
+    JsonResult, LlmCodecDecodeRequest, LlmCodecDecodeResponse, LlmCodecEncodeRequest, LlmCodecKind,
+    LlmNextRequest, LlmRequestInterceptResult, LlmStreamNextRequest, PopScopeRequest,
+    PushScopeRequest, RegisterRequest, RegisterResponse, Registration, RegistrationSurface,
+    RuntimeDiagnostic as ProtoRuntimeDiagnostic, ScopeContext, ShutdownRequest, StreamChunk,
     ToolExecutionInterceptOutcome as ProtoToolExecutionInterceptOutcome,
     ToolExecutionInterceptResult, ToolExecutionResult as ProtoToolExecutionResult,
     ToolExecutionResultResponse, ToolNextRequest, ValidateRequest, ValidateResponse, WorkerAck,
@@ -84,6 +84,37 @@ use tower::service_fn;
 
 /// SDK result type.
 pub type Result<T> = std::result::Result<T, WorkerSdkError>;
+
+/// One bounded runtime diagnostic reported by the Relay host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeDiagnostic {
+    /// Stable identifier for the diagnostic condition.
+    pub code: String,
+    /// Most recently recorded message for this condition.
+    pub message: String,
+    /// Total number of occurrences recorded for this condition.
+    pub count: u64,
+}
+
+/// Bounded snapshot of active host runtime diagnostics.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeDiagnostics {
+    entries: Vec<RuntimeDiagnostic>,
+}
+
+impl RuntimeDiagnostics {
+    /// Return diagnostics in stable code order.
+    pub fn entries(&self) -> &[RuntimeDiagnostic] {
+        &self.entries
+    }
+
+    /// Return a diagnostic by its stable code.
+    pub fn get(&self, code: &str) -> Option<&RuntimeDiagnostic> {
+        self.entries
+            .iter()
+            .find(|diagnostic| diagnostic.code == code)
+    }
+}
 
 /// Boxed future returned by async worker callbacks.
 pub type BoxFutureResult<T> = Pin<Box<dyn Future<Output = Result<T>> + Send>>;
@@ -813,6 +844,39 @@ impl PluginRuntime {
             .map_err(|err| WorkerSdkError::Transport(err.to_string()))?
             .into_inner();
         ack_to_result(response.ok, response.error)
+    }
+
+    /// Return a bounded snapshot of active host runtime diagnostics.
+    pub async fn runtime_diagnostics(&self) -> Result<RuntimeDiagnostics> {
+        let mut client = self.host_client().await?;
+        let response = client
+            .get_runtime_diagnostics(Request::new(GetRuntimeDiagnosticsRequest {
+                activation_id: self.activation_id.clone(),
+                auth_token: self.auth_token.clone(),
+            }))
+            .await
+            .map_err(|error| {
+                if error.code() == tonic::Code::Unimplemented {
+                    WorkerSdkError::Callback(
+                        "runtime diagnostics require a Relay host with the grpc-v1 diagnostics extension"
+                            .into(),
+                    )
+                } else {
+                    WorkerSdkError::Transport(error.to_string())
+                }
+            })?
+            .into_inner();
+        Ok(RuntimeDiagnostics {
+            entries: response
+                .entries
+                .into_iter()
+                .map(|diagnostic: ProtoRuntimeDiagnostic| RuntimeDiagnostic {
+                    code: diagnostic.code,
+                    message: diagnostic.message,
+                    count: diagnostic.count,
+                })
+                .collect(),
+        })
     }
 
     /// Emits a validated Relay metric-measurement mark through the host runtime.

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -30,10 +30,11 @@ use nemo_relay_worker_proto::v1::relay_host_runtime_server::{
 };
 use nemo_relay_worker_proto::v1::{
     CancelInvocationRequest, CreateScopeStackRequest, CreateScopeStackResponse,
-    DropScopeStackRequest, EmitMarkRequest, HandshakeRequest, HealthRequest, HostAck,
-    InvokeRequest, InvokeResponse, JsonEnvelope, JsonResult, LlmInvocation, LlmNextRequest,
-    LlmStreamNextRequest, PopScopeRequest, PushScopeRequest, PushScopeResponse, RegisterRequest,
-    RegistrationSurface, ScopeContext, ShutdownRequest, StreamChunk,
+    DropScopeStackRequest, EmitMarkRequest, GetRuntimeDiagnosticsRequest,
+    GetRuntimeDiagnosticsResponse, HandshakeRequest, HealthRequest, HostAck, InvokeRequest,
+    InvokeResponse, JsonEnvelope, JsonResult, LlmInvocation, LlmNextRequest, LlmStreamNextRequest,
+    PopScopeRequest, PushScopeRequest, PushScopeResponse, RegisterRequest, RegistrationSurface,
+    RuntimeDiagnostic as ProtoRuntimeDiagnostic, ScopeContext, ShutdownRequest, StreamChunk,
     ToolExecutionInterceptOutcome as ProtoToolExecutionInterceptOutcome,
     ToolExecutionResult as ProtoToolExecutionResult, ToolExecutionResultResponse, ToolInvocation,
     ToolNextRequest, ValidateRequest, WorkerError,
@@ -789,6 +790,7 @@ async fn worker_service_invokes_every_registration_surface() {
     assert_eq!(stream_auth.code(), tonic::Code::PermissionDenied);
 
     let calls = host.calls();
+    assert!(calls.contains(&"runtime_diagnostics".into()));
     assert!(calls.contains(&"mark:tool-exec:stack-1:parent-1".into()));
     assert!(calls.contains(&"create_scope_stack".into()));
     assert!(calls.contains(&"mark:tool-exec-isolated:isolated-stack:".into()));
@@ -1456,6 +1458,13 @@ async fn worker_service_propagates_host_runtime_errors() {
     for (failures, expected) in [
         (
             MockHostFailures {
+                runtime_diagnostics_unimplemented: true,
+                ..Default::default()
+            },
+            "runtime diagnostics require a Relay host with the grpc-v1 diagnostics extension",
+        ),
+        (
+            MockHostFailures {
                 emit_mark: HostFailure::WorkerError,
                 ..Default::default()
             },
@@ -1828,6 +1837,16 @@ impl WorkerPlugin for SurfacePlugin {
         ctx.register_tool_execution_intercept("tool-exec", 1, move |_, value, next: ToolNext| {
             let runtime = tool_runtime.clone();
             async move {
+                let diagnostics = runtime.runtime_diagnostics().await?;
+                if diagnostics
+                    .get("otel.metric_mark_invalid")
+                    .map(|diagnostic| diagnostic.count)
+                    != Some(3)
+                {
+                    return Err(WorkerSdkError::Callback(
+                        "runtime diagnostics response did not contain the expected entry".into(),
+                    ));
+                }
                 runtime.emit_mark("tool-exec", None, None).await?;
                 runtime
                     .emit_mark_with_options(
@@ -2061,6 +2080,7 @@ enum MockStreamMode {
 
 #[derive(Clone, Copy, Default)]
 struct MockHostFailures {
+    runtime_diagnostics_unimplemented: bool,
     emit_mark: HostFailure,
     create_scope_stack: bool,
     push_scope: bool,
@@ -2106,6 +2126,25 @@ impl MockHost {
 
 #[tonic::async_trait]
 impl RelayHostRuntime for MockHost {
+    async fn get_runtime_diagnostics(
+        &self,
+        request: Request<GetRuntimeDiagnosticsRequest>,
+    ) -> std::result::Result<Response<GetRuntimeDiagnosticsResponse>, Status> {
+        let request = request.into_inner();
+        authorize_host(&request.activation_id, &request.auth_token)?;
+        self.record("runtime_diagnostics");
+        if self.failures().runtime_diagnostics_unimplemented {
+            return Err(Status::unimplemented("runtime diagnostics are unavailable"));
+        }
+        Ok(Response::new(GetRuntimeDiagnosticsResponse {
+            entries: vec![ProtoRuntimeDiagnostic {
+                code: "otel.metric_mark_invalid".into(),
+                message: "metric mark has an unsupported value".into(),
+                count: 3,
+            }],
+        }))
+    }
+
     async fn emit_mark(
         &self,
         request: Request<EmitMarkRequest>,

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -20,9 +20,10 @@ use hyper_util::rt::TokioIo;
 use nemo_relay_types::api::event::{BaseEvent, Event, MarkEvent, PendingMarkSpec};
 use nemo_relay_worker::{
     ANNOTATED_LLM_REQUEST_SCHEMA, DataSchema, EmitMarkOptions, Json, JsonStream, LlmNext,
-    LlmRequest, LlmStreamNext, LogSeverity, PluginContext, PluginRuntime, Result, ScopeType,
-    ToolExecutionInterceptOutcome, ToolNext, WorkerPlugin, WorkerSdkError, WorkerServerConfig,
-    serve_plugin, serve_plugin_arc, serve_plugin_arc_with_config,
+    LlmRequest, LlmStreamNext, LogSeverity, MetricKind, MetricMeasurement, MetricValueType,
+    PluginContext, PluginRuntime, Result, ScopeType, ToolExecutionInterceptOutcome, ToolNext,
+    WorkerPlugin, WorkerSdkError, WorkerServerConfig, serve_plugin, serve_plugin_arc,
+    serve_plugin_arc_with_config,
 };
 use nemo_relay_worker_proto::v1::plugin_worker_client::PluginWorkerClient;
 use nemo_relay_worker_proto::v1::relay_host_runtime_server::{
@@ -821,6 +822,34 @@ async fn worker_service_invokes_every_registration_surface() {
             .name("nemo.relay.metric_measurements")
             .version("1")
             .build()
+    );
+    let metric_mark = host
+        .marks()
+        .into_iter()
+        .find(|request| request.name == "tool-exec-metric")
+        .expect("metric mark request");
+    let metric_schema = metric_mark.data_schema.expect("metric data schema");
+    assert_eq!(
+        decode_json_envelope::<DataSchema>(&metric_schema).unwrap(),
+        DataSchema::builder()
+            .name("nemo.relay.metric_measurements")
+            .version("1")
+            .build()
+    );
+    assert_eq!(
+        decode_json_envelope::<Json>(&metric_mark.data.expect("metric data")).unwrap(),
+        json!({
+            "measurements": [{
+                "name": "worker.requests",
+                "kind": "counter",
+                "value_type": "u64",
+                "value": 1,
+                "unit": null,
+                "description": null,
+                "attributes": null,
+                "boundaries": null
+            }]
+        })
     );
 
     worker_handle.abort();
@@ -1862,6 +1891,22 @@ impl WorkerPlugin for SurfacePlugin {
                             ),
                             severity: Some(LogSeverity::Warn),
                         },
+                    )
+                    .await?;
+                runtime
+                    .emit_metric(
+                        "tool-exec-metric",
+                        vec![MetricMeasurement {
+                            name: "worker.requests".into(),
+                            kind: MetricKind::Counter,
+                            value_type: MetricValueType::U64,
+                            value: json!(1),
+                            unit: None,
+                            description: None,
+                            attributes: None,
+                            boundaries: None,
+                        }],
+                        None,
                     )
                     .await?;
                 let stack_id = runtime.create_scope_stack().await?;

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -19,10 +19,10 @@ use futures_util::{Stream, StreamExt};
 use hyper_util::rt::TokioIo;
 use nemo_relay_types::api::event::{BaseEvent, Event, MarkEvent, PendingMarkSpec};
 use nemo_relay_worker::{
-    ANNOTATED_LLM_REQUEST_SCHEMA, Json, JsonStream, LlmNext, LlmRequest, LlmStreamNext,
-    PluginContext, PluginRuntime, Result, ScopeType, ToolExecutionInterceptOutcome, ToolNext,
-    WorkerPlugin, WorkerSdkError, WorkerServerConfig, serve_plugin, serve_plugin_arc,
-    serve_plugin_arc_with_config,
+    ANNOTATED_LLM_REQUEST_SCHEMA, DataSchema, EmitMarkOptions, Json, JsonStream, LlmNext,
+    LlmRequest, LlmStreamNext, LogSeverity, PluginContext, PluginRuntime, Result, ScopeType,
+    ToolExecutionInterceptOutcome, ToolNext, WorkerPlugin, WorkerSdkError, WorkerServerConfig,
+    serve_plugin, serve_plugin_arc, serve_plugin_arc_with_config,
 };
 use nemo_relay_worker_proto::v1::plugin_worker_client::PluginWorkerClient;
 use nemo_relay_worker_proto::v1::relay_host_runtime_server::{
@@ -805,6 +805,21 @@ async fn worker_service_invokes_every_registration_surface() {
     assert!(calls.contains(&"mark:stream-poll:stack-1:parent-1".into()));
     assert!(calls.contains(&"push:scope-agent:explicit-stack:".into()));
     assert!(calls.contains(&"push:scope-unknown:explicit-stack:".into()));
+    let telemetry_mark = host
+        .marks()
+        .into_iter()
+        .find(|request| request.name == "tool-exec-telemetry")
+        .expect("extended mark request");
+    assert_eq!(telemetry_mark.severity, "warn");
+    let data_schema = telemetry_mark.data_schema.expect("mark data schema");
+    assert_eq!(data_schema.schema, "nemo.relay.DataSchema@1");
+    assert_eq!(
+        decode_json_envelope::<DataSchema>(&data_schema).unwrap(),
+        DataSchema::builder()
+            .name("nemo.relay.metric_measurements")
+            .version("1")
+            .build()
+    );
 
     worker_handle.abort();
     host_handle.abort();
@@ -1814,6 +1829,22 @@ impl WorkerPlugin for SurfacePlugin {
             let runtime = tool_runtime.clone();
             async move {
                 runtime.emit_mark("tool-exec", None, None).await?;
+                runtime
+                    .emit_mark_with_options(
+                        "tool-exec-telemetry",
+                        Some(json!({"measurements": []})),
+                        None,
+                        EmitMarkOptions {
+                            data_schema: Some(
+                                DataSchema::builder()
+                                    .name("nemo.relay.metric_measurements")
+                                    .version("1")
+                                    .build(),
+                            ),
+                            severity: Some(LogSeverity::Warn),
+                        },
+                    )
+                    .await?;
                 let stack_id = runtime.create_scope_stack().await?;
                 let isolated_runtime = runtime.clone();
                 runtime
@@ -2047,6 +2078,7 @@ struct MockHostFailures {
 #[derive(Clone, Default)]
 struct MockHost {
     calls: Arc<Mutex<Vec<String>>>,
+    marks: Arc<Mutex<Vec<EmitMarkRequest>>>,
     failures: Arc<Mutex<MockHostFailures>>,
 }
 
@@ -2057,6 +2089,10 @@ impl MockHost {
 
     fn record(&self, call: impl Into<String>) {
         self.calls.lock().expect("calls lock").push(call.into());
+    }
+
+    fn marks(&self) -> Vec<EmitMarkRequest> {
+        self.marks.lock().expect("marks lock").clone()
     }
 
     fn failures(&self) -> MockHostFailures {
@@ -2076,6 +2112,7 @@ impl RelayHostRuntime for MockHost {
     ) -> std::result::Result<Response<HostAck>, Status> {
         let request = request.into_inner();
         authorize_host(&request.activation_id, &request.auth_token)?;
+        self.marks.lock().expect("marks lock").push(request.clone());
         let scope = request.scope.expect("scope context");
         self.record(format!(
             "mark:{}:{}:{}",

--- a/justfile
+++ b/justfile
@@ -1067,6 +1067,13 @@ check-python-worker-proto:
     assert pb.LLM_STREAM_EXECUTION_INTERCEPT == 25
     tool_next = pb.DESCRIPTOR.services_by_name["RelayHostRuntime"].methods_by_name["ToolNext"]
     assert tool_next.output_type.full_name == "nemo.relay.worker.v1.ToolExecutionResultResponse"
+    runtime_diagnostics = pb.DESCRIPTOR.services_by_name["RelayHostRuntime"].methods_by_name["GetRuntimeDiagnostics"]
+    assert runtime_diagnostics.input_type.full_name == "nemo.relay.worker.v1.GetRuntimeDiagnosticsRequest"
+    assert runtime_diagnostics.output_type.full_name == "nemo.relay.worker.v1.GetRuntimeDiagnosticsResponse"
+    runtime_diagnostic = pb.RuntimeDiagnostic.DESCRIPTOR.fields_by_name
+    assert runtime_diagnostic["code"].number == 1
+    assert runtime_diagnostic["message"].number == 2
+    assert runtime_diagnostic["count"].number == 3
     tool_result = pb.ToolExecutionResult.DESCRIPTOR.fields_by_name
     assert tool_result["result"].message_type.full_name == "nemo.relay.worker.v1.JsonValue"
     assert tool_result["annotation"].message_type.full_name == "nemo.relay.worker.v1.JsonValue"

--- a/justfile
+++ b/justfile
@@ -1074,6 +1074,11 @@ check-python-worker-proto:
     assert runtime_diagnostic["code"].number == 1
     assert runtime_diagnostic["message"].number == 2
     assert runtime_diagnostic["count"].number == 3
+    runtime_diagnostics_response = pb.GetRuntimeDiagnosticsResponse.DESCRIPTOR.fields_by_name
+    assert runtime_diagnostics_response["entries"].number == 1
+    emit_mark = pb.EmitMarkRequest.DESCRIPTOR.fields_by_name
+    assert emit_mark["data_schema"].number == 7
+    assert emit_mark["severity"].number == 8
     tool_result = pb.ToolExecutionResult.DESCRIPTOR.fields_by_name
     assert tool_result["result"].message_type.full_name == "nemo.relay.worker.v1.JsonValue"
     assert tool_result["annotation"].message_type.full_name == "nemo.relay.worker.v1.JsonValue"

--- a/python/plugin/src/nemo_relay_plugin/__init__.py
+++ b/python/plugin/src/nemo_relay_plugin/__init__.py
@@ -45,6 +45,8 @@ Public data types:
     ToolExecutionInterceptOutcome: Canonical tool execution-intercept result.
     DiagnosticLevel: Severity of a configuration diagnostic.
     ConfigDiagnostic: Structured configuration warning or error.
+    RuntimeDiagnostic: One aggregated host runtime diagnostic entry.
+    RuntimeDiagnostics: Immutable host runtime diagnostics snapshot.
     ScopeType: Semantic category for a Relay execution scope.
     WorkerSdkError: SDK, host-call, or worker protocol error.
 
@@ -110,6 +112,8 @@ from ._api import (
     PendingMarkSpec,
     PluginContext,
     PluginRuntime,
+    RuntimeDiagnostic,
+    RuntimeDiagnostics,
     ScopeType,
     SubscriberCallback,
     ToolConditionalCallback,
@@ -161,6 +165,8 @@ __all__ = [
     "LlmStreamExecutionCallback",
     "PluginContext",
     "PluginRuntime",
+    "RuntimeDiagnostic",
+    "RuntimeDiagnostics",
     "PendingMarkSpec",
     "ScopeType",
     "SubscriberCallback",

--- a/python/plugin/src/nemo_relay_plugin/__init__.py
+++ b/python/plugin/src/nemo_relay_plugin/__init__.py
@@ -17,6 +17,11 @@ appropriate executor.
 
 Public data types:
     Json: Any JSON-serializable Python value.
+    DataSchema: Schema identity for a mark's opaque data payload.
+    LogSeverity: Telemetry severity assigned to an exported mark log.
+    MetricKind: OpenTelemetry instrument kind for a metric measurement.
+    MetricValueType: Explicit numeric representation for a metric measurement.
+    MetricMeasurement: One recording operation in a Relay metric mark.
     Event: A Relay event represented as a JSON object.
     EventSanitizeFields: Mutable event observability fields.
     LlmRequest: A Relay LLM request represented as a JSON object.
@@ -72,6 +77,7 @@ Public functions:
 from ._api import (
     AnnotatedLlmRequest,
     ConfigDiagnostic,
+    DataSchema,
     DiagnosticLevel,
     Event,
     EventSanitizeCallback,
@@ -97,6 +103,10 @@ from ._api import (
     LlmSanitizeResponseContext,
     LlmStreamExecutionCallback,
     LlmStreamNext,
+    LogSeverity,
+    MetricKind,
+    MetricMeasurement,
+    MetricValueType,
     PendingMarkSpec,
     PluginContext,
     PluginRuntime,
@@ -119,6 +129,7 @@ from ._api import (
 __all__ = [
     "AnnotatedLlmRequest",
     "ConfigDiagnostic",
+    "DataSchema",
     "DiagnosticLevel",
     "Event",
     "EventSanitizeCallback",
@@ -127,6 +138,10 @@ __all__ = [
     "LlmConditionalCallback",
     "LlmCodecIdentity",
     "LlmExecutionCallback",
+    "LogSeverity",
+    "MetricKind",
+    "MetricMeasurement",
+    "MetricValueType",
     "LlmOptimizationContribution",
     "LlmOptimizationDataSchema",
     "LlmOptimizationEvidenceQuality",

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -76,7 +76,7 @@ from dataclasses import asdict, dataclass, field
 from enum import Enum
 from importlib import metadata
 from pathlib import Path
-from typing import Any, ClassVar, Protocol, TypeAlias, TypedDict
+from typing import Any, ClassVar, NotRequired, Protocol, TypeAlias, TypedDict
 from urllib.parse import urlsplit
 
 grpc: Any = importlib.import_module("grpc")
@@ -205,6 +205,9 @@ def _llm_codec_capability(invocation: pb.LlmInvocation) -> str | None:
 
 WORKER_PROTOCOL = "grpc-v1"
 JSON_SCHEMA = "nemo.relay.Json@1"
+DATA_SCHEMA_SCHEMA = "nemo.relay.DataSchema@1"
+METRIC_DATA_SCHEMA_NAME = "nemo.relay.metric_measurements"
+METRIC_DATA_SCHEMA_VERSION = "1"
 EVENT_SCHEMA = "nemo.relay.Event@1"
 LLM_REQUEST_SCHEMA = "nemo.relay.LlmRequest@1"
 ANNOTATED_LLM_REQUEST_SCHEMA = "nemo.relay.AnnotatedLlmRequest@2"
@@ -223,6 +226,66 @@ _SCOPE_CONTEXT: contextvars.ContextVar[_BoundScopeContext | None] = contextvars.
     "nemo_relay_plugin_scope_context",
     default=None,
 )
+
+
+@dataclass(frozen=True)
+class DataSchema:
+    """Identify the schema of a mark's opaque data payload."""
+
+    name: str
+    version: str
+
+    def __post_init__(self) -> None:
+        """Validate required schema identity fields."""
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("data schema name must be a non-empty string")
+        if not isinstance(self.version, str) or not self.version.strip():
+            raise ValueError("data schema version must be a non-empty string")
+
+    def to_json(self) -> dict[str, str]:
+        """Return the canonical JSON representation."""
+        return {"name": self.name, "version": self.version}
+
+
+class LogSeverity(str, Enum):
+    """Telemetry severity assigned to an exported mark log."""
+
+    TRACE = "trace"
+    DEBUG = "debug"
+    INFO = "info"
+    WARN = "warn"
+    WARNING = "warn"
+    ERROR = "error"
+
+
+class MetricKind(str, Enum):
+    """OpenTelemetry instrument kind recorded by a metric mark."""
+
+    COUNTER = "counter"
+    UP_DOWN_COUNTER = "up_down_counter"
+    GAUGE = "gauge"
+    HISTOGRAM = "histogram"
+
+
+class MetricValueType(str, Enum):
+    """Explicit numeric representation of a metric measurement value."""
+
+    U64 = "u64"
+    I64 = "i64"
+    F64 = "f64"
+
+
+class MetricMeasurement(TypedDict):
+    """One recording operation in a Relay metric-measurement mark."""
+
+    name: str
+    kind: MetricKind | str
+    value_type: MetricValueType | str
+    value: int | float
+    unit: NotRequired[str]
+    description: NotRequired[str]
+    attributes: NotRequired[dict[str, Json]]
+    boundaries: NotRequired[list[float] | None]
 
 
 class WorkerSdkError(Exception):
@@ -334,6 +397,8 @@ class PendingMarkSpec:
     category_profile: Json | None = None
     data: Json | None = None
     metadata: Json | None = None
+    data_schema: DataSchema | Mapping[str, Json] | None = None
+    severity: LogSeverity | str | None = None
 
     def to_json(self) -> dict[str, Json]:
         """Convert this pending mark to its canonical JSON object."""
@@ -341,7 +406,11 @@ class PendingMarkSpec:
             raise WorkerSdkError("pending mark name must be a string")
         if self.category is not None and not isinstance(self.category, str):
             raise WorkerSdkError("pending mark category must be a string or None")
-        return asdict(self)
+        severity = _log_severity_value(self.severity)
+        encoded = asdict(self)
+        encoded["data_schema"] = _data_schema_json(self.data_schema)
+        encoded["severity"] = severity or None
+        return encoded
 
 
 @dataclass(slots=True)
@@ -1376,6 +1445,8 @@ class PluginRuntime:
         data: Json | None = None,
         metadata: Json | None = None,
         *,
+        data_schema: DataSchema | Mapping[str, Json] | None = None,
+        severity: LogSeverity | str | None = None,
         scope_stack_id: str | None = None,
         parent_scope_id: str | None = None,
     ) -> None:
@@ -1385,6 +1456,9 @@ class PluginRuntime:
             name: Mark event name.
             data: Optional JSON application payload.
             metadata: Optional JSON metadata attached to the event.
+            data_schema: Optional typed schema identity for ``data``.
+            severity: Optional telemetry log severity. ``warning`` is accepted
+                as an alias for ``warn``.
             scope_stack_id: Optional host-issued stack to correlate the event
                 with. When omitted, the current local binding is used.
             parent_scope_id: Optional parent scope for the event. When omitted,
@@ -1403,9 +1477,43 @@ class PluginRuntime:
                 name=name,
                 data=_optional_json_envelope(data),
                 metadata=_optional_json_envelope(metadata),
+                data_schema=_optional_json_envelope(
+                    _data_schema_json(data_schema),
+                    DATA_SCHEMA_SCHEMA,
+                ),
+                severity=_log_severity_value(severity),
             )
         )
         _ack_to_result(response)
+
+    async def emit_metric(
+        self,
+        name: str,
+        measurements: Iterable[MetricMeasurement | Mapping[str, Json]],
+        metadata: Json | None = None,
+        *,
+        scope_stack_id: str | None = None,
+        parent_scope_id: str | None = None,
+    ) -> None:
+        """Emit a Relay metric-measurement mark through the host runtime.
+
+        Relay performs authoritative metric-schema validation after the mark is
+        sanitized. This helper supplies the reserved schema and preserves each
+        measurement mapping without maintaining a second validator in the SDK.
+        """
+        encoded: list[dict[str, Json]] = []
+        for measurement in measurements:
+            if not isinstance(measurement, Mapping):
+                raise TypeError("measurements must contain mappings")
+            encoded.append({key: value for key, value in measurement.items()})
+        await self.emit_mark(
+            name,
+            {"measurements": encoded},
+            metadata,
+            data_schema=DataSchema(METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION),
+            scope_stack_id=scope_stack_id,
+            parent_scope_id=parent_scope_id,
+        )
 
     async def create_scope_stack(self) -> str:
         """Create an isolated, host-owned scope stack.
@@ -2297,6 +2405,38 @@ def _optional_json_envelope(value: Json | None, schema: str = JSON_SCHEMA) -> An
     if value is None:
         return None
     return _json_envelope(schema, value)
+
+
+def _data_schema_json(value: DataSchema | Mapping[str, Json] | None) -> dict[str, str] | None:
+    if value is None:
+        return None
+    if isinstance(value, DataSchema):
+        return value.to_json()
+    if not isinstance(value, Mapping):
+        raise TypeError("data_schema must be DataSchema, a mapping, or None")
+    if set(value) != {"name", "version"}:
+        raise ValueError("data_schema must contain exactly name and version")
+    name = value["name"]
+    version = value["version"]
+    if not isinstance(name, str) or not isinstance(version, str):
+        raise ValueError("data_schema name and version must be strings")
+    return DataSchema(name=name, version=version).to_json()
+
+
+def _log_severity_value(value: LogSeverity | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, LogSeverity):
+        return value.value
+    if not isinstance(value, str):
+        raise TypeError("severity must be LogSeverity, a string, or None")
+    normalized = value.strip().lower()
+    if normalized == "warning":
+        normalized = "warn"
+    try:
+        return LogSeverity(normalized).value
+    except ValueError as exc:
+        raise ValueError(f"invalid log severity: {value!r}") from exc
 
 
 def _decode_required_envelope(envelope: Any, field: str, expected_schema: str = JSON_SCHEMA) -> Json:

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -112,6 +112,26 @@ class LlmCodecIdentity:
 
 
 @dataclass(frozen=True)
+class RuntimeDiagnostic:
+    """One bounded runtime diagnostic reported by the Relay host."""
+
+    code: str
+    message: str
+    count: int
+
+
+@dataclass(frozen=True)
+class RuntimeDiagnostics:
+    """Bounded snapshot of active host runtime diagnostics."""
+
+    entries: tuple[RuntimeDiagnostic, ...]
+
+    def get(self, code: str) -> RuntimeDiagnostic | None:
+        """Return the diagnostic with ``code``, when present."""
+        return next((diagnostic for diagnostic in self.entries if diagnostic.code == code), None)
+
+
+@dataclass(frozen=True)
 class LlmSanitizeRequestContext:
     """Structured per-call context provided to an LLM request sanitizer."""
 
@@ -1485,6 +1505,33 @@ class PluginRuntime:
             )
         )
         _ack_to_result(response)
+
+    async def runtime_diagnostics(self) -> RuntimeDiagnostics:
+        """Return a bounded snapshot of active host runtime diagnostics.
+
+        Raises:
+            WorkerSdkError: The host rejects the request or lacks the additive
+                ``grpc-v1`` runtime-diagnostics operation.
+        """
+        try:
+            response = await self._host_stub.GetRuntimeDiagnostics(
+                pb.GetRuntimeDiagnosticsRequest(
+                    activation_id=self._activation_id,
+                    auth_token=self._auth_token,
+                )
+            )
+        except grpc.aio.AioRpcError as exc:
+            if exc.code() == grpc.StatusCode.UNIMPLEMENTED:
+                raise WorkerSdkError(
+                    "runtime diagnostics require a Relay host with the grpc-v1 diagnostics extension"
+                ) from exc
+            raise WorkerSdkError(f"GetRuntimeDiagnostics failed: {exc.details()}") from exc
+        return RuntimeDiagnostics(
+            entries=tuple(
+                RuntimeDiagnostic(code=entry.code, message=entry.message, count=entry.count)
+                for entry in response.entries
+            )
+        )
 
     async def emit_metric(
         self,

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -36,6 +36,8 @@ from nemo_relay_plugin import (  # noqa: E402
     PendingMarkSpec,
     PluginContext,
     PluginRuntime,
+    RuntimeDiagnostic,
+    RuntimeDiagnostics,
     ScopeType,
     ToolExecutionInterceptOutcome,
     ToolExecutionResult,
@@ -379,6 +381,15 @@ class RecordingHostStub:
         self.requests.append(request)
         return self._host_ack("EmitMark")
 
+    async def GetRuntimeDiagnostics(self, request: Any) -> Any:
+        self.requests.append(request)
+        return pb.GetRuntimeDiagnosticsResponse(
+            entries=[
+                pb.RuntimeDiagnostic(code="alpha", message="first", count=1),
+                pb.RuntimeDiagnostic(code="zeta", message="latest", count=3),
+            ]
+        )
+
     async def CreateScopeStack(self, request: Any) -> Any:
         self.requests.append(request)
         if self.failures.get("CreateScopeStack") == "error":
@@ -625,6 +636,9 @@ def test_generated_proto_matches_worker_contract():
     assert pb.CUSTOM == 10
 
     host_runtime = pb.DESCRIPTOR.services_by_name["RelayHostRuntime"]
+    diagnostics = host_runtime.methods_by_name["GetRuntimeDiagnostics"]
+    assert diagnostics.input_type.full_name == "nemo.relay.worker.v1.GetRuntimeDiagnosticsRequest"
+    assert diagnostics.output_type.full_name == "nemo.relay.worker.v1.GetRuntimeDiagnosticsResponse"
     tool_next = host_runtime.methods_by_name["ToolNext"]
     assert tool_next.output_type.full_name == "nemo.relay.worker.v1.ToolExecutionResultResponse"
     tool_result = pb.ToolExecutionResult.DESCRIPTOR.fields_by_name
@@ -2106,6 +2120,15 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
     assert runtime.current_scope_stack_id() is None
     assert runtime.current_parent_scope_id() is None
 
+    diagnostics = await runtime.runtime_diagnostics()
+    assert isinstance(diagnostics, RuntimeDiagnostics)
+    assert diagnostics.entries == (
+        RuntimeDiagnostic(code="alpha", message="first", count=1),
+        RuntimeDiagnostic(code="zeta", message="latest", count=3),
+    )
+    assert diagnostics.get("zeta") == RuntimeDiagnostic(code="zeta", message="latest", count=3)
+    assert diagnostics.get("missing") is None
+
     stack_id = await runtime.create_scope_stack()
     assert stack_id == "stack-1"
     with runtime.bind_scope_stack(stack_id, parent_scope_id="parent-1"):
@@ -2282,6 +2305,24 @@ async def test_runtime_host_call_error_paths(host_stub: RecordingHostStub):
     host_stub.failures["EmitMark"] = "empty"
     with pytest.raises(WorkerSdkError, match="host call failed"):
         await runtime.emit_mark("mark")
+
+    class UnimplementedRuntimeDiagnosticsError(Exception):
+        def code(self) -> grpc.StatusCode:
+            return grpc.StatusCode.UNIMPLEMENTED
+
+    class OldHostStub:
+        async def GetRuntimeDiagnostics(self, request: Any) -> Any:
+            del request
+            raise UnimplementedRuntimeDiagnosticsError()
+
+    with mock.patch.object(grpc.aio, "AioRpcError", UnimplementedRuntimeDiagnosticsError):
+        old_host_runtime = PluginRuntime(
+            activation_id=ACTIVATION_ID,
+            auth_token=AUTH_TOKEN,
+            host_stub=OldHostStub(),
+        )
+        with pytest.raises(WorkerSdkError, match="grpc-v1 diagnostics extension"):
+            await old_host_runtime.runtime_diagnostics()
 
     host_stub.failures["CreateScopeStack"] = "error"
     with pytest.raises(WorkerSdkError, match="CreateScopeStack failed"):

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -186,6 +186,8 @@ def test_tool_execution_outcome_proto_preserves_annotation_and_pending_marks():
             "category_profile": {"subtype": "checkpoint", "nested": {"ok": True}},
             "data": False,
             "metadata": 0,
+            "data_schema": None,
+            "severity": None,
         }
     ]
 
@@ -206,6 +208,8 @@ def test_tool_execution_outcome_proto_omits_null_annotation_and_optional_mark_fi
             "category_profile": None,
             "data": None,
             "metadata": None,
+            "data_schema": None,
+            "severity": None,
         }
     ]
 

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -25,12 +25,14 @@ grpc = pytest.importorskip("grpc")
 
 from nemo_relay_plugin import (  # noqa: E402
     ConfigDiagnostic,
+    DataSchema,
     DiagnosticLevel,
     Json,
     LlmOptimizationContribution,
     LlmRequestInterceptOutcome,
     LlmSanitizeRequestContext,
     LlmSanitizeResponseContext,
+    LogSeverity,
     PendingMarkSpec,
     PluginContext,
     PluginRuntime,
@@ -272,6 +274,31 @@ def test_optimization_contribution_omitted_applied_defaults_consistently():
     assert decoded.applied is False
     assert direct.to_json()["applied"] is False
     assert decoded.to_json()["applied"] is False
+
+
+def test_pending_mark_spec_serializes_telemetry_fields():
+    mark = PendingMarkSpec(
+        "worker.telemetry",
+        data={"measurements": []},
+        data_schema={"name": "nemo.relay.metric_measurements", "version": "1"},
+        severity="warning",
+    )
+
+    assert mark.to_json() == {
+        "name": "worker.telemetry",
+        "category": None,
+        "category_profile": None,
+        "data": {"measurements": []},
+        "data_schema": {
+            "name": "nemo.relay.metric_measurements",
+            "version": "1",
+        },
+        "metadata": None,
+        "severity": "warn",
+    }
+
+    with pytest.raises(ValueError, match="invalid log severity"):
+        PendingMarkSpec("worker.invalid", severity="fatal").to_json()
 
 
 def test_optimization_contribution_preserves_future_quality_strings():
@@ -1617,7 +1644,9 @@ async def test_unary_invoke_success_paths(service: _WorkerService, host_stub: Re
             "category": None,
             "category_profile": None,
             "data": {"source": "python"},
+            "data_schema": None,
             "metadata": None,
+            "severity": None,
         }
     ]
 
@@ -2099,6 +2128,23 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
     assert llm_next["next_llm"]["content"]["prompt"] == "hello"
     assert stream_next[0]["next_stream"]["content"]["prompt"] == "hello"
 
+    await runtime.emit_mark(
+        "telemetry-options",
+        {"measurements": []},
+        data_schema=DataSchema("nemo.relay.metric_measurements", "1"),
+        severity=LogSeverity.WARNING,
+    )
+    await runtime.emit_metric(
+        "telemetry-metric",
+        [
+            {
+                "name": "example.tokens.saved",
+                "kind": "counter",
+                "value_type": "u64",
+                "value": 42,
+            }
+        ],
+    )
     await runtime.emit_mark("explicit", scope_stack_id="explicit-stack", parent_scope_id="explicit-parent")
     await runtime.drop_scope_stack(stack_id)
     mark_request = _last_request(host_stub, pb.EmitMarkRequest)
@@ -2107,6 +2153,28 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
     push_request = _last_request(host_stub, pb.PushScopeRequest)
     assert push_request.scope.scope_stack_id == "stack-1"
     assert push_request.scope.parent_scope_id == "parent-1"
+
+    telemetry_mark = next(
+        request
+        for request in host_stub.requests
+        if isinstance(request, pb.EmitMarkRequest) and request.name == "telemetry-options"
+    )
+    assert telemetry_mark.data_schema.schema == "nemo.relay.DataSchema@1"
+    assert json.loads(telemetry_mark.data_schema.json) == {
+        "name": "nemo.relay.metric_measurements",
+        "version": "1",
+    }
+    assert telemetry_mark.severity == "warn"
+    metric_mark = next(
+        request
+        for request in host_stub.requests
+        if isinstance(request, pb.EmitMarkRequest) and request.name == "telemetry-metric"
+    )
+    assert json.loads(metric_mark.data.json)["measurements"][0]["value"] == 42
+    assert json.loads(metric_mark.data_schema.json) == {
+        "name": "nemo.relay.metric_measurements",
+        "version": "1",
+    }
 
     override_mark = next(
         request
@@ -2131,6 +2199,12 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         await runtime.emit_mark("empty-stack", scope_stack_id="")
     with pytest.raises(WorkerSdkError, match="parent_scope_id must not be empty"):
         await runtime.emit_mark("empty-parent", scope_stack_id="stack", parent_scope_id="")
+    with pytest.raises(ValueError, match="invalid log severity"):
+        await runtime.emit_mark("invalid-severity", severity="fatal")
+    with pytest.raises(ValueError, match="exactly name and version"):
+        await runtime.emit_mark("invalid-schema", data_schema={"name": "schema"})
+    with pytest.raises(TypeError, match="measurements must contain mappings"):
+        await runtime.emit_metric("invalid-metric", cast(Any, [42]))
 
 
 async def test_invocation_scope_context_is_isolated_across_concurrent_requests(host_stub: RecordingHostStub):


### PR DESCRIPTION
#### Overview

Expose typed OTLP log and metric marks plus host-level runtime diagnostics to native and `grpc-v1` worker dynamic plugins.

This PR is independently rebased on `main` after [#780](https://github.com/NVIDIA/NeMo-Relay/pull/780). It includes the Rust native SDK and the Rust/Python worker SDKs; the public PyO3, Node.js, C FFI, and Go binding follow-ups remain separate. Consolidated user documentation remains in draft PR #795.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Finalize the Relay 0.8 native ABI-v4 host table with `emit_mark_v2` for data schemas and severity, followed by `get_runtime_diagnostics(out_json)`. `NEMO_RELAY_NATIVE_ABI_VERSION` remains `4`.
- Treat v4 as one finalized table: the native SDK verifies the final v4 `struct_size` before exposing v4 callbacks. Frozen ABI-v2 and ABI-v3 tables remain supported; the interim shorter v4 table was not a released compatibility baseline.
- Expose `PluginRuntime::runtime_diagnostics()` in the Rust native SDK as `RuntimeDiagnostics { entries, get(code) }` over `RuntimeDiagnostic { code, message, count }`.
- Project active host diagnostics only: aggregate by code, retain the newest message, saturate counts, sort by code, and cap snapshots at 32 entries. Failed-teardown reports stay available through the existing `active_plugin_report()`; per-plugin attribution is deferred.
- Extend the `grpc-v1` worker protocol additively with authenticated `GetRuntimeDiagnostics`. No handshake capability is required: an older host returns gRPC `UNIMPLEMENTED`, which the Rust and Python worker SDKs translate to a clear unsupported-runtime-diagnostics error.
- Add equivalent Rust-worker and Python-worker SDK methods, including immutable Python diagnostic snapshot types.
- Retain native and worker typed-mark support, helpers, fixtures, and compatibility coverage from the original scope.

Validation:

- `cargo fmt --all -- --check`, targeted native SDK/core/protocol/worker tests, and `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `just check-python-worker-proto`, targeted Python worker SDK tests, `just test-rust`, `just test-python` (672 passed), `just test-go`, `just test-node` (375 passed), and `uv run pre-commit run --all-files` passed.

Breaking changes: none to released native ABI versions. Relay 0.8 continues to use ABI v4, whose final table is established by this PR.

#### Where should the reviewer start?

Start with `crates/plugin/src/lib.rs` for the finalized ABI-v4 table and native SDK, then `crates/core/src/plugin.rs` for active-only aggregation and restore behavior. Review `crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto`, `crates/worker/src/lib.rs`, and `python/plugin/src/nemo_relay_plugin/_api.py` for the worker transport and SDK surfaces.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #780
- Relates to: #781
- Relates to: #795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added telemetry metric emission with schemas, measurements, and severity levels.
  - Added bounded runtime diagnostics with aggregated codes, messages, and occurrence counts.
  - Added optional data schemas and severity settings for emitted marks.
  - Exposed telemetry and diagnostics capabilities across native, worker, and Python SDKs.

- **Compatibility**
  - Added support for plugin ABI versions 2–4.
  - Preserved legacy mark behavior when newer capabilities are unavailable.

- **Validation**
  - Added coverage for metrics, diagnostics, schemas, severity validation, and ABI compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
