### PR TITLE
feat(ffi): add OTLP log and metric bindings

### DIFF
--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -464,7 +464,8 @@ typedef int32_t NemoRelayLogSeverity;
  *
  * This is intentionally not a Rust enum because foreign callers can supply any
  * `int32_t` value. Exported functions validate the value before converting it
- * to the core metric kind.
+ * to the core metric kind. Zero is reserved as unspecified so a
+ * zero-initialized measurement cannot select a metric kind accidentally.
  */
 typedef int32_t NemoRelayMetricKind;
 
@@ -474,7 +475,8 @@ typedef int32_t NemoRelayMetricKind;
  *
  * This is intentionally not a Rust enum because foreign callers can supply any
  * `int32_t` value. Exported functions validate the value before converting it
- * to the core metric value type.
+ * to the core metric value type. Zero is reserved as unspecified so a
+ * zero-initialized measurement cannot select a value field accidentally.
  */
 typedef int32_t NemoRelayMetricValueType;
 
@@ -494,11 +496,11 @@ typedef struct NemoRelayMetricMeasurement {
    */
   const char *name;
   /**
-   * Instrument kind.
+   * Required instrument kind. `NEMO_RELAY_METRIC_KIND_UNSPECIFIED` is invalid.
    */
   NemoRelayMetricKind kind;
   /**
-   * Numeric value representation.
+   * Required numeric value representation. `NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED` is invalid.
    */
   NemoRelayMetricValueType value_type;
   /**
@@ -544,24 +546,29 @@ typedef struct NemoRelayMetricMeasurement {
 typedef char *(*NemoRelayToolExecCb)(void *user_data, const char *args_json);
 
 /**
+ * Unspecified metric kind. This value is invalid for a measurement.
+ */
+#define NEMO_RELAY_METRIC_KIND_UNSPECIFIED 0
+
+/**
  * Monotonic additive counter.
  */
-#define NEMO_RELAY_METRIC_KIND_COUNTER 0
+#define NEMO_RELAY_METRIC_KIND_COUNTER 1
 
 /**
  * Additive counter that may increase or decrease.
  */
-#define NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER 1
+#define NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER 2
 
 /**
  * Current sampled value.
  */
-#define NEMO_RELAY_METRIC_KIND_GAUGE 2
+#define NEMO_RELAY_METRIC_KIND_GAUGE 3
 
 /**
  * Distribution sample.
  */
-#define NEMO_RELAY_METRIC_KIND_HISTOGRAM 3
+#define NEMO_RELAY_METRIC_KIND_HISTOGRAM 4
 
 /**
  * Fine-grained tracing information.
@@ -589,19 +596,24 @@ typedef char *(*NemoRelayToolExecCb)(void *user_data, const char *args_json);
 #define NEMO_RELAY_LOG_SEVERITY_ERROR 4
 
 /**
+ * Unspecified metric value type. This value is invalid for a measurement.
+ */
+#define NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED 0
+
+/**
  * Read `u64_value`.
  */
-#define NEMO_RELAY_METRIC_VALUE_TYPE_U64 0
+#define NEMO_RELAY_METRIC_VALUE_TYPE_U64 1
 
 /**
  * Read `i64_value`.
  */
-#define NEMO_RELAY_METRIC_VALUE_TYPE_I64 1
+#define NEMO_RELAY_METRIC_VALUE_TYPE_I64 2
 
 /**
  * Read `f64_value`.
  */
-#define NEMO_RELAY_METRIC_VALUE_TYPE_F64 2
+#define NEMO_RELAY_METRIC_VALUE_TYPE_F64 3
 
 /**
  * Initializes the Go binding runtime and installs default operational logging.
@@ -2374,6 +2386,8 @@ NemoRelayStatus nemo_relay_metric_json(const char *name,
  * `measurements` must reference `measurements_len` initialized entries. Each
  * measurement's `value_type` selects the corresponding numeric value field.
  * Relay validates the complete array before emitting any recording operation.
+ * Relay does not retain `measurements`, their strings, or histogram boundaries;
+ * caller-owned storage need only remain valid until this function returns.
  *
  * # Safety
  * `name` must be a valid non-null C string. `measurements` must be non-null

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -183,6 +183,16 @@ typedef struct FfiLlmSanitizeRequestCodec FfiLlmSanitizeRequestCodec;
 typedef struct FfiLlmSanitizeResponseCodec FfiLlmSanitizeResponseCodec;
 
 /**
+ * Opaque OpenTelemetry log subscriber handle.
+ */
+typedef struct FfiOpenTelemetryLogSubscriber FfiOpenTelemetryLogSubscriber;
+
+/**
+ * Opaque OpenTelemetry metric subscriber handle.
+ */
+typedef struct FfiOpenTelemetryMetricSubscriber FfiOpenTelemetryMetricSubscriber;
+
+/**
  * Opaque OpenTelemetry subscriber handle.
  */
 typedef struct FfiOpenTelemetrySubscriber FfiOpenTelemetrySubscriber;
@@ -441,12 +451,157 @@ typedef char *(*NemoRelayToolExecInterceptCb)(void *user_data,
                                               void *next_ctx);
 
 /**
+ * Integer-backed typed severity for a mark exported as an OpenTelemetry log.
+ *
+ * This is intentionally not a Rust enum because foreign callers can supply any
+ * `int32_t` value. Exported functions validate the value before converting it
+ * to the core log severity.
+ */
+typedef int32_t NemoRelayLogSeverity;
+
+/**
+ * Integer-backed OpenTelemetry instrument kind for one typed metric measurement.
+ *
+ * This is intentionally not a Rust enum because foreign callers can supply any
+ * `int32_t` value. Exported functions validate the value before converting it
+ * to the core metric kind.
+ */
+typedef int32_t NemoRelayMetricKind;
+
+/**
+ * Integer-backed numeric representation selected from a typed metric
+ * measurement's value fields.
+ *
+ * This is intentionally not a Rust enum because foreign callers can supply any
+ * `int32_t` value. Exported functions validate the value before converting it
+ * to the core metric value type.
+ */
+typedef int32_t NemoRelayMetricValueType;
+
+/**
+ * C representation of one typed metric SDK recording operation.
+ *
+ * `value_type` selects exactly one of `u64_value`, `i64_value`, or
+ * `f64_value`. `unit`, `description`, and `attributes_json` are optional.
+ * A null `boundaries` pointer with `boundaries_len == 0` leaves histogram
+ * boundaries unspecified. A non-null pointer with zero length requests an
+ * explicit empty boundary list. For nonzero lengths, `boundaries` must point
+ * to that many doubles.
+ */
+typedef struct NemoRelayMetricMeasurement {
+  /**
+   * Required null-terminated OpenTelemetry instrument name.
+   */
+  const char *name;
+  /**
+   * Instrument kind.
+   */
+  NemoRelayMetricKind kind;
+  /**
+   * Numeric value representation.
+   */
+  NemoRelayMetricValueType value_type;
+  /**
+   * Unsigned value used when `value_type` is `U64`.
+   */
+  uint64_t u64_value;
+  /**
+   * Signed value used when `value_type` is `I64`.
+   */
+  int64_t i64_value;
+  /**
+   * Double value used when `value_type` is `F64`.
+   */
+  double f64_value;
+  /**
+   * Optional null-terminated ASCII unit.
+   */
+  const char *unit;
+  /**
+   * Optional null-terminated description.
+   */
+  const char *description;
+  /**
+   * Optional null-terminated JSON attributes object.
+   */
+  const char *attributes_json;
+  /**
+   * Optional histogram boundary array.
+   */
+  const double *boundaries;
+  /**
+   * Number of entries in `boundaries`.
+   */
+  uintptr_t boundaries_len;
+} NemoRelayMetricMeasurement;
+
+/**
  * Callback for tool execution (default callable). Receives arguments as JSON
  * and returns a serialized `ToolExecutionResult` with required `result` and
  * optional `annotation` fields. The returned string must be allocated with
  * `malloc` or equivalent.
  */
 typedef char *(*NemoRelayToolExecCb)(void *user_data, const char *args_json);
+
+/**
+ * Monotonic additive counter.
+ */
+#define NEMO_RELAY_METRIC_KIND_COUNTER 0
+
+/**
+ * Additive counter that may increase or decrease.
+ */
+#define NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER 1
+
+/**
+ * Current sampled value.
+ */
+#define NEMO_RELAY_METRIC_KIND_GAUGE 2
+
+/**
+ * Distribution sample.
+ */
+#define NEMO_RELAY_METRIC_KIND_HISTOGRAM 3
+
+/**
+ * Fine-grained tracing information.
+ */
+#define NEMO_RELAY_LOG_SEVERITY_TRACE 0
+
+/**
+ * Diagnostic information.
+ */
+#define NEMO_RELAY_LOG_SEVERITY_DEBUG 1
+
+/**
+ * Normal informational event.
+ */
+#define NEMO_RELAY_LOG_SEVERITY_INFO 2
+
+/**
+ * Warning condition.
+ */
+#define NEMO_RELAY_LOG_SEVERITY_WARN 3
+
+/**
+ * Error condition.
+ */
+#define NEMO_RELAY_LOG_SEVERITY_ERROR 4
+
+/**
+ * Read `u64_value`.
+ */
+#define NEMO_RELAY_METRIC_VALUE_TYPE_U64 0
+
+/**
+ * Read `i64_value`.
+ */
+#define NEMO_RELAY_METRIC_VALUE_TYPE_I64 1
+
+/**
+ * Read `f64_value`.
+ */
+#define NEMO_RELAY_METRIC_VALUE_TYPE_F64 2
 
 /**
  * Initializes the Go binding runtime and installs default operational logging.
@@ -1573,6 +1728,118 @@ NemoRelayStatus nemo_relay_otel_subscriber_force_flush(const struct FfiOpenTelem
 NemoRelayStatus nemo_relay_otel_subscriber_shutdown(const struct FfiOpenTelemetrySubscriber *subscriber);
 
 /**
+ * Creates an independently managed OpenTelemetry log subscriber.
+ *
+ * Numeric processing settings use their documented defaults when zero.
+ *
+ * # Safety
+ * Any non-null C strings must be valid and `out` must be non-null.
+ */
+NemoRelayStatus nemo_relay_otel_log_subscriber_create(const char *transport,
+                                                      const char *endpoint,
+                                                      const char *headers_json,
+                                                      const char *resource_attributes_json,
+                                                      const char *service_name,
+                                                      const char *service_namespace,
+                                                      const char *service_version,
+                                                      const char *instrumentation_scope,
+                                                      uint64_t timeout_millis,
+                                                      const char *minimum_severity,
+                                                      uint64_t max_queue_size,
+                                                      uint64_t max_export_batch_size,
+                                                      uint64_t scheduled_delay_millis,
+                                                      struct FfiOpenTelemetryLogSubscriber **out);
+
+/**
+ * Registers an OpenTelemetry log subscriber globally.
+ *
+ * # Safety
+ * `subscriber` and `name` must be valid, non-null pointers.
+ */
+NemoRelayStatus nemo_relay_otel_log_subscriber_register(const struct FfiOpenTelemetryLogSubscriber *subscriber,
+                                                        const char *name);
+
+/**
+ * Deregisters an OpenTelemetry log subscriber by name.
+ *
+ * # Safety
+ * `name` must be a valid C string.
+ */
+NemoRelayStatus nemo_relay_otel_log_subscriber_deregister(const char *name);
+
+/**
+ * Flushes queued Relay events and OTLP log batches.
+ *
+ * # Safety
+ * `subscriber` must be a valid, non-null pointer.
+ */
+NemoRelayStatus nemo_relay_otel_log_subscriber_force_flush(const struct FfiOpenTelemetryLogSubscriber *subscriber);
+
+/**
+ * Shuts down the OpenTelemetry logger provider.
+ *
+ * # Safety
+ * `subscriber` must be a valid, non-null pointer.
+ */
+NemoRelayStatus nemo_relay_otel_log_subscriber_shutdown(const struct FfiOpenTelemetryLogSubscriber *subscriber);
+
+/**
+ * Creates an independently managed OpenTelemetry metric subscriber.
+ *
+ * Numeric processing settings use their documented defaults when zero.
+ *
+ * # Safety
+ * Any non-null C strings must be valid and `out` must be non-null.
+ */
+NemoRelayStatus nemo_relay_otel_metric_subscriber_create(const char *transport,
+                                                         const char *endpoint,
+                                                         const char *headers_json,
+                                                         const char *resource_attributes_json,
+                                                         const char *service_name,
+                                                         const char *service_namespace,
+                                                         const char *service_version,
+                                                         const char *instrumentation_scope,
+                                                         uint64_t timeout_millis,
+                                                         uint64_t export_interval_millis,
+                                                         const char *temporality,
+                                                         uint64_t max_instruments,
+                                                         uint64_t cardinality_limit,
+                                                         struct FfiOpenTelemetryMetricSubscriber **out);
+
+/**
+ * Registers an OpenTelemetry metric subscriber globally.
+ *
+ * # Safety
+ * `subscriber` and `name` must be valid, non-null pointers.
+ */
+NemoRelayStatus nemo_relay_otel_metric_subscriber_register(const struct FfiOpenTelemetryMetricSubscriber *subscriber,
+                                                           const char *name);
+
+/**
+ * Deregisters an OpenTelemetry metric subscriber by name.
+ *
+ * # Safety
+ * `name` must be a valid C string.
+ */
+NemoRelayStatus nemo_relay_otel_metric_subscriber_deregister(const char *name);
+
+/**
+ * Flushes queued Relay events and collects current metric aggregates.
+ *
+ * # Safety
+ * `subscriber` must be a valid, non-null pointer.
+ */
+NemoRelayStatus nemo_relay_otel_metric_subscriber_force_flush(const struct FfiOpenTelemetryMetricSubscriber *subscriber);
+
+/**
+ * Shuts down the OpenTelemetry meter provider and performs final collection.
+ *
+ * # Safety
+ * `subscriber` must be a valid, non-null pointer.
+ */
+NemoRelayStatus nemo_relay_otel_metric_subscriber_shutdown(const struct FfiOpenTelemetryMetricSubscriber *subscriber);
+
+/**
  * Load and activate dynamic plugins as one owned transaction.
  *
  * **Experimental:** this API needs a production consumer before its lifecycle
@@ -2016,6 +2283,68 @@ NemoRelayStatus nemo_relay_event(const char *name,
                                  const char *data_json,
                                  const char *metadata_json,
                                  const int64_t *timestamp_unix_micros);
+
+/**
+ * Emit a named lifecycle event with optional data schema and log severity.
+ *
+ * This is the additive form of [`nemo_relay_event`]. The legacy function
+ * remains ABI-compatible and behaves as if both new arguments were null.
+ *
+ * # Parameters
+ * - `data_schema_json`: Optional `{"name":"...","version":"..."}` JSON.
+ * - `severity`: Optional typed telemetry-log severity.
+ *
+ * # Safety
+ * The pointer requirements are the same as [`nemo_relay_event`]. Optional
+ * pointers may be null and otherwise must remain valid for the call.
+ */
+NemoRelayStatus nemo_relay_event_v2(const char *name,
+                                    const struct FfiScopeHandle *parent,
+                                    const char *data_json,
+                                    const char *data_schema_json,
+                                    const char *metadata_json,
+                                    const NemoRelayLogSeverity *severity,
+                                    const int64_t *timestamp_unix_micros);
+
+/**
+ * Emit an atomic metric measurement mark from canonical JSON.
+ *
+ * `measurements_json` must be a nonempty JSON array using Relay's canonical
+ * `MetricMeasurement` shape. Relay validates the complete array before
+ * emitting the metric mark.
+ *
+ * # Safety
+ * `name` and `measurements_json` must be valid non-null C strings. Optional
+ * pointers may be null and otherwise must remain valid for the call.
+ */
+NemoRelayStatus nemo_relay_metric_json(const char *name,
+                                       const struct FfiScopeHandle *parent,
+                                       const char *measurements_json,
+                                       const char *metadata_json,
+                                       const int64_t *timestamp_unix_micros);
+
+/**
+ * Emit an atomic metric measurement mark from typed C measurements.
+ *
+ * `measurements` must reference `measurements_len` initialized entries. Each
+ * measurement's `value_type` selects the corresponding numeric value field.
+ * Relay validates the complete array before emitting any recording operation.
+ *
+ * # Safety
+ * `name` must be a valid non-null C string. `measurements` must be non-null
+ * and valid for `measurements_len` reads when the length is nonzero. Every
+ * measurement name must be a valid C string; optional strings and JSON must
+ * be valid when non-null. A null `boundaries` pointer with zero length leaves
+ * boundaries unspecified, while a non-null pointer with zero length requests
+ * an explicit empty boundary list. For nonzero lengths, `boundaries` must
+ * reference `boundaries_len` doubles.
+ */
+NemoRelayStatus nemo_relay_metric(const char *name,
+                                  const struct FfiScopeHandle *parent,
+                                  const struct NemoRelayMetricMeasurement *measurements,
+                                  uintptr_t measurements_len,
+                                  const char *metadata_json,
+                                  const int64_t *timestamp_unix_micros);
 
 /**
  * Register a scope-local tool conditional execution guardrail.
@@ -2716,6 +3045,24 @@ void nemo_relay_atof_exporter_free(struct FfiAtofExporter *ptr);
  * `ptr` must be a valid pointer returned by `nemo_relay_otel_subscriber_create`, or null.
  */
 void nemo_relay_otel_subscriber_free(struct FfiOpenTelemetrySubscriber *ptr);
+
+/**
+ * Free an OpenTelemetry log subscriber handle.
+ *
+ * # Safety
+ * `ptr` must be a valid pointer returned by
+ * `nemo_relay_otel_log_subscriber_create`, or null.
+ */
+void nemo_relay_otel_log_subscriber_free(struct FfiOpenTelemetryLogSubscriber *ptr);
+
+/**
+ * Free an OpenTelemetry metric subscriber handle.
+ *
+ * # Safety
+ * `ptr` must be a valid pointer returned by
+ * `nemo_relay_otel_metric_subscriber_create`, or null.
+ */
+void nemo_relay_otel_metric_subscriber_free(struct FfiOpenTelemetryMetricSubscriber *ptr);
 
 /**
  * Free an adaptive runtime handle previously returned by

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -1743,7 +1743,7 @@ NemoRelayStatus nemo_relay_otel_subscriber_shutdown(const struct FfiOpenTelemetr
 /**
  * Creates an independently managed OpenTelemetry log subscriber.
  *
- * Numeric processing settings use their documented defaults when zero.
+ * Numeric processing settings use their core-config defaults when zero.
  *
  * # Safety
  * Any non-null C strings must be valid and `out` must be non-null.
@@ -1773,7 +1773,10 @@ NemoRelayStatus nemo_relay_otel_log_subscriber_register(const struct FfiOpenTele
                                                         const char *name);
 
 /**
- * Deregisters an OpenTelemetry log subscriber by name.
+ * Deregisters a subscriber by name from the shared subscriber registry.
+ *
+ * Subscriber names share one global namespace across trace, log, and metric
+ * subscribers. This function does not verify the subscriber type.
  *
  * # Safety
  * `name` must be a valid C string.
@@ -1812,7 +1815,7 @@ NemoRelayStatus nemo_relay_otel_log_subscriber_shutdown(const struct FfiOpenTele
 /**
  * Creates an independently managed OpenTelemetry metric subscriber.
  *
- * Numeric processing settings use their documented defaults when zero.
+ * Numeric processing settings use their core-config defaults when zero.
  *
  * # Safety
  * Any non-null C strings must be valid and `out` must be non-null.
@@ -1842,7 +1845,10 @@ NemoRelayStatus nemo_relay_otel_metric_subscriber_register(const struct FfiOpenT
                                                            const char *name);
 
 /**
- * Deregisters an OpenTelemetry metric subscriber by name.
+ * Deregisters a subscriber by name from the shared subscriber registry.
+ *
+ * Subscriber names share one global namespace across trace, log, and metric
+ * subscribers. This function does not verify the subscriber type.
  *
  * # Safety
  * `name` must be a valid C string.

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -1720,6 +1720,19 @@ NemoRelayStatus nemo_relay_otel_subscriber_deregister(const char *name);
 NemoRelayStatus nemo_relay_otel_subscriber_force_flush(const struct FfiOpenTelemetrySubscriber *subscriber);
 
 /**
+ * Return a bounded JSON snapshot of runtime diagnostics for this subscriber.
+ *
+ * The result is a JSON array of `{"code": "…", "message": "…", "count": N}`
+ * entries in stable code order. The caller owns `out_json` and must free it
+ * with `nemo_relay_string_free`.
+ *
+ * # Safety
+ * `subscriber` and `out_json` must be valid, non-null pointers.
+ */
+NemoRelayStatus nemo_relay_otel_subscriber_runtime_diagnostics_json(const struct FfiOpenTelemetrySubscriber *subscriber,
+                                                                    char **out_json);
+
+/**
  * Shuts down the underlying tracer provider.
  *
  * # Safety
@@ -1776,6 +1789,19 @@ NemoRelayStatus nemo_relay_otel_log_subscriber_deregister(const char *name);
 NemoRelayStatus nemo_relay_otel_log_subscriber_force_flush(const struct FfiOpenTelemetryLogSubscriber *subscriber);
 
 /**
+ * Return a bounded JSON snapshot of runtime diagnostics for this subscriber.
+ *
+ * The result is a JSON array of `{"code": "…", "message": "…", "count": N}`
+ * entries in stable code order. The caller owns `out_json` and must free it
+ * with `nemo_relay_string_free`.
+ *
+ * # Safety
+ * `subscriber` and `out_json` must be valid, non-null pointers.
+ */
+NemoRelayStatus nemo_relay_otel_log_subscriber_runtime_diagnostics_json(const struct FfiOpenTelemetryLogSubscriber *subscriber,
+                                                                        char **out_json);
+
+/**
  * Shuts down the OpenTelemetry logger provider.
  *
  * # Safety
@@ -1830,6 +1856,19 @@ NemoRelayStatus nemo_relay_otel_metric_subscriber_deregister(const char *name);
  * `subscriber` must be a valid, non-null pointer.
  */
 NemoRelayStatus nemo_relay_otel_metric_subscriber_force_flush(const struct FfiOpenTelemetryMetricSubscriber *subscriber);
+
+/**
+ * Return a bounded JSON snapshot of runtime diagnostics for this subscriber.
+ *
+ * The result is a JSON array of `{"code": "…", "message": "…", "count": N}`
+ * entries in stable code order. The caller owns `out_json` and must free it
+ * with `nemo_relay_string_free`.
+ *
+ * # Safety
+ * `subscriber` and `out_json` must be valid, non-null pointers.
+ */
+NemoRelayStatus nemo_relay_otel_metric_subscriber_runtime_diagnostics_json(const struct FfiOpenTelemetryMetricSubscriber *subscriber,
+                                                                           char **out_json);
 
 /**
  * Shuts down the OpenTelemetry meter provider and performs final collection.

--- a/crates/ffi/src/api/mod.rs
+++ b/crates/ffi/src/api/mod.rs
@@ -34,12 +34,16 @@ use crate::error::{
     NemoRelayStatus, clear_last_error, last_error_message, set_last_error, status_from_error,
     status_from_plugin_error,
 };
-pub use crate::types::nemo_relay_otel_subscriber_free;
 use crate::types::{
     FfiAtifExporter, FfiAtofExporter, FfiCodecHandle, FfiLLMHandle, FfiLLMRequest,
-    FfiLlmSanitizeRequestCodec, FfiLlmSanitizeResponseCodec, FfiOpenTelemetrySubscriber,
-    FfiPluginActivation, FfiPluginContext, FfiScopeHandle, FfiScopeStack,
-    FfiThreadScopeStackBinding, FfiToolHandle, NemoRelayScopeType,
+    FfiLlmSanitizeRequestCodec, FfiLlmSanitizeResponseCodec, FfiOpenTelemetryLogSubscriber,
+    FfiOpenTelemetryMetricSubscriber, FfiOpenTelemetrySubscriber, FfiPluginActivation,
+    FfiPluginContext, FfiScopeHandle, FfiScopeStack, FfiThreadScopeStackBinding, FfiToolHandle,
+    NemoRelayLogSeverity, NemoRelayMetricMeasurement, NemoRelayScopeType,
+};
+pub use crate::types::{
+    nemo_relay_otel_log_subscriber_free, nemo_relay_otel_metric_subscriber_free,
+    nemo_relay_otel_subscriber_free,
 };
 use libc::c_char;
 use nemo_relay::api::llm as core_llm_api;

--- a/crates/ffi/src/api/observability.rs
+++ b/crates/ffi/src/api/observability.rs
@@ -31,7 +31,11 @@ fn status_from_atof_error(error: &AtofExporterError) -> NemoRelayStatus {
     }
 }
 
-fn write_runtime_diagnostics(
+/// Write `diagnostics` to a valid, non-null C-string output slot.
+///
+/// # Safety
+/// `out_json` must point to writable storage for one C-string pointer.
+unsafe fn write_runtime_diagnostics(
     diagnostics: nemo_relay::observability::OpenTelemetryRuntimeDiagnostics,
     out_json: *mut *mut c_char,
 ) -> NemoRelayStatus {
@@ -621,7 +625,13 @@ fn parse_transport(ptr: *const c_char) -> Result<String, NemoRelayStatus> {
 fn parse_otlp_transport(
     ptr: *const c_char,
 ) -> Result<nemo_relay::observability::otel::OtlpTransport, NemoRelayStatus> {
-    match parse_transport(ptr)?.as_str() {
+    transport_from_str(&parse_transport(ptr)?)
+}
+
+fn transport_from_str(
+    value: &str,
+) -> Result<nemo_relay::observability::otel::OtlpTransport, NemoRelayStatus> {
+    match value {
         "http_binary" => Ok(nemo_relay::observability::otel::OtlpTransport::HttpBinary),
         "grpc" => Ok(nemo_relay::observability::otel::OtlpTransport::Grpc),
         other => {
@@ -687,16 +697,7 @@ fn otel_config_for_transport(
     endpoint: String,
     service_name: String,
 ) -> Result<OpenTelemetryConfig, NemoRelayStatus> {
-    let transport = match transport {
-        "http_binary" => nemo_relay::observability::otel::OtlpTransport::HttpBinary,
-        "grpc" => nemo_relay::observability::otel::OtlpTransport::Grpc,
-        other => {
-            set_last_error(&format!(
-                "transport must be 'http_binary' or 'grpc', got {other:?}"
-            ));
-            return Err(NemoRelayStatus::InvalidArg);
-        }
-    };
+    let transport = transport_from_str(transport)?;
     Ok(OpenTelemetryConfig::new(otel_type, endpoint)
         .with_transport(transport)
         .with_service_name(service_name))
@@ -1002,7 +1003,7 @@ pub unsafe extern "C" fn nemo_relay_otel_subscriber_runtime_diagnostics_json(
     if let Err(status) = required_out_ptr(out_json) {
         return status;
     }
-    write_runtime_diagnostics(unsafe { &*subscriber }.0.runtime_diagnostics(), out_json)
+    unsafe { write_runtime_diagnostics((&*subscriber).0.runtime_diagnostics(), out_json) }
 }
 
 /// Shuts down the underlying tracer provider.
@@ -1028,20 +1029,11 @@ pub unsafe extern "C" fn nemo_relay_otel_subscriber_shutdown(
     }
 }
 
-fn parse_usize_or_default(
-    value: u64,
-    default: usize,
-    field_name: &str,
-) -> Result<usize, NemoRelayStatus> {
-    let value = if value == 0 {
-        default
-    } else {
-        usize::try_from(value).map_err(|_| {
-            set_last_error(&format!("{field_name} exceeds the platform size limit"));
-            NemoRelayStatus::InvalidArg
-        })?
-    };
-    Ok(value)
+fn parse_usize(value: u64, field_name: &str) -> Result<usize, NemoRelayStatus> {
+    usize::try_from(value).map_err(|_| {
+        set_last_error(&format!("{field_name} exceeds the platform size limit"));
+        NemoRelayStatus::InvalidArg
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1060,40 +1052,43 @@ fn build_ffi_otel_log_config(
     max_export_batch_size: u64,
     scheduled_delay_millis: u64,
 ) -> Result<OpenTelemetryLogConfig, NemoRelayStatus> {
-    let severity = parse_string_or_default(minimum_severity, "info")?
-        .parse()
-        .map_err(|error: nemo_relay::api::event::ParseLogSeverityError| {
-            set_last_error(&error.to_string());
-            NemoRelayStatus::InvalidArg
-        })?;
     let mut config = OpenTelemetryLogConfig::new(parse_required_otel_endpoint(endpoint)?)
-        .with_transport(parse_otlp_transport(transport)?)
-        .with_service_name(parse_string_or_default(service_name, "unknown_service")?)
-        .with_instrumentation_scope(parse_string_or_default(
-            instrumentation_scope,
-            "opentelemetry",
-        )?)
-        .with_timeout(Duration::from_millis(if timeout_millis == 0 {
-            3_000
-        } else {
-            timeout_millis
-        }))
-        .with_minimum_severity(severity)
-        .with_max_queue_size(parse_usize_or_default(
-            max_queue_size,
-            2_048,
-            "max_queue_size",
-        )?)
-        .with_max_export_batch_size(parse_usize_or_default(
+        .with_transport(parse_otlp_transport(transport)?);
+    config = apply_optional_string(
+        config,
+        service_name,
+        OpenTelemetryLogConfig::with_service_name,
+    )?;
+    config = apply_optional_string(
+        config,
+        instrumentation_scope,
+        OpenTelemetryLogConfig::with_instrumentation_scope,
+    )?;
+    if timeout_millis != 0 {
+        config = config.with_timeout(Duration::from_millis(timeout_millis));
+    }
+    if let Some(value) = parse_optional_string(minimum_severity)? {
+        let severity =
+            value
+                .parse()
+                .map_err(|error: nemo_relay::api::event::ParseLogSeverityError| {
+                    set_last_error(&error.to_string());
+                    NemoRelayStatus::InvalidArg
+                })?;
+        config = config.with_minimum_severity(severity);
+    }
+    if max_queue_size != 0 {
+        config = config.with_max_queue_size(parse_usize(max_queue_size, "max_queue_size")?);
+    }
+    if max_export_batch_size != 0 {
+        config = config.with_max_export_batch_size(parse_usize(
             max_export_batch_size,
-            512,
             "max_export_batch_size",
-        )?)
-        .with_scheduled_delay(Duration::from_millis(if scheduled_delay_millis == 0 {
-            1_000
-        } else {
-            scheduled_delay_millis
-        }));
+        )?);
+    }
+    if scheduled_delay_millis != 0 {
+        config = config.with_scheduled_delay(Duration::from_millis(scheduled_delay_millis));
+    }
     config = apply_optional_string(
         config,
         service_namespace,
@@ -1120,7 +1115,7 @@ fn build_ffi_otel_log_config(
 
 /// Creates an independently managed OpenTelemetry log subscriber.
 ///
-/// Numeric processing settings use their documented defaults when zero.
+/// Numeric processing settings use their core-config defaults when zero.
 ///
 /// # Safety
 /// Any non-null C strings must be valid and `out` must be non-null.
@@ -1204,7 +1199,10 @@ pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_register(
     }
 }
 
-/// Deregisters an OpenTelemetry log subscriber by name.
+/// Deregisters a subscriber by name from the shared subscriber registry.
+///
+/// Subscriber names share one global namespace across trace, log, and metric
+/// subscribers. This function does not verify the subscriber type.
 ///
 /// # Safety
 /// `name` must be a valid C string.
@@ -1258,7 +1256,7 @@ pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_runtime_diagnostics_json
     if let Err(status) = required_out_ptr(out_json) {
         return status;
     }
-    write_runtime_diagnostics(unsafe { &*subscriber }.0.runtime_diagnostics(), out_json)
+    unsafe { write_runtime_diagnostics((&*subscriber).0.runtime_diagnostics(), out_json) }
 }
 
 /// Shuts down the OpenTelemetry logger provider.
@@ -1299,40 +1297,38 @@ fn build_ffi_otel_metric_config(
     max_instruments: u64,
     cardinality_limit: u64,
 ) -> Result<OpenTelemetryMetricConfig, NemoRelayStatus> {
-    let temporality = parse_string_or_default(temporality, "cumulative")?
-        .parse()
-        .map_err(|error: String| {
+    let mut config = OpenTelemetryMetricConfig::new(parse_required_otel_endpoint(endpoint)?)
+        .with_transport(parse_otlp_transport(transport)?);
+    config = apply_optional_string(
+        config,
+        service_name,
+        OpenTelemetryMetricConfig::with_service_name,
+    )?;
+    config = apply_optional_string(
+        config,
+        instrumentation_scope,
+        OpenTelemetryMetricConfig::with_instrumentation_scope,
+    )?;
+    if timeout_millis != 0 {
+        config = config.with_timeout(Duration::from_millis(timeout_millis));
+    }
+    if export_interval_millis != 0 {
+        config = config.with_export_interval(Duration::from_millis(export_interval_millis));
+    }
+    if let Some(value) = parse_optional_string(temporality)? {
+        let temporality = value.parse().map_err(|error: String| {
             set_last_error(&error);
             NemoRelayStatus::InvalidArg
         })?;
-    let mut config = OpenTelemetryMetricConfig::new(parse_required_otel_endpoint(endpoint)?)
-        .with_transport(parse_otlp_transport(transport)?)
-        .with_service_name(parse_string_or_default(service_name, "unknown_service")?)
-        .with_instrumentation_scope(parse_string_or_default(
-            instrumentation_scope,
-            "opentelemetry",
-        )?)
-        .with_timeout(Duration::from_millis(if timeout_millis == 0 {
-            3_000
-        } else {
-            timeout_millis
-        }))
-        .with_export_interval(Duration::from_millis(if export_interval_millis == 0 {
-            60_000
-        } else {
-            export_interval_millis
-        }))
-        .with_temporality(temporality)
-        .with_max_instruments(parse_usize_or_default(
-            max_instruments,
-            256,
-            "max_instruments",
-        )?)
-        .with_cardinality_limit(parse_usize_or_default(
-            cardinality_limit,
-            2_000,
-            "cardinality_limit",
-        )?);
+        config = config.with_temporality(temporality);
+    }
+    if max_instruments != 0 {
+        config = config.with_max_instruments(parse_usize(max_instruments, "max_instruments")?);
+    }
+    if cardinality_limit != 0 {
+        config =
+            config.with_cardinality_limit(parse_usize(cardinality_limit, "cardinality_limit")?);
+    }
     config = apply_optional_string(
         config,
         service_namespace,
@@ -1359,7 +1355,7 @@ fn build_ffi_otel_metric_config(
 
 /// Creates an independently managed OpenTelemetry metric subscriber.
 ///
-/// Numeric processing settings use their documented defaults when zero.
+/// Numeric processing settings use their core-config defaults when zero.
 ///
 /// # Safety
 /// Any non-null C strings must be valid and `out` must be non-null.
@@ -1443,7 +1439,10 @@ pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_register(
     }
 }
 
-/// Deregisters an OpenTelemetry metric subscriber by name.
+/// Deregisters a subscriber by name from the shared subscriber registry.
+///
+/// Subscriber names share one global namespace across trace, log, and metric
+/// subscribers. This function does not verify the subscriber type.
 ///
 /// # Safety
 /// `name` must be a valid C string.
@@ -1497,7 +1496,7 @@ pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_runtime_diagnostics_j
     if let Err(status) = required_out_ptr(out_json) {
         return status;
     }
-    write_runtime_diagnostics(unsafe { &*subscriber }.0.runtime_diagnostics(), out_json)
+    unsafe { write_runtime_diagnostics((&*subscriber).0.runtime_diagnostics(), out_json) }
 }
 
 /// Shuts down the OpenTelemetry meter provider and performs final collection.

--- a/crates/ffi/src/api/observability.rs
+++ b/crates/ffi/src/api/observability.rs
@@ -31,6 +31,27 @@ fn status_from_atof_error(error: &AtofExporterError) -> NemoRelayStatus {
     }
 }
 
+fn write_runtime_diagnostics(
+    diagnostics: nemo_relay::observability::OpenTelemetryRuntimeDiagnostics,
+    out_json: *mut *mut c_char,
+) -> NemoRelayStatus {
+    let entries = serde_json::Value::Array(
+        diagnostics
+            .entries()
+            .iter()
+            .map(|diagnostic| {
+                serde_json::json!({
+                    "code": diagnostic.code,
+                    "message": diagnostic.message,
+                    "count": diagnostic.count,
+                })
+            })
+            .collect(),
+    );
+    unsafe { *out_json = json_to_c_string(&entries) };
+    NemoRelayStatus::Ok
+}
+
 // ---------------------------------------------------------------------------
 // Observability plugin component helpers
 // ---------------------------------------------------------------------------
@@ -960,6 +981,30 @@ pub unsafe extern "C" fn nemo_relay_otel_subscriber_force_flush(
     }
 }
 
+/// Return a bounded JSON snapshot of runtime diagnostics for this subscriber.
+///
+/// The result is a JSON array of `{"code": "…", "message": "…", "count": N}`
+/// entries in stable code order. The caller owns `out_json` and must free it
+/// with `nemo_relay_string_free`.
+///
+/// # Safety
+/// `subscriber` and `out_json` must be valid, non-null pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_subscriber_runtime_diagnostics_json(
+    subscriber: *const FfiOpenTelemetrySubscriber,
+    out_json: *mut *mut c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    if let Err(status) = required_out_ptr(out_json) {
+        return status;
+    }
+    write_runtime_diagnostics(unsafe { &*subscriber }.0.runtime_diagnostics(), out_json)
+}
+
 /// Shuts down the underlying tracer provider.
 ///
 /// # Safety
@@ -1192,6 +1237,30 @@ pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_force_flush(
     }
 }
 
+/// Return a bounded JSON snapshot of runtime diagnostics for this subscriber.
+///
+/// The result is a JSON array of `{"code": "…", "message": "…", "count": N}`
+/// entries in stable code order. The caller owns `out_json` and must free it
+/// with `nemo_relay_string_free`.
+///
+/// # Safety
+/// `subscriber` and `out_json` must be valid, non-null pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_runtime_diagnostics_json(
+    subscriber: *const FfiOpenTelemetryLogSubscriber,
+    out_json: *mut *mut c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    if let Err(status) = required_out_ptr(out_json) {
+        return status;
+    }
+    write_runtime_diagnostics(unsafe { &*subscriber }.0.runtime_diagnostics(), out_json)
+}
+
 /// Shuts down the OpenTelemetry logger provider.
 ///
 /// # Safety
@@ -1405,6 +1474,30 @@ pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_force_flush(
             NemoRelayStatus::Internal
         }
     }
+}
+
+/// Return a bounded JSON snapshot of runtime diagnostics for this subscriber.
+///
+/// The result is a JSON array of `{"code": "…", "message": "…", "count": N}`
+/// entries in stable code order. The caller owns `out_json` and must free it
+/// with `nemo_relay_string_free`.
+///
+/// # Safety
+/// `subscriber` and `out_json` must be valid, non-null pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_runtime_diagnostics_json(
+    subscriber: *const FfiOpenTelemetryMetricSubscriber,
+    out_json: *mut *mut c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    if let Err(status) = required_out_ptr(out_json) {
+        return status;
+    }
+    write_runtime_diagnostics(unsafe { &*subscriber }.0.runtime_diagnostics(), out_json)
 }
 
 /// Shuts down the OpenTelemetry meter provider and performs final collection.

--- a/crates/ffi/src/api/observability.rs
+++ b/crates/ffi/src/api/observability.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    Duration, FfiAtifExporter, FfiAtofExporter, FfiOpenTelemetrySubscriber, NemoRelayStatus,
-    c_char, c_str_to_json, c_str_to_string, clear_last_error, core_subscriber_api,
-    json_to_c_string, set_last_error, status_from_error, str_to_c_string, tokio_runtime,
+    Duration, FfiAtifExporter, FfiAtofExporter, FfiOpenTelemetryLogSubscriber,
+    FfiOpenTelemetryMetricSubscriber, FfiOpenTelemetrySubscriber, NemoRelayStatus, c_char,
+    c_str_to_json, c_str_to_string, clear_last_error, core_subscriber_api, json_to_c_string,
+    set_last_error, status_from_error, str_to_c_string, tokio_runtime,
 };
 
 type AtofExporter = nemo_relay::observability::atof::AtofExporter;
@@ -13,6 +14,11 @@ type AtofExporterError = nemo_relay::observability::atof::AtofExporterError;
 type AtofExporterMode = nemo_relay::observability::atof::AtofExporterMode;
 type OpenTelemetryConfig = nemo_relay::observability::otel::OpenTelemetryConfig;
 type OpenTelemetrySubscriber = nemo_relay::observability::otel::OpenTelemetrySubscriber;
+type OpenTelemetryLogConfig = nemo_relay::observability::otel_logs::OpenTelemetryLogConfig;
+type OpenTelemetryLogSubscriber = nemo_relay::observability::otel_logs::OpenTelemetryLogSubscriber;
+type OpenTelemetryMetricConfig = nemo_relay::observability::otel_metrics::OpenTelemetryMetricConfig;
+type OpenTelemetryMetricSubscriber =
+    nemo_relay::observability::otel_metrics::OpenTelemetryMetricSubscriber;
 type ObservabilityComponentSpec = nemo_relay::observability::plugin_component::ComponentSpec;
 type ObservabilityConfig = nemo_relay::observability::plugin_component::ObservabilityConfig;
 
@@ -591,6 +597,21 @@ fn parse_transport(ptr: *const c_char) -> Result<String, NemoRelayStatus> {
     parse_string_or_default(ptr, "http_binary")
 }
 
+fn parse_otlp_transport(
+    ptr: *const c_char,
+) -> Result<nemo_relay::observability::otel::OtlpTransport, NemoRelayStatus> {
+    match parse_transport(ptr)?.as_str() {
+        "http_binary" => Ok(nemo_relay::observability::otel::OtlpTransport::HttpBinary),
+        "grpc" => Ok(nemo_relay::observability::otel::OtlpTransport::Grpc),
+        other => {
+            set_last_error(&format!(
+                "transport must be 'http_binary' or 'grpc', got {other:?}"
+            ));
+            Err(NemoRelayStatus::InvalidArg)
+        }
+    }
+}
+
 fn parse_mark_projection(
     ptr: *const c_char,
 ) -> Result<nemo_relay::observability::MarkProjection, NemoRelayStatus> {
@@ -957,6 +978,452 @@ pub unsafe extern "C" fn nemo_relay_otel_subscriber_shutdown(
         Ok(()) => NemoRelayStatus::Ok,
         Err(e) => {
             set_last_error(&e.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+fn parse_usize_or_default(
+    value: u64,
+    default: usize,
+    field_name: &str,
+) -> Result<usize, NemoRelayStatus> {
+    let value = if value == 0 {
+        default
+    } else {
+        usize::try_from(value).map_err(|_| {
+            set_last_error(&format!("{field_name} exceeds the platform size limit"));
+            NemoRelayStatus::InvalidArg
+        })?
+    };
+    Ok(value)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_ffi_otel_log_config(
+    transport: *const c_char,
+    endpoint: *const c_char,
+    headers_json: *const c_char,
+    resource_attributes_json: *const c_char,
+    service_name: *const c_char,
+    service_namespace: *const c_char,
+    service_version: *const c_char,
+    instrumentation_scope: *const c_char,
+    timeout_millis: u64,
+    minimum_severity: *const c_char,
+    max_queue_size: u64,
+    max_export_batch_size: u64,
+    scheduled_delay_millis: u64,
+) -> Result<OpenTelemetryLogConfig, NemoRelayStatus> {
+    let severity = parse_string_or_default(minimum_severity, "info")?
+        .parse()
+        .map_err(|error: nemo_relay::api::event::ParseLogSeverityError| {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::InvalidArg
+        })?;
+    let mut config = OpenTelemetryLogConfig::new(parse_required_otel_endpoint(endpoint)?)
+        .with_transport(parse_otlp_transport(transport)?)
+        .with_service_name(parse_string_or_default(service_name, "unknown_service")?)
+        .with_instrumentation_scope(parse_string_or_default(
+            instrumentation_scope,
+            "opentelemetry",
+        )?)
+        .with_timeout(Duration::from_millis(if timeout_millis == 0 {
+            3_000
+        } else {
+            timeout_millis
+        }))
+        .with_minimum_severity(severity)
+        .with_max_queue_size(parse_usize_or_default(
+            max_queue_size,
+            2_048,
+            "max_queue_size",
+        )?)
+        .with_max_export_batch_size(parse_usize_or_default(
+            max_export_batch_size,
+            512,
+            "max_export_batch_size",
+        )?)
+        .with_scheduled_delay(Duration::from_millis(if scheduled_delay_millis == 0 {
+            1_000
+        } else {
+            scheduled_delay_millis
+        }));
+    config = apply_optional_string(
+        config,
+        service_namespace,
+        OpenTelemetryLogConfig::with_service_namespace,
+    )?;
+    config = apply_optional_string(
+        config,
+        service_version,
+        OpenTelemetryLogConfig::with_service_version,
+    )?;
+    config = apply_string_map(
+        config,
+        headers_json,
+        "headers",
+        OpenTelemetryLogConfig::with_header,
+    )?;
+    apply_string_map(
+        config,
+        resource_attributes_json,
+        "resource_attributes",
+        OpenTelemetryLogConfig::with_resource_attribute,
+    )
+}
+
+/// Creates an independently managed OpenTelemetry log subscriber.
+///
+/// Numeric processing settings use their documented defaults when zero.
+///
+/// # Safety
+/// Any non-null C strings must be valid and `out` must be non-null.
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_create(
+    transport: *const c_char,
+    endpoint: *const c_char,
+    headers_json: *const c_char,
+    resource_attributes_json: *const c_char,
+    service_name: *const c_char,
+    service_namespace: *const c_char,
+    service_version: *const c_char,
+    instrumentation_scope: *const c_char,
+    timeout_millis: u64,
+    minimum_severity: *const c_char,
+    max_queue_size: u64,
+    max_export_batch_size: u64,
+    scheduled_delay_millis: u64,
+    out: *mut *mut FfiOpenTelemetryLogSubscriber,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if let Err(status) = required_out_ptr(out) {
+        return status;
+    }
+    let config = match build_ffi_otel_log_config(
+        transport,
+        endpoint,
+        headers_json,
+        resource_attributes_json,
+        service_name,
+        service_namespace,
+        service_version,
+        instrumentation_scope,
+        timeout_millis,
+        minimum_severity,
+        max_queue_size,
+        max_export_batch_size,
+        scheduled_delay_millis,
+    ) {
+        Ok(config) => config,
+        Err(status) => return status,
+    };
+    let _runtime_guard = tokio_runtime().enter();
+    match OpenTelemetryLogSubscriber::new(config) {
+        Ok(subscriber) => {
+            unsafe { *out = Box::into_raw(Box::new(FfiOpenTelemetryLogSubscriber(subscriber))) };
+            NemoRelayStatus::Ok
+        }
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Registers an OpenTelemetry log subscriber globally.
+///
+/// # Safety
+/// `subscriber` and `name` must be valid, non-null pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_register(
+    subscriber: *const FfiOpenTelemetryLogSubscriber,
+    name: *const c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    let name = match c_str_to_string(name) {
+        Ok(name) => name,
+        Err(status) => return status,
+    };
+    match unsafe { &*subscriber }.0.register(&name) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Deregisters an OpenTelemetry log subscriber by name.
+///
+/// # Safety
+/// `name` must be a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_deregister(
+    name: *const c_char,
+) -> NemoRelayStatus {
+    unsafe { nemo_relay_otel_subscriber_deregister(name) }
+}
+
+/// Flushes queued Relay events and OTLP log batches.
+///
+/// # Safety
+/// `subscriber` must be a valid, non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_force_flush(
+    subscriber: *const FfiOpenTelemetryLogSubscriber,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    match unsafe { &*subscriber }.0.force_flush() {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Shuts down the OpenTelemetry logger provider.
+///
+/// # Safety
+/// `subscriber` must be a valid, non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_shutdown(
+    subscriber: *const FfiOpenTelemetryLogSubscriber,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    match unsafe { &*subscriber }.0.shutdown() {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_ffi_otel_metric_config(
+    transport: *const c_char,
+    endpoint: *const c_char,
+    headers_json: *const c_char,
+    resource_attributes_json: *const c_char,
+    service_name: *const c_char,
+    service_namespace: *const c_char,
+    service_version: *const c_char,
+    instrumentation_scope: *const c_char,
+    timeout_millis: u64,
+    export_interval_millis: u64,
+    temporality: *const c_char,
+    max_instruments: u64,
+    cardinality_limit: u64,
+) -> Result<OpenTelemetryMetricConfig, NemoRelayStatus> {
+    let temporality = parse_string_or_default(temporality, "cumulative")?
+        .parse()
+        .map_err(|error: String| {
+            set_last_error(&error);
+            NemoRelayStatus::InvalidArg
+        })?;
+    let mut config = OpenTelemetryMetricConfig::new(parse_required_otel_endpoint(endpoint)?)
+        .with_transport(parse_otlp_transport(transport)?)
+        .with_service_name(parse_string_or_default(service_name, "unknown_service")?)
+        .with_instrumentation_scope(parse_string_or_default(
+            instrumentation_scope,
+            "opentelemetry",
+        )?)
+        .with_timeout(Duration::from_millis(if timeout_millis == 0 {
+            3_000
+        } else {
+            timeout_millis
+        }))
+        .with_export_interval(Duration::from_millis(if export_interval_millis == 0 {
+            60_000
+        } else {
+            export_interval_millis
+        }))
+        .with_temporality(temporality)
+        .with_max_instruments(parse_usize_or_default(
+            max_instruments,
+            256,
+            "max_instruments",
+        )?)
+        .with_cardinality_limit(parse_usize_or_default(
+            cardinality_limit,
+            2_000,
+            "cardinality_limit",
+        )?);
+    config = apply_optional_string(
+        config,
+        service_namespace,
+        OpenTelemetryMetricConfig::with_service_namespace,
+    )?;
+    config = apply_optional_string(
+        config,
+        service_version,
+        OpenTelemetryMetricConfig::with_service_version,
+    )?;
+    config = apply_string_map(
+        config,
+        headers_json,
+        "headers",
+        OpenTelemetryMetricConfig::with_header,
+    )?;
+    apply_string_map(
+        config,
+        resource_attributes_json,
+        "resource_attributes",
+        OpenTelemetryMetricConfig::with_resource_attribute,
+    )
+}
+
+/// Creates an independently managed OpenTelemetry metric subscriber.
+///
+/// Numeric processing settings use their documented defaults when zero.
+///
+/// # Safety
+/// Any non-null C strings must be valid and `out` must be non-null.
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_create(
+    transport: *const c_char,
+    endpoint: *const c_char,
+    headers_json: *const c_char,
+    resource_attributes_json: *const c_char,
+    service_name: *const c_char,
+    service_namespace: *const c_char,
+    service_version: *const c_char,
+    instrumentation_scope: *const c_char,
+    timeout_millis: u64,
+    export_interval_millis: u64,
+    temporality: *const c_char,
+    max_instruments: u64,
+    cardinality_limit: u64,
+    out: *mut *mut FfiOpenTelemetryMetricSubscriber,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if let Err(status) = required_out_ptr(out) {
+        return status;
+    }
+    let config = match build_ffi_otel_metric_config(
+        transport,
+        endpoint,
+        headers_json,
+        resource_attributes_json,
+        service_name,
+        service_namespace,
+        service_version,
+        instrumentation_scope,
+        timeout_millis,
+        export_interval_millis,
+        temporality,
+        max_instruments,
+        cardinality_limit,
+    ) {
+        Ok(config) => config,
+        Err(status) => return status,
+    };
+    let _runtime_guard = tokio_runtime().enter();
+    match OpenTelemetryMetricSubscriber::new(config) {
+        Ok(subscriber) => {
+            unsafe { *out = Box::into_raw(Box::new(FfiOpenTelemetryMetricSubscriber(subscriber))) };
+            NemoRelayStatus::Ok
+        }
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Registers an OpenTelemetry metric subscriber globally.
+///
+/// # Safety
+/// `subscriber` and `name` must be valid, non-null pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_register(
+    subscriber: *const FfiOpenTelemetryMetricSubscriber,
+    name: *const c_char,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    let name = match c_str_to_string(name) {
+        Ok(name) => name,
+        Err(status) => return status,
+    };
+    match unsafe { &*subscriber }.0.register(&name) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Deregisters an OpenTelemetry metric subscriber by name.
+///
+/// # Safety
+/// `name` must be a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_deregister(
+    name: *const c_char,
+) -> NemoRelayStatus {
+    unsafe { nemo_relay_otel_subscriber_deregister(name) }
+}
+
+/// Flushes queued Relay events and collects current metric aggregates.
+///
+/// # Safety
+/// `subscriber` must be a valid, non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_force_flush(
+    subscriber: *const FfiOpenTelemetryMetricSubscriber,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    match unsafe { &*subscriber }.0.force_flush() {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => {
+            set_last_error(&error.to_string());
+            NemoRelayStatus::Internal
+        }
+    }
+}
+
+/// Shuts down the OpenTelemetry meter provider and performs final collection.
+///
+/// # Safety
+/// `subscriber` must be a valid, non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_shutdown(
+    subscriber: *const FfiOpenTelemetryMetricSubscriber,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if subscriber.is_null() {
+        set_last_error("subscriber pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    match unsafe { &*subscriber }.0.shutdown() {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => {
+            set_last_error(&error.to_string());
             NemoRelayStatus::Internal
         }
     }

--- a/crates/ffi/src/api/scope.rs
+++ b/crates/ffi/src/api/scope.rs
@@ -6,11 +6,30 @@ use super::{
     NemoRelayStatus, ScopeAttributes, c_char, c_str_to_opt_json, c_str_to_string, clear_last_error,
     core_scope_api, set_last_error, status_from_error, unix_micros_to_opt_timestamp,
 };
+use crate::types::{NEMO_RELAY_METRIC_KIND_UNSPECIFIED, NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED};
 use crate::types::{log_severity_from_ffi, metric_kind_from_ffi, metric_value_type_from_ffi};
 
 // ---------------------------------------------------------------------------
 // Scope / handle operations
 // ---------------------------------------------------------------------------
+
+fn set_metric_discriminator_error(
+    index: usize,
+    field: &str,
+    value: i32,
+    unspecified: i32,
+    expected: &str,
+) {
+    if value == unspecified {
+        set_last_error(&format!(
+            "measurements[{index}].{field} is unspecified; set one of {expected}"
+        ));
+    } else {
+        set_last_error(&format!(
+            "measurements[{index}].{field} has invalid value {value}"
+        ));
+    }
+}
 
 /// Retrieve the current scope handle from the thread-local scope stack.
 ///
@@ -388,6 +407,8 @@ pub unsafe extern "C" fn nemo_relay_metric_json(
 /// `measurements` must reference `measurements_len` initialized entries. Each
 /// measurement's `value_type` selects the corresponding numeric value field.
 /// Relay validates the complete array before emitting any recording operation.
+/// Relay does not retain `measurements`, their strings, or histogram boundaries;
+/// caller-owned storage need only remain valid until this function returns.
 ///
 /// # Safety
 /// `name` must be a valid non-null C string. `measurements` must be non-null
@@ -430,17 +451,23 @@ pub unsafe extern "C" fn nemo_relay_metric(
             }
         };
         let Some(kind) = metric_kind_from_ffi(measurement.kind) else {
-            set_last_error(&format!(
-                "measurements[{index}].kind has invalid value {}",
-                measurement.kind
-            ));
+            set_metric_discriminator_error(
+                index,
+                "kind",
+                measurement.kind,
+                NEMO_RELAY_METRIC_KIND_UNSPECIFIED,
+                "NEMO_RELAY_METRIC_KIND_COUNTER, NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER, NEMO_RELAY_METRIC_KIND_GAUGE, or NEMO_RELAY_METRIC_KIND_HISTOGRAM",
+            );
             return NemoRelayStatus::InvalidArg;
         };
         let Some(value_type) = metric_value_type_from_ffi(measurement.value_type) else {
-            set_last_error(&format!(
-                "measurements[{index}].value_type has invalid value {}",
-                measurement.value_type
-            ));
+            set_metric_discriminator_error(
+                index,
+                "value_type",
+                measurement.value_type,
+                NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED,
+                "NEMO_RELAY_METRIC_VALUE_TYPE_U64, NEMO_RELAY_METRIC_VALUE_TYPE_I64, or NEMO_RELAY_METRIC_VALUE_TYPE_F64",
+            );
             return NemoRelayStatus::InvalidArg;
         };
         let value = match value_type {

--- a/crates/ffi/src/api/scope.rs
+++ b/crates/ffi/src/api/scope.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    FfiScopeHandle, NemoRelayScopeType, NemoRelayStatus, ScopeAttributes, c_char,
-    c_str_to_opt_json, c_str_to_string, clear_last_error, core_scope_api, set_last_error,
-    status_from_error, unix_micros_to_opt_timestamp,
+    FfiScopeHandle, NemoRelayLogSeverity, NemoRelayMetricMeasurement, NemoRelayScopeType,
+    NemoRelayStatus, ScopeAttributes, c_char, c_str_to_opt_json, c_str_to_string, clear_last_error,
+    core_scope_api, set_last_error, status_from_error, unix_micros_to_opt_timestamp,
 };
+use crate::types::{log_severity_from_ffi, metric_kind_from_ffi, metric_value_type_from_ffi};
 
 // ---------------------------------------------------------------------------
 // Scope / handle operations
@@ -222,6 +223,42 @@ pub unsafe extern "C" fn nemo_relay_event(
     metadata_json: *const c_char,
     timestamp_unix_micros: *const i64,
 ) -> NemoRelayStatus {
+    unsafe {
+        nemo_relay_event_v2(
+            name,
+            parent,
+            data_json,
+            std::ptr::null(),
+            metadata_json,
+            std::ptr::null(),
+            timestamp_unix_micros,
+        )
+    }
+}
+
+/// Emit a named lifecycle event with optional data schema and log severity.
+///
+/// This is the additive form of [`nemo_relay_event`]. The legacy function
+/// remains ABI-compatible and behaves as if both new arguments were null.
+///
+/// # Parameters
+/// - `data_schema_json`: Optional `{"name":"...","version":"..."}` JSON.
+/// - `severity`: Optional typed telemetry-log severity.
+///
+/// # Safety
+/// The pointer requirements are the same as [`nemo_relay_event`]. Optional
+/// pointers may be null and otherwise must remain valid for the call.
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn nemo_relay_event_v2(
+    name: *const c_char,
+    parent: *const FfiScopeHandle,
+    data_json: *const c_char,
+    data_schema_json: *const c_char,
+    metadata_json: *const c_char,
+    severity: *const NemoRelayLogSeverity,
+    timestamp_unix_micros: *const i64,
+) -> NemoRelayStatus {
     clear_last_error();
     let name = match c_str_to_string(name) {
         Ok(s) => s,
@@ -236,9 +273,30 @@ pub unsafe extern "C" fn nemo_relay_event(
         Some(d) => d,
         None => return NemoRelayStatus::InvalidJson,
     };
+    let data_schema = match c_str_to_opt_json(data_schema_json) {
+        Some(Some(value)) => match serde_json::from_value(value) {
+            Ok(schema) => Some(schema),
+            Err(error) => {
+                set_last_error(&format!("invalid data_schema JSON: {error}"));
+                return NemoRelayStatus::InvalidJson;
+            }
+        },
+        Some(None) => None,
+        None => return NemoRelayStatus::InvalidJson,
+    };
     let metadata = match c_str_to_opt_json(metadata_json) {
         Some(m) => m,
         None => return NemoRelayStatus::InvalidJson,
+    };
+    let severity = if severity.is_null() {
+        None
+    } else {
+        let raw_severity = unsafe { *severity };
+        let Some(severity) = log_severity_from_ffi(raw_severity) else {
+            set_last_error(&format!("severity has invalid value {raw_severity}"));
+            return NemoRelayStatus::InvalidArg;
+        };
+        Some(severity)
     };
     let timestamp = match unix_micros_to_opt_timestamp(timestamp_unix_micros) {
         Some(v) => v,
@@ -250,11 +308,226 @@ pub unsafe extern "C" fn nemo_relay_event(
             .name(&name)
             .parent_opt(parent_ref)
             .data_opt(data)
+            .data_schema_opt(data_schema)
             .metadata_opt(metadata)
+            .severity_opt(severity)
             .timestamp_opt(timestamp)
             .build(),
     ) {
         Ok(()) => NemoRelayStatus::Ok,
         Err(e) => status_from_error(&e),
+    }
+}
+
+/// Emit an atomic metric measurement mark from canonical JSON.
+///
+/// `measurements_json` must be a nonempty JSON array using Relay's canonical
+/// `MetricMeasurement` shape. Relay validates the complete array before
+/// emitting the metric mark.
+///
+/// # Safety
+/// `name` and `measurements_json` must be valid non-null C strings. Optional
+/// pointers may be null and otherwise must remain valid for the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_metric_json(
+    name: *const c_char,
+    parent: *const FfiScopeHandle,
+    measurements_json: *const c_char,
+    metadata_json: *const c_char,
+    timestamp_unix_micros: *const i64,
+) -> NemoRelayStatus {
+    clear_last_error();
+    let name = match c_str_to_string(name) {
+        Ok(name) => name,
+        Err(status) => return status,
+    };
+    let parent_ref = if parent.is_null() {
+        None
+    } else {
+        Some(&unsafe { &*parent }.0)
+    };
+    let Some(measurements_json) = c_str_to_opt_json(measurements_json) else {
+        return NemoRelayStatus::InvalidJson;
+    };
+    let Some(measurements_json) = measurements_json else {
+        set_last_error("measurements_json is required");
+        return NemoRelayStatus::NullPointer;
+    };
+    let measurements = match serde_json::from_value(measurements_json) {
+        Ok(measurements) => measurements,
+        Err(error) => {
+            set_last_error(&format!("invalid metric measurements JSON: {error}"));
+            return NemoRelayStatus::InvalidJson;
+        }
+    };
+    let metadata = match c_str_to_opt_json(metadata_json) {
+        Some(metadata) => metadata,
+        None => return NemoRelayStatus::InvalidJson,
+    };
+    let timestamp = match unix_micros_to_opt_timestamp(timestamp_unix_micros) {
+        Some(timestamp) => timestamp,
+        None => return NemoRelayStatus::InvalidArg,
+    };
+
+    match core_scope_api::metric(
+        core_scope_api::EmitMetricEventParams::builder()
+            .name(&name)
+            .measurements(measurements)
+            .parent_opt(parent_ref)
+            .metadata_opt(metadata)
+            .timestamp_opt(timestamp)
+            .build(),
+    ) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => status_from_error(&error),
+    }
+}
+
+/// Emit an atomic metric measurement mark from typed C measurements.
+///
+/// `measurements` must reference `measurements_len` initialized entries. Each
+/// measurement's `value_type` selects the corresponding numeric value field.
+/// Relay validates the complete array before emitting any recording operation.
+///
+/// # Safety
+/// `name` must be a valid non-null C string. `measurements` must be non-null
+/// and valid for `measurements_len` reads when the length is nonzero. Every
+/// measurement name must be a valid C string; optional strings and JSON must
+/// be valid when non-null. A null `boundaries` pointer with zero length leaves
+/// boundaries unspecified, while a non-null pointer with zero length requests
+/// an explicit empty boundary list. For nonzero lengths, `boundaries` must
+/// reference `boundaries_len` doubles.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_metric(
+    name: *const c_char,
+    parent: *const FfiScopeHandle,
+    measurements: *const NemoRelayMetricMeasurement,
+    measurements_len: usize,
+    metadata_json: *const c_char,
+    timestamp_unix_micros: *const i64,
+) -> NemoRelayStatus {
+    clear_last_error();
+    let name = match c_str_to_string(name) {
+        Ok(name) => name,
+        Err(status) => return status,
+    };
+    if measurements_len > 0 && measurements.is_null() {
+        set_last_error("measurements pointer is null");
+        return NemoRelayStatus::NullPointer;
+    }
+    let raw_measurements = if measurements_len == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(measurements, measurements_len) }
+    };
+    let mut typed_measurements = Vec::with_capacity(raw_measurements.len());
+    for (index, measurement) in raw_measurements.iter().enumerate() {
+        let measurement_name = match c_str_to_string(measurement.name) {
+            Ok(name) => name,
+            Err(status) => {
+                set_last_error(&format!("measurements[{index}].name is invalid"));
+                return status;
+            }
+        };
+        let Some(kind) = metric_kind_from_ffi(measurement.kind) else {
+            set_last_error(&format!(
+                "measurements[{index}].kind has invalid value {}",
+                measurement.kind
+            ));
+            return NemoRelayStatus::InvalidArg;
+        };
+        let Some(value_type) = metric_value_type_from_ffi(measurement.value_type) else {
+            set_last_error(&format!(
+                "measurements[{index}].value_type has invalid value {}",
+                measurement.value_type
+            ));
+            return NemoRelayStatus::InvalidArg;
+        };
+        let value = match value_type {
+            nemo_relay::api::event::MetricValueType::U64 => {
+                serde_json::Value::from(measurement.u64_value)
+            }
+            nemo_relay::api::event::MetricValueType::I64 => {
+                serde_json::Value::from(measurement.i64_value)
+            }
+            nemo_relay::api::event::MetricValueType::F64 => {
+                let Some(number) = serde_json::Number::from_f64(measurement.f64_value) else {
+                    set_last_error(&format!("measurements[{index}].f64_value must be finite"));
+                    return NemoRelayStatus::InvalidArg;
+                };
+                serde_json::Value::Number(number)
+            }
+        };
+        let unit = if measurement.unit.is_null() {
+            None
+        } else {
+            match c_str_to_string(measurement.unit) {
+                Ok(value) => Some(value),
+                Err(status) => return status,
+            }
+        };
+        let description = if measurement.description.is_null() {
+            None
+        } else {
+            match c_str_to_string(measurement.description) {
+                Ok(value) => Some(value),
+                Err(status) => return status,
+            }
+        };
+        let attributes = match c_str_to_opt_json(measurement.attributes_json) {
+            Some(value) => value,
+            None => return NemoRelayStatus::InvalidJson,
+        };
+        if measurement.boundaries_len > 0 && measurement.boundaries.is_null() {
+            set_last_error(&format!("measurements[{index}].boundaries pointer is null"));
+            return NemoRelayStatus::NullPointer;
+        }
+        let boundaries = if measurement.boundaries.is_null() {
+            None
+        } else if measurement.boundaries_len == 0 {
+            Some(Vec::new())
+        } else {
+            Some(
+                unsafe {
+                    std::slice::from_raw_parts(measurement.boundaries, measurement.boundaries_len)
+                }
+                .to_vec(),
+            )
+        };
+        typed_measurements.push(nemo_relay::api::event::MetricMeasurement {
+            name: measurement_name,
+            kind,
+            value_type,
+            value,
+            unit,
+            description,
+            attributes,
+            boundaries,
+        });
+    }
+    let parent_ref = if parent.is_null() {
+        None
+    } else {
+        Some(&unsafe { &*parent }.0)
+    };
+    let metadata = match c_str_to_opt_json(metadata_json) {
+        Some(metadata) => metadata,
+        None => return NemoRelayStatus::InvalidJson,
+    };
+    let timestamp = match unix_micros_to_opt_timestamp(timestamp_unix_micros) {
+        Some(timestamp) => timestamp,
+        None => return NemoRelayStatus::InvalidArg,
+    };
+    match core_scope_api::metric(
+        core_scope_api::EmitMetricEventParams::builder()
+            .name(&name)
+            .measurements(typed_measurements)
+            .parent_opt(parent_ref)
+            .metadata_opt(metadata)
+            .timestamp_opt(timestamp)
+            .build(),
+    ) {
+        Ok(()) => NemoRelayStatus::Ok,
+        Err(error) => status_from_error(&error),
     }
 }

--- a/crates/ffi/src/types/mod.rs
+++ b/crates/ffi/src/types/mod.rs
@@ -138,17 +138,20 @@ pub enum NemoRelayScopeType {
 ///
 /// This is intentionally not a Rust enum because foreign callers can supply any
 /// `int32_t` value. Exported functions validate the value before converting it
-/// to the core metric kind.
+/// to the core metric kind. Zero is reserved as unspecified so a
+/// zero-initialized measurement cannot select a metric kind accidentally.
 pub type NemoRelayMetricKind = i32;
 
+/// Unspecified metric kind. This value is invalid for a measurement.
+pub const NEMO_RELAY_METRIC_KIND_UNSPECIFIED: NemoRelayMetricKind = 0;
 /// Monotonic additive counter.
-pub const NEMO_RELAY_METRIC_KIND_COUNTER: NemoRelayMetricKind = 0;
+pub const NEMO_RELAY_METRIC_KIND_COUNTER: NemoRelayMetricKind = 1;
 /// Additive counter that may increase or decrease.
-pub const NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER: NemoRelayMetricKind = 1;
+pub const NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER: NemoRelayMetricKind = 2;
 /// Current sampled value.
-pub const NEMO_RELAY_METRIC_KIND_GAUGE: NemoRelayMetricKind = 2;
+pub const NEMO_RELAY_METRIC_KIND_GAUGE: NemoRelayMetricKind = 3;
 /// Distribution sample.
-pub const NEMO_RELAY_METRIC_KIND_HISTOGRAM: NemoRelayMetricKind = 3;
+pub const NEMO_RELAY_METRIC_KIND_HISTOGRAM: NemoRelayMetricKind = 4;
 
 /// Integer-backed typed severity for a mark exported as an OpenTelemetry log.
 ///
@@ -194,15 +197,18 @@ pub(crate) fn metric_kind_from_ffi(value: NemoRelayMetricKind) -> Option<MetricK
 ///
 /// This is intentionally not a Rust enum because foreign callers can supply any
 /// `int32_t` value. Exported functions validate the value before converting it
-/// to the core metric value type.
+/// to the core metric value type. Zero is reserved as unspecified so a
+/// zero-initialized measurement cannot select a value field accidentally.
 pub type NemoRelayMetricValueType = i32;
 
+/// Unspecified metric value type. This value is invalid for a measurement.
+pub const NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED: NemoRelayMetricValueType = 0;
 /// Read `u64_value`.
-pub const NEMO_RELAY_METRIC_VALUE_TYPE_U64: NemoRelayMetricValueType = 0;
+pub const NEMO_RELAY_METRIC_VALUE_TYPE_U64: NemoRelayMetricValueType = 1;
 /// Read `i64_value`.
-pub const NEMO_RELAY_METRIC_VALUE_TYPE_I64: NemoRelayMetricValueType = 1;
+pub const NEMO_RELAY_METRIC_VALUE_TYPE_I64: NemoRelayMetricValueType = 2;
 /// Read `f64_value`.
-pub const NEMO_RELAY_METRIC_VALUE_TYPE_F64: NemoRelayMetricValueType = 2;
+pub const NEMO_RELAY_METRIC_VALUE_TYPE_F64: NemoRelayMetricValueType = 3;
 
 pub(crate) fn metric_value_type_from_ffi(
     value: NemoRelayMetricValueType,
@@ -228,9 +234,9 @@ pub(crate) fn metric_value_type_from_ffi(
 pub struct NemoRelayMetricMeasurement {
     /// Required null-terminated OpenTelemetry instrument name.
     pub name: *const c_char,
-    /// Instrument kind.
+    /// Required instrument kind. `NEMO_RELAY_METRIC_KIND_UNSPECIFIED` is invalid.
     pub kind: NemoRelayMetricKind,
-    /// Numeric value representation.
+    /// Required numeric value representation. `NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED` is invalid.
     pub value_type: NemoRelayMetricValueType,
     /// Unsigned value used when `value_type` is `U64`.
     pub u64_value: u64,

--- a/crates/ffi/src/types/mod.rs
+++ b/crates/ffi/src/types/mod.rs
@@ -15,7 +15,7 @@ use nemo_relay::api::runtime::{ScopeStackHandle, ThreadScopeStackBinding};
 use nemo_relay::plugin::PluginRegistrationContext;
 use serde_json::Value as Json;
 
-use nemo_relay::api::event::Event;
+use nemo_relay::api::event::{Event, LogSeverity, MetricKind, MetricValueType};
 #[cfg(test)]
 use nemo_relay::api::llm::LlmAttributes;
 use nemo_relay::api::llm::{LlmHandle, LlmRequest};
@@ -63,6 +63,14 @@ pub struct FfiAtifExporter(pub nemo_relay::observability::atif::AtifExporter);
 pub struct FfiAtofExporter(pub nemo_relay::observability::atof::AtofExporter);
 /// Opaque OpenTelemetry subscriber handle.
 pub struct FfiOpenTelemetrySubscriber(pub nemo_relay::observability::otel::OpenTelemetrySubscriber);
+/// Opaque OpenTelemetry log subscriber handle.
+pub struct FfiOpenTelemetryLogSubscriber(
+    pub nemo_relay::observability::otel_logs::OpenTelemetryLogSubscriber,
+);
+/// Opaque OpenTelemetry metric subscriber handle.
+pub struct FfiOpenTelemetryMetricSubscriber(
+    pub nemo_relay::observability::otel_metrics::OpenTelemetryMetricSubscriber,
+);
 /// Opaque owned adaptive runtime handle.
 pub struct FfiAdaptiveRuntime(pub std::sync::Mutex<Option<AdaptiveRuntime>>);
 /// Opaque owned dynamic plugin host activation.
@@ -124,6 +132,122 @@ pub enum NemoRelayScopeType {
     Custom = 9,
     /// Unknown or unspecified scope type.
     Unknown = 10,
+}
+
+/// Integer-backed OpenTelemetry instrument kind for one typed metric measurement.
+///
+/// This is intentionally not a Rust enum because foreign callers can supply any
+/// `int32_t` value. Exported functions validate the value before converting it
+/// to the core metric kind.
+pub type NemoRelayMetricKind = i32;
+
+/// Monotonic additive counter.
+pub const NEMO_RELAY_METRIC_KIND_COUNTER: NemoRelayMetricKind = 0;
+/// Additive counter that may increase or decrease.
+pub const NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER: NemoRelayMetricKind = 1;
+/// Current sampled value.
+pub const NEMO_RELAY_METRIC_KIND_GAUGE: NemoRelayMetricKind = 2;
+/// Distribution sample.
+pub const NEMO_RELAY_METRIC_KIND_HISTOGRAM: NemoRelayMetricKind = 3;
+
+/// Integer-backed typed severity for a mark exported as an OpenTelemetry log.
+///
+/// This is intentionally not a Rust enum because foreign callers can supply any
+/// `int32_t` value. Exported functions validate the value before converting it
+/// to the core log severity.
+pub type NemoRelayLogSeverity = i32;
+
+/// Fine-grained tracing information.
+pub const NEMO_RELAY_LOG_SEVERITY_TRACE: NemoRelayLogSeverity = 0;
+/// Diagnostic information.
+pub const NEMO_RELAY_LOG_SEVERITY_DEBUG: NemoRelayLogSeverity = 1;
+/// Normal informational event.
+pub const NEMO_RELAY_LOG_SEVERITY_INFO: NemoRelayLogSeverity = 2;
+/// Warning condition.
+pub const NEMO_RELAY_LOG_SEVERITY_WARN: NemoRelayLogSeverity = 3;
+/// Error condition.
+pub const NEMO_RELAY_LOG_SEVERITY_ERROR: NemoRelayLogSeverity = 4;
+
+pub(crate) fn log_severity_from_ffi(value: NemoRelayLogSeverity) -> Option<LogSeverity> {
+    match value {
+        NEMO_RELAY_LOG_SEVERITY_TRACE => Some(LogSeverity::Trace),
+        NEMO_RELAY_LOG_SEVERITY_DEBUG => Some(LogSeverity::Debug),
+        NEMO_RELAY_LOG_SEVERITY_INFO => Some(LogSeverity::Info),
+        NEMO_RELAY_LOG_SEVERITY_WARN => Some(LogSeverity::Warn),
+        NEMO_RELAY_LOG_SEVERITY_ERROR => Some(LogSeverity::Error),
+        _ => None,
+    }
+}
+
+pub(crate) fn metric_kind_from_ffi(value: NemoRelayMetricKind) -> Option<MetricKind> {
+    match value {
+        NEMO_RELAY_METRIC_KIND_COUNTER => Some(MetricKind::Counter),
+        NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER => Some(MetricKind::UpDownCounter),
+        NEMO_RELAY_METRIC_KIND_GAUGE => Some(MetricKind::Gauge),
+        NEMO_RELAY_METRIC_KIND_HISTOGRAM => Some(MetricKind::Histogram),
+        _ => None,
+    }
+}
+
+/// Integer-backed numeric representation selected from a typed metric
+/// measurement's value fields.
+///
+/// This is intentionally not a Rust enum because foreign callers can supply any
+/// `int32_t` value. Exported functions validate the value before converting it
+/// to the core metric value type.
+pub type NemoRelayMetricValueType = i32;
+
+/// Read `u64_value`.
+pub const NEMO_RELAY_METRIC_VALUE_TYPE_U64: NemoRelayMetricValueType = 0;
+/// Read `i64_value`.
+pub const NEMO_RELAY_METRIC_VALUE_TYPE_I64: NemoRelayMetricValueType = 1;
+/// Read `f64_value`.
+pub const NEMO_RELAY_METRIC_VALUE_TYPE_F64: NemoRelayMetricValueType = 2;
+
+pub(crate) fn metric_value_type_from_ffi(
+    value: NemoRelayMetricValueType,
+) -> Option<MetricValueType> {
+    match value {
+        NEMO_RELAY_METRIC_VALUE_TYPE_U64 => Some(MetricValueType::U64),
+        NEMO_RELAY_METRIC_VALUE_TYPE_I64 => Some(MetricValueType::I64),
+        NEMO_RELAY_METRIC_VALUE_TYPE_F64 => Some(MetricValueType::F64),
+        _ => None,
+    }
+}
+
+/// C representation of one typed metric SDK recording operation.
+///
+/// `value_type` selects exactly one of `u64_value`, `i64_value`, or
+/// `f64_value`. `unit`, `description`, and `attributes_json` are optional.
+/// A null `boundaries` pointer with `boundaries_len == 0` leaves histogram
+/// boundaries unspecified. A non-null pointer with zero length requests an
+/// explicit empty boundary list. For nonzero lengths, `boundaries` must point
+/// to that many doubles.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct NemoRelayMetricMeasurement {
+    /// Required null-terminated OpenTelemetry instrument name.
+    pub name: *const c_char,
+    /// Instrument kind.
+    pub kind: NemoRelayMetricKind,
+    /// Numeric value representation.
+    pub value_type: NemoRelayMetricValueType,
+    /// Unsigned value used when `value_type` is `U64`.
+    pub u64_value: u64,
+    /// Signed value used when `value_type` is `I64`.
+    pub i64_value: i64,
+    /// Double value used when `value_type` is `F64`.
+    pub f64_value: f64,
+    /// Optional null-terminated ASCII unit.
+    pub unit: *const c_char,
+    /// Optional null-terminated description.
+    pub description: *const c_char,
+    /// Optional null-terminated JSON attributes object.
+    pub attributes_json: *const c_char,
+    /// Optional histogram boundary array.
+    pub boundaries: *const f64,
+    /// Number of entries in `boundaries`.
+    pub boundaries_len: usize,
 }
 
 impl From<NemoRelayScopeType> for ScopeType {
@@ -261,6 +385,34 @@ pub unsafe extern "C" fn nemo_relay_atof_exporter_free(ptr: *mut FfiAtofExporter
 /// `ptr` must be a valid pointer returned by `nemo_relay_otel_subscriber_create`, or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nemo_relay_otel_subscriber_free(ptr: *mut FfiOpenTelemetrySubscriber) {
+    if !ptr.is_null() {
+        drop(unsafe { Box::from_raw(ptr) });
+    }
+}
+
+/// Free an OpenTelemetry log subscriber handle.
+///
+/// # Safety
+/// `ptr` must be a valid pointer returned by
+/// `nemo_relay_otel_log_subscriber_create`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_log_subscriber_free(
+    ptr: *mut FfiOpenTelemetryLogSubscriber,
+) {
+    if !ptr.is_null() {
+        drop(unsafe { Box::from_raw(ptr) });
+    }
+}
+
+/// Free an OpenTelemetry metric subscriber handle.
+///
+/// # Safety
+/// `ptr` must be a valid pointer returned by
+/// `nemo_relay_otel_metric_subscriber_create`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_metric_subscriber_free(
+    ptr: *mut FfiOpenTelemetryMetricSubscriber,
+) {
     if !ptr.is_null() {
         drop(unsafe { Box::from_raw(ptr) });
     }

--- a/crates/ffi/tests/unit/api/core_tests.rs
+++ b/crates/ffi/tests/unit/api/core_tests.rs
@@ -1329,6 +1329,231 @@ fn test_ffi_manual_lifecycle_timestamps_reject_out_of_range_unix_micros() {
 }
 
 #[test]
+fn test_ffi_event_v2_and_metric_mark_contracts() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let stack = fresh_scope_stack();
+        let subscriber_name = cstring(&unique_name("ffi_metric_api"));
+        assert_status!(
+            nemo_relay_register_subscriber(
+                subscriber_name.as_ptr(),
+                subscriber_cb,
+                ptr::null_mut(),
+                None,
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let log_name = cstring("ffi_structured_log");
+        let data = cstring(r#"{"message":"hello"}"#);
+        let schema = cstring(r#"{"name":"example.log","version":"1"}"#);
+        let metadata = cstring(r#"{"nemo_relay.log.severity":"debug"}"#);
+        let warning = types::NEMO_RELAY_LOG_SEVERITY_WARN;
+        assert_status!(
+            api::nemo_relay_event_v2(
+                log_name.as_ptr(),
+                ptr::null(),
+                data.as_ptr(),
+                schema.as_ptr(),
+                metadata.as_ptr(),
+                ptr::from_ref(&warning),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let metric_name = cstring("ffi_metric");
+        let instrument_name = cstring("example.tokens.saved");
+        let unit = cstring("{token}");
+        let measurement = types::NemoRelayMetricMeasurement {
+            name: instrument_name.as_ptr(),
+            kind: types::NEMO_RELAY_METRIC_KIND_COUNTER,
+            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_U64,
+            u64_value: 42,
+            i64_value: 0,
+            f64_value: 0.0,
+            unit: unit.as_ptr(),
+            description: ptr::null(),
+            attributes_json: ptr::null(),
+            boundaries: ptr::null(),
+            boundaries_len: 0,
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&measurement),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let histogram_name = cstring("example.request.duration");
+        let explicit_empty_boundary_sentinel = 0.0;
+        let explicit_empty_boundaries = types::NemoRelayMetricMeasurement {
+            name: histogram_name.as_ptr(),
+            kind: types::NEMO_RELAY_METRIC_KIND_HISTOGRAM,
+            boundaries: ptr::from_ref(&explicit_empty_boundary_sentinel),
+            ..measurement
+        };
+        let explicit_empty_metric_name = cstring("ffi_metric_empty_boundaries");
+        assert_status!(
+            api::nemo_relay_metric(
+                explicit_empty_metric_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&explicit_empty_boundaries),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let missing_boundaries = types::NemoRelayMetricMeasurement {
+            boundaries: ptr::null(),
+            boundaries_len: 1,
+            ..explicit_empty_boundaries
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&missing_boundaries),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        let empty_measurements = cstring("[]");
+        assert_status!(
+            api::nemo_relay_metric_json(
+                metric_name.as_ptr(),
+                ptr::null(),
+                empty_measurements.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        let invalid_metadata = cstring("[]");
+        let info = types::NEMO_RELAY_LOG_SEVERITY_INFO;
+        assert_status!(
+            api::nemo_relay_event_v2(
+                log_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                invalid_metadata.as_ptr(),
+                ptr::from_ref(&info),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+
+        let invalid_severity: types::NemoRelayLogSeverity = i32::MAX;
+        assert_status!(
+            api::nemo_relay_event_v2(
+                log_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&invalid_severity),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert!(
+            read_last_error()
+                .unwrap()
+                .contains("severity has invalid value 2147483647")
+        );
+
+        let invalid_kind = types::NemoRelayMetricMeasurement {
+            kind: i32::MAX,
+            ..measurement
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&invalid_kind),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert!(
+            read_last_error()
+                .unwrap()
+                .contains("measurements[0].kind has invalid value 2147483647")
+        );
+
+        let invalid_value_type = types::NemoRelayMetricMeasurement {
+            value_type: i32::MIN,
+            ..measurement
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&invalid_value_type),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert!(
+            read_last_error()
+                .unwrap()
+                .contains("measurements[0].value_type has invalid value -2147483648")
+        );
+
+        assert_status!(nemo_relay_flush_subscribers(), NemoRelayStatus::Ok);
+        let events = lock_unpoisoned(event_log()).clone();
+        let log = events
+            .iter()
+            .find(|event| event["name"] == json!("ffi_structured_log"))
+            .expect("structured log mark");
+        assert_eq!(
+            log["json"]["data_schema"],
+            json!({"name": "example.log", "version": "1"})
+        );
+        assert_eq!(log["metadata"]["nemo_relay.log.severity"], "warn");
+        let metric = events
+            .iter()
+            .find(|event| event["name"] == json!("ffi_metric"))
+            .expect("metric mark");
+        assert_eq!(
+            metric["json"]["data_schema"],
+            json!({"name": "nemo.relay.metric_measurements", "version": "1"})
+        );
+        assert_eq!(metric["data"]["measurements"][0]["boundaries"], Json::Null);
+        let explicit_empty_metric = events
+            .iter()
+            .find(|event| event["name"] == json!("ffi_metric_empty_boundaries"))
+            .expect("metric mark with explicit empty boundaries");
+        assert_eq!(
+            explicit_empty_metric["data"]["measurements"][0]["boundaries"],
+            json!([])
+        );
+
+        assert_status!(
+            nemo_relay_deregister_subscriber(subscriber_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_scope_stack_free(stack);
+    }
+}
+
+#[test]
 fn test_ffi_additional_null_and_invalid_json_paths() {
     let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     reset_globals();

--- a/crates/ffi/tests/unit/api/core_tests.rs
+++ b/crates/ffi/tests/unit/api/core_tests.rs
@@ -1516,6 +1516,28 @@ fn test_ffi_event_v2_and_metric_mark_contracts() {
                 .contains("measurements[0].value_type has invalid value -2147483648")
         );
 
+        let non_finite = types::NemoRelayMetricMeasurement {
+            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_F64,
+            f64_value: f64::NAN,
+            ..measurement
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                [measurement, non_finite].as_ptr(),
+                2,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert!(
+            read_last_error()
+                .unwrap()
+                .contains("measurements[1].f64_value must be finite")
+        );
+
         assert_status!(nemo_relay_flush_subscribers(), NemoRelayStatus::Ok);
         let events = lock_unpoisoned(event_log()).clone();
         let log = events

--- a/crates/ffi/tests/unit/api/core_tests.rs
+++ b/crates/ffi/tests/unit/api/core_tests.rs
@@ -1329,6 +1329,69 @@ fn test_ffi_manual_lifecycle_timestamps_reject_out_of_range_unix_micros() {
 }
 
 #[test]
+fn test_ffi_metric_discriminators_reject_zero_initialized_measurements() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let metric_name = cstring("ffi_metric");
+        let instrument_name = cstring("example.tokens.saved");
+        assert_eq!(types::NEMO_RELAY_METRIC_KIND_UNSPECIFIED, 0);
+        assert_eq!(types::NEMO_RELAY_METRIC_KIND_COUNTER, 1);
+        assert_eq!(types::NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER, 2);
+        assert_eq!(types::NEMO_RELAY_METRIC_KIND_GAUGE, 3);
+        assert_eq!(types::NEMO_RELAY_METRIC_KIND_HISTOGRAM, 4);
+        assert_eq!(types::NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED, 0);
+        assert_eq!(types::NEMO_RELAY_METRIC_VALUE_TYPE_U64, 1);
+        assert_eq!(types::NEMO_RELAY_METRIC_VALUE_TYPE_I64, 2);
+        assert_eq!(types::NEMO_RELAY_METRIC_VALUE_TYPE_F64, 3);
+        let zero_initialized: types::NemoRelayMetricMeasurement = std::mem::zeroed();
+        let unspecified_kind = types::NemoRelayMetricMeasurement {
+            name: instrument_name.as_ptr(),
+            f64_value: 12.5,
+            ..zero_initialized
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&unspecified_kind),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert!(
+            read_last_error()
+                .unwrap()
+                .contains("measurements[0].kind is unspecified")
+        );
+        let unspecified_value_type = types::NemoRelayMetricMeasurement {
+            kind: types::NEMO_RELAY_METRIC_KIND_COUNTER,
+            u64_value: 42,
+            ..unspecified_kind
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&unspecified_value_type),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert!(
+            read_last_error()
+                .unwrap()
+                .contains("measurements[0].value_type is unspecified")
+        );
+    }
+}
+
+#[test]
 fn test_ffi_event_v2_and_metric_mark_contracts() {
     let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     reset_globals();

--- a/crates/ffi/tests/unit/api/registry_tests.rs
+++ b/crates/ffi/tests/unit/api/registry_tests.rs
@@ -956,6 +956,177 @@ fn test_ffi_open_telemetry_log_and_metric_subscribers_export_signals() {
 }
 
 #[test]
+fn test_ffi_open_telemetry_subscribers_return_runtime_diagnostics() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let endpoint = cstring("http://127.0.0.1:4318/v1/traces");
+        let mut trace_subscriber: *mut FfiOpenTelemetrySubscriber = ptr::null_mut();
+        let mut log_subscriber: *mut types::FfiOpenTelemetryLogSubscriber = ptr::null_mut();
+        let mut metric_subscriber: *mut types::FfiOpenTelemetryMetricSubscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_subscriber_create(
+                c"full".as_ptr(),
+                ptr::null(),
+                endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                &mut trace_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_create(
+                ptr::null(),
+                endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                0,
+                0,
+                &mut log_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_create(
+                ptr::null(),
+                endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                0,
+                ptr::null(),
+                0,
+                0,
+                &mut metric_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let trace_name = cstring(&unique_name("ffi_otel_trace_diagnostics"));
+        let log_name = cstring(&unique_name("ffi_otel_log_diagnostics"));
+        let metric_name = cstring(&unique_name("ffi_otel_metric_diagnostics"));
+        assert_status!(
+            nemo_relay_otel_subscriber_register(trace_subscriber, trace_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+
+        let stack = fresh_scope_stack();
+        let event_name = cstring("invalid_metric");
+        let data = cstring(r#"{"measurements":[]}"#);
+        let data_schema = cstring(r#"{"name":"nemo.relay.metric_measurements","version":"999"}"#);
+        assert_status!(
+            api::nemo_relay_event_v2(
+                event_name.as_ptr(),
+                ptr::null(),
+                data.as_ptr(),
+                data_schema.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(nemo_relay_flush_subscribers(), NemoRelayStatus::Ok);
+
+        let mut trace_diagnostics = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_subscriber_runtime_diagnostics_json(
+                trace_subscriber,
+                &mut trace_diagnostics,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let mut log_diagnostics = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_log_subscriber_runtime_diagnostics_json(
+                log_subscriber,
+                &mut log_diagnostics,
+            ),
+            NemoRelayStatus::Ok
+        );
+        let mut metric_diagnostics = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_runtime_diagnostics_json(
+                metric_subscriber,
+                &mut metric_diagnostics,
+            ),
+            NemoRelayStatus::Ok
+        );
+        for diagnostics in [trace_diagnostics, log_diagnostics, metric_diagnostics] {
+            let entries = returned_json(diagnostics);
+            let diagnostic = entries
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|entry| entry["code"] == "otel.metric_mark_invalid")
+                .unwrap();
+            assert_eq!(diagnostic["count"], 1);
+            assert!(
+                diagnostic["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("unsupported metric schema version")
+            );
+        }
+
+        assert_status!(
+            nemo_relay_otel_subscriber_deregister(trace_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_deregister(log_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_deregister(metric_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_subscriber_shutdown(trace_subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_otel_subscriber_free(trace_subscriber);
+        types::nemo_relay_otel_log_subscriber_free(log_subscriber);
+        types::nemo_relay_otel_metric_subscriber_free(metric_subscriber);
+        nemo_relay_scope_stack_free(stack);
+    }
+}
+
+#[test]
 fn test_ffi_open_telemetry_typed_required_fields_and_gen_ai_wire_output() {
     let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     reset_globals();

--- a/crates/ffi/tests/unit/api/registry_tests.rs
+++ b/crates/ffi/tests/unit/api/registry_tests.rs
@@ -799,6 +799,163 @@ fn test_ffi_open_telemetry_log_and_metric_subscriber_construction() {
 }
 
 #[test]
+fn test_ffi_open_telemetry_log_and_metric_subscribers_export_signals() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let (log_endpoint, log_requests, log_collector) = start_otlp_http_collector();
+        let (metric_endpoint, metric_requests, metric_collector) = start_otlp_http_collector();
+        let log_endpoint = cstring(&log_endpoint);
+        let metric_endpoint = cstring(&metric_endpoint);
+        let mut log_subscriber: *mut types::FfiOpenTelemetryLogSubscriber = ptr::null_mut();
+        let mut metric_subscriber: *mut types::FfiOpenTelemetryMetricSubscriber = ptr::null_mut();
+
+        assert_status!(
+            nemo_relay_otel_log_subscriber_create(
+                ptr::null(),
+                log_endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                0,
+                0,
+                &mut log_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_create(
+                ptr::null(),
+                metric_endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                0,
+                ptr::null(),
+                0,
+                0,
+                &mut metric_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let log_subscriber_name = cstring(&unique_name("ffi_otel_log_signal"));
+        let metric_subscriber_name = cstring(&unique_name("ffi_otel_metric_signal"));
+        assert_status!(
+            nemo_relay_otel_log_subscriber_register(log_subscriber, log_subscriber_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_register(
+                metric_subscriber,
+                metric_subscriber_name.as_ptr(),
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let stack = fresh_scope_stack();
+        let log_name = cstring("ffi_exported_log");
+        let severity = types::NEMO_RELAY_LOG_SEVERITY_ERROR;
+        assert_status!(
+            api::nemo_relay_event_v2(
+                log_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&severity),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let metric_mark_name = cstring("ffi_exported_metric");
+        let instrument_name = cstring("example.ffi.requests");
+        let measurement = types::NemoRelayMetricMeasurement {
+            name: instrument_name.as_ptr(),
+            kind: types::NEMO_RELAY_METRIC_KIND_COUNTER,
+            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_U64,
+            u64_value: 1,
+            i64_value: 0,
+            f64_value: 0.0,
+            unit: ptr::null(),
+            description: ptr::null(),
+            attributes_json: ptr::null(),
+            boundaries: ptr::null(),
+            boundaries_len: 0,
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_mark_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&measurement),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        assert_status!(
+            nemo_relay_otel_log_subscriber_force_flush(log_subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_force_flush(metric_subscriber),
+            NemoRelayStatus::Ok
+        );
+
+        let log_body = log_requests.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(
+            log_body
+                .windows(b"ffi_exported_log".len())
+                .any(|value| value == b"ffi_exported_log")
+        );
+        let metric_body = metric_requests
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap();
+        assert!(
+            metric_body
+                .windows(b"example.ffi.requests".len())
+                .any(|value| value == b"example.ffi.requests")
+        );
+
+        assert_status!(
+            nemo_relay_otel_log_subscriber_deregister(log_subscriber_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_deregister(metric_subscriber_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
+            NemoRelayStatus::Ok
+        );
+        types::nemo_relay_otel_log_subscriber_free(log_subscriber);
+        types::nemo_relay_otel_metric_subscriber_free(metric_subscriber);
+        nemo_relay_scope_stack_free(stack);
+        log_collector.join().unwrap();
+        metric_collector.join().unwrap();
+    }
+}
+
+#[test]
 fn test_ffi_open_telemetry_typed_required_fields_and_gen_ai_wire_output() {
     let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     reset_globals();

--- a/crates/ffi/tests/unit/api/registry_tests.rs
+++ b/crates/ffi/tests/unit/api/registry_tests.rs
@@ -697,6 +697,108 @@ fn test_ffi_open_telemetry_subscriber_lifecycle_and_errors() {
 }
 
 #[test]
+fn test_ffi_open_telemetry_log_and_metric_subscriber_construction() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let endpoint = cstring("http://localhost:4318/v1/traces");
+        let invalid = cstring("invalid");
+        let mut log_subscriber: *mut types::FfiOpenTelemetryLogSubscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_log_subscriber_create(
+                ptr::null(),
+                endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                invalid.as_ptr(),
+                0,
+                0,
+                0,
+                &mut log_subscriber,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_create(
+                ptr::null(),
+                endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                0,
+                0,
+                &mut log_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert!(!log_subscriber.is_null());
+        assert_status!(
+            nemo_relay_otel_log_subscriber_force_flush(ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+        types::nemo_relay_otel_log_subscriber_free(log_subscriber);
+
+        let mut metric_subscriber: *mut types::FfiOpenTelemetryMetricSubscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_create(
+                ptr::null(),
+                endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                0,
+                invalid.as_ptr(),
+                0,
+                0,
+                &mut metric_subscriber,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_create(
+                ptr::null(),
+                endpoint.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                0,
+                ptr::null(),
+                0,
+                0,
+                &mut metric_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert!(!metric_subscriber.is_null());
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_shutdown(ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+        types::nemo_relay_otel_metric_subscriber_free(metric_subscriber);
+    }
+}
+
+#[test]
 fn test_ffi_open_telemetry_typed_required_fields_and_gen_ai_wire_output() {
     let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     reset_globals();

--- a/crates/ffi/tests/unit/api/registry_tests.rs
+++ b/crates/ffi/tests/unit/api/registry_tests.rs
@@ -17,7 +17,7 @@ fn start_otlp_http_collector() -> (String, Receiver<Vec<u8>>, JoinHandle<()>) {
     listener.set_nonblocking(true).unwrap();
     let (sender, receiver) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(10);
         let mut last_request = None;
         while Instant::now() < deadline {
             match listener.accept() {
@@ -708,6 +708,25 @@ fn test_ffi_open_telemetry_log_and_metric_subscriber_construction() {
         assert_status!(
             nemo_relay_otel_log_subscriber_create(
                 ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+                0,
+                0,
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_create(
+                ptr::null(),
                 endpoint.as_ptr(),
                 ptr::null(),
                 ptr::null(),
@@ -744,13 +763,53 @@ fn test_ffi_open_telemetry_log_and_metric_subscriber_construction() {
             NemoRelayStatus::Ok
         );
         assert!(!log_subscriber.is_null());
+        let unused_name = cstring("unused");
+        let mut unused_json = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_log_subscriber_register(ptr::null(), unused_name.as_ptr()),
+            NemoRelayStatus::NullPointer
+        );
         assert_status!(
             nemo_relay_otel_log_subscriber_force_flush(ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_runtime_diagnostics_json(ptr::null(), &mut unused_json),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_runtime_diagnostics_json(
+                log_subscriber,
+                ptr::null_mut()
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_shutdown(ptr::null()),
             NemoRelayStatus::NullPointer
         );
         types::nemo_relay_otel_log_subscriber_free(log_subscriber);
 
         let mut metric_subscriber: *mut types::FfiOpenTelemetryMetricSubscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_create(
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                0,
+                ptr::null(),
+                0,
+                0,
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
         assert_status!(
             nemo_relay_otel_metric_subscriber_create(
                 ptr::null(),
@@ -790,6 +849,28 @@ fn test_ffi_open_telemetry_log_and_metric_subscriber_construction() {
             NemoRelayStatus::Ok
         );
         assert!(!metric_subscriber.is_null());
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_register(ptr::null(), unused_name.as_ptr()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_force_flush(ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_runtime_diagnostics_json(
+                ptr::null(),
+                &mut unused_json
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_runtime_diagnostics_json(
+                metric_subscriber,
+                ptr::null_mut()
+            ),
+            NemoRelayStatus::NullPointer
+        );
         assert_status!(
             nemo_relay_otel_metric_subscriber_shutdown(ptr::null()),
             NemoRelayStatus::NullPointer

--- a/go/nemo_relay/callbacks.go
+++ b/go/nemo_relay/callbacks.go
@@ -435,7 +435,9 @@ type PendingMarkSpec struct {
 	Category        *string         `json:"category,omitempty"`
 	CategoryProfile json.RawMessage `json:"category_profile,omitempty"`
 	Data            json.RawMessage `json:"data,omitempty"`
+	DataSchema      *DataSchema     `json:"data_schema,omitempty"`
 	Metadata        json.RawMessage `json:"metadata,omitempty"`
+	Severity        LogSeverity     `json:"severity,omitempty"`
 }
 
 // LLMRequestInterceptOutcome is the canonical result of an LLM request intercept.

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -628,6 +628,14 @@ type eventOptions struct {
 	timestamp  *C.int64_t
 }
 
+// replaceCString replaces an option-owned C string and frees its prior value.
+func replaceCString(slot **C.char, value string) {
+	if *slot != nil {
+		C.free(unsafe.Pointer(*slot))
+	}
+	*slot = C.CString(value)
+}
+
 // DataSchema identifies the name and version of a structured mark payload.
 type DataSchema struct {
 	Name    string `json:"name"`
@@ -668,7 +676,7 @@ func WithEventParent(parent *ScopeHandle) EventOption {
 // logging, tracing, or custom instrumentation.
 func WithEventData(data json.RawMessage) EventOption {
 	return func(o *eventOptions) {
-		o.data = C.CString(string(data))
+		replaceCString(&o.data, string(data))
 	}
 }
 
@@ -677,7 +685,7 @@ func WithEventDataSchema(schema DataSchema) EventOption {
 	return func(o *eventOptions) {
 		encoded, err := jsonMarshal(schema)
 		if err == nil {
-			o.dataSchema = C.CString(string(encoded))
+			replaceCString(&o.dataSchema, string(encoded))
 		}
 	}
 }
@@ -687,7 +695,7 @@ func WithEventDataSchema(schema DataSchema) EventOption {
 // hints) as opposed to the primary data payload.
 func WithEventMetadata(metadata json.RawMessage) EventOption {
 	return func(o *eventOptions) {
-		o.metadata = C.CString(string(metadata))
+		replaceCString(&o.metadata, string(metadata))
 	}
 }
 
@@ -801,7 +809,7 @@ func WithMetricParent(parent *ScopeHandle) MetricOption {
 // converted into metric attributes by the exporter.
 func WithMetricMetadata(metadata json.RawMessage) MetricOption {
 	return func(o *metricOptions) {
-		o.metadata = C.CString(string(metadata))
+		replaceCString(&o.metadata, string(metadata))
 	}
 }
 

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -52,6 +52,8 @@ extern int32_t nemo_relay_get_handle(FfiScopeHandle** out);
 extern int32_t nemo_relay_push_scope(const char* name, int32_t scope_type, const FfiScopeHandle* parent, uint32_t attributes, const char* data_json, const char* metadata_json, const char* input_json, const int64_t* timestamp_unix_micros, FfiScopeHandle** out);
 extern int32_t nemo_relay_pop_scope(const FfiScopeHandle* handle, const char* output_json, const char* metadata_json, const int64_t* timestamp_unix_micros);
 extern int32_t nemo_relay_event(const char* name, const FfiScopeHandle* parent, const char* data_json, const char* metadata_json, const int64_t* timestamp_unix_micros);
+extern int32_t nemo_relay_event_v2(const char* name, const FfiScopeHandle* parent, const char* data_json, const char* data_schema_json, const char* metadata_json, const int32_t* severity, const int64_t* timestamp_unix_micros);
+extern int32_t nemo_relay_metric_json(const char* name, const FfiScopeHandle* parent, const char* measurements_json, const char* metadata_json, const int64_t* timestamp_unix_micros);
 
 // Tool lifecycle
 extern int32_t nemo_relay_tool_call(const char* name, const char* args_json, const FfiScopeHandle* parent, uint32_t attributes, const char* data_json, const char* metadata_json, const char* tool_call_id, const int64_t* timestamp_unix_micros, FfiToolHandle** out);
@@ -269,6 +271,18 @@ extern int32_t nemo_relay_otel_subscriber_deregister(const char*);
 extern int32_t nemo_relay_otel_subscriber_force_flush(const void*);
 extern int32_t nemo_relay_otel_subscriber_shutdown(const void*);
 extern void nemo_relay_otel_subscriber_free(void*);
+extern int32_t nemo_relay_otel_log_subscriber_create(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, uint64_t, const char*, uint64_t, uint64_t, uint64_t, void**);
+extern int32_t nemo_relay_otel_log_subscriber_register(const void*, const char*);
+extern int32_t nemo_relay_otel_log_subscriber_deregister(const char*);
+extern int32_t nemo_relay_otel_log_subscriber_force_flush(const void*);
+extern int32_t nemo_relay_otel_log_subscriber_shutdown(const void*);
+extern void nemo_relay_otel_log_subscriber_free(void*);
+extern int32_t nemo_relay_otel_metric_subscriber_create(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, uint64_t, uint64_t, const char*, uint64_t, uint64_t, void**);
+extern int32_t nemo_relay_otel_metric_subscriber_register(const void*, const char*);
+extern int32_t nemo_relay_otel_metric_subscriber_deregister(const char*);
+extern int32_t nemo_relay_otel_metric_subscriber_force_flush(const void*);
+extern int32_t nemo_relay_otel_metric_subscriber_shutdown(const void*);
+extern void nemo_relay_otel_metric_subscriber_free(void*);
 
 // Go trampoline forward declarations (defined via //export in callbacks.go)
 extern char* goToolSanitizeTrampoline(void*, const char*, const char*);
@@ -388,6 +402,27 @@ func cTimestampMicros(timestamp time.Time) *C.int64_t {
 	ptr := (*C.int64_t)(C.malloc(C.size_t(unsafe.Sizeof(C.int64_t(0)))))
 	*ptr = C.int64_t(timestamp.UTC().UnixMicro())
 	return ptr
+}
+
+func cLogSeverity(severity LogSeverity) (*C.int32_t, error) {
+	var value C.int32_t
+	switch severity {
+	case LogSeverityTrace:
+		value = 0
+	case LogSeverityDebug:
+		value = 1
+	case LogSeverityInfo:
+		value = 2
+	case LogSeverityWarn, LogSeverityWarning:
+		value = 3
+	case LogSeverityError:
+		value = 4
+	default:
+		return nil, fmt.Errorf("invalid log severity %q", severity)
+	}
+	ptr := (*C.int32_t)(C.malloc(C.size_t(unsafe.Sizeof(value))))
+	*ptr = value
+	return ptr, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -582,15 +617,37 @@ func PopScope(handle *ScopeHandle, opts ...ScopeEndOption) error {
 // ---------------------------------------------------------------------------
 
 type eventOptions struct {
-	parent    *C.FfiScopeHandle
-	data      *C.char
-	metadata  *C.char
-	timestamp *C.int64_t
+	parent     *C.FfiScopeHandle
+	data       *C.char
+	dataSchema *C.char
+	metadata   *C.char
+	severity   LogSeverity
+	timestamp  *C.int64_t
 }
+
+// DataSchema identifies the name and version of a structured mark payload.
+type DataSchema struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// LogSeverity controls the severity of a mark exported as an OTLP log.
+type LogSeverity string
+
+const (
+	LogSeverityTrace LogSeverity = "trace"
+	LogSeverityDebug LogSeverity = "debug"
+	LogSeverityInfo  LogSeverity = "info"
+	LogSeverityWarn  LogSeverity = "warn"
+	// LogSeverityWarning is accepted as an alias for LogSeverityWarn.
+	LogSeverityWarning LogSeverity = "warning"
+	LogSeverityError   LogSeverity = "error"
+)
 
 // EventOption is a functional option that configures optional parameters for
 // [EmitEvent]. Available options include [WithEventParent], [WithEventData],
-// [WithEventMetadata], and [WithEventTimestamp].
+// [WithEventDataSchema], [WithEventMetadata], [WithEventSeverity], and
+// [WithEventTimestamp].
 type EventOption func(*eventOptions)
 
 // WithEventParent sets the parent scope handle for the event. If not provided,
@@ -612,12 +669,30 @@ func WithEventData(data json.RawMessage) EventOption {
 	}
 }
 
+// WithEventDataSchema identifies the schema of the event data payload.
+func WithEventDataSchema(schema DataSchema) EventOption {
+	return func(o *eventOptions) {
+		encoded, err := jsonMarshal(schema)
+		if err == nil {
+			o.dataSchema = C.CString(string(encoded))
+		}
+	}
+}
+
 // WithEventMetadata attaches an arbitrary JSON metadata payload to the event.
 // Metadata is typically used for operational context (e.g., trace IDs, timing
 // hints) as opposed to the primary data payload.
 func WithEventMetadata(metadata json.RawMessage) EventOption {
 	return func(o *eventOptions) {
 		o.metadata = C.CString(string(metadata))
+	}
+}
+
+// WithEventSeverity attaches a typed log severity to the mark. Relay stores
+// it authoritatively in the reserved sanitizer-visible metadata key.
+func WithEventSeverity(severity LogSeverity) EventOption {
+	return func(o *eventOptions) {
+		o.severity = severity
 	}
 }
 
@@ -646,14 +721,118 @@ func EmitEvent(name string, opts ...EventOption) error {
 	if o.data != nil {
 		defer C.free(unsafe.Pointer(o.data))
 	}
+	if o.dataSchema != nil {
+		defer C.free(unsafe.Pointer(o.dataSchema))
+	}
 	if o.metadata != nil {
 		defer C.free(unsafe.Pointer(o.metadata))
 	}
 	if o.timestamp != nil {
 		defer C.free(unsafe.Pointer(o.timestamp))
 	}
+	var severity *C.int32_t
+	if o.severity != "" {
+		var err error
+		severity, err = cLogSeverity(o.severity)
+		if err != nil {
+			return err
+		}
+		defer C.free(unsafe.Pointer(severity))
+	}
 
-	return checkStatus(C.nemo_relay_event(cName, o.parent, o.data, o.metadata, o.timestamp))
+	return checkStatus(C.nemo_relay_event_v2(cName, o.parent, o.data, o.dataSchema, o.metadata, severity, o.timestamp))
+}
+
+// MetricKind selects the OpenTelemetry instrument used for a measurement.
+type MetricKind string
+
+const (
+	MetricKindCounter       MetricKind = "counter"
+	MetricKindUpDownCounter MetricKind = "up_down_counter"
+	MetricKindGauge         MetricKind = "gauge"
+	MetricKindHistogram     MetricKind = "histogram"
+)
+
+// MetricValueType identifies the numeric representation of a measurement.
+type MetricValueType string
+
+const (
+	MetricValueTypeU64 MetricValueType = "u64"
+	MetricValueTypeI64 MetricValueType = "i64"
+	MetricValueTypeF64 MetricValueType = "f64"
+)
+
+// MetricMeasurement is one SDK recording operation in an atomic metric mark.
+type MetricMeasurement struct {
+	Name        string                 `json:"name"`
+	Kind        MetricKind             `json:"kind"`
+	ValueType   MetricValueType        `json:"value_type"`
+	Value       interface{}            `json:"value"`
+	Unit        string                 `json:"unit,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	Attributes  map[string]interface{} `json:"attributes,omitempty"`
+	Boundaries  []float64              `json:"boundaries"`
+}
+
+type metricOptions struct {
+	parent       *C.FfiScopeHandle
+	parentHandle *ScopeHandle // prevents GC of the ScopeHandle during the FFI call
+	metadata     *C.char
+	timestamp    *C.int64_t
+}
+
+// MetricOption configures optional fields for [EmitMetric].
+type MetricOption func(*metricOptions)
+
+// WithMetricParent sets the containing scope for a metric mark.
+func WithMetricParent(parent *ScopeHandle) MetricOption {
+	return func(o *metricOptions) {
+		if parent != nil {
+			o.parent = parent.ptr
+			o.parentHandle = parent
+		}
+	}
+}
+
+// WithMetricMetadata attaches JSON metadata to a metric mark. Metadata is not
+// converted into metric attributes by the exporter.
+func WithMetricMetadata(metadata json.RawMessage) MetricOption {
+	return func(o *metricOptions) {
+		o.metadata = C.CString(string(metadata))
+	}
+}
+
+// WithMetricTimestamp records an explicit timestamp on the underlying mark.
+// SDK-backed metric points use collection timestamps.
+func WithMetricTimestamp(timestamp time.Time) MetricOption {
+	return func(o *metricOptions) {
+		o.timestamp = cTimestampMicros(timestamp)
+	}
+}
+
+// EmitMetric emits measurements as one atomically validated metric mark.
+func EmitMetric(name string, measurements []MetricMeasurement, opts ...MetricOption) error {
+	encoded, err := jsonMarshal(measurements)
+	if err != nil {
+		return err
+	}
+	o := &metricOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cMeasurements := C.CString(string(encoded))
+	defer C.free(unsafe.Pointer(cMeasurements))
+	if o.metadata != nil {
+		defer C.free(unsafe.Pointer(o.metadata))
+	}
+	if o.timestamp != nil {
+		defer C.free(unsafe.Pointer(o.timestamp))
+	}
+	status := C.nemo_relay_metric_json(cName, o.parent, cMeasurements, o.metadata, o.timestamp)
+	runtime.KeepAlive(o.parentHandle)
+	return checkStatus(status)
 }
 
 // ---------------------------------------------------------------------------
@@ -2234,6 +2413,388 @@ func (s *OpenTelemetrySubscriber) Shutdown() error {
 func (s *OpenTelemetrySubscriber) Close() {
 	if s.ptr != nil {
 		C.nemo_relay_otel_subscriber_free(s.ptr)
+		s.ptr = nil
+	}
+}
+
+// OpenTelemetryLogConfig configures an independent OTLP log subscriber.
+type OpenTelemetryLogConfig struct {
+	Transport            OpenTelemetryTransport
+	Endpoint             string
+	Headers              map[string]string
+	ResourceAttributes   map[string]string
+	ServiceName          string
+	ServiceNamespace     string
+	ServiceVersion       string
+	InstrumentationScope string
+	Timeout              time.Duration
+	MinimumSeverity      LogSeverity
+	MaxQueueSize         uint64
+	MaxExportBatchSize   uint64
+	ScheduledDelay       time.Duration
+}
+
+// NewOpenTelemetryLogConfig returns log settings initialized with native defaults.
+func NewOpenTelemetryLogConfig(endpoint string) OpenTelemetryLogConfig {
+	return OpenTelemetryLogConfig{
+		Transport:            OpenTelemetryTransportHTTPBinary,
+		Endpoint:             endpoint,
+		Headers:              map[string]string{},
+		ResourceAttributes:   map[string]string{},
+		ServiceName:          "unknown_service",
+		InstrumentationScope: "opentelemetry",
+		Timeout:              3 * time.Second,
+		MinimumSeverity:      LogSeverityInfo,
+		MaxQueueSize:         2048,
+		MaxExportBatchSize:   512,
+		ScheduledDelay:       time.Second,
+	}
+}
+
+// OpenTelemetryLogSubscriber exports sanitized non-metric marks as OTLP logs.
+type OpenTelemetryLogSubscriber struct {
+	ptr unsafe.Pointer
+}
+
+// OpenTelemetryMetricTemporality controls SDK metric aggregation temporality.
+type OpenTelemetryMetricTemporality string
+
+const (
+	OpenTelemetryMetricTemporalityCumulative OpenTelemetryMetricTemporality = "cumulative"
+	OpenTelemetryMetricTemporalityDelta      OpenTelemetryMetricTemporality = "delta"
+	OpenTelemetryMetricTemporalityLowMemory  OpenTelemetryMetricTemporality = "low_memory"
+)
+
+// OpenTelemetryMetricConfig configures an independent OTLP metric subscriber.
+type OpenTelemetryMetricConfig struct {
+	Transport            OpenTelemetryTransport
+	Endpoint             string
+	Headers              map[string]string
+	ResourceAttributes   map[string]string
+	ServiceName          string
+	ServiceNamespace     string
+	ServiceVersion       string
+	InstrumentationScope string
+	Timeout              time.Duration
+	ExportInterval       time.Duration
+	Temporality          OpenTelemetryMetricTemporality
+	MaxInstruments       uint64
+	CardinalityLimit     uint64
+}
+
+// NewOpenTelemetryMetricConfig returns metric settings initialized with native defaults.
+func NewOpenTelemetryMetricConfig(endpoint string) OpenTelemetryMetricConfig {
+	return OpenTelemetryMetricConfig{
+		Transport:            OpenTelemetryTransportHTTPBinary,
+		Endpoint:             endpoint,
+		Headers:              map[string]string{},
+		ResourceAttributes:   map[string]string{},
+		ServiceName:          "unknown_service",
+		InstrumentationScope: "opentelemetry",
+		Timeout:              3 * time.Second,
+		ExportInterval:       60 * time.Second,
+		Temporality:          OpenTelemetryMetricTemporalityCumulative,
+		MaxInstruments:       256,
+		CardinalityLimit:     2000,
+	}
+}
+
+// OpenTelemetryMetricSubscriber records Relay metric marks through the OTLP metrics SDK.
+type OpenTelemetryMetricSubscriber struct {
+	ptr unsafe.Pointer
+}
+
+type openTelemetrySignalCStrings struct {
+	transport            *C.char
+	endpoint             *C.char
+	headers              *C.char
+	resourceAttributes   *C.char
+	serviceName          *C.char
+	serviceNamespace     *C.char
+	serviceVersion       *C.char
+	instrumentationScope *C.char
+}
+
+func newOpenTelemetrySignalCStrings(
+	transport OpenTelemetryTransport,
+	endpoint string,
+	headers map[string]string,
+	resourceAttributes map[string]string,
+	serviceName string,
+	serviceNamespace string,
+	serviceVersion string,
+	instrumentationScope string,
+) (openTelemetrySignalCStrings, error) {
+	encodedHeaders, err := jsonMarshal(headers)
+	if err != nil {
+		return openTelemetrySignalCStrings{}, err
+	}
+	encodedResources, err := jsonMarshal(resourceAttributes)
+	if err != nil {
+		return openTelemetrySignalCStrings{}, err
+	}
+	return openTelemetrySignalCStrings{
+		transport:            C.CString(string(transport)),
+		endpoint:             C.CString(endpoint),
+		headers:              C.CString(string(encodedHeaders)),
+		resourceAttributes:   C.CString(string(encodedResources)),
+		serviceName:          C.CString(serviceName),
+		serviceNamespace:     optionalCString(serviceNamespace),
+		serviceVersion:       optionalCString(serviceVersion),
+		instrumentationScope: C.CString(instrumentationScope),
+	}, nil
+}
+
+func (values *openTelemetrySignalCStrings) free() {
+	C.free(unsafe.Pointer(values.transport))
+	C.free(unsafe.Pointer(values.endpoint))
+	C.free(unsafe.Pointer(values.headers))
+	C.free(unsafe.Pointer(values.resourceAttributes))
+	C.free(unsafe.Pointer(values.serviceName))
+	C.free(unsafe.Pointer(values.serviceNamespace))
+	C.free(unsafe.Pointer(values.serviceVersion))
+	C.free(unsafe.Pointer(values.instrumentationScope))
+}
+
+func requireWholeMillisecondDuration(field string, value time.Duration) error {
+	if value > 0 && value%time.Millisecond != 0 {
+		return fmt.Errorf("%s must be zero or an exact multiple of 1ms", field)
+	}
+	return nil
+}
+
+func normalizeOpenTelemetryLogConfig(config OpenTelemetryLogConfig) (OpenTelemetryLogConfig, error) {
+	if config.Transport == "" {
+		config.Transport = OpenTelemetryTransportHTTPBinary
+	}
+	if config.Endpoint == "" {
+		return config, fmt.Errorf("endpoint is required")
+	}
+	if config.ServiceName == "" {
+		config.ServiceName = "unknown_service"
+	}
+	if config.InstrumentationScope == "" {
+		config.InstrumentationScope = "opentelemetry"
+	}
+	if config.Timeout == 0 {
+		config.Timeout = 3 * time.Second
+	}
+	if config.Timeout < 0 || config.ScheduledDelay < 0 {
+		return config, fmt.Errorf("durations must not be negative")
+	}
+	if err := requireWholeMillisecondDuration("timeout", config.Timeout); err != nil {
+		return config, err
+	}
+	if err := requireWholeMillisecondDuration("scheduled delay", config.ScheduledDelay); err != nil {
+		return config, err
+	}
+	if config.MinimumSeverity == "" {
+		config.MinimumSeverity = LogSeverityInfo
+	}
+	if config.MaxQueueSize == 0 {
+		config.MaxQueueSize = 2048
+	}
+	if config.MaxExportBatchSize == 0 {
+		config.MaxExportBatchSize = 512
+	}
+	if config.ScheduledDelay == 0 {
+		config.ScheduledDelay = time.Second
+	}
+	if config.Headers == nil {
+		config.Headers = map[string]string{}
+	}
+	if config.ResourceAttributes == nil {
+		config.ResourceAttributes = map[string]string{}
+	}
+	return config, nil
+}
+
+// NewOpenTelemetryLogSubscriber creates an independent OTLP log subscriber.
+func NewOpenTelemetryLogSubscriber(config OpenTelemetryLogConfig) (*OpenTelemetryLogSubscriber, error) {
+	config, err := normalizeOpenTelemetryLogConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	common, err := newOpenTelemetrySignalCStrings(
+		config.Transport, config.Endpoint, config.Headers, config.ResourceAttributes,
+		config.ServiceName, config.ServiceNamespace, config.ServiceVersion,
+		config.InstrumentationScope,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer common.free()
+	cSeverity := C.CString(string(config.MinimumSeverity))
+	defer C.free(unsafe.Pointer(cSeverity))
+	var ptr unsafe.Pointer
+	status := C.nemo_relay_otel_log_subscriber_create(
+		common.transport,
+		common.endpoint,
+		common.headers,
+		common.resourceAttributes,
+		common.serviceName,
+		common.serviceNamespace,
+		common.serviceVersion,
+		common.instrumentationScope,
+		C.uint64_t(config.Timeout/time.Millisecond),
+		cSeverity,
+		C.uint64_t(config.MaxQueueSize),
+		C.uint64_t(config.MaxExportBatchSize),
+		C.uint64_t(config.ScheduledDelay/time.Millisecond),
+		&ptr,
+	)
+	if err := checkStatus(status); err != nil {
+		return nil, err
+	}
+	return &OpenTelemetryLogSubscriber{ptr: ptr}, nil
+}
+
+// Register registers the log subscriber globally with the given name.
+func (s *OpenTelemetryLogSubscriber) Register(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return checkStatus(C.nemo_relay_otel_log_subscriber_register(s.ptr, cName))
+}
+
+// Deregister removes the log subscriber by name.
+func (s *OpenTelemetryLogSubscriber) Deregister(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return checkStatus(C.nemo_relay_otel_log_subscriber_deregister(cName))
+}
+
+// ForceFlush drains Relay delivery and queued log batches.
+func (s *OpenTelemetryLogSubscriber) ForceFlush() error {
+	return checkStatus(C.nemo_relay_otel_log_subscriber_force_flush(s.ptr))
+}
+
+// Shutdown drains and shuts down the logger provider.
+func (s *OpenTelemetryLogSubscriber) Shutdown() error {
+	return checkStatus(C.nemo_relay_otel_log_subscriber_shutdown(s.ptr))
+}
+
+// Close frees the log subscriber handle.
+func (s *OpenTelemetryLogSubscriber) Close() {
+	if s.ptr != nil {
+		C.nemo_relay_otel_log_subscriber_free(s.ptr)
+		s.ptr = nil
+	}
+}
+
+func normalizeOpenTelemetryMetricConfig(config OpenTelemetryMetricConfig) (OpenTelemetryMetricConfig, error) {
+	if config.Transport == "" {
+		config.Transport = OpenTelemetryTransportHTTPBinary
+	}
+	if config.Endpoint == "" {
+		return config, fmt.Errorf("endpoint is required")
+	}
+	if config.ServiceName == "" {
+		config.ServiceName = "unknown_service"
+	}
+	if config.InstrumentationScope == "" {
+		config.InstrumentationScope = "opentelemetry"
+	}
+	if config.Timeout == 0 {
+		config.Timeout = 3 * time.Second
+	}
+	if config.ExportInterval == 0 {
+		config.ExportInterval = 60 * time.Second
+	}
+	if config.Timeout < 0 || config.ExportInterval < 0 {
+		return config, fmt.Errorf("durations must not be negative")
+	}
+	if err := requireWholeMillisecondDuration("timeout", config.Timeout); err != nil {
+		return config, err
+	}
+	if err := requireWholeMillisecondDuration("export interval", config.ExportInterval); err != nil {
+		return config, err
+	}
+	if config.Temporality == "" {
+		config.Temporality = OpenTelemetryMetricTemporalityCumulative
+	}
+	if config.MaxInstruments == 0 {
+		config.MaxInstruments = 256
+	}
+	if config.CardinalityLimit == 0 {
+		config.CardinalityLimit = 2000
+	}
+	if config.Headers == nil {
+		config.Headers = map[string]string{}
+	}
+	if config.ResourceAttributes == nil {
+		config.ResourceAttributes = map[string]string{}
+	}
+	return config, nil
+}
+
+// NewOpenTelemetryMetricSubscriber creates an independent OTLP metric subscriber.
+func NewOpenTelemetryMetricSubscriber(config OpenTelemetryMetricConfig) (*OpenTelemetryMetricSubscriber, error) {
+	config, err := normalizeOpenTelemetryMetricConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	common, err := newOpenTelemetrySignalCStrings(
+		config.Transport, config.Endpoint, config.Headers, config.ResourceAttributes,
+		config.ServiceName, config.ServiceNamespace, config.ServiceVersion,
+		config.InstrumentationScope,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer common.free()
+	cTemporality := C.CString(string(config.Temporality))
+	defer C.free(unsafe.Pointer(cTemporality))
+	var ptr unsafe.Pointer
+	status := C.nemo_relay_otel_metric_subscriber_create(
+		common.transport,
+		common.endpoint,
+		common.headers,
+		common.resourceAttributes,
+		common.serviceName,
+		common.serviceNamespace,
+		common.serviceVersion,
+		common.instrumentationScope,
+		C.uint64_t(config.Timeout/time.Millisecond),
+		C.uint64_t(config.ExportInterval/time.Millisecond),
+		cTemporality,
+		C.uint64_t(config.MaxInstruments),
+		C.uint64_t(config.CardinalityLimit),
+		&ptr,
+	)
+	if err := checkStatus(status); err != nil {
+		return nil, err
+	}
+	return &OpenTelemetryMetricSubscriber{ptr: ptr}, nil
+}
+
+// Register registers the metric subscriber globally with the given name.
+func (s *OpenTelemetryMetricSubscriber) Register(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return checkStatus(C.nemo_relay_otel_metric_subscriber_register(s.ptr, cName))
+}
+
+// Deregister removes the metric subscriber by name.
+func (s *OpenTelemetryMetricSubscriber) Deregister(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return checkStatus(C.nemo_relay_otel_metric_subscriber_deregister(cName))
+}
+
+// ForceFlush drains Relay delivery and collects current metric aggregates.
+func (s *OpenTelemetryMetricSubscriber) ForceFlush() error {
+	return checkStatus(C.nemo_relay_otel_metric_subscriber_force_flush(s.ptr))
+}
+
+// Shutdown performs final collection and shuts down the meter provider.
+func (s *OpenTelemetryMetricSubscriber) Shutdown() error {
+	return checkStatus(C.nemo_relay_otel_metric_subscriber_shutdown(s.ptr))
+}
+
+// Close frees the metric subscriber handle.
+func (s *OpenTelemetryMetricSubscriber) Close() {
+	if s.ptr != nil {
+		C.nemo_relay_otel_metric_subscriber_free(s.ptr)
 		s.ptr = nil
 	}
 }

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -269,18 +269,21 @@ extern int32_t nemo_relay_otel_subscriber_create_with_projection_options(const c
 extern int32_t nemo_relay_otel_subscriber_register(const void*, const char*);
 extern int32_t nemo_relay_otel_subscriber_deregister(const char*);
 extern int32_t nemo_relay_otel_subscriber_force_flush(const void*);
+extern int32_t nemo_relay_otel_subscriber_runtime_diagnostics_json(const void*, char**);
 extern int32_t nemo_relay_otel_subscriber_shutdown(const void*);
 extern void nemo_relay_otel_subscriber_free(void*);
 extern int32_t nemo_relay_otel_log_subscriber_create(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, uint64_t, const char*, uint64_t, uint64_t, uint64_t, void**);
 extern int32_t nemo_relay_otel_log_subscriber_register(const void*, const char*);
 extern int32_t nemo_relay_otel_log_subscriber_deregister(const char*);
 extern int32_t nemo_relay_otel_log_subscriber_force_flush(const void*);
+extern int32_t nemo_relay_otel_log_subscriber_runtime_diagnostics_json(const void*, char**);
 extern int32_t nemo_relay_otel_log_subscriber_shutdown(const void*);
 extern void nemo_relay_otel_log_subscriber_free(void*);
 extern int32_t nemo_relay_otel_metric_subscriber_create(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, uint64_t, uint64_t, const char*, uint64_t, uint64_t, void**);
 extern int32_t nemo_relay_otel_metric_subscriber_register(const void*, const char*);
 extern int32_t nemo_relay_otel_metric_subscriber_deregister(const char*);
 extern int32_t nemo_relay_otel_metric_subscriber_force_flush(const void*);
+extern int32_t nemo_relay_otel_metric_subscriber_runtime_diagnostics_json(const void*, char**);
 extern int32_t nemo_relay_otel_metric_subscriber_shutdown(const void*);
 extern void nemo_relay_otel_metric_subscriber_free(void*);
 
@@ -2259,6 +2262,23 @@ type OpenTelemetrySubscriber struct {
 	ptr unsafe.Pointer
 }
 
+// OpenTelemetryRuntimeDiagnostic is one bounded aggregate of an OTLP exporter
+// or event-processing failure.
+type OpenTelemetryRuntimeDiagnostic struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Count   uint64 `json:"count"`
+}
+
+func decodeOpenTelemetryRuntimeDiagnostics(out *C.char) ([]OpenTelemetryRuntimeDiagnostic, error) {
+	defer C.nemo_relay_string_free(out)
+	var diagnostics []OpenTelemetryRuntimeDiagnostic
+	if err := jsonUnmarshal([]byte(C.GoString(out)), &diagnostics); err != nil {
+		return nil, err
+	}
+	return diagnostics, nil
+}
+
 func normalizeOpenTelemetryConfig(config OpenTelemetryConfig) (OpenTelemetryConfig, error) {
 	if config.Transport == "" {
 		config.Transport = OpenTelemetryTransportHTTPBinary
@@ -2401,6 +2421,15 @@ func (s *OpenTelemetrySubscriber) Deregister(name string) error {
 func (s *OpenTelemetrySubscriber) ForceFlush() error {
 	status := C.nemo_relay_otel_subscriber_force_flush(s.ptr)
 	return checkStatus(status)
+}
+
+// RuntimeDiagnostics returns a bounded snapshot of exporter and event-processing failures.
+func (s *OpenTelemetrySubscriber) RuntimeDiagnostics() ([]OpenTelemetryRuntimeDiagnostic, error) {
+	var out *C.char
+	if err := checkStatus(C.nemo_relay_otel_subscriber_runtime_diagnostics_json(s.ptr, &out)); err != nil {
+		return nil, err
+	}
+	return decodeOpenTelemetryRuntimeDiagnostics(out)
 }
 
 // Shutdown shuts down the underlying tracer provider.
@@ -2668,6 +2697,15 @@ func (s *OpenTelemetryLogSubscriber) ForceFlush() error {
 	return checkStatus(C.nemo_relay_otel_log_subscriber_force_flush(s.ptr))
 }
 
+// RuntimeDiagnostics returns a bounded snapshot of exporter and event-processing failures.
+func (s *OpenTelemetryLogSubscriber) RuntimeDiagnostics() ([]OpenTelemetryRuntimeDiagnostic, error) {
+	var out *C.char
+	if err := checkStatus(C.nemo_relay_otel_log_subscriber_runtime_diagnostics_json(s.ptr, &out)); err != nil {
+		return nil, err
+	}
+	return decodeOpenTelemetryRuntimeDiagnostics(out)
+}
+
 // Shutdown drains and shuts down the logger provider.
 func (s *OpenTelemetryLogSubscriber) Shutdown() error {
 	return checkStatus(C.nemo_relay_otel_log_subscriber_shutdown(s.ptr))
@@ -2784,6 +2822,15 @@ func (s *OpenTelemetryMetricSubscriber) Deregister(name string) error {
 // ForceFlush drains Relay delivery and collects current metric aggregates.
 func (s *OpenTelemetryMetricSubscriber) ForceFlush() error {
 	return checkStatus(C.nemo_relay_otel_metric_subscriber_force_flush(s.ptr))
+}
+
+// RuntimeDiagnostics returns a bounded snapshot of exporter and event-processing failures.
+func (s *OpenTelemetryMetricSubscriber) RuntimeDiagnostics() ([]OpenTelemetryRuntimeDiagnostic, error) {
+	var out *C.char
+	if err := checkStatus(C.nemo_relay_otel_metric_subscriber_runtime_diagnostics_json(s.ptr, &out)); err != nil {
+		return nil, err
+	}
+	return decodeOpenTelemetryRuntimeDiagnostics(out)
 }
 
 // Shutdown performs final collection and shuts down the meter provider.

--- a/go/nemo_relay/observability_plugin.go
+++ b/go/nemo_relay/observability_plugin.go
@@ -23,6 +23,44 @@ type ObservabilityConfig struct {
 type ObservabilityOpenTelemetryConfig struct {
 	Enabled   bool                                       `json:"enabled,omitempty"`
 	Endpoints []ObservabilityOpenTelemetryEndpointConfig `json:"endpoints,omitempty"`
+	Logs      *ObservabilityOpenTelemetryLogConfig       `json:"logs,omitempty"`
+	Metrics   *ObservabilityOpenTelemetryMetricConfig    `json:"metrics,omitempty"`
+}
+
+// ObservabilityOpenTelemetrySignalEndpointConfig configures one log or metric OTLP destination.
+type ObservabilityOpenTelemetrySignalEndpointConfig struct {
+	Endpoint             string            `json:"endpoint"`
+	Transport            string            `json:"transport,omitempty"`
+	Headers              map[string]string `json:"headers,omitempty"`
+	HeaderEnv            map[string]string `json:"header_env,omitempty"`
+	ResourceAttributes   map[string]string `json:"resource_attributes,omitempty"`
+	ServiceName          string            `json:"service_name,omitempty"`
+	ServiceNamespace     string            `json:"service_namespace,omitempty"`
+	ServiceVersion       string            `json:"service_version,omitempty"`
+	InstrumentationScope string            `json:"instrumentation_scope,omitempty"`
+	TimeoutMillis        uint64            `json:"timeout_millis,omitempty"`
+}
+
+// ObservabilityOpenTelemetryLogConfig configures the plugin's OTLP log pipeline.
+// A nil Endpoints pointer derives log destinations from the trace endpoint list.
+type ObservabilityOpenTelemetryLogConfig struct {
+	Enabled              bool                                              `json:"enabled,omitempty"`
+	Endpoints            *[]ObservabilityOpenTelemetrySignalEndpointConfig `json:"endpoints,omitempty"`
+	MinimumSeverity      LogSeverity                                       `json:"minimum_severity,omitempty"`
+	MaxQueueSize         uint64                                            `json:"max_queue_size,omitempty"`
+	MaxExportBatchSize   uint64                                            `json:"max_export_batch_size,omitempty"`
+	ScheduledDelayMillis uint64                                            `json:"scheduled_delay_millis,omitempty"`
+}
+
+// ObservabilityOpenTelemetryMetricConfig configures the plugin's OTLP metric pipeline.
+// A nil Endpoints pointer derives metric destinations from the trace endpoint list.
+type ObservabilityOpenTelemetryMetricConfig struct {
+	Enabled              bool                                              `json:"enabled,omitempty"`
+	Endpoints            *[]ObservabilityOpenTelemetrySignalEndpointConfig `json:"endpoints,omitempty"`
+	ExportIntervalMillis uint64                                            `json:"export_interval_millis,omitempty"`
+	Temporality          OpenTelemetryMetricTemporality                    `json:"temporality,omitempty"`
+	MaxInstruments       uint64                                            `json:"max_instruments,omitempty"`
+	CardinalityLimit     uint64                                            `json:"cardinality_limit,omitempty"`
 }
 
 // ObservabilityOpenTelemetryEndpointConfig configures one typed OTLP destination.
@@ -201,9 +239,9 @@ type ObservabilityComponentSpec struct {
 	Config  ObservabilityConfig `json:"config"`
 }
 
-// NewObservabilityConfig returns a default observability config with version 3.
+// NewObservabilityConfig returns a default observability config with version 4.
 func NewObservabilityConfig() ObservabilityConfig {
-	return ObservabilityConfig{Version: 3}
+	return ObservabilityConfig{Version: 4}
 }
 
 // NewObservabilityAtofConfig returns disabled ATOF JSONL settings with native defaults.
@@ -243,6 +281,49 @@ func NewObservabilityHttpStorageConfig(endpoint string) ObservabilityHttpStorage
 // NewObservabilityOpenTelemetryConfig returns disabled multi-endpoint settings.
 func NewObservabilityOpenTelemetryConfig() ObservabilityOpenTelemetryConfig {
 	return ObservabilityOpenTelemetryConfig{}
+}
+
+// NewObservabilityOpenTelemetrySignalEndpointConfig returns a signal endpoint with native defaults.
+func NewObservabilityOpenTelemetrySignalEndpointConfig(endpoint string) ObservabilityOpenTelemetrySignalEndpointConfig {
+	return ObservabilityOpenTelemetrySignalEndpointConfig{
+		Endpoint:             endpoint,
+		Transport:            "http_binary",
+		Headers:              map[string]string{},
+		HeaderEnv:            map[string]string{},
+		ResourceAttributes:   map[string]string{},
+		ServiceName:          "unknown_service",
+		InstrumentationScope: "opentelemetry",
+		TimeoutMillis:        3000,
+	}
+}
+
+// ObservabilityOpenTelemetrySignalEndpoints returns an explicit signal endpoint list.
+// Passing no endpoints intentionally serializes an empty list, which the core
+// validator distinguishes from omitted endpoints used for trace derivation.
+func ObservabilityOpenTelemetrySignalEndpoints(endpoints ...ObservabilityOpenTelemetrySignalEndpointConfig) *[]ObservabilityOpenTelemetrySignalEndpointConfig {
+	copyOfEndpoints := make([]ObservabilityOpenTelemetrySignalEndpointConfig, len(endpoints))
+	copy(copyOfEndpoints, endpoints)
+	return &copyOfEndpoints
+}
+
+// NewObservabilityOpenTelemetryLogConfig returns disabled log settings with native defaults.
+func NewObservabilityOpenTelemetryLogConfig() ObservabilityOpenTelemetryLogConfig {
+	return ObservabilityOpenTelemetryLogConfig{
+		MinimumSeverity:      LogSeverityInfo,
+		MaxQueueSize:         2048,
+		MaxExportBatchSize:   512,
+		ScheduledDelayMillis: 1000,
+	}
+}
+
+// NewObservabilityOpenTelemetryMetricConfig returns disabled metric settings with native defaults.
+func NewObservabilityOpenTelemetryMetricConfig() ObservabilityOpenTelemetryMetricConfig {
+	return ObservabilityOpenTelemetryMetricConfig{
+		ExportIntervalMillis: 60000,
+		Temporality:          OpenTelemetryMetricTemporalityCumulative,
+		MaxInstruments:       256,
+		CardinalityLimit:     2000,
+	}
 }
 
 // NewObservabilityOpenTelemetryEndpointConfig returns one typed endpoint with defaults.

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
@@ -323,6 +324,82 @@ func TestObservabilityPluginAtofAndAtifFiles(t *testing.T) {
 
 	AssertAtofRecordCount(t, filepath.Join(dir, eventsJSONLFilename), 3)
 	AssertAtifAgentMetadata(t, TrajectoryFilePath(dir, handle))
+}
+
+func TestObservabilityPluginActivatesDerivedLogsAndExplicitMetrics(t *testing.T) {
+	if err := ClearPluginConfiguration(); err != nil {
+		t.Fatalf(fatalErrorFormat, ClearPluginConfigurationFailed, err)
+	}
+	t.Cleanup(func() {
+		requireNoError(t, ClearPluginConfiguration(), ClearPluginConfigurationFailed)
+	})
+
+	derivedRequests := make(chan otelRequest, 4)
+	derivedServer := NewOtelTestServer(t, derivedRequests)
+	defer derivedServer.Close()
+	metricRequests := make(chan otelRequest, 2)
+	metricServer := NewOtelTestServer(t, metricRequests)
+	defer metricServer.Close()
+
+	config := NewObservabilityConfig()
+	openTelemetry := NewObservabilityOpenTelemetryConfig()
+	openTelemetry.Enabled = true
+	openTelemetry.Endpoints = []ObservabilityOpenTelemetryEndpointConfig{
+		NewObservabilityOpenTelemetryEndpointConfig(OpenTelemetryTypeFull, derivedServer.URL+otelTestPath),
+	}
+	logs := NewObservabilityOpenTelemetryLogConfig()
+	logs.Enabled = true
+	openTelemetry.Logs = &logs
+	metrics := NewObservabilityOpenTelemetryMetricConfig()
+	metrics.Enabled = true
+	metrics.Endpoints = ObservabilityOpenTelemetrySignalEndpoints(
+		NewObservabilityOpenTelemetrySignalEndpointConfig(metricServer.URL),
+	)
+	openTelemetry.Metrics = &metrics
+	config.OpenTelemetry = &openTelemetry
+
+	if _, err := InitializePlugins(PluginConfig{
+		Version:    1,
+		Components: []PluginComponentSpec{ObservabilityComponent(config)},
+	}); err != nil {
+		t.Fatalf(fatalErrorFormat, InitializePluginsFailed, err)
+	}
+
+	runWithTestScopeStack(t, func() {
+		requireNoError(t, EmitEvent("go_plugin_exported_log", WithEventSeverity(LogSeverityError)), "EmitEvent failed")
+		requireNoError(t, EmitMetric("go_plugin_exported_metric", []MetricMeasurement{{
+			Name:      "example.go.plugin.requests",
+			Kind:      MetricKindCounter,
+			ValueType: MetricValueTypeU64,
+			Value:     uint64(1),
+		}}), "EmitMetric failed")
+	})
+	if err := ClearPluginConfiguration(); err != nil {
+		t.Fatalf(fatalErrorFormat, ClearPluginConfigurationFailed, err)
+	}
+
+	requireOtelRequest(t, derivedRequests, "/v1/logs", "go_plugin_exported_log")
+	requireOtelRequest(t, metricRequests, "/v1/metrics", "example.go.plugin.requests")
+}
+
+func requireOtelRequest(t *testing.T, requests <-chan otelRequest, path, bodyFragment string) {
+	t.Helper()
+	timeout := time.NewTimer(5 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case request := <-requests:
+			if request.Path != path {
+				continue
+			}
+			if !strings.Contains(string(request.Body), bodyFragment) {
+				t.Fatalf("OTLP %s export did not contain %q", path, bodyFragment)
+			}
+			return
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for OTLP %s export", path)
+		}
+	}
 }
 
 func NewAtofAndAtifTestConfig(dir string) ObservabilityConfig {

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -189,20 +189,41 @@ func assertWrappedObservabilityConfig(t *testing.T, wrapped PluginComponentSpec)
 func TestObservabilitySignalEndpointOmittedVersusExplicitEmpty(t *testing.T) {
 	logs := NewObservabilityOpenTelemetryLogConfig()
 	logs.Enabled = true
-	omitted, err := json.Marshal(logs)
-	if err != nil {
-		t.Fatalf("marshal omitted endpoints: %v", err)
+	metrics := NewObservabilityOpenTelemetryMetricConfig()
+	metrics.Enabled = true
+	cases := []struct {
+		name     string
+		omitted  any
+		explicit any
+	}{
+		{"logs", logs, func() any {
+			config := logs
+			config.Endpoints = ObservabilityOpenTelemetrySignalEndpoints()
+			return config
+		}()},
+		{"metrics", metrics, func() any {
+			config := metrics
+			config.Endpoints = ObservabilityOpenTelemetrySignalEndpoints()
+			return config
+		}()},
 	}
-	if strings.Contains(string(omitted), `"endpoints"`) {
-		t.Fatalf("omitted endpoint list should derive from traces: %s", omitted)
-	}
-	logs.Endpoints = ObservabilityOpenTelemetrySignalEndpoints()
-	explicitEmpty, err := json.Marshal(logs)
-	if err != nil {
-		t.Fatalf("marshal explicit empty endpoints: %v", err)
-	}
-	if !strings.Contains(string(explicitEmpty), `"endpoints":[]`) {
-		t.Fatalf("explicit empty endpoint list must be preserved: %s", explicitEmpty)
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			omitted, err := json.Marshal(testCase.omitted)
+			if err != nil {
+				t.Fatalf("marshal omitted endpoints: %v", err)
+			}
+			if strings.Contains(string(omitted), `"endpoints"`) {
+				t.Fatalf("omitted endpoint list should derive from traces: %s", omitted)
+			}
+			explicitEmpty, err := json.Marshal(testCase.explicit)
+			if err != nil {
+				t.Fatalf("marshal explicit empty endpoints: %v", err)
+			}
+			if !strings.Contains(string(explicitEmpty), `"endpoints":[]`) {
+				t.Fatalf("explicit empty endpoint list must be preserved: %s", explicitEmpty)
+			}
+		})
 	}
 }
 

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -28,8 +28,8 @@ const (
 
 func TestObservabilityConfigHelpers(t *testing.T) {
 	config := NewObservabilityConfig()
-	if config.Version != 3 {
-		t.Fatalf("expected version 3, got %d", config.Version)
+	if config.Version != 4 {
+		t.Fatalf("expected version 4, got %d", config.Version)
 	}
 	if config.EnableFullPayloads {
 		t.Fatal("full payloads should be disabled by default")
@@ -80,6 +80,16 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 	otel.Endpoints[0].MaxQueueSize = &maxQueueSize
 	otel.Endpoints[0].MaxExportBatchSize = &maxExportBatchSize
 	otel.Endpoints[0].ScheduledDelayMillis = &scheduledDelayMillis
+	logs := NewObservabilityOpenTelemetryLogConfig()
+	logs.Enabled = true
+	metrics := NewObservabilityOpenTelemetryMetricConfig()
+	metrics.Enabled = true
+	metricEndpoint := NewObservabilityOpenTelemetrySignalEndpointConfig("https://collector.example/custom/metrics")
+	metricEndpoint.Headers["x-nv-project"] = "observability-dev"
+	metricEndpoint.ResourceAttributes["nv.project"] = "observability-dev"
+	metrics.Endpoints = ObservabilityOpenTelemetrySignalEndpoints(metricEndpoint)
+	otel.Logs = &logs
+	otel.Metrics = &metrics
 
 	config.Atof = &atof
 	config.Atif = &atif
@@ -155,6 +165,43 @@ func assertWrappedObservabilityConfig(t *testing.T, wrapped PluginComponentSpec)
 		otelEndpoints[0].(map[string]any)["max_export_batch_size"] != float64(256) ||
 		otelEndpoints[0].(map[string]any)["scheduled_delay_millis"] != float64(750) {
 		t.Fatalf("expected OpenTelemetry batch settings in serialized config: %#v", wrapped.Config)
+	}
+	otelConfig := wrapped.Config["opentelemetry"].(map[string]any)
+	logs := otelConfig["logs"].(map[string]any)
+	if logs["minimum_severity"] != "info" || logs["max_queue_size"] != float64(2048) {
+		t.Fatalf("expected OpenTelemetry log defaults in serialized config: %#v", logs)
+	}
+	if _, explicit := logs["endpoints"]; explicit {
+		t.Fatalf("derived log endpoints should remain omitted: %#v", logs)
+	}
+	metrics := otelConfig["metrics"].(map[string]any)
+	metricEndpoints := metrics["endpoints"].([]any)
+	metricEndpoint := metricEndpoints[0].(map[string]any)
+	if metrics["temporality"] != "cumulative" || metrics["cardinality_limit"] != float64(2000) ||
+		metricEndpoint["endpoint"] != "https://collector.example/custom/metrics" ||
+		metricEndpoint["headers"].(map[string]any)["x-nv-project"] != "observability-dev" ||
+		metricEndpoint["resource_attributes"].(map[string]any)["nv.project"] != "observability-dev" {
+		t.Fatalf("expected OpenTelemetry metric settings in serialized config: %#v", metrics)
+	}
+}
+
+func TestObservabilitySignalEndpointOmittedVersusExplicitEmpty(t *testing.T) {
+	logs := NewObservabilityOpenTelemetryLogConfig()
+	logs.Enabled = true
+	omitted, err := json.Marshal(logs)
+	if err != nil {
+		t.Fatalf("marshal omitted endpoints: %v", err)
+	}
+	if strings.Contains(string(omitted), `"endpoints"`) {
+		t.Fatalf("omitted endpoint list should derive from traces: %s", omitted)
+	}
+	logs.Endpoints = ObservabilityOpenTelemetrySignalEndpoints()
+	explicitEmpty, err := json.Marshal(logs)
+	if err != nil {
+		t.Fatalf("marshal explicit empty endpoints: %v", err)
+	}
+	if !strings.Contains(string(explicitEmpty), `"endpoints":[]`) {
+		t.Fatalf("explicit empty endpoint list must be preserved: %s", explicitEmpty)
 	}
 }
 

--- a/go/nemo_relay/otel_signals_test.go
+++ b/go/nemo_relay/otel_signals_test.go
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nemo_relay
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEventSchemaSeverityAndMetricParity(t *testing.T) {
+	var (
+		events []Event
+		mu     sync.Mutex
+	)
+	name := "go_signal_api_" + time.Now().Format(otelTimeFormat)
+	requireNoError(t, RegisterSubscriber(name, func(event Event) {
+		if event.Name() == "go_structured_log" || event.Name() == "go_metric" {
+			mu.Lock()
+			events = append(events, event)
+			mu.Unlock()
+		}
+	}), "RegisterSubscriber failed")
+	defer func() { _ = DeregisterSubscriber(name) }()
+
+	runWithTestScopeStack(t, func() {
+		err := EmitEvent(
+			"go_structured_log",
+			WithEventData(json.RawMessage(`{"message":"hello"}`)),
+			WithEventDataSchema(DataSchema{Name: "example.log", Version: "1"}),
+			WithEventMetadata(json.RawMessage(`{"nemo_relay.log.severity":"debug"}`)),
+			WithEventSeverity(LogSeverityWarn),
+		)
+		requireNoError(t, err, "EmitEvent failed")
+
+		err = EmitMetric("go_metric", []MetricMeasurement{{
+			Name:      "example.tokens.saved",
+			Kind:      MetricKindCounter,
+			ValueType: MetricValueTypeU64,
+			Value:     uint64(42),
+			Unit:      "{token}",
+			Attributes: map[string]interface{}{
+				"model": "example-model",
+			},
+		}})
+		requireNoError(t, err, "EmitMetric failed")
+	})
+	requireNoError(t, FlushSubscribers(), "FlushSubscribers failed")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 marks, got %d", len(events))
+	}
+	var schema DataSchema
+	if err := json.Unmarshal(events[0].DataSchema(), &schema); err != nil {
+		t.Fatalf("decode log schema: %v", err)
+	}
+	if schema.Name != "example.log" || schema.Version != "1" {
+		t.Fatalf("unexpected log schema: %#v", schema)
+	}
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(events[0].Metadata(), &metadata); err != nil {
+		t.Fatalf("decode log metadata: %v", err)
+	}
+	if metadata["nemo_relay.log.severity"] != "warn" {
+		t.Fatalf("typed severity did not override metadata: %#v", metadata)
+	}
+	if !bytes.Contains(events[1].DataSchema(), []byte("nemo.relay.metric_measurements")) {
+		t.Fatalf("metric schema missing: %s", events[1].DataSchema())
+	}
+	if !bytes.Contains(events[1].Data(), []byte("example.tokens.saved")) {
+		t.Fatalf("metric envelope missing measurement: %s", events[1].Data())
+	}
+}
+
+func TestEventAndMetricValidationErrors(t *testing.T) {
+	if err := EmitEvent("invalid_severity", WithEventSeverity(LogSeverity("verbose"))); err == nil {
+		t.Fatal("expected invalid severity to fail")
+	}
+	if err := EmitEvent(
+		"invalid_metadata",
+		WithEventMetadata(json.RawMessage(`[]`)),
+		WithEventSeverity(LogSeverityInfo),
+	); err == nil {
+		t.Fatal("expected severity with non-object metadata to fail")
+	}
+	if err := EmitMetric("empty_metric", nil); err == nil {
+		t.Fatal("expected empty measurements to fail")
+	}
+}
+
+func TestWithMetricParentRetainsScopeHandle(t *testing.T) {
+	parent := &ScopeHandle{}
+	options := &metricOptions{}
+
+	WithMetricParent(parent)(options)
+
+	if options.parentHandle != parent {
+		t.Fatal("metric options did not retain the parent scope handle")
+	}
+}
+
+func TestMetricMeasurementBoundarySerializationPreservesNilAndEmpty(t *testing.T) {
+	encoded, err := json.Marshal([]MetricMeasurement{
+		{Boundaries: nil},
+		{Boundaries: []float64{}},
+	})
+	requireNoError(t, err, "marshal metric measurements failed")
+
+	var measurements []map[string]interface{}
+	requireNoError(t, json.Unmarshal(encoded, &measurements), "decode metric measurements failed")
+	if boundaries, ok := measurements[0]["boundaries"]; !ok || boundaries != nil {
+		t.Fatalf("nil boundaries must serialize as null, got %#v", boundaries)
+	}
+	boundaries, ok := measurements[1]["boundaries"].([]interface{})
+	if !ok || len(boundaries) != 0 {
+		t.Fatalf("explicit empty boundaries must serialize as [], got %#v", measurements[1]["boundaries"])
+	}
+}
+
+func TestOpenTelemetrySignalConfigRejectsFractionalMillisecondDurations(t *testing.T) {
+	tests := []struct {
+		name      string
+		normalize func() error
+	}{
+		{
+			name: "log timeout",
+			normalize: func() error {
+				_, err := normalizeOpenTelemetryLogConfig(OpenTelemetryLogConfig{
+					Endpoint: "http://localhost:4318",
+					Timeout:  time.Nanosecond,
+				})
+				return err
+			},
+		},
+		{
+			name: "log scheduled delay",
+			normalize: func() error {
+				_, err := normalizeOpenTelemetryLogConfig(OpenTelemetryLogConfig{
+					Endpoint:       "http://localhost:4318",
+					ScheduledDelay: time.Millisecond + 500*time.Microsecond,
+				})
+				return err
+			},
+		},
+		{
+			name: "metric timeout",
+			normalize: func() error {
+				_, err := normalizeOpenTelemetryMetricConfig(OpenTelemetryMetricConfig{
+					Endpoint: "http://localhost:4318",
+					Timeout:  500 * time.Microsecond,
+				})
+				return err
+			},
+		},
+		{
+			name: "metric export interval",
+			normalize: func() error {
+				_, err := normalizeOpenTelemetryMetricConfig(OpenTelemetryMetricConfig{
+					Endpoint:       "http://localhost:4318",
+					ExportInterval: 2*time.Millisecond + 500*time.Microsecond,
+				})
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.normalize(); err == nil {
+				t.Fatal("expected fractional-millisecond duration to fail")
+			}
+		})
+	}
+}
+
+func TestOpenTelemetryLogSubscriberLifecycleAndDerivation(t *testing.T) {
+	requests := make(chan otelRequest, 4)
+	server := NewOtelTestServer(t, requests)
+	defer server.Close()
+
+	config := NewOpenTelemetryLogConfig(server.URL + "/v1/traces")
+	config.ServiceName = "go-log-test"
+	subscriber, err := NewOpenTelemetryLogSubscriber(config)
+	requireNoError(t, err, "NewOpenTelemetryLogSubscriber failed")
+	defer subscriber.Close()
+	name := "go_otel_log_" + time.Now().Format(otelTimeFormat)
+	requireNoError(t, subscriber.Register(name), "log Register failed")
+	defer func() { _ = subscriber.Deregister(name) }()
+
+	runWithTestScopeStack(t, func() {
+		requireNoError(t, EmitEvent("go_exported_log", WithEventSeverity(LogSeverityError)), "EmitEvent failed")
+	})
+	requireNoError(t, subscriber.ForceFlush(), "log ForceFlush failed")
+
+	select {
+	case request := <-requests:
+		if request.Path != "/v1/logs" {
+			t.Fatalf("expected /v1/logs path, got %q", request.Path)
+		}
+		if !bytes.Contains(request.Body, []byte("go_exported_log")) {
+			t.Fatal("log export did not contain mark name")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for OTLP log request")
+	}
+	requireNoError(t, subscriber.Deregister(name), "log Deregister failed")
+	requireNoError(t, subscriber.Shutdown(), "log Shutdown failed")
+}
+
+func TestOpenTelemetryMetricSubscriberLifecycleAndDerivation(t *testing.T) {
+	requests := make(chan otelRequest, 4)
+	server := NewOtelTestServer(t, requests)
+	defer server.Close()
+
+	config := NewOpenTelemetryMetricConfig(server.URL + "/v1/traces")
+	config.ServiceName = "go-metric-test"
+	subscriber, err := NewOpenTelemetryMetricSubscriber(config)
+	requireNoError(t, err, "NewOpenTelemetryMetricSubscriber failed")
+	defer subscriber.Close()
+	name := "go_otel_metric_" + time.Now().Format(otelTimeFormat)
+	requireNoError(t, subscriber.Register(name), "metric Register failed")
+	defer func() { _ = subscriber.Deregister(name) }()
+
+	runWithTestScopeStack(t, func() {
+		requireNoError(t, EmitMetric("go_exported_metric", []MetricMeasurement{{
+			Name:      "example.requests",
+			Kind:      MetricKindCounter,
+			ValueType: MetricValueTypeU64,
+			Value:     uint64(1),
+		}}), "EmitMetric failed")
+	})
+	requireNoError(t, subscriber.ForceFlush(), "metric ForceFlush failed")
+
+	select {
+	case request := <-requests:
+		if request.Path != "/v1/metrics" {
+			t.Fatalf("expected /v1/metrics path, got %q", request.Path)
+		}
+		if !bytes.Contains(request.Body, []byte("example.requests")) {
+			t.Fatal("metric export did not contain instrument name")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for OTLP metric request")
+	}
+	requireNoError(t, subscriber.Deregister(name), "metric Deregister failed")
+	requireNoError(t, subscriber.Shutdown(), "metric Shutdown failed")
+}

--- a/go/nemo_relay/otel_signals_test.go
+++ b/go/nemo_relay/otel_signals_test.go
@@ -178,6 +178,64 @@ func TestOpenTelemetrySignalConfigRejectsFractionalMillisecondDurations(t *testi
 	}
 }
 
+func TestOpenTelemetrySubscribersExposeRuntimeDiagnostics(t *testing.T) {
+	endpoint := "http://127.0.0.1:4318/v1/traces"
+	traceSubscriber, err := NewOpenTelemetrySubscriber(NewOpenTelemetryConfig(OpenTelemetryTypeFull, endpoint))
+	requireNoError(t, err, "NewOpenTelemetrySubscriber failed")
+	defer traceSubscriber.Close()
+	logSubscriber, err := NewOpenTelemetryLogSubscriber(NewOpenTelemetryLogConfig(endpoint))
+	requireNoError(t, err, "NewOpenTelemetryLogSubscriber failed")
+	defer logSubscriber.Close()
+	metricSubscriber, err := NewOpenTelemetryMetricSubscriber(NewOpenTelemetryMetricConfig(endpoint))
+	requireNoError(t, err, "NewOpenTelemetryMetricSubscriber failed")
+	defer metricSubscriber.Close()
+
+	subscribers := []struct {
+		name               string
+		register           func(string) error
+		deregister         func(string) error
+		runtimeDiagnostics func() ([]OpenTelemetryRuntimeDiagnostic, error)
+	}{
+		{"trace", traceSubscriber.Register, traceSubscriber.Deregister, traceSubscriber.RuntimeDiagnostics},
+		{"log", logSubscriber.Register, logSubscriber.Deregister, logSubscriber.RuntimeDiagnostics},
+		{"metric", metricSubscriber.Register, metricSubscriber.Deregister, metricSubscriber.RuntimeDiagnostics},
+	}
+	for index := range subscribers {
+		subscribers[index].name = "go_otel_" + subscribers[index].name + "_diagnostics_" + time.Now().Format(otelTimeFormat)
+		requireNoError(t, subscribers[index].register(subscribers[index].name), "subscriber Register failed")
+		defer func(subscriberName string, deregister func(string) error) {
+			_ = deregister(subscriberName)
+		}(subscribers[index].name, subscribers[index].deregister)
+	}
+
+	runWithTestScopeStack(t, func() {
+		requireNoError(t, EmitEvent(
+			"invalid_metric",
+			WithEventData(json.RawMessage(`{"measurements":[]}`)),
+			WithEventDataSchema(DataSchema{Name: "nemo.relay.metric_measurements", Version: "999"}),
+		), "EmitEvent failed")
+	})
+	requireNoError(t, FlushSubscribers(), "FlushSubscribers failed")
+
+	for _, subscriber := range subscribers {
+		diagnostics, err := subscriber.runtimeDiagnostics()
+		requireNoError(t, err, "RuntimeDiagnostics failed")
+		var invalidMetric *OpenTelemetryRuntimeDiagnostic
+		for index := range diagnostics {
+			if diagnostics[index].Code == "otel.metric_mark_invalid" {
+				invalidMetric = &diagnostics[index]
+				break
+			}
+		}
+		if invalidMetric == nil {
+			t.Fatalf("expected invalid metric diagnostic for %s subscriber, got %#v", subscriber.name, diagnostics)
+		}
+		if invalidMetric.Count != 1 || !bytes.Contains([]byte(invalidMetric.Message), []byte("unsupported metric schema version")) {
+			t.Fatalf("unexpected invalid metric diagnostic for %s subscriber: %#v", subscriber.name, invalidMetric)
+		}
+	}
+}
+
 func TestOpenTelemetryLogSubscriberLifecycleAndDerivation(t *testing.T) {
 	requests := make(chan otelRequest, 4)
 	server := NewOtelTestServer(t, requests)

--- a/go/nemo_relay/otel_signals_test.go
+++ b/go/nemo_relay/otel_signals_test.go
@@ -6,6 +6,7 @@ package nemo_relay
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -80,17 +81,25 @@ func TestEventSchemaSeverityAndMetricParity(t *testing.T) {
 func TestEventAndMetricValidationErrors(t *testing.T) {
 	if err := EmitEvent("invalid_severity", WithEventSeverity(LogSeverity("verbose"))); err == nil {
 		t.Fatal("expected invalid severity to fail")
+	} else if !strings.Contains(err.Error(), "invalid log severity") {
+		t.Fatalf("unexpected severity error: %v", err)
 	}
-	if err := EmitEvent(
-		"invalid_metadata",
-		WithEventMetadata(json.RawMessage(`[]`)),
-		WithEventSeverity(LogSeverityInfo),
-	); err == nil {
-		t.Fatal("expected severity with non-object metadata to fail")
-	}
-	if err := EmitMetric("empty_metric", nil); err == nil {
-		t.Fatal("expected empty measurements to fail")
-	}
+	runWithTestScopeStack(t, func() {
+		if err := EmitEvent(
+			"invalid_metadata",
+			WithEventMetadata(json.RawMessage(`[]`)),
+			WithEventSeverity(LogSeverityInfo),
+		); err == nil {
+			t.Fatal("expected severity with non-object metadata to fail")
+		} else if !strings.Contains(err.Error(), "mark metadata must be a JSON object") {
+			t.Fatalf("unexpected metadata error: %v", err)
+		}
+		if err := EmitMetric("empty_metric", []MetricMeasurement{}); err == nil {
+			t.Fatal("expected empty measurements to fail")
+		} else if !strings.Contains(err.Error(), "measurements must contain at least one entry") {
+			t.Fatalf("unexpected empty measurement error: %v", err)
+		}
+	})
 }
 
 func TestWithMetricParentRetainsScopeHandle(t *testing.T) {

--- a/go/nemo_relay/otel_signals_test.go
+++ b/go/nemo_relay/otel_signals_test.go
@@ -30,8 +30,11 @@ func TestEventSchemaSeverityAndMetricParity(t *testing.T) {
 	runWithTestScopeStack(t, func() {
 		err := EmitEvent(
 			"go_structured_log",
+			WithEventData(json.RawMessage(`{"message":"ignored"}`)),
 			WithEventData(json.RawMessage(`{"message":"hello"}`)),
+			WithEventDataSchema(DataSchema{Name: "ignored", Version: "0"}),
 			WithEventDataSchema(DataSchema{Name: "example.log", Version: "1"}),
+			WithEventMetadata(json.RawMessage(`{"context":"ignored"}`)),
 			WithEventMetadata(json.RawMessage(`{"nemo_relay.log.severity":"debug"}`)),
 			WithEventSeverity(LogSeverityWarn),
 		)
@@ -46,7 +49,10 @@ func TestEventSchemaSeverityAndMetricParity(t *testing.T) {
 			Attributes: map[string]interface{}{
 				"model": "example-model",
 			},
-		}})
+		}},
+			WithMetricMetadata(json.RawMessage(`{"context":"ignored"}`)),
+			WithMetricMetadata(json.RawMessage(`{"context":"final"}`)),
+		)
 		requireNoError(t, err, "EmitMetric failed")
 	})
 	requireNoError(t, FlushSubscribers(), "FlushSubscribers failed")
@@ -63,6 +69,9 @@ func TestEventSchemaSeverityAndMetricParity(t *testing.T) {
 	if schema.Name != "example.log" || schema.Version != "1" {
 		t.Fatalf("unexpected log schema: %#v", schema)
 	}
+	if !bytes.Equal(events[0].Data(), []byte(`{"message":"hello"}`)) {
+		t.Fatalf("final event data should replace the earlier value: %s", events[0].Data())
+	}
 	var metadata map[string]interface{}
 	if err := json.Unmarshal(events[0].Metadata(), &metadata); err != nil {
 		t.Fatalf("decode log metadata: %v", err)
@@ -70,11 +79,21 @@ func TestEventSchemaSeverityAndMetricParity(t *testing.T) {
 	if metadata["nemo_relay.log.severity"] != "warn" {
 		t.Fatalf("typed severity did not override metadata: %#v", metadata)
 	}
+	if _, ok := metadata["context"]; ok {
+		t.Fatalf("final event metadata should replace the earlier value: %#v", metadata)
+	}
 	if !bytes.Contains(events[1].DataSchema(), []byte("nemo.relay.metric_measurements")) {
 		t.Fatalf("metric schema missing: %s", events[1].DataSchema())
 	}
 	if !bytes.Contains(events[1].Data(), []byte("example.tokens.saved")) {
 		t.Fatalf("metric envelope missing measurement: %s", events[1].Data())
+	}
+	var metricMetadata map[string]interface{}
+	if err := json.Unmarshal(events[1].Metadata(), &metricMetadata); err != nil {
+		t.Fatalf("decode metric metadata: %v", err)
+	}
+	if metricMetadata["context"] != "final" {
+		t.Fatalf("final metric metadata should replace the earlier value: %#v", metricMetadata)
 	}
 }
 

--- a/go/nemo_relay/scope/scope.go
+++ b/go/nemo_relay/scope/scope.go
@@ -4,7 +4,7 @@
 // Package scope provides shorthand access to NeMo Relay scope operations.
 //
 // It re-exports the core scope management functions (GetHandle, PushScope,
-// PopScope, EmitEvent) under shorter names for convenience.
+// PopScope, EmitEvent, EmitMetric) under shorter names for convenience.
 //
 // Example usage:
 //
@@ -80,6 +80,12 @@ func Pop(handle *nemo_relay.ScopeHandle, opts ...nemo_relay.ScopeEndOption) erro
 // [nemo_relay.WithEventTimestamp], are forwarded to [nemo_relay.EmitEvent].
 func Event(name string, opts ...nemo_relay.EventOption) error {
 	return nemo_relay.EmitEvent(name, opts...)
+}
+
+// Metric emits an atomically validated metric mark within the current scope.
+// This is a shorthand for [nemo_relay.EmitMetric].
+func Metric(name string, measurements []nemo_relay.MetricMeasurement, opts ...nemo_relay.MetricOption) error {
+	return nemo_relay.EmitMetric(name, measurements, opts...)
 }
 
 // WithScope pushes a new scope and returns a cleanup function that pops it.


### PR DESCRIPTION
#### Overview

Expose core OTLP log and metric contracts through the C ABI and experimental Go binding.

This PR is independently rebased on `main` after [#780](https://github.com/NVIDIA/NeMo-Relay/pull/780). It owns the C FFI/Go layer and can merge independently of the Python, Node.js, and dynamic-plugin follow-ups; end-user documentation is tracked separately in [#795](https://github.com/NVIDIA/NeMo-Relay/pull/795).

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add checked C representations and emission APIs for log severity, structured marks, and metric measurements.
- Add independently managed OTLP log and metric subscribers: create, register, flush, diagnostics, shutdown, and cleanup.
- Expose runtime diagnostics through C JSON accessors and typed Go results for direct trace, log, and metric subscribers.
- Add Go structured-event options, `EmitMetric`, direct signal subscriber APIs, and v4 observability plugin configuration.
- Preserve nil versus explicit-empty histogram boundaries, scope-parent lifetimes, and last-option-wins C-string ownership.
- Regenerate the public C header and add FFI/Go validation, lifecycle, activation, serialization, diagnostics, and OTLP export coverage.

Validation:

- `cargo fmt --all` and `cargo clippy -p nemo-relay-ffi --all-targets -- -D warnings`
- FFI unit suite: 93 passed
- Focused FFI OTLP signal export integration test
- Focused Go signal API regression test
- GitHub Actions runs the full Rust and Go platform matrix with coverage reporting

Breaking changes: none; existing C entry points remain available.

#### Where should the reviewer start?

Start with `crates/ffi/src/api/observability.rs`, then `crates/ffi/src/api/scope.rs` and `go/nemo_relay/nemo_relay.go`. The focused FFI and Go regression coverage is in their corresponding test files.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #780
- Relates to: #795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent OpenTelemetry log and metric subscribers with configuration, registration, flushing, diagnostics, shutdown, and cleanup.
  * Added structured event schemas, severity levels, and typed or JSON metric emission with metadata and histogram boundaries.
  * Added Go APIs for metric recording and OpenTelemetry log/metric workflows.
  * Added signal-specific endpoints and configuration defaults.
* **Diagnostics**
  * Added runtime diagnostics for OpenTelemetry subscribers.
* **Bug Fixes**
  * Improved validation for invalid metrics, schemas, enums, pointers, and measurement values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->