### PR TITLE
fix(cli): serialize bootstrap key initialization

### DIFF
--- a/crates/cli/src/configuration/mod.rs
+++ b/crates/cli/src/configuration/mod.rs
@@ -792,6 +792,9 @@ fn load_or_create_bootstrap_hmac_key_at(
     path: &Path,
 ) -> Result<[u8; BOOTSTRAP_HMAC_KEY_BYTES], CliError> {
     if bootstrap_hmac_key_permissions_are_private(path)?
+        && fs::metadata(path)
+            .map(|metadata| metadata.len() == BOOTSTRAP_HMAC_KEY_BYTES as u64)
+            .unwrap_or(false)
         && let Some(key) = load_existing_bootstrap_hmac_key_at(path)?
     {
         return Ok(key);

--- a/crates/cli/tests/coverage/shared/config_tests.rs
+++ b/crates/cli/tests/coverage/shared/config_tests.rs
@@ -2598,6 +2598,25 @@ fn bootstrap_hmac_key_creation_is_concurrency_safe_and_stable() {
 
 #[cfg(unix)]
 #[test]
+fn bootstrap_hmac_key_completes_empty_private_state() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("state/fingerprint-hmac.key");
+    let parent = path.parent().unwrap();
+    std::fs::create_dir_all(parent).unwrap();
+    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+    std::fs::File::create(&path).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    let key = load_or_create_bootstrap_hmac_key_at(&path).unwrap();
+
+    assert_eq!(std::fs::metadata(&path).unwrap().len(), 32);
+    assert_eq!(load_or_create_bootstrap_hmac_key_at(&path).unwrap(), key);
+}
+
+#[cfg(unix)]
+#[test]
 fn bootstrap_hmac_key_reuses_private_state_without_changing_permissions() {
     use std::os::unix::fs::PermissionsExt;
 


### PR DESCRIPTION
#### Overview

Ensure the bootstrap HMAC key is fully initialized before the read-only reuse path accepts it. This backports the correction to `release/0.7`, where concurrent CLI hook invocations can otherwise fail during first-time bootstrap state creation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

`BootstrapChallengeKey::load()` is reached by authenticated CLI hook forwarding. During first-time key creation, one process opens `fingerprint-hmac.key` with `create(true)`, which publishes a private, zero-byte file before that process acquires the exclusive advisory lock and writes the 32-byte key. A second hook process can observe the private permissions, enter the read-only fast path, acquire a shared lock before the creator has locked the file, and reject the transient zero-byte file as corrupt. The second hook then fails even though the first process finishes initialization correctly.

The fast path now reuses a key only when its metadata confirms the canonical 32-byte length. A missing or empty file instead enters the existing exclusive-lock creation path. That preserves cross-process serialization: one caller writes and syncs the key, while every other caller waits or reads the completed value. A process-local mutex would not address independent CLI processes, so this fix retains the file-locking boundary.

The regression test starts from an empty file with the same private permissions that expose the race. It verifies that the loader completes initialization and that later reads return the same key.

Validation:

- Passed: focused bootstrap HMAC-key tests (6 tests).
- Passed: `just test-rust`.
- Passed: `cargo clippy --workspace --all-targets -- -D warnings`.
- Passed: changed-file pre-commit checks and commit hooks.

#### Where should the reviewer start?

Start with `load_or_create_bootstrap_hmac_key_at` in `crates/cli/src/configuration/mod.rs`. The additional ready-state check keeps transient creation state out of the lock-free reuse path; the adjacent regression test demonstrates that state directly.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of existing bootstrap security key files by validating their expected size before use.
  * Empty key files are now automatically populated and can be loaded consistently afterward.

* **Tests**
  * Added coverage for creating, validating, and reloading an initially empty key file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->