### PR TITLE
fix: reject unknown model pricing fields

### DIFF
--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -2719,6 +2719,42 @@ fn cli_model_pricing_validate_rejects_invalid_catalog() {
 }
 
 #[test]
+fn cli_model_pricing_validate_rejects_unknown_nested_field() {
+    let temp = tempfile::tempdir().unwrap();
+    let catalog = temp.path().join("pricing.json");
+    std::fs::write(
+        &catalog,
+        r#"{
+  "version": 1,
+  "entries": [{
+    "provider": "test",
+    "model_id": "bad-model",
+    "rates": {
+      "input_per_million": 1.0,
+      "output_per_million": 2.0,
+      "cache_writ_per_million": 0.1
+    },
+    "prompt_cache": { "read_accounting": "included_in_prompt_tokens" },
+    "pricing_as_of": "2026-06-05",
+    "pricing_source": "test"
+  }]
+}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(gateway_bin())
+        .args(["model-pricing", "validate"])
+        .arg(&catalog)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid model pricing catalog"));
+    assert!(stderr.contains("unknown field `cache_writ_per_million`"));
+}
+
+#[test]
 fn cli_model_pricing_init_creates_user_pricing_component() {
     let temp = tempfile::tempdir().unwrap();
     let xdg = temp.path().join("xdg");

--- a/crates/cli/tests/coverage/commands/model_pricing_tests.rs
+++ b/crates/cli/tests/coverage/commands/model_pricing_tests.rs
@@ -19,9 +19,7 @@ fn catalog_json() -> Value {
                 "output_per_million": 2.0
             },
             "prompt_cache": {
-                "read_accounting": "separate",
-                "read_per_million": 0.1,
-                "write_per_million": 0.2
+                "read_accounting": "separate"
             }
         }]
     })

--- a/crates/core/src/codec/model_pricing.rs
+++ b/crates/core/src/codec/model_pricing.rs
@@ -80,6 +80,7 @@ pub enum PricingCatalogError {
 
 /// Collection of model pricing entries.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PricingCatalog {
     /// Catalog schema version.
     pub version: u32,
@@ -151,7 +152,7 @@ pub struct PricingConfig {
 
 /// Declarative model pricing source supported by Relay configuration.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(deny_unknown_fields, tag = "type", rename_all = "snake_case")]
 pub enum PricingSourceConfig {
     /// Inline catalog entries from project, user, system, or plugin config.
     Inline {
@@ -262,6 +263,7 @@ impl PricingResolver {
 
 /// Per-token model pricing expressed in USD per one million tokens.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelPricing {
     /// Provider that owns this model pricing entry.
     pub provider: String,
@@ -424,6 +426,7 @@ pub enum PricingUnit {
 
 /// Token rates expressed as USD per one million tokens.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokenPricingRates {
     /// Uncached prompt/input token price.
     pub input_per_million: f64,
@@ -469,7 +472,7 @@ impl TokenPricingRates {
 
 /// Data-driven token rate schedule for model pricing with request thresholds.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(deny_unknown_fields, tag = "type", rename_all = "snake_case")]
 pub enum TokenRateSchedule {
     /// Selects one full-request rate tier based on prompt/input tokens.
     PromptTokenThreshold {
@@ -526,6 +529,7 @@ pub enum RateScheduleApplication {
 
 /// A model pricing tier selected by prompt/input token count.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokenRateTier {
     /// Inclusive lower bound for prompt tokens.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -565,6 +569,7 @@ impl TokenRateTier {
 
 /// Prompt-cache accounting rules for a model pricing entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PromptCachePricing {
     /// Whether cache-read tokens are included in `prompt_tokens`.
     pub read_accounting: CacheReadAccounting,

--- a/crates/core/tests/unit/codec/response_tests.rs
+++ b/crates/core/tests/unit/codec/response_tests.rs
@@ -1049,6 +1049,104 @@ fn test_pricing_catalog_rejects_empty_required_fields_and_invalid_rates() {
 }
 
 #[test]
+fn test_pricing_catalog_rejects_unknown_fields_in_nested_structures() {
+    let valid_entry = flat_pricing_entry("configured", "configured-model", 1.0, 2.0);
+
+    let mut catalog_with_unknown = json!({
+        "version": 1,
+        "entries": [valid_entry.clone()]
+    });
+    catalog_with_unknown["unexpected_catalog"] = json!(true);
+
+    let mut entry_with_unknown = valid_entry.clone();
+    entry_with_unknown["unexpected_entry"] = json!(true);
+
+    let mut rates_with_unknown = valid_entry.clone();
+    rates_with_unknown["rates"]["cache_writ_per_million"] = json!(0.1);
+
+    let mut prompt_cache_with_unknown = valid_entry.clone();
+    prompt_cache_with_unknown["prompt_cache"]["read_accountng"] = json!("separate");
+
+    let schedule_with_unknown = json!([{
+        "provider": "configured",
+        "model_id": "scheduled-model",
+        "pricing_as_of": "2026-06-04",
+        "pricing_source": "test",
+        "rate_schedule": {
+            "type": "prompt_token_threshold",
+            "tierz": [{
+                "min_prompt_tokens": 0,
+                "rates": {
+                    "input_per_million": 1.0,
+                    "output_per_million": 2.0
+                }
+            }],
+            "tiers": [{
+                "min_prompt_tokens": 0,
+                "rates": {
+                    "input_per_million": 1.0,
+                    "output_per_million": 2.0
+                }
+            }]
+        },
+        "prompt_cache": {
+            "read_accounting": "separate"
+        }
+    }]);
+
+    let tier_with_unknown = json!([{
+        "provider": "configured",
+        "model_id": "tiered-model",
+        "pricing_as_of": "2026-06-04",
+        "pricing_source": "test",
+        "rate_schedule": {
+            "type": "prompt_token_threshold",
+            "tiers": [{
+                "min_prompt_toknes": 0,
+                "rates": {
+                    "input_per_million": 1.0,
+                    "output_per_million": 2.0
+                }
+            }]
+        },
+        "prompt_cache": {
+            "read_accounting": "separate"
+        }
+    }]);
+
+    for (payload, expected_field) in [
+        (catalog_with_unknown, "unexpected_catalog"),
+        (
+            json!({ "version": 1, "entries": [entry_with_unknown] }),
+            "unexpected_entry",
+        ),
+        (
+            json!({ "version": 1, "entries": [rates_with_unknown] }),
+            "cache_writ_per_million",
+        ),
+        (
+            json!({ "version": 1, "entries": [prompt_cache_with_unknown] }),
+            "read_accountng",
+        ),
+        (
+            json!({ "version": 1, "entries": schedule_with_unknown }),
+            "tierz",
+        ),
+        (
+            json!({ "version": 1, "entries": tier_with_unknown }),
+            "min_prompt_toknes",
+        ),
+    ] {
+        let err = PricingCatalog::from_json_str(&payload.to_string()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("unknown field `{expected_field}`")),
+            "expected unknown field `{expected_field}`, got {err}"
+        );
+    }
+}
+
+#[test]
 fn test_pricing_catalog_rejects_invalid_rate_schedules() {
     let empty_tiers = pricing_catalog_error(json!([
         {

--- a/crates/core/tests/unit/codec/response_tests.rs
+++ b/crates/core/tests/unit/codec/response_tests.rs
@@ -1147,6 +1147,33 @@ fn test_pricing_catalog_rejects_unknown_fields_in_nested_structures() {
 }
 
 #[test]
+fn test_pricing_source_config_rejects_unknown_fields_on_variants() {
+    let valid_entry = flat_pricing_entry("configured", "configured-model", 1.0, 2.0);
+
+    for source in [
+        json!({
+            "type": "inline",
+            "catalog": {
+                "version": 1,
+                "entries": [valid_entry.clone()]
+            },
+            "unexpected": true
+        }),
+        json!({
+            "type": "file",
+            "path": "pricing.json",
+            "unexpected": true
+        }),
+    ] {
+        let err = serde_json::from_value::<PricingSourceConfig>(source).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown field `unexpected`"),
+            "expected unknown field `unexpected`, got {err}"
+        );
+    }
+}
+
+#[test]
 fn test_pricing_catalog_rejects_invalid_rate_schedules() {
     let empty_tiers = pricing_catalog_error(json!([
         {


### PR DESCRIPTION
#### Overview

Reject unknown or misspelled fields in model pricing catalogs instead of silently accepting them during parsing and CLI validation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `serde(deny_unknown_fields)` to the model pricing catalog types so unknown nested fields are rejected during catalog parsing.
- Add core regression coverage for unknown fields at the catalog, entry, rates, prompt-cache, rate-schedule, and tier levels.
- Add a CLI regression test that proves `nemo-relay model-pricing validate` fails on an unknown nested pricing field.
- Refresh one CLI coverage fixture so it matches the current prompt-cache schema under stricter validation.

Validation:
- `cargo fmt --all`
- `just test-rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-python`
- `just test-go`
- `just test-node`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start with `crates/core/src/codec/model_pricing.rs`, especially the pricing catalog structs that now reject unknown fields. The most useful regression coverage is in `crates/core/tests/unit/codec/response_tests.rs` and `crates/cli/tests/cli_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pricing catalog validation now rejects unrecognized fields and identifies the specific field causing the error.
  * Validation consistently covers catalog entries, rate schedules, tiers, prompt-cache settings, and pricing sources.

* **Tests**
  * Added coverage for unknown-field handling across pricing configuration levels.
  * Updated pricing fixtures to reflect supported read-accounting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->