### PR TITLE
fix(cli): provision bootstrap key before sandboxed startup

### DIFF
--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -96,6 +96,9 @@ pub(super) fn install(command: InstallCommand) -> Result<ExitCode, CliError> {
             "no supported Claude Code, Codex, or Hermes host CLI was detected".into(),
         ));
     }
+    if !request.dry_run {
+        crate::configuration::BootstrapChallengeKey::load()?;
+    }
     run_agent_operations(agents, "install", |agent| {
         crate::agents::install_integration(agent, request.clone())
     })

--- a/crates/cli/src/configuration/mod.rs
+++ b/crates/cli/src/configuration/mod.rs
@@ -658,7 +658,13 @@ fn bootstrap_hmac_key_path() -> Result<PathBuf, CliError> {
 
 fn load_existing_bootstrap_hmac_key() -> Result<Option<[u8; BOOTSTRAP_HMAC_KEY_BYTES]>, CliError> {
     let path = bootstrap_hmac_key_path()?;
-    let mut file = match OpenOptions::new().read(true).open(&path) {
+    load_existing_bootstrap_hmac_key_at(&path)
+}
+
+fn load_existing_bootstrap_hmac_key_at(
+    path: &Path,
+) -> Result<Option<[u8; BOOTSTRAP_HMAC_KEY_BYTES]>, CliError> {
+    let mut file = match OpenOptions::new().read(true).open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
@@ -714,9 +720,82 @@ fn load_existing_bootstrap_hmac_key() -> Result<Option<[u8; BOOTSTRAP_HMAC_KEY_B
     Ok(Some(key))
 }
 
+fn bootstrap_hmac_key_permissions_are_private(path: &Path) -> Result<bool, CliError> {
+    let Some(parent) = path.parent() else {
+        return Ok(false);
+    };
+    for candidate in [parent, path] {
+        match candidate.try_exists() {
+            Ok(true) => {}
+            Ok(false) => return Ok(false),
+            Err(error) if error.kind() == std::io::ErrorKind::NotADirectory => return Ok(false),
+            Err(error) => {
+                return Err(CliError::Config(format!(
+                    "failed to inspect bootstrap path {}: {error}",
+                    candidate.display()
+                )));
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory_mode = fs::metadata(parent)
+            .map_err(|error| {
+                CliError::Config(format!(
+                    "failed to inspect bootstrap state directory {}: {error}",
+                    parent.display()
+                ))
+            })?
+            .permissions()
+            .mode();
+        let key_mode = fs::metadata(path)
+            .map_err(|error| {
+                CliError::Config(format!(
+                    "failed to inspect bootstrap HMAC key {}: {error}",
+                    path.display()
+                ))
+            })?
+            .permissions()
+            .mode();
+        Ok(directory_mode & 0o077 == 0
+            && directory_mode & 0o500 == 0o500
+            && key_mode & 0o077 == 0
+            && key_mode & 0o400 == 0o400)
+    }
+
+    #[cfg(windows)]
+    {
+        let directory_is_private =
+            crate::filesystem::windows_path_is_private(parent).map_err(|error| {
+                CliError::Config(format!(
+                    "failed to inspect bootstrap state directory {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        let key_is_private = crate::filesystem::windows_path_is_private(path).map_err(|error| {
+            CliError::Config(format!(
+                "failed to inspect bootstrap HMAC key {}: {error}",
+                path.display()
+            ))
+        })?;
+        Ok(directory_is_private && key_is_private)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    Ok(false)
+}
+
 fn load_or_create_bootstrap_hmac_key_at(
     path: &Path,
 ) -> Result<[u8; BOOTSTRAP_HMAC_KEY_BYTES], CliError> {
+    if bootstrap_hmac_key_permissions_are_private(path)?
+        && let Some(key) = load_existing_bootstrap_hmac_key_at(path)?
+    {
+        return Ok(key);
+    }
     load_or_create_bootstrap_hmac_key_at_with_timeout(path, BOOTSTRAP_HMAC_LOCK_TIMEOUT)
 }
 

--- a/crates/cli/src/filesystem/mod.rs
+++ b/crates/cli/src/filesystem/mod.rs
@@ -11,16 +11,16 @@ pub(crate) mod temp;
 
 #[cfg(test)]
 pub(crate) use atomic::fail_next_atomic_write;
+#[cfg(all(test, windows))]
+pub(crate) use atomic::windows_wide;
 pub(crate) use atomic::{
     atomic_write, atomic_write_private, atomic_write_system_readable, atomic_write_with_permissions,
 };
 #[cfg(windows)]
 pub(crate) use atomic::{
     atomic_write_with_windows_dacl, open_private_windows_file, protect_private_windows_path,
-    read_windows_dacl,
+    read_windows_dacl, windows_path_is_private,
 };
-#[cfg(all(test, windows))]
-pub(crate) use atomic::{windows_path_is_private, windows_wide};
 #[cfg(all(test, windows))]
 pub(crate) use locks::normalize_lock_attempt;
 pub(crate) use locks::{LockAttempt, try_lock_exclusive, try_lock_shared, unlock_file};

--- a/crates/cli/tests/coverage/commands/main_tests.rs
+++ b/crates/cli/tests/coverage/commands/main_tests.rs
@@ -533,6 +533,54 @@ async fn run_command_dispatches_safe_plugin_and_install_paths() {
     );
 }
 
+#[tokio::test]
+async fn run_command_install_requires_a_valid_bootstrap_key_except_dry_runs() {
+    let temp = tempfile::tempdir().unwrap();
+    let _env = EnvScope::hermetic(&temp);
+    let install_dir = temp.path().join("plugin-install");
+    let install_dir_arg = install_dir.to_string_lossy().to_string();
+    let key_path = temp
+        .path()
+        .join("xdg/nemo-relay/bootstrap/fingerprint-hmac.key");
+    std::fs::create_dir_all(key_path.parent().unwrap()).unwrap();
+    std::fs::write(&key_path, [0_u8; 31]).unwrap();
+
+    let cli = Cli::try_parse_from([
+        "nemo-relay",
+        "install",
+        "codex",
+        "--install-dir",
+        install_dir_arg.as_str(),
+        "--skip-doctor",
+    ])
+    .unwrap();
+    let error = run_command(cli.command.unwrap(), &cli.server, None)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("bootstrap HMAC key"));
+    assert!(error.contains("invalid length 31"));
+    assert!(!install_dir.exists());
+
+    let cli = Cli::try_parse_from([
+        "nemo-relay",
+        "install",
+        "codex",
+        "--install-dir",
+        install_dir_arg.as_str(),
+        "--dry-run",
+        "--skip-doctor",
+    ])
+    .unwrap();
+    assert_eq!(
+        run_command(cli.command.unwrap(), &cli.server, None)
+            .await
+            .unwrap(),
+        ExitCode::SUCCESS
+    );
+    assert_eq!(std::fs::read(key_path).unwrap(), [0_u8; 31]);
+}
+
 #[test]
 fn pricing_validate_dispatch_covers_success_read_and_parse_errors() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/cli/tests/coverage/shared/config_tests.rs
+++ b/crates/cli/tests/coverage/shared/config_tests.rs
@@ -2596,6 +2596,60 @@ fn bootstrap_hmac_key_creation_is_concurrency_safe_and_stable() {
     assert_eq!(std::fs::metadata(path).unwrap().len(), 32);
 }
 
+#[cfg(unix)]
+#[test]
+fn bootstrap_hmac_key_reuses_private_state_without_changing_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("state/fingerprint-hmac.key");
+    let original = load_or_create_bootstrap_hmac_key_at(&path).unwrap();
+    let parent = path.parent().unwrap();
+    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o500)).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o400)).unwrap();
+
+    let reloaded = load_or_create_bootstrap_hmac_key_at(&path).unwrap();
+
+    assert_eq!(reloaded, original);
+    assert_eq!(
+        std::fs::metadata(parent).unwrap().permissions().mode() & 0o777,
+        0o500
+    );
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+        0o400
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn bootstrap_hmac_key_repairs_group_or_other_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("state/fingerprint-hmac.key");
+    let original = load_or_create_bootstrap_hmac_key_at(&path).unwrap();
+    let parent = path.parent().unwrap();
+
+    for (directory_mode, key_mode) in [(0o750, 0o640), (0o701, 0o604)] {
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(directory_mode)).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(key_mode)).unwrap();
+
+        assert_eq!(
+            load_or_create_bootstrap_hmac_key_at(&path).unwrap(),
+            original
+        );
+        assert_eq!(
+            std::fs::metadata(parent).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
 #[cfg(windows)]
 #[test]
 fn bootstrap_hmac_key_uses_and_repairs_a_private_windows_dacl() {

--- a/crates/core/tests/unit/codec/response_tests.rs
+++ b/crates/core/tests/unit/codec/response_tests.rs
@@ -15,7 +15,7 @@ use crate::error::FlowError;
 use crate::json::Json;
 use crate::plugin::{
     DiagnosticLevel, PluginComponentSpec, PluginConfig, clear_plugin_configuration,
-    initialize_plugins, validate_plugin_config,
+    initialize_plugins_exact, validate_plugin_config,
 };
 use crate::plugins::model_pricing::register_pricing_component;
 
@@ -811,7 +811,7 @@ fn test_pricing_plugin_configures_process_resolver_and_clears_to_default() {
 
     tokio::runtime::Runtime::new()
         .unwrap()
-        .block_on(async { initialize_plugins(config).await.unwrap() });
+        .block_on(async { initialize_plugins_exact(config).await.unwrap() });
     let _clear_guard = ClearPluginConfigurationGuard;
     let usage = Usage {
         prompt_tokens: Some(1_000),


### PR DESCRIPTION
#### Overview

Provision Relay's bootstrap key during installation so later constrained agent processes can start Relay without modifying that key's filesystem permissions.

- [ ] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [ ] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Relay previously reapplied private permissions to its bootstrap HMAC key whenever a Relay MCP process started. A constrained process can read an existing key but may not be allowed to change the key or its parent directory, preventing Relay from finishing startup.

This release backport creates or repairs the key during a real `nemo-relay install` invocation. Later startup reuses a key only after confirming that both the key and its directory are private; otherwise the installer repairs it. The change preserves the equivalent Windows privacy check and adds regression coverage for readonly reuse, unsafe permissions, malformed keys, and dry-run installation.

Validation:

- Passed: `cargo fmt --all --check` and the focused bootstrap-key, installation, and plugin-configuration tests.
- Attempted: `just test-rust`. It ran 1,186 tests; 1,163 passed and 23 unchanged core Guardrails tests failed because their fixtures request unsupported observability config version 1. The failures do not exercise any file changed by this backport.

#### Where should the reviewer start?

Start with `crates/cli/src/configuration/mod.rs`, which validates a private existing bootstrap key before reuse. `crates/cli/src/commands/install.rs` provisions that key before agents start.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bootstrap security keys are now validated before plugin installation.
  * Invalid keys are rejected during normal installations without creating installation files.
  * Existing keys are reused only when stored securely; unsafe permissions are automatically corrected.
  * Dry-run installations continue without modifying invalid keys.

* **Tests**
  * Added coverage for invalid key lengths, secure permissions, and dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->