### PR TITLE
feat(node): expose OTLP log and metric APIs

### DIFF
--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -115,9 +115,17 @@ const execution = await toolCallExecuteAsync('lookup', { query: 'relay' }, async
 console.log(execution.result.answer);
 ```
 
-Pass `LogSeverity.Info` to the optional final `event` argument for a mark
-intended for log export. Call `metric()` with `MetricMeasurement` objects for
-metrics; Relay validates the complete measurement group before publishing it.
+The core mark contract uses positional optional arguments. Pass `null` for
+`dataSchema` before supplying the final `severity` argument:
+
+```js
+const { LogSeverity } = require('nemo-relay-node');
+
+event('initialized', handle, { binding: 'node' }, null, null, null, LogSeverity.Info);
+```
+
+Call `metric()` with `MetricMeasurement` objects for metrics; Relay validates
+the complete measurement group before publishing it.
 
 Native subscriber delivery is asynchronous. Awaiting `flushSubscribers()` drains
 the native dispatcher and waits for managed terminal publications registered

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -48,9 +48,11 @@ The Node.js package provides the following capabilities:
 - **Middleware APIs**: Guardrails and intercepts for tool and LLM boundaries,
   plus mark and scope event sanitizers for `data`, `categoryProfile`, and
   `metadata`.
-- **Observability exporters**: `OpenTelemetrySubscriber` accepts one required
-  `full`, `gen_ai`, or `openinference` endpoint configuration. The
-  `nemo-relay-node/observability` helper configures plugin-owned endpoint
+- **Observability exporters**: `OpenTelemetrySubscriber` exports traces;
+  `OpenTelemetryLogSubscriber` and `OpenTelemetryMetricSubscriber` export
+  severity-tagged marks and typed metric measurements. Bare OTLP/HTTP origins
+  resolve to `/v1/traces`, `/v1/logs`, or `/v1/metrics` for the selected signal.
+  The `nemo-relay-node/observability` helper configures plugin-owned endpoint
   fan-out.
 - **Additional entry points**: `nemo-relay-node/typed`,
   `nemo-relay-node/plugin`, `nemo-relay-node/adaptive`, and
@@ -112,6 +114,10 @@ const execution = await toolCallExecuteAsync('lookup', { query: 'relay' }, async
 
 console.log(execution.result.answer);
 ```
+
+Pass `LogSeverity.Info` to the optional final `event` argument for a mark
+intended for log export. Call `metric()` with `MetricMeasurement` objects for
+metrics; Relay validates the complete measurement group before publishing it.
 
 Native subscriber delivery is asynchronous. Awaiting `flushSubscribers()` drains
 the native dispatcher and waits for managed terminal publications registered

--- a/crates/node/observability.d.ts
+++ b/crates/node/observability.d.ts
@@ -86,9 +86,42 @@ export interface OpenTelemetryEndpointConfig {
   scheduled_delay_millis?: number;
 }
 
+export interface OpenTelemetrySignalEndpointConfig {
+  endpoint: string;
+  transport?: 'http_binary' | 'grpc';
+  headers?: Record<string, string>;
+  header_env?: Record<string, string>;
+  resource_attributes?: Record<string, string>;
+  service_name?: string;
+  service_namespace?: string;
+  service_version?: string;
+  instrumentation_scope?: string;
+  timeout_millis?: number;
+}
+
+export interface OpenTelemetryLogSectionConfig {
+  enabled?: boolean;
+  endpoints?: OpenTelemetrySignalEndpointConfig[];
+  minimum_severity?: 'trace' | 'debug' | 'info' | 'warn' | 'warning' | 'error';
+  max_queue_size?: number;
+  max_export_batch_size?: number;
+  scheduled_delay_millis?: number;
+}
+
+export interface OpenTelemetryMetricSectionConfig {
+  enabled?: boolean;
+  endpoints?: OpenTelemetrySignalEndpointConfig[];
+  export_interval_millis?: number;
+  temporality?: 'cumulative' | 'delta' | 'low_memory';
+  max_instruments?: number;
+  cardinality_limit?: number;
+}
+
 export interface OpenTelemetrySectionConfig {
   enabled?: boolean;
   endpoints?: OpenTelemetryEndpointConfig[];
+  logs?: OpenTelemetryLogSectionConfig;
+  metrics?: OpenTelemetryMetricSectionConfig;
 }
 
 export interface Config {
@@ -117,6 +150,16 @@ export declare function atofConfig(config?: AtofConfig): AtofConfig;
 export declare function atifConfig(config?: AtifConfig): AtifConfig;
 /** Create one typed OpenTelemetry endpoint. */
 export declare function openTelemetryEndpoint(config: OpenTelemetryEndpointConfig): OpenTelemetryEndpointConfig;
+/** Create one signal-specific OpenTelemetry endpoint for logs or metrics. */
+export declare function openTelemetrySignalEndpoint(
+  config: OpenTelemetrySignalEndpointConfig,
+): OpenTelemetrySignalEndpointConfig;
+/** Create OTLP log pipeline settings with defaults applied. */
+export declare function openTelemetryLogConfig(config?: OpenTelemetryLogSectionConfig): OpenTelemetryLogSectionConfig;
+/** Create OTLP metric pipeline settings with defaults applied. */
+export declare function openTelemetryMetricConfig(
+  config?: OpenTelemetryMetricSectionConfig,
+): OpenTelemetryMetricSectionConfig;
 /** Create multi-endpoint OpenTelemetry settings. */
 export declare function openTelemetryConfig(config?: OpenTelemetrySectionConfig): OpenTelemetrySectionConfig;
 /** Wrap observability config as a top-level plugin component. */

--- a/crates/node/observability.js
+++ b/crates/node/observability.js
@@ -10,11 +10,11 @@ const OBSERVABILITY_PLUGIN_KIND = 'observability';
 /**
  * Create a default observability component config.
  *
- * @returns {object} The minimal observability config with schema version 3.
+ * @returns {object} The minimal observability config with schema version 4.
  */
 function defaultConfig() {
   return {
-    version: 3,
+    version: 4,
   };
 }
 
@@ -76,6 +76,65 @@ function openTelemetryEndpoint(config) {
 }
 
 /**
+ * Create one signal-specific OpenTelemetry endpoint for logs or metrics.
+ *
+ * @param {object} config - Endpoint settings including required `endpoint`.
+ * @returns {object} A normalized signal endpoint config object.
+ */
+function openTelemetrySignalEndpoint(config) {
+  if (!config || typeof config !== 'object') {
+    throw new TypeError('OpenTelemetry signal endpoint config is required');
+  }
+  if (typeof config.endpoint !== 'string' || config.endpoint.trim() === '') {
+    throw new TypeError('OpenTelemetry signal endpoint must be a nonblank string');
+  }
+  return {
+    transport: 'http_binary',
+    headers: {},
+    header_env: {},
+    resource_attributes: {},
+    service_name: 'unknown_service',
+    instrumentation_scope: 'opentelemetry',
+    timeout_millis: 3000,
+    ...config,
+  };
+}
+
+/**
+ * Create OTLP log pipeline settings with defaults applied.
+ *
+ * @param {object} [config={}] - Partial log pipeline settings.
+ * @returns {object} A normalized OpenTelemetry log section.
+ */
+function openTelemetryLogConfig(config = {}) {
+  return {
+    enabled: false,
+    minimum_severity: 'info',
+    max_queue_size: 2048,
+    max_export_batch_size: 512,
+    scheduled_delay_millis: 1000,
+    ...config,
+  };
+}
+
+/**
+ * Create OTLP metric pipeline settings with defaults applied.
+ *
+ * @param {object} [config={}] - Partial metric pipeline settings.
+ * @returns {object} A normalized OpenTelemetry metric section.
+ */
+function openTelemetryMetricConfig(config = {}) {
+  return {
+    enabled: false,
+    export_interval_millis: 60000,
+    temporality: 'cumulative',
+    max_instruments: 256,
+    cardinality_limit: 2000,
+    ...config,
+  };
+}
+
+/**
  * Create multi-endpoint OpenTelemetry settings.
  *
  * @param {object} [config={}] - Partial section settings.
@@ -108,6 +167,9 @@ module.exports = {
   atofConfig,
   atifConfig,
   openTelemetryEndpoint,
+  openTelemetrySignalEndpoint,
+  openTelemetryLogConfig,
+  openTelemetryMetricConfig,
   openTelemetryConfig,
   ComponentSpec,
 };

--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -9,7 +9,10 @@ import type { LlmCodec, LlmResponseCodec } from './typed';
 /** Codec identity available while a managed LLM event is sanitized. */
 export type LlmCodecIdentity =
   | { kind: 'none' }
-  | { kind: 'builtin'; id: 'openai_chat' | 'openai_responses' | 'anthropic_messages' | 'oci_genai' | 'gemini_generate_content' }
+  | {
+      kind: 'builtin';
+      id: 'openai_chat' | 'openai_responses' | 'anthropic_messages' | 'oci_genai' | 'gemini_generate_content';
+    }
   | { kind: 'runtime'; id: string }
   | { kind: 'opaque' };
 
@@ -113,7 +116,9 @@ export interface PendingMarkSpec {
   category?: string | null;
   categoryProfile?: Json;
   data?: Json;
+  dataSchema?: { name: string; version: string } | null;
   metadata?: Json;
+  severity?: 'trace' | 'debug' | 'info' | 'warn' | 'warning' | 'error' | null;
 }
 
 /** Schema tag attached to an opaque optimization contribution payload. */

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -397,6 +397,24 @@ fn build_otel_metric_config(
     Ok(config)
 }
 
+fn otel_runtime_diagnostics_json(
+    diagnostics: nemo_relay::observability::OpenTelemetryRuntimeDiagnostics,
+) -> Json {
+    Json::Array(
+        diagnostics
+            .entries()
+            .iter()
+            .map(|diagnostic| {
+                serde_json::json!({
+                    "code": diagnostic.code,
+                    "message": diagnostic.message,
+                    "count": diagnostic.count,
+                })
+            })
+            .collect(),
+    )
+}
+
 fn build_atof_config(
     options: Option<AtofExporterConfig>,
 ) -> napi::Result<nemo_relay::observability::atof::AtofExporterConfig> {
@@ -4666,6 +4684,12 @@ impl OpenTelemetryLogSubscriber {
             .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
+    /// Return bounded runtime diagnostics recorded by this subscriber.
+    #[napi(ts_return_type = "Array<{ code: string; message: string; count: number }>")]
+    pub fn runtime_diagnostics(&self) -> Json {
+        otel_runtime_diagnostics_json(self.inner.runtime_diagnostics())
+    }
+
     /// Shut down the underlying logger provider.
     #[napi]
     pub fn shutdown(&self) -> napi::Result<()> {
@@ -4750,6 +4774,12 @@ impl OpenTelemetryMetricSubscriber {
         self.inner
             .force_flush()
             .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Return bounded runtime diagnostics recorded by this subscriber.
+    #[napi(ts_return_type = "Array<{ code: string; message: string; count: number }>")]
+    pub fn runtime_diagnostics(&self) -> Json {
+        otel_runtime_diagnostics_json(self.inner.runtime_diagnostics())
     }
 
     /// Shut down the underlying meter provider.

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -88,7 +88,8 @@ use crate::promise_call::PromiseAwareFn;
 use crate::promise_call::with_publication_callback_context;
 use crate::stream::LlmStream;
 use crate::types::{
-    LlmHandle, ScopeHandle, ScopeStack, ScopeType, ToolExecutionResult, ToolHandle,
+    DataSchema, LlmHandle, LogSeverity, MetricMeasurement, MetricTemporality, ScopeHandle,
+    ScopeStack, ScopeType, ToolExecutionResult, ToolHandle,
 };
 
 static NODE_ENVIRONMENT_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -298,6 +299,101 @@ fn build_otel_config(
                 .unwrap_or_else(nemo_relay::observability::default_mark_exclude_names),
         )
         .with_attribute_mappings(parse_attribute_mappings(options.attribute_mappings)?);
+    Ok(config)
+}
+
+fn build_otel_log_config(
+    options: OpenTelemetryLogConfig,
+) -> napi::Result<nemo_relay::observability::otel_logs::OpenTelemetryLogConfig> {
+    let endpoint = options.endpoint.trim().to_string();
+    if endpoint.is_empty() {
+        return Err(napi::Error::from_reason(
+            "endpoint must be a nonblank string",
+        ));
+    }
+    let mut config = nemo_relay::observability::otel_logs::OpenTelemetryLogConfig::new(endpoint)
+        .with_transport(parse_otel_transport(options.transport)?)
+        .with_service_name(
+            options
+                .service_name
+                .unwrap_or_else(|| "unknown_service".to_string()),
+        )
+        .with_instrumentation_scope(
+            options
+                .instrumentation_scope
+                .unwrap_or_else(|| "opentelemetry".to_string()),
+        )
+        .with_timeout(std::time::Duration::from_millis(
+            options.timeout_millis.unwrap_or(3_000).into(),
+        ))
+        .with_max_queue_size(options.max_queue_size.unwrap_or(2_048) as usize)
+        .with_max_export_batch_size(options.max_export_batch_size.unwrap_or(512) as usize)
+        .with_scheduled_delay(std::time::Duration::from_millis(
+            options.scheduled_delay_millis.unwrap_or(1_000).into(),
+        ));
+    if let Some(severity) = options.minimum_severity {
+        config = config.with_minimum_severity(severity.into());
+    }
+    if let Some(namespace) = options.service_namespace {
+        config = config.with_service_namespace(namespace);
+    }
+    if let Some(version) = options.service_version {
+        config = config.with_service_version(version);
+    }
+    for (key, value) in parse_string_map(options.headers, "headers")? {
+        config = config.with_header(key, value);
+    }
+    for (key, value) in parse_string_map(options.resource_attributes, "resourceAttributes")? {
+        config = config.with_resource_attribute(key, value);
+    }
+    Ok(config)
+}
+
+fn build_otel_metric_config(
+    options: OpenTelemetryMetricConfig,
+) -> napi::Result<nemo_relay::observability::otel_metrics::OpenTelemetryMetricConfig> {
+    let endpoint = options.endpoint.trim().to_string();
+    if endpoint.is_empty() {
+        return Err(napi::Error::from_reason(
+            "endpoint must be a nonblank string",
+        ));
+    }
+    let mut config =
+        nemo_relay::observability::otel_metrics::OpenTelemetryMetricConfig::new(endpoint)
+            .with_transport(parse_otel_transport(options.transport)?)
+            .with_service_name(
+                options
+                    .service_name
+                    .unwrap_or_else(|| "unknown_service".to_string()),
+            )
+            .with_instrumentation_scope(
+                options
+                    .instrumentation_scope
+                    .unwrap_or_else(|| "opentelemetry".to_string()),
+            )
+            .with_timeout(std::time::Duration::from_millis(
+                options.timeout_millis.unwrap_or(3_000).into(),
+            ))
+            .with_export_interval(std::time::Duration::from_millis(
+                options.export_interval_millis.unwrap_or(60_000).into(),
+            ))
+            .with_max_instruments(options.max_instruments.unwrap_or(256) as usize)
+            .with_cardinality_limit(options.cardinality_limit.unwrap_or(2_000) as usize);
+    if let Some(temporality) = options.temporality {
+        config = config.with_temporality(temporality.into());
+    }
+    if let Some(namespace) = options.service_namespace {
+        config = config.with_service_namespace(namespace);
+    }
+    if let Some(version) = options.service_version {
+        config = config.with_service_version(version);
+    }
+    for (key, value) in parse_string_map(options.headers, "headers")? {
+        config = config.with_header(key, value);
+    }
+    for (key, value) in parse_string_map(options.resource_attributes, "resourceAttributes")? {
+        config = config.with_resource_attribute(key, value);
+    }
     Ok(config)
 }
 
@@ -2227,7 +2323,10 @@ pub fn with_scope(
 /// the event is associated with that scope; otherwise it uses the current top scope.
 /// Optional `timestamp` is a Unix timestamp in microseconds recorded on the mark event.
 /// It must be a safe integer number; omit it to use the current runtime time.
+/// Optional `dataSchema` identifies the shape of `data`; `severity` supplies the
+/// typed severity used by OpenTelemetry log exporters.
 #[napi]
+#[allow(clippy::too_many_arguments)]
 pub fn event(
     env: Env,
     name: String,
@@ -2235,6 +2334,8 @@ pub fn event(
     data: Option<Json>,
     metadata: Option<Json>,
     timestamp: Option<f64>,
+    data_schema: Option<DataSchema>,
+    severity: Option<LogSeverity>,
 ) -> Result<()> {
     let timestamp = parse_timestamp_micros(timestamp)?;
     with_effective_scope_stack(&env, || {
@@ -2243,6 +2344,37 @@ pub fn event(
                 .name(&name)
                 .parent_opt(handle.map(|h| &h.inner))
                 .data_opt(opt_json(data))
+                .data_schema_opt(data_schema.map(Into::into))
+                .metadata_opt(opt_json(metadata))
+                .severity_opt(severity.map(Into::into))
+                .timestamp_opt(timestamp)
+                .build(),
+        )
+    })?
+    .map_err(to_napi_err)
+}
+
+/// Emit an atomic, validated group of OpenTelemetry metric recording operations.
+///
+/// `name` is the metric mark name. Every measurement is validated before any
+/// event is published. Optional `handle`, `metadata`, and microsecond `timestamp`
+/// have the same behavior as the corresponding `event` parameters.
+#[napi]
+pub fn metric(
+    env: Env,
+    name: String,
+    measurements: Vec<MetricMeasurement>,
+    handle: Option<&ScopeHandle>,
+    metadata: Option<Json>,
+    timestamp: Option<f64>,
+) -> Result<()> {
+    let timestamp = parse_timestamp_micros(timestamp)?;
+    with_effective_scope_stack(&env, || {
+        core_scope_api::metric(
+            core_scope_api::EmitMetricEventParams::builder()
+                .name(&name)
+                .measurements(measurements.into_iter().map(Into::into).collect())
+                .parent_opt(handle.map(|handle| &handle.inner))
                 .metadata_opt(opt_json(metadata))
                 .timestamp_opt(timestamp)
                 .build(),
@@ -3152,7 +3284,7 @@ pub fn register_tool_execution_intercept(
     name: String,
     priority: i32,
     #[napi(
-        ts_arg_type = "(args: Json, next: (args: Json) => ToolExecutionResult | Promise<ToolExecutionResult>) => { result: Json; annotation?: Json; pendingMarks?: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }> } | Promise<{ result: Json; annotation?: Json; pendingMarks?: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }> }>"
+        ts_arg_type = "(args: Json, next: (args: Json) => ToolExecutionResult | Promise<ToolExecutionResult>) => { result: Json; annotation?: Json; pendingMarks?: Array<import('./plugin').PendingMarkSpec> } | Promise<{ result: Json; annotation?: Json; pendingMarks?: Array<import('./plugin').PendingMarkSpec> }>"
     )]
     callable: JsFunction,
 ) -> Result<()> {
@@ -3731,7 +3863,7 @@ pub fn scope_register_tool_execution_intercept(
     name: String,
     priority: i32,
     #[napi(
-        ts_arg_type = "(args: Json, next: (args: Json) => ToolExecutionResult | Promise<ToolExecutionResult>) => { result: Json; annotation?: Json; pendingMarks?: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }> } | Promise<{ result: Json; annotation?: Json; pendingMarks?: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }> }>"
+        ts_arg_type = "(args: Json, next: (args: Json) => ToolExecutionResult | Promise<ToolExecutionResult>) => { result: Json; annotation?: Json; pendingMarks?: Array<import('./plugin').PendingMarkSpec> } | Promise<{ result: Json; annotation?: Json; pendingMarks?: Array<import('./plugin').PendingMarkSpec> }>"
     )]
     callable: JsFunction,
 ) -> Result<()> {
@@ -4141,7 +4273,7 @@ pub fn tool_conditional_execution(env: Env, name: String, args: Json) -> Result<
 /// The `request` should be a JSON object with `headers` and `content` fields matching
 /// the `LlmRequest` schema. Returns the transformed request as JSON.
 #[napi(
-    ts_return_type = "Promise<{ request: Json; annotated: Json | null; pendingMarks: Array<{ name: string; category?: string | null; categoryProfile?: Json; data?: Json; metadata?: Json }>; optimizationContributions: Array<{ id?: string; sequence?: number; producer: string; kind: 'input_compression' | 'model_routing' | (string & {}); applied: boolean; model_transition?: { baseline?: { model: string; provider?: string }; effective?: { model: string; provider?: string } }; token_impact?: { baseline?: { prompt_tokens?: number; completion_tokens?: number; cache_read_tokens?: number; cache_write_tokens?: number; total_tokens?: number }; effective?: { prompt_tokens?: number; completion_tokens?: number; cache_read_tokens?: number; cache_write_tokens?: number; total_tokens?: number }; saved?: { prompt_tokens?: number; completion_tokens?: number; cache_read_tokens?: number; cache_write_tokens?: number; total_tokens?: number }; quality?: 'observed' | 'estimated'; estimation_method?: string }; payload_schema?: { name: string; version: string }; payload?: Json; [key: string]: Json | undefined }> }>"
+    ts_return_type = "Promise<{ request: Json; annotated: Json | null; pendingMarks: Array<import('./plugin').PendingMarkSpec>; optimizationContributions: Array<{ id?: string; sequence?: number; producer: string; kind: 'input_compression' | 'model_routing' | (string & {}); applied: boolean; model_transition?: { baseline?: { model: string; provider?: string }; effective?: { model: string; provider?: string } }; token_impact?: { baseline?: { prompt_tokens?: number; completion_tokens?: number; cache_read_tokens?: number; cache_write_tokens?: number; total_tokens?: number }; effective?: { prompt_tokens?: number; completion_tokens?: number; cache_read_tokens?: number; cache_write_tokens?: number; total_tokens?: number }; saved?: { prompt_tokens?: number; completion_tokens?: number; cache_read_tokens?: number; cache_write_tokens?: number; total_tokens?: number }; quality?: 'observed' | 'estimated'; estimation_method?: string }; payload_schema?: { name: string; version: string }; payload?: Json; [key: string]: Json | undefined }> }>"
 )]
 pub fn llm_request_intercepts(env: Env, name: String, request: Json) -> Result<JsObject> {
     let llm_request: LlmRequest = serde_json::from_value(request)
@@ -4454,6 +4586,178 @@ impl OpenTelemetrySubscriber {
         self.inner
             .shutdown()
             .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+}
+
+/// Configuration object for `OpenTelemetryLogSubscriber`.
+#[napi(object)]
+#[derive(Default)]
+pub struct OpenTelemetryLogConfig {
+    /// OTLP endpoint. Bare HTTP origins append `/v1/logs`.
+    pub endpoint: String,
+    /// `"http_binary"` (default) or `"grpc"`.
+    #[napi(ts_type = "\"http_binary\" | \"grpc\"")]
+    pub transport: Option<String>,
+    /// Extra exporter headers/metadata as string key/value pairs.
+    #[napi(ts_type = "Record<string, string>")]
+    pub headers: Option<Json>,
+    /// Extra OpenTelemetry resource attributes as string key/value pairs.
+    #[napi(ts_type = "Record<string, string>")]
+    pub resource_attributes: Option<Json>,
+    /// `service.name` resource attribute. Defaults to `"unknown_service"`.
+    pub service_name: Option<String>,
+    /// Optional `service.namespace` resource attribute.
+    pub service_namespace: Option<String>,
+    /// Optional `service.version` resource attribute.
+    pub service_version: Option<String>,
+    /// Instrumentation scope name. Defaults to `"opentelemetry"`.
+    pub instrumentation_scope: Option<String>,
+    /// Export timeout in milliseconds. Defaults to `3000`.
+    pub timeout_millis: Option<u32>,
+    /// Minimum severity exported. Defaults to `LogSeverity.Info`.
+    pub minimum_severity: Option<LogSeverity>,
+    /// Maximum queued log records. Defaults to `2048`.
+    pub max_queue_size: Option<u32>,
+    /// Maximum records per export batch. Defaults to `512`.
+    pub max_export_batch_size: Option<u32>,
+    /// Maximum delay before a partial batch is exported. Defaults to `1000`.
+    pub scheduled_delay_millis: Option<u32>,
+}
+
+/// Subscriber that exports severity-tagged marks through OTLP logs.
+#[napi]
+pub struct OpenTelemetryLogSubscriber {
+    inner: nemo_relay::observability::otel_logs::OpenTelemetryLogSubscriber,
+}
+
+#[napi]
+impl OpenTelemetryLogSubscriber {
+    /// Create a log subscriber from a config object.
+    #[napi(constructor)]
+    pub fn new(config: OpenTelemetryLogConfig) -> napi::Result<Self> {
+        let inner = nemo_relay::observability::otel_logs::OpenTelemetryLogSubscriber::new(
+            build_otel_log_config(config)?,
+        )
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    /// Register this subscriber globally with the given name.
+    #[napi]
+    pub fn register(&self, name: String) -> napi::Result<()> {
+        self.inner
+            .register(&name)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Deregister a subscriber by name.
+    #[napi]
+    pub fn deregister(&self, name: String) -> napi::Result<bool> {
+        self.inner
+            .deregister(&name)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Flush queued Relay events and the OTLP log processor.
+    #[napi]
+    pub fn force_flush(&self) -> napi::Result<()> {
+        self.inner
+            .force_flush()
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Shut down the underlying logger provider.
+    #[napi]
+    pub fn shutdown(&self) -> napi::Result<()> {
+        self.inner
+            .shutdown()
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+}
+
+/// Configuration object for `OpenTelemetryMetricSubscriber`.
+#[napi(object)]
+#[derive(Default)]
+pub struct OpenTelemetryMetricConfig {
+    /// OTLP endpoint. Bare HTTP origins append `/v1/metrics`.
+    pub endpoint: String,
+    /// `"http_binary"` (default) or `"grpc"`.
+    #[napi(ts_type = "\"http_binary\" | \"grpc\"")]
+    pub transport: Option<String>,
+    /// Extra exporter headers/metadata as string key/value pairs.
+    #[napi(ts_type = "Record<string, string>")]
+    pub headers: Option<Json>,
+    /// Extra OpenTelemetry resource attributes as string key/value pairs.
+    #[napi(ts_type = "Record<string, string>")]
+    pub resource_attributes: Option<Json>,
+    /// `service.name` resource attribute. Defaults to `"unknown_service"`.
+    pub service_name: Option<String>,
+    /// Optional `service.namespace` resource attribute.
+    pub service_namespace: Option<String>,
+    /// Optional `service.version` resource attribute.
+    pub service_version: Option<String>,
+    /// Instrumentation scope name. Defaults to `"opentelemetry"`.
+    pub instrumentation_scope: Option<String>,
+    /// Export timeout in milliseconds. Defaults to `3000`.
+    pub timeout_millis: Option<u32>,
+    /// Collection interval in milliseconds. Defaults to `60000`.
+    pub export_interval_millis: Option<u32>,
+    /// Preferred aggregation temporality. Defaults to cumulative.
+    pub temporality: Option<MetricTemporality>,
+    /// Maximum number of retained instrument descriptors. Defaults to `256`.
+    pub max_instruments: Option<u32>,
+    /// Maximum series cardinality per instrument. Defaults to `2000`.
+    pub cardinality_limit: Option<u32>,
+}
+
+/// Subscriber that records metric marks and exports them through OTLP metrics.
+#[napi]
+pub struct OpenTelemetryMetricSubscriber {
+    inner: nemo_relay::observability::otel_metrics::OpenTelemetryMetricSubscriber,
+}
+
+#[napi]
+impl OpenTelemetryMetricSubscriber {
+    /// Create a metric subscriber from a config object.
+    #[napi(constructor)]
+    pub fn new(config: OpenTelemetryMetricConfig) -> napi::Result<Self> {
+        let inner = nemo_relay::observability::otel_metrics::OpenTelemetryMetricSubscriber::new(
+            build_otel_metric_config(config)?,
+        )
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    /// Register this subscriber globally with the given name.
+    #[napi]
+    pub fn register(&self, name: String) -> napi::Result<()> {
+        self.inner
+            .register(&name)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Deregister a subscriber by name.
+    #[napi]
+    pub fn deregister(&self, name: String) -> napi::Result<bool> {
+        self.inner
+            .deregister(&name)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Collect and export current metric aggregates immediately.
+    #[napi]
+    pub fn force_flush(&self) -> napi::Result<()> {
+        self.inner
+            .force_flush()
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Shut down the underlying meter provider.
+    #[napi]
+    pub fn shutdown(&self) -> napi::Result<()> {
+        self.inner
+            .shutdown()
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 }
 

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -32,8 +32,8 @@ use serde_json::Value as Json;
 use tokio_stream::StreamExt;
 
 use nemo_relay::api::event::{
-    CategoryProfile, Event, EventCategory, EventSanitizeFields as CoreEventSanitizeFields,
-    PendingMarkSpec,
+    CategoryProfile, DataSchema, Event, EventCategory,
+    EventSanitizeFields as CoreEventSanitizeFields, LogSeverity, PendingMarkSpec,
 };
 use nemo_relay::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 use nemo_relay::api::tool::{ToolExecutionInterceptOutcome, ToolExecutionResult};
@@ -123,7 +123,11 @@ pub(crate) struct JsPendingMarkSpec {
     #[serde(default)]
     data: Option<Json>,
     #[serde(default)]
+    data_schema: Option<DataSchema>,
+    #[serde(default)]
     metadata: Option<Json>,
+    #[serde(default)]
+    severity: Option<LogSeverity>,
 }
 
 impl From<JsPendingMarkSpec> for PendingMarkSpec {
@@ -133,9 +137,9 @@ impl From<JsPendingMarkSpec> for PendingMarkSpec {
             category: mark.category,
             category_profile: mark.category_profile,
             data: mark.data,
-            data_schema: None,
+            data_schema: mark.data_schema,
             metadata: mark.metadata,
-            severity: None,
+            severity: mark.severity,
         }
     }
 }
@@ -147,7 +151,9 @@ impl From<PendingMarkSpec> for JsPendingMarkSpec {
             category: mark.category,
             category_profile: mark.category_profile,
             data: mark.data,
+            data_schema: mark.data_schema,
             metadata: mark.metadata,
+            severity: mark.severity,
         }
     }
 }

--- a/crates/node/src/types/mod.rs
+++ b/crates/node/src/types/mod.rs
@@ -13,7 +13,11 @@ use nemo_relay::api::runtime::{ScopeStackHandle, create_scope_stack};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
 
-use nemo_relay::api::event::Event;
+use nemo_relay::api::event::{
+    DataSchema as CoreDataSchema, Event, LogSeverity as CoreLogSeverity,
+    MetricKind as CoreMetricKind, MetricMeasurement as CoreMetricMeasurement,
+    MetricValueType as CoreMetricValueType,
+};
 use nemo_relay::api::llm::{LlmHandle as CoreLlmHandle, LlmRequest as CoreLlmRequest};
 use nemo_relay::api::scope::{ScopeHandle as CoreScopeHandle, ScopeType as CoreScopeType};
 use nemo_relay::api::tool::{
@@ -85,6 +89,129 @@ impl From<CoreScopeType> for ScopeType {
             CoreScopeType::Evaluator => ScopeType::Evaluator,
             CoreScopeType::Custom => ScopeType::Custom,
             CoreScopeType::Unknown => ScopeType::Unknown,
+        }
+    }
+}
+
+/// Severity attached to a mark projected as an OpenTelemetry log.
+#[napi]
+pub enum LogSeverity {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<LogSeverity> for CoreLogSeverity {
+    fn from(value: LogSeverity) -> Self {
+        match value {
+            LogSeverity::Trace => Self::Trace,
+            LogSeverity::Debug => Self::Debug,
+            LogSeverity::Info => Self::Info,
+            LogSeverity::Warn => Self::Warn,
+            LogSeverity::Error => Self::Error,
+        }
+    }
+}
+
+/// OpenTelemetry instrument kind recorded by a metric measurement.
+#[napi]
+pub enum MetricKind {
+    Counter,
+    UpDownCounter,
+    Gauge,
+    Histogram,
+}
+
+impl From<MetricKind> for CoreMetricKind {
+    fn from(value: MetricKind) -> Self {
+        match value {
+            MetricKind::Counter => Self::Counter,
+            MetricKind::UpDownCounter => Self::UpDownCounter,
+            MetricKind::Gauge => Self::Gauge,
+            MetricKind::Histogram => Self::Histogram,
+        }
+    }
+}
+
+/// Explicit numeric representation used by a metric measurement.
+#[napi]
+pub enum MetricValueType {
+    U64,
+    I64,
+    F64,
+}
+
+/// Preferred aggregation temporality for OTLP metric export.
+#[napi]
+pub enum MetricTemporality {
+    Cumulative,
+    Delta,
+    LowMemory,
+}
+
+impl From<MetricTemporality> for nemo_relay::observability::otel_metrics::MetricTemporality {
+    fn from(value: MetricTemporality) -> Self {
+        match value {
+            MetricTemporality::Cumulative => Self::Cumulative,
+            MetricTemporality::Delta => Self::Delta,
+            MetricTemporality::LowMemory => Self::LowMemory,
+        }
+    }
+}
+
+impl From<MetricValueType> for CoreMetricValueType {
+    fn from(value: MetricValueType) -> Self {
+        match value {
+            MetricValueType::U64 => Self::U64,
+            MetricValueType::I64 => Self::I64,
+            MetricValueType::F64 => Self::F64,
+        }
+    }
+}
+
+/// Schema identifier attached to an event's opaque data payload.
+#[napi(object)]
+pub struct DataSchema {
+    pub name: String,
+    pub version: String,
+}
+
+impl From<DataSchema> for CoreDataSchema {
+    fn from(value: DataSchema) -> Self {
+        Self {
+            name: value.name,
+            version: value.version,
+        }
+    }
+}
+
+/// One typed recording operation emitted by `metric`.
+#[napi(object)]
+pub struct MetricMeasurement {
+    pub name: String,
+    pub kind: MetricKind,
+    pub value_type: MetricValueType,
+    #[napi(ts_type = "number")]
+    pub value: Json,
+    pub unit: Option<String>,
+    pub description: Option<String>,
+    pub attributes: Option<Json>,
+    pub boundaries: Option<Vec<f64>>,
+}
+
+impl From<MetricMeasurement> for CoreMetricMeasurement {
+    fn from(value: MetricMeasurement) -> Self {
+        Self {
+            name: value.name,
+            kind: value.kind.into(),
+            value_type: value.value_type.into(),
+            value: value.value,
+            unit: value.unit,
+            description: value.description,
+            attributes: value.attributes,
+            boundaries: value.boundaries,
         }
     }
 }

--- a/crates/node/tests/llm_tests.mjs
+++ b/crates/node/tests/llm_tests.mjs
@@ -1917,6 +1917,8 @@ describe('LLM intercepts', () => {
             name: 'request.first',
             categoryProfile: { subtype: 'optimizer.saved_tokens' },
             data: { order: 1 },
+            dataSchema: { name: 'example.pending', version: '1' },
+            severity: 'info',
           },
           { name: 'request.second', metadata: { source: 'node' } },
         ],
@@ -1933,14 +1935,18 @@ describe('LLM intercepts', () => {
         category: null,
         categoryProfile: { subtype: 'optimizer.saved_tokens' },
         data: { order: 1 },
+        dataSchema: { name: 'example.pending', version: '1' },
         metadata: null,
+        severity: 'info',
       },
       {
         name: 'request.second',
         category: null,
         categoryProfile: null,
         data: null,
+        dataSchema: null,
         metadata: { source: 'node' },
+        severity: null,
       },
     ]);
     assert.deepEqual(result.optimizationContributions, [contributionFixture]);

--- a/crates/node/tests/observability_plugin_tests.mjs
+++ b/crates/node/tests/observability_plugin_tests.mjs
@@ -115,6 +115,33 @@ describe('observability plugin helpers', () => {
     assert.throws(() => observability.openTelemetrySignalEndpoint({ endpoint: ' ' }), /nonblank/);
   });
 
+  it('initializes a version 4 log and metric configuration without exporting signals', async () => {
+    const config = {
+      version: 4,
+      opentelemetry: observability.openTelemetryConfig({
+        enabled: true,
+        logs: observability.openTelemetryLogConfig({
+          enabled: true,
+          endpoints: [observability.openTelemetrySignalEndpoint({ endpoint: 'http://127.0.0.1:4318/v1/logs' })],
+        }),
+        metrics: observability.openTelemetryMetricConfig({
+          enabled: true,
+          endpoints: [observability.openTelemetrySignalEndpoint({ endpoint: 'http://127.0.0.1:4318/v1/metrics' })],
+        }),
+      }),
+    };
+
+    await plugin.initialize({
+      version: 1,
+      components: [observability.ComponentSpec(config)],
+    });
+    try {
+      assert.deepEqual(plugin.report()?.runtime_diagnostics ?? [], []);
+    } finally {
+      plugin.clear();
+    }
+  });
+
   it('lists builtin observability kind and validates bad values', () => {
     assert.throws(() => observability.openTelemetryEndpoint(), /config is required/);
     assert.throws(

--- a/crates/node/tests/observability_plugin_tests.mjs
+++ b/crates/node/tests/observability_plugin_tests.mjs
@@ -19,7 +19,7 @@ function tempDir(prefix) {
 
 describe('observability plugin helpers', () => {
   it('builds defaults and plugin component shape', () => {
-    assert.deepEqual(observability.defaultConfig(), { version: 3 });
+    assert.deepEqual(observability.defaultConfig(), { version: 4 });
     assert.equal(
       observability.ComponentSpec({ version: 3, enable_full_payloads: true }).config.enable_full_payloads,
       true,
@@ -63,6 +63,56 @@ describe('observability plugin helpers', () => {
     const component = observability.ComponentSpec({ version: 3, atof: observability.atofConfig() });
     assert.equal(component.kind, observability.OBSERVABILITY_PLUGIN_KIND);
     assert.equal(component.enabled, true);
+  });
+
+  it('builds OTLP log and metric sections with signal defaults', () => {
+    const endpoint = observability.openTelemetrySignalEndpoint({
+      endpoint: 'https://collector.example/custom/logs',
+      headers: { 'x-static': 'value' },
+      header_env: { authorization: 'OTEL_AUTHORIZATION' },
+      resource_attributes: { 'nv.project': 'observability-dev' },
+      service_namespace: 'telemetry',
+      service_version: '1.0',
+    });
+    assert.deepEqual(endpoint, {
+      endpoint: 'https://collector.example/custom/logs',
+      transport: 'http_binary',
+      headers: { 'x-static': 'value' },
+      header_env: { authorization: 'OTEL_AUTHORIZATION' },
+      resource_attributes: { 'nv.project': 'observability-dev' },
+      service_name: 'unknown_service',
+      service_namespace: 'telemetry',
+      service_version: '1.0',
+      instrumentation_scope: 'opentelemetry',
+      timeout_millis: 3000,
+    });
+
+    const logs = observability.openTelemetryLogConfig({ enabled: true, endpoints: [endpoint] });
+    const metrics = observability.openTelemetryMetricConfig({ enabled: true, endpoints: [] });
+    assert.deepEqual(observability.openTelemetryLogConfig(), {
+      enabled: false,
+      minimum_severity: 'info',
+      max_queue_size: 2048,
+      max_export_batch_size: 512,
+      scheduled_delay_millis: 1000,
+    });
+    assert.deepEqual(observability.openTelemetryMetricConfig(), {
+      enabled: false,
+      export_interval_millis: 60000,
+      temporality: 'cumulative',
+      max_instruments: 256,
+      cardinality_limit: 2000,
+    });
+    assert.deepEqual(observability.openTelemetryConfig({ enabled: true, logs, metrics }), {
+      enabled: true,
+      endpoints: [],
+      logs,
+      metrics,
+    });
+    assert.deepEqual(metrics.endpoints, []);
+
+    assert.throws(() => observability.openTelemetrySignalEndpoint(), /config is required/);
+    assert.throws(() => observability.openTelemetrySignalEndpoint({ endpoint: ' ' }), /nonblank/);
   });
 
   it('lists builtin observability kind and validates bad values', () => {

--- a/crates/node/tests/otel_tests.mjs
+++ b/crates/node/tests/otel_tests.mjs
@@ -195,6 +195,7 @@ describe('OpenTelemetry log and metric subscribers', () => {
     logSubscriber.register(logName);
     assert.equal(logSubscriber.deregister(logName), true);
     logSubscriber.forceFlush();
+    assert.deepEqual(logSubscriber.runtimeDiagnostics(), []);
     logSubscriber.shutdown();
 
     const metricSubscriber = new OpenTelemetryMetricSubscriber({
@@ -210,6 +211,7 @@ describe('OpenTelemetry log and metric subscribers', () => {
     metricSubscriber.register(metricName);
     assert.equal(metricSubscriber.deregister(metricName), true);
     metricSubscriber.forceFlush();
+    assert.deepEqual(metricSubscriber.runtimeDiagnostics(), []);
     metricSubscriber.shutdown();
   });
 

--- a/crates/node/tests/otel_tests.mjs
+++ b/crates/node/tests/otel_tests.mjs
@@ -244,7 +244,7 @@ describe('OpenTelemetry log and metric subscribers', () => {
       subscriber.forceFlush();
       const request = await collector.nextRequest();
       assert.equal(request.url, '/v1/logs');
-      assert.ok(request.body.length > 0);
+      assertBodyContains(request.body, 'log_mark');
     } finally {
       subscriber.deregister(name);
       subscriber.shutdown();
@@ -278,7 +278,7 @@ describe('OpenTelemetry log and metric subscribers', () => {
       subscriber.forceFlush();
       const request = await collector.nextRequest();
       assert.equal(request.url, '/v1/metrics');
-      assert.ok(request.body.length > 0);
+      assertBodyContains(request.body, 'relay.tokens');
     } finally {
       subscriber.deregister(name);
       subscriber.shutdown();

--- a/crates/node/tests/otel_tests.mjs
+++ b/crates/node/tests/otel_tests.mjs
@@ -7,7 +7,20 @@ import { createRequire } from 'node:module';
 import { startCollector } from '../../../scripts/test-support/otel_test_utils.mjs';
 
 const require = createRequire(import.meta.url);
-const { OpenTelemetrySubscriber, ScopeType, pushScope, popScope, event } = require('../index.js');
+const {
+  LogSeverity,
+  MetricKind,
+  MetricTemporality,
+  MetricValueType,
+  OpenTelemetryLogSubscriber,
+  OpenTelemetryMetricSubscriber,
+  OpenTelemetrySubscriber,
+  ScopeType,
+  pushScope,
+  popScope,
+  event,
+  metric,
+} = require('../index.js');
 
 function uniqueId(prefix) {
   return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
@@ -87,14 +100,8 @@ describe('OpenTelemetrySubscriber', () => {
         }),
       /attribute mapping key must not be blank/i,
     );
-    assert.throws(
-      () => new OpenTelemetrySubscriber({ endpoint: 'http://localhost:4318' }),
-      /missing field `type`/i,
-    );
-    assert.throws(
-      () => new OpenTelemetrySubscriber({ type: 'full' }),
-      /missing field `endpoint`/i,
-    );
+    assert.throws(() => new OpenTelemetrySubscriber({ endpoint: 'http://localhost:4318' }), /missing field `type`/i);
+    assert.throws(() => new OpenTelemetrySubscriber({ type: 'full' }), /missing field `endpoint`/i);
     assert.throws(
       () =>
         new OpenTelemetrySubscriber({
@@ -165,6 +172,111 @@ describe('OpenTelemetrySubscriber', () => {
       assertBodyContains(request.body, 'invoke_agent research-agent');
       assertBodyContains(request.body, 'gen_ai.operation.name');
       assert.equal(request.body.includes(Buffer.from('nemo_relay.', 'utf8')), false);
+    } finally {
+      subscriber.deregister(name);
+      subscriber.shutdown();
+      await collector.close();
+    }
+  });
+});
+
+describe('OpenTelemetry log and metric subscribers', () => {
+  it('constructs signal-specific subscribers and supports lifecycle methods', () => {
+    const logSubscriber = new OpenTelemetryLogSubscriber({
+      endpoint: 'http://localhost:4318/v1/logs',
+      minimumSeverity: LogSeverity.Warn,
+      maxQueueSize: 32,
+      maxExportBatchSize: 16,
+      scheduledDelayMillis: 100,
+      headers: { authorization: 'Bearer token' },
+      resourceAttributes: { 'deployment.environment': 'test' },
+    });
+    const logName = uniqueId('node_otel_log');
+    logSubscriber.register(logName);
+    assert.equal(logSubscriber.deregister(logName), true);
+    logSubscriber.forceFlush();
+    logSubscriber.shutdown();
+
+    const metricSubscriber = new OpenTelemetryMetricSubscriber({
+      endpoint: 'http://localhost:4318/v1/metrics',
+      exportIntervalMillis: 100,
+      temporality: MetricTemporality.Delta,
+      maxInstruments: 32,
+      cardinalityLimit: 100,
+      headers: { authorization: 'Bearer token' },
+      resourceAttributes: { 'deployment.environment': 'test' },
+    });
+    const metricName = uniqueId('node_otel_metric');
+    metricSubscriber.register(metricName);
+    assert.equal(metricSubscriber.deregister(metricName), true);
+    metricSubscriber.forceFlush();
+    metricSubscriber.shutdown();
+  });
+
+  it('validates signal-specific limits', () => {
+    assert.throws(
+      () =>
+        new OpenTelemetryLogSubscriber({
+          endpoint: 'http://localhost:4318/v1/logs',
+          maxQueueSize: 0,
+        }),
+      /max_queue_size must be greater than 0/,
+    );
+    assert.throws(
+      () =>
+        new OpenTelemetryMetricSubscriber({
+          endpoint: 'http://localhost:4318/v1/metrics',
+          cardinalityLimit: 0,
+        }),
+      /cardinality_limit must be greater than 0/,
+    );
+  });
+
+  it('exports logs to the logs signal path', async () => {
+    const collector = await startCollector();
+    const subscriber = new OpenTelemetryLogSubscriber({ endpoint: collector.endpoint });
+    const name = uniqueId('node_otel_log_e2e');
+    subscriber.register(name);
+    try {
+      event('log_mark', null, { message: 'ready' }, null, null, null, LogSeverity.Info);
+      subscriber.forceFlush();
+      const request = await collector.nextRequest();
+      assert.equal(request.url, '/v1/logs');
+      assert.ok(request.body.length > 0);
+    } finally {
+      subscriber.deregister(name);
+      subscriber.shutdown();
+      await collector.close();
+    }
+  });
+
+  it('exports metrics to the metrics signal path', async () => {
+    const collector = await startCollector();
+    const subscriber = new OpenTelemetryMetricSubscriber({
+      endpoint: collector.endpoint,
+      exportIntervalMillis: 100,
+    });
+    const name = uniqueId('node_otel_metric_e2e');
+    subscriber.register(name);
+    try {
+      metric(
+        'metric_mark',
+        [
+          {
+            name: 'relay.tokens',
+            kind: MetricKind.Counter,
+            valueType: MetricValueType.U64,
+            value: 3,
+          },
+        ],
+        null,
+        null,
+        null,
+      );
+      subscriber.forceFlush();
+      const request = await collector.nextRequest();
+      assert.equal(request.url, '/v1/metrics');
+      assert.ok(request.body.length > 0);
     } finally {
       subscriber.deregister(name);
       subscriber.shutdown();

--- a/crates/node/tests/otel_tests.mjs
+++ b/crates/node/tests/otel_tests.mjs
@@ -193,7 +193,9 @@ describe('OpenTelemetry log and metric subscribers', () => {
     });
     const logName = uniqueId('node_otel_log');
     logSubscriber.register(logName);
+    assert.throws(() => logSubscriber.register(logName), /already exists/i);
     assert.equal(logSubscriber.deregister(logName), true);
+    assert.equal(logSubscriber.deregister(logName), false);
     logSubscriber.forceFlush();
     assert.deepEqual(logSubscriber.runtimeDiagnostics(), []);
     logSubscriber.shutdown();
@@ -209,7 +211,9 @@ describe('OpenTelemetry log and metric subscribers', () => {
     });
     const metricName = uniqueId('node_otel_metric');
     metricSubscriber.register(metricName);
+    assert.throws(() => metricSubscriber.register(metricName), /already exists/i);
     assert.equal(metricSubscriber.deregister(metricName), true);
+    assert.equal(metricSubscriber.deregister(metricName), false);
     metricSubscriber.forceFlush();
     assert.deepEqual(metricSubscriber.runtimeDiagnostics(), []);
     metricSubscriber.shutdown();

--- a/crates/node/tests/public_observability_api_fixture.ts
+++ b/crates/node/tests/public_observability_api_fixture.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  event,
+  metric,
+  LogSeverity,
+  MetricKind,
+  MetricTemporality,
+  MetricValueType,
+  OpenTelemetryLogSubscriber,
+  OpenTelemetryMetricSubscriber,
+} from '../index.js';
+
+const logSubscriber = new OpenTelemetryLogSubscriber({
+  endpoint: 'http://localhost:4318/v1/logs',
+  minimumSeverity: LogSeverity.Warn,
+});
+const metricSubscriber = new OpenTelemetryMetricSubscriber({
+  endpoint: 'http://localhost:4318/v1/metrics',
+  temporality: MetricTemporality.Delta,
+});
+
+event('fixture.log', null, { ready: true }, null, null, null, LogSeverity.Info);
+metric(
+  'fixture.metric',
+  [
+    {
+      name: 'relay.tokens',
+      kind: MetricKind.Counter,
+      valueType: MetricValueType.U64,
+      value: 1,
+    },
+  ],
+  null,
+  null,
+  null,
+);
+
+const logDiagnostics: Array<{ code: string; message: string; count: number }> = logSubscriber.runtimeDiagnostics();
+const metricDiagnostics: Array<{ code: string; message: string; count: number }> =
+  metricSubscriber.runtimeDiagnostics();
+
+void logDiagnostics;
+void metricDiagnostics;

--- a/crates/node/tests/public_observability_api_fixture.ts
+++ b/crates/node/tests/public_observability_api_fixture.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  type DataSchema,
   event,
   metric,
   LogSeverity,
@@ -12,6 +13,8 @@ import {
   OpenTelemetryMetricSubscriber,
 } from '../index.js';
 
+const dataSchema: DataSchema = { name: 'example.fixture', version: '1' };
+
 const logSubscriber = new OpenTelemetryLogSubscriber({
   endpoint: 'http://localhost:4318/v1/logs',
   minimumSeverity: LogSeverity.Warn,
@@ -21,7 +24,7 @@ const metricSubscriber = new OpenTelemetryMetricSubscriber({
   temporality: MetricTemporality.Delta,
 });
 
-event('fixture.log', null, { ready: true }, null, null, null, LogSeverity.Info);
+event('fixture.log', null, { ready: true }, null, null, dataSchema, LogSeverity.Info);
 metric(
   'fixture.metric',
   [
@@ -40,6 +43,16 @@ metric(
 const logDiagnostics: Array<{ code: string; message: string; count: number }> = logSubscriber.runtimeDiagnostics();
 const metricDiagnostics: Array<{ code: string; message: string; count: number }> =
   metricSubscriber.runtimeDiagnostics();
+logSubscriber.register('fixture-log-subscriber');
+const logDeregistered: boolean = logSubscriber.deregister('fixture-log-subscriber');
+logSubscriber.forceFlush();
+logSubscriber.shutdown();
+metricSubscriber.register('fixture-metric-subscriber');
+const metricDeregistered: boolean = metricSubscriber.deregister('fixture-metric-subscriber');
+metricSubscriber.forceFlush();
+metricSubscriber.shutdown();
 
 void logDiagnostics;
 void metricDiagnostics;
+void logDeregistered;
+void metricDeregistered;

--- a/crates/node/tests/scope_tests.mjs
+++ b/crates/node/tests/scope_tests.mjs
@@ -424,6 +424,21 @@ describe('Events', () => {
     }
   });
 
+  it('event serializes representative log severities', async () => {
+    const events = [];
+    registerSubscriber('node_log_severity_collector', (e) => events.push(e));
+    try {
+      event('trace_log', null, null, null, null, null, LogSeverity.Trace);
+      event('error_log', null, null, null, null, null, LogSeverity.Error);
+      await flushSubscribers();
+
+      assert.equal(events.find((e) => e.name === 'trace_log')?.metadata?.['nemo_relay.log.severity'], 'trace');
+      assert.equal(events.find((e) => e.name === 'error_log')?.metadata?.['nemo_relay.log.severity'], 'error');
+    } finally {
+      deregisterSubscriber('node_log_severity_collector');
+    }
+  });
+
   it('metric emits a validated metric mark', async () => {
     const events = [];
     registerSubscriber('node_metric_collector', (e) => events.push(e));

--- a/crates/node/tests/scope_tests.mjs
+++ b/crates/node/tests/scope_tests.mjs
@@ -17,6 +17,7 @@ const {
   pushScope,
   popScope,
   event,
+  metric,
   withScope,
   toolCallExecute,
   llmCallExecute,
@@ -24,6 +25,9 @@ const {
   deregisterSubscriber,
   flushSubscribers,
   ScopeType,
+  LogSeverity,
+  MetricKind,
+  MetricValueType,
 } = lib;
 
 const SCOPE_ATTR_PARALLEL = 0b01;
@@ -392,6 +396,100 @@ describe('Events', () => {
     const scope = pushScope('event_parent', ScopeType.Agent, null, null);
     event('child_event', scope, null, null);
     popScope(scope);
+  });
+
+  it('event accepts a data schema and typed log severity', async () => {
+    const events = [];
+    registerSubscriber('node_structured_log_collector', (e) => events.push(e));
+    try {
+      event(
+        'structured_log',
+        null,
+        { message: 'ready' },
+        { source: 'node' },
+        null,
+        { name: 'example.log', version: '1' },
+        LogSeverity.Warn,
+      );
+      await flushSubscribers();
+
+      const mark = events.find((e) => e.name === 'structured_log');
+      assert.deepEqual(mark.data_schema, { name: 'example.log', version: '1' });
+      assert.deepEqual(mark.metadata, {
+        source: 'node',
+        'nemo_relay.log.severity': 'warn',
+      });
+    } finally {
+      deregisterSubscriber('node_structured_log_collector');
+    }
+  });
+
+  it('metric emits a validated metric mark', async () => {
+    const events = [];
+    registerSubscriber('node_metric_collector', (e) => events.push(e));
+    try {
+      metric(
+        'token_usage',
+        [
+          {
+            name: 'relay.tokens',
+            kind: MetricKind.Counter,
+            valueType: MetricValueType.U64,
+            value: 12,
+            unit: '{token}',
+            attributes: { model: 'test' },
+          },
+        ],
+        null,
+        { source: 'node' },
+        null,
+      );
+      await flushSubscribers();
+
+      const mark = events.find((e) => e.name === 'token_usage');
+      assert.deepEqual(mark.data_schema, {
+        name: 'nemo.relay.metric_measurements',
+        version: '1',
+      });
+      assert.equal(mark.data.measurements[0].name, 'relay.tokens');
+      assert.equal(mark.data.measurements[0].kind, 'counter');
+      assert.equal(mark.data.measurements[0].value_type, 'u64');
+      assert.equal(mark.data.measurements[0].value, 12);
+    } finally {
+      deregisterSubscriber('node_metric_collector');
+    }
+  });
+
+  it('metric rejects invalid measurements atomically', async () => {
+    const events = [];
+    registerSubscriber('node_invalid_metric_collector', (e) => events.push(e));
+    try {
+      assert.throws(
+        () =>
+          metric(
+            'invalid_metric',
+            [
+              {
+                name: 'relay.tokens',
+                kind: MetricKind.Counter,
+                valueType: MetricValueType.I64,
+                value: -1,
+              },
+            ],
+            null,
+            null,
+            null,
+          ),
+        /does not support value_type i64/,
+      );
+      await flushSubscribers();
+      assert.equal(
+        events.some((e) => e.name === 'invalid_metric'),
+        false,
+      );
+    } finally {
+      deregisterSubscriber('node_invalid_metric_collector');
+    }
   });
 });
 

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -922,7 +922,13 @@ describe('Tool intercepts', () => {
           wrapped: true,
         },
         annotation: downstream.annotation,
-        pendingMarks: [{ name: 'node.tool.execution' }],
+        pendingMarks: [
+          {
+            name: 'node.tool.execution',
+            dataSchema: { name: 'example.tool.mark', version: '1' },
+            severity: 'warning',
+          },
+        ],
       };
     });
     try {
@@ -956,6 +962,8 @@ describe('Tool intercepts', () => {
       assert.ok(end, 'expected tool end event');
       assert.ok(mark, 'expected tool execution pending mark');
       assert.deepEqual(end.category_profile.tool_result_annotation, { source: 'provider' });
+      assert.deepEqual(mark.data_schema, { name: 'example.tool.mark', version: '1' });
+      assert.equal(mark.metadata['nemo_relay.log.severity'], 'warn');
       assert.equal(mark.parent_uuid, start.uuid);
       assert.ok(events.indexOf(end) < events.indexOf(mark), 'expected tool end before pending mark');
       assert.ok(mark.timestamp > end.timestamp, 'expected pending mark timestamp after tool end');

--- a/crates/node/tests/types_tests.mjs
+++ b/crates/node/tests/types_tests.mjs
@@ -3,7 +3,9 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const lib = require('../index.js');
@@ -39,6 +41,29 @@ describe('Type constants', () => {
     assert.equal(ScopeType.Evaluator, 8);
     assert.equal(ScopeType.Custom, 9);
     assert.equal(ScopeType.Unknown, 10);
+  });
+
+  it('type-checks the public observability API fixture', () => {
+    execFileSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL('../../../node_modules/typescript/bin/tsc', import.meta.url)),
+        '--noEmit',
+        '--skipLibCheck',
+        '--strict',
+        '--target',
+        'ES2022',
+        '--module',
+        'NodeNext',
+        '--moduleResolution',
+        'NodeNext',
+        'tests/public_observability_api_fixture.ts',
+      ],
+      {
+        cwd: fileURLToPath(new URL('..', import.meta.url)),
+        stdio: 'pipe',
+      },
+    );
   });
 });
 


### PR DESCRIPTION
#### Overview

Expose the core OTLP log and metric contracts through the Node.js binding.

This PR is independently rebased on `main` after [#780](https://github.com/NVIDIA/NeMo-Relay/pull/780). It contains only the Node.js/N-API layer and has no branch dependency on the Python, FFI/Go, or dynamic-plugin/docs follow-up PRs. Review and merge it on its own readiness.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add Node.js log severity and metric measurement types.
- Add optional `dataSchema` and `severity` arguments to the positional `event()` contract, plus the `metric()` API.
- Add direct OTLP log and metric subscriber configuration, lifecycle, and runtime-diagnostics APIs.
- Add version 4 observability plugin configuration helpers.
- Add initialization, representative severity, pending-mark, TypeScript public-surface, lifecycle error-path, direct-subscriber diagnostics, and serialized OTLP log/metric payload coverage.
- Update TypeScript declarations and package guidance, including the positional `event()` argument contract.

Validation:

- `cargo test -p nemo-relay-node --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-rust`
- Full Node.js suite: 386 passed.
- `uv run pre-commit run --all-files`

Breaking changes: none.

#### Where should the reviewer start?

Start with `crates/node/src/types/mod.rs` for the public types and `crates/node/src/api/mod.rs` for mark emission, subscriber lifecycle, and runtime diagnostics. Then review `crates/node/tests/otel_tests.mjs` for the direct OTLP behavior and `crates/node/tests/public_observability_api_fixture.ts` for the public TypeScript contract.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #780
- Relates to: #799