### PR TITLE
fix: omit model-pricing totals when nonzero usage lacks a rate

### DIFF
--- a/crates/core/src/codec/model_pricing.rs
+++ b/crates/core/src/codec/model_pricing.rs
@@ -327,13 +327,16 @@ impl ModelPricing {
             .cache_write_per_million
             .and_then(|price| cost_component_if_nonzero(cache_write_tokens, price));
 
-        let total: f64 = [input_cost, output_cost, cache_read_cost, cache_write_cost]
+        let has_unpriced_nonzero_usage = (cache_read_tokens > 0
+            && rates.cache_read_per_million.is_none())
+            || (cache_write_tokens > 0 && rates.cache_write_per_million.is_none());
+        let component_sum: f64 = [input_cost, output_cost, cache_read_cost, cache_write_cost]
             .into_iter()
             .flatten()
             .sum();
 
         Some(CostEstimate {
-            total: Some(round_cost_amount(total)),
+            total: (!has_unpriced_nonzero_usage).then_some(round_cost_amount(component_sum)),
             currency: self.currency.clone(),
             input: input_cost,
             output: output_cost,

--- a/crates/core/tests/unit/codec/response_tests.rs
+++ b/crates/core/tests/unit/codec/response_tests.rs
@@ -598,6 +598,42 @@ fn test_model_pricing_omits_total_when_nonzero_usage_lacks_a_rate() {
 }
 
 #[test]
+fn test_model_pricing_omits_total_when_nonzero_cache_read_usage_lacks_a_rate() {
+    let catalog = pricing_catalog(json!([
+        {
+            "provider": "future-ai",
+            "model_id": "future-model",
+            "pricing_as_of": "2026-06-04",
+            "pricing_source": "https://example.test/pricing",
+            "rates": {
+                "input_per_million": 1.0,
+                "output_per_million": 2.0,
+                "cache_write_per_million": 1.5
+            },
+            "prompt_cache": {
+                "read_accounting": "separate"
+            }
+        }
+    ]));
+    let usage = Usage {
+        prompt_tokens: Some(1_000),
+        completion_tokens: Some(2_000),
+        cache_read_tokens: Some(3_000),
+        cache_write_tokens: Some(4_000),
+        ..Usage::default()
+    };
+
+    let cost = estimate_cost_with_catalog(&catalog, "future-model", &usage).unwrap();
+
+    assert_eq!(cost.total, None);
+    assert_eq!(cost.input, Some(0.001));
+    assert_eq!(cost.output, Some(0.004));
+    assert_eq!(cost.cache_read, None);
+    assert_eq!(cost.cache_write, Some(0.006));
+    assert_eq!(cost.source, CostSource::ModelPricing);
+}
+
+#[test]
 fn test_prompt_threshold_pricing_applies_selected_tier_to_full_request() {
     let catalog = threshold_pricing_catalog("included_in_prompt_tokens");
     let usage = Usage {

--- a/crates/core/tests/unit/codec/response_tests.rs
+++ b/crates/core/tests/unit/codec/response_tests.rs
@@ -562,6 +562,42 @@ fn test_custom_pricing_catalog_supports_future_models_without_code_changes() {
 }
 
 #[test]
+fn test_model_pricing_omits_total_when_nonzero_usage_lacks_a_rate() {
+    let catalog = pricing_catalog(json!([
+        {
+            "provider": "future-ai",
+            "model_id": "future-model",
+            "pricing_as_of": "2026-06-04",
+            "pricing_source": "https://example.test/pricing",
+            "rates": {
+                "input_per_million": 1.0,
+                "output_per_million": 2.0,
+                "cache_read_per_million": 0.25
+            },
+            "prompt_cache": {
+                "read_accounting": "separate"
+            }
+        }
+    ]));
+    let usage = Usage {
+        prompt_tokens: Some(1_000),
+        completion_tokens: Some(2_000),
+        cache_read_tokens: Some(3_000),
+        cache_write_tokens: Some(4_000),
+        ..Usage::default()
+    };
+
+    let cost = estimate_cost_with_catalog(&catalog, "future-model", &usage).unwrap();
+
+    assert_eq!(cost.total, None);
+    assert_eq!(cost.input, Some(0.001));
+    assert_eq!(cost.output, Some(0.004));
+    assert_eq!(cost.cache_read, Some(0.000_75));
+    assert_eq!(cost.cache_write, None);
+    assert_eq!(cost.source, CostSource::ModelPricing);
+}
+
+#[test]
 fn test_prompt_threshold_pricing_applies_selected_tier_to_full_request() {
     let catalog = threshold_pricing_catalog("included_in_prompt_tokens");
     let usage = Usage {
@@ -1245,6 +1281,8 @@ fn test_attach_estimated_cost_preserves_existing_or_incomplete_responses() {
 
     let mut priced = full_response();
     priced.model = Some("configured-model".into());
+    priced.usage.as_mut().unwrap().cache_read_tokens = None;
+    priced.usage.as_mut().unwrap().cache_write_tokens = None;
     attach_estimated_cost_for_provider(&mut priced, Some("configured"));
     assert_eq!(
         priced.usage.as_ref().unwrap().cost.as_ref().unwrap().total,
@@ -1350,6 +1388,25 @@ fn test_cost_estimate_total_helpers_sum_components_and_match_currency() {
     assert_eq!(component_cost.total_for_currency("USD"), None);
     assert_eq!(
         component_cost.total_or_component_sum_for_currency("EUR"),
+        None
+    );
+
+    let partial_model_pricing_cost = CostEstimate {
+        total: None,
+        currency: "USD".to_string(),
+        input: Some(0.12),
+        output: Some(0.30),
+        cache_read: Some(0.01),
+        cache_write: None,
+        source: CostSource::ModelPricing,
+        pricing_provider: Some("test".to_string()),
+        pricing_model: Some("model".to_string()),
+        pricing_as_of: Some("2026-06-04".to_string()),
+        pricing_source: Some("test".to_string()),
+    };
+    assert_eq!(partial_model_pricing_cost.total_or_component_sum(), None);
+    assert_eq!(
+        partial_model_pricing_cost.total_or_component_sum_for_currency("USD"),
         None
     );
 

--- a/crates/core/tests/unit/observability/exporter_parity_tests.rs
+++ b/crates/core/tests/unit/observability/exporter_parity_tests.rs
@@ -10,6 +10,7 @@
 //! the documented behavior fails loudly instead of silently.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SdkTracerProvider, SpanData};
@@ -23,7 +24,8 @@ use crate::api::event::{
 use crate::api::runtime::{create_scope_stack, with_scope_stack};
 use crate::codec::model_pricing::pricing_test_mutex;
 use crate::codec::response::{
-    PricingCatalog, PricingResolver, reset_active_pricing_resolver, set_active_pricing_resolver,
+    AnnotatedLlmResponse, CostEstimate, CostSource, PricingCatalog, PricingResolver, Usage,
+    reset_active_pricing_resolver, set_active_pricing_resolver,
 };
 use crate::json::Json;
 use crate::observability::OpenTelemetryType;
@@ -405,6 +407,75 @@ fn test_exporters_agree_on_cost_total_for_anthropic_payload() {
         openinference.get("llm.cost.total"),
         Some(&"0.000435".to_string())
     );
+}
+
+#[test]
+fn test_exporters_omit_partial_model_pricing_totals_consistently() {
+    let uuid = Uuid::now_v7();
+    let exports = export_through_all_exporters(&[
+        llm_start(
+            uuid,
+            "model-call",
+            chat_request_content("parity-priced-model"),
+        ),
+        make_scope_event(
+            ScopeCategory::End,
+            uuid,
+            "model-call",
+            EventCategory::llm(),
+            Some(json!({"message": "hello"})),
+            Some(
+                CategoryProfile::builder()
+                    .model_name("parity-priced-model")
+                    .annotated_response(Arc::new(AnnotatedLlmResponse {
+                        model: Some("parity-priced-model".to_string()),
+                        usage: Some(Usage {
+                            prompt_tokens: Some(1_000),
+                            completion_tokens: Some(500),
+                            total_tokens: Some(1_500),
+                            cache_read_tokens: Some(200),
+                            cache_write_tokens: Some(10),
+                            cost: Some(CostEstimate {
+                                total: None,
+                                currency: "USD".to_string(),
+                                input: Some(0.000_12),
+                                output: Some(0.000_3),
+                                cache_read: Some(0.000_015),
+                                cache_write: None,
+                                source: CostSource::ModelPricing,
+                                pricing_provider: Some("test".to_string()),
+                                pricing_model: Some("parity-priced-model".to_string()),
+                                pricing_as_of: Some("2026-06-05".to_string()),
+                                pricing_source: Some("test".to_string()),
+                            }),
+                        }),
+                        ..AnnotatedLlmResponse::default()
+                    }))
+                    .build(),
+            ),
+        ),
+    ]);
+
+    assert_eq!(
+        exports.agent_step().metrics.as_ref().unwrap().cost_usd,
+        None
+    );
+    assert_eq!(
+        exports
+            .trajectory
+            .final_metrics
+            .as_ref()
+            .unwrap()
+            .total_cost_usd,
+        None
+    );
+
+    let otel = exports.otel_attrs("model-call");
+    assert!(!otel.contains_key("nemo_relay.llm.cost.total"));
+    assert!(!otel.contains_key("nemo_relay.llm.cost.currency"));
+
+    let openinference = exports.openinference_attrs("model-call");
+    assert!(!openinference.contains_key("llm.cost.total"));
 }
 
 // ===================================================================

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -3563,6 +3563,39 @@ fn assert_otel_catalog_cost_branches() {
             Some(&"USD".to_string())
         );
     }
+
+    {
+        let _pricing_guard = pricing_test_mutex().lock().unwrap();
+        install_test_pricing("priced-model");
+        let _reset_guard = ResetPricingResolverGuard;
+        let partial_cost_event = make_scope_event_with_profile(
+            ScopeCategory::End,
+            Uuid::now_v7(),
+            None,
+            "test",
+            ScopeType::Llm,
+            Some(json!({"answer": "ok"})),
+            Some(
+                CategoryProfile::builder()
+                    .model_name("priced-model")
+                    .annotated_response(std::sync::Arc::new(AnnotatedLlmResponse {
+                        usage: Some(Usage {
+                            prompt_tokens: Some(1_000),
+                            completion_tokens: Some(500),
+                            total_tokens: Some(1_500),
+                            cache_read_tokens: Some(200),
+                            cache_write_tokens: Some(10),
+                            cost: None,
+                        }),
+                        ..empty_annotated_response()
+                    }))
+                    .build(),
+            ),
+        );
+        let partial_cost_attributes = attr_map(&end_attributes(&partial_cost_event));
+        assert!(!partial_cost_attributes.contains_key("nemo_relay.llm.cost.total"));
+        assert!(!partial_cost_attributes.contains_key("nemo_relay.llm.cost.currency"));
+    }
 }
 
 fn assert_otel_normalized_cost_branches() {

--- a/crates/core/tests/unit/optimization_tests.rs
+++ b/crates/core/tests/unit/optimization_tests.rs
@@ -37,6 +37,21 @@ fn resolver_with_rates(baseline_input: f64, effective_input: f64) -> PricingReso
     PricingResolver::from_catalogs(vec![catalog])
 }
 
+fn resolver_without_cache_write_rate() -> PricingResolver {
+    let catalog = PricingCatalog::from_json_str(
+        &json!({
+            "version": 1,
+            "entries": [
+                {"provider":"test","model_id":"baseline","pricing_as_of":"2026-07-08","pricing_source":"test-snapshot","rates":{"input_per_million":2.0,"output_per_million":4.0,"cache_read_per_million":0.5},"prompt_cache":{"read_accounting":"included_in_prompt_tokens"}},
+                {"provider":"test","model_id":"effective","pricing_as_of":"2026-07-08","pricing_source":"test-snapshot","rates":{"input_per_million":1.0,"output_per_million":2.0,"cache_read_per_million":0.25},"prompt_cache":{"read_accounting":"included_in_prompt_tokens"}}
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    PricingResolver::from_catalogs(vec![catalog])
+}
+
 fn contribution() -> LlmOptimizationContribution {
     let mut contribution = LlmOptimizationContribution::new(
         "test.optimizer",
@@ -1195,6 +1210,52 @@ fn incomplete_cost_object_makes_the_summary_partial() {
     let summary =
         finalize_optimization_summary(&recorder, Some(&mut response), None, &resolver()).unwrap();
     assert_eq!(summary.status, LlmOptimizationSummaryStatus::Partial);
+    assert!(
+        summary
+            .limitations
+            .contains(&"missing_actual_cost_total".to_string())
+    );
+    assert!(summary.estimated_cost_saved.is_none());
+    assert!(summary.currency.is_none());
+}
+
+#[test]
+fn missing_model_pricing_rate_makes_the_summary_partial() {
+    let recorder = LlmOptimizationRecorder::default();
+    assert!(recorder.record(contribution()));
+    let mut response = AnnotatedLlmResponse {
+        model: Some("effective".to_string()),
+        usage: Some(Usage {
+            prompt_tokens: Some(800),
+            completion_tokens: Some(100),
+            total_tokens: Some(900),
+            cache_write_tokens: Some(3),
+            ..Usage::default()
+        }),
+        ..AnnotatedLlmResponse::default()
+    };
+
+    let summary = finalize_optimization_summary(
+        &recorder,
+        Some(&mut response),
+        None,
+        &resolver_without_cache_write_rate(),
+    )
+    .unwrap();
+    assert_eq!(summary.status, LlmOptimizationSummaryStatus::Partial);
+    assert_eq!(
+        summary.baseline_cost.as_ref().and_then(|cost| cost.total),
+        None
+    );
+    assert_eq!(
+        summary.actual_cost.as_ref().and_then(|cost| cost.total),
+        None
+    );
+    assert!(
+        summary
+            .limitations
+            .contains(&"missing_baseline_cost_total".to_string())
+    );
     assert!(
         summary
             .limitations

--- a/crates/types/src/codec/response.rs
+++ b/crates/types/src/codec/response.rs
@@ -148,10 +148,14 @@ pub struct CostEstimate {
 }
 
 impl CostEstimate {
-    /// Returns the explicit total, or the sum of component costs when no total was supplied.
+    /// Returns the explicit total, or for provider-reported costs only, the sum of component
+    /// costs when no total was supplied.
     #[must_use]
     pub fn total_or_component_sum(&self) -> Option<f64> {
         self.total.or_else(|| {
+            if self.source != CostSource::ProviderReported {
+                return None;
+            }
             let (has_component, total) =
                 [self.input, self.output, self.cache_read, self.cache_write]
                     .into_iter()

--- a/docs/configure-plugins/model-pricing.mdx
+++ b/docs/configure-plugins/model-pricing.mdx
@@ -56,6 +56,12 @@ Use `type = "file"` with a JSON catalog path or `type = "inline"` with the
 catalog in `plugins.toml`. Relay checks sources and catalog entries in listed
 order, and it uses the first entry that matches the provider and model.
 
+Relay publishes a numeric total only when every nonzero usage category has a
+configured rate. If a response reports nonzero cache-read or cache-write usage
+and the matching catalog entry omits `cache_read_per_million` or
+`cache_write_per_million`, Relay keeps the priced components but omits the
+aggregate total. Set a rate to `0.0` when a category is intentionally free.
+
 When Relay merges explicit-or-user and system configuration files, it prepends
 higher-priority `sources` instead of replacing lower-priority sources. The
 effective order is system, then explicit-or-user. This lets an

--- a/docs/nemo-relay-cli/basic-usage.mdx
+++ b/docs/nemo-relay-cli/basic-usage.mdx
@@ -387,6 +387,14 @@ nemo-relay model-pricing resolve gpt-4o-mini \
 and an estimated total when token counts are supplied. Use it to debug
 overlapping system, explicit, and user model pricing sources.
 
+Relay now treats missing rates for nonzero cache usage as unknown totals, not
+free usage. If a response reports nonzero cache-read or cache-write tokens and
+the matching catalog omits `cache_read_per_million` or
+`cache_write_per_million`, Relay omits the aggregate total instead of
+undercounting it. Set either rate to `0.0` when that category is intentionally
+free. Catalogs that define only input and output rates therefore emit no total
+for responses that report cached tokens.
+
 Run doctor to validate the active model pricing sources alongside exporter
 checks:
 


### PR DESCRIPTION
#### Overview

Prevent Relay from publishing a complete model-pricing total when the observed
usage includes a nonzero category with no configured rate. The known component
costs still remain available, but the overall total is treated as unavailable
instead of silently undercounting.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

This change tightens the model-pricing contract in four places:

- `ModelPricing::estimate_cost()` now omits `total` when nonzero cache read or cache write usage is present without a configured rate for that category.
- `CostEstimate::total_or_component_sum()` no longer reconstructs a model-pricing total from partial components. That fallback remains available for provider-reported component costs.
- OpenTelemetry, OpenInference, and ATIF now omit aggregate total-cost fields when the normalized model-pricing cost is partial.
- Optimization summaries now leave `estimated_cost_saved` unavailable and record `missing_baseline_cost_total` or `missing_actual_cost_total` when nonzero usage includes a category with no configured rate.

Docs now state the public behavior change as well:

- missing `cache_read_per_million` or `cache_write_per_million` for nonzero usage means "unknown total", not "free"
- `0.0` remains the explicit way to declare an intentionally free category

Tests added or updated:

- regression coverage for missing-rate model pricing with nonzero cache write usage
- regression coverage for the symmetric missing cache-read rate path
- response-helper coverage that partial model-pricing costs do not synthesize a total
- parity coverage that ATIF, OpenTelemetry, and OpenInference all omit aggregate totals for partial model-pricing costs
- optimization-summary coverage that missing model-pricing rates keep the summary partial and suppress estimated savings
- OTel coverage that partial model-pricing estimates do not emit total cost fields
- response-cost attachment coverage for the non-cache path, so the existing helper test still checks the contract it is intended to cover

Validation:

- `just test-rust`
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-python`
- `just test-go`
- `just test-node`
- `just docs`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start in `crates/core/src/codec/model_pricing.rs` at the `ModelPricing::estimate_cost()` change, then review the matching contract update in `crates/types/src/codec/response.rs`. The main regressions are in:

- `crates/core/tests/unit/codec/response_tests.rs`
- `crates/core/tests/unit/observability/exporter_parity_tests.rs`
- `crates/core/tests/unit/optimization_tests.rs`
- `crates/core/tests/unit/observability/otel_tests.rs`

The public behavior note is in:

- `docs/configure-plugins/model-pricing.mdx`
- `docs/nemo-relay-cli/basic-usage.mdx`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cost reporting when model pricing is incomplete.
  - Preserved available component costs while omitting unreliable aggregate totals.
  - Prevented partial pricing from appearing as total or currency cost attributes.
  - Ensured consistent reporting across supported observability formats.
  - Provider-reported costs may still use component sums when no total is available.
  - Optimization summaries now identify incomplete pricing and omit estimated savings when costs are uncertain.

- **Documentation**
  - Clarified cache pricing requirements and how to mark categories as explicitly free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->