### PR TITLE
ci: serialize async plugin identity tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,10 @@
 junit = { path = "rust_junit_report.xml" }
 
 [[profile.ci.overrides]]
+filter = 'test(typed_async_llm_sanitize_context_decodes_all_builtin_identities) | test(typed_async_llm_sanitize_context_decodes_oci_genai_builtin_identity)'
+threads-required = "num-cpus"
+
+[[profile.ci.overrides]]
 filter = 'test(windows_supervision_assigns_before_a_wrapper_can_spawn_a_descendant)'
 slow-timeout = { period = "20s", terminate-after = 2 }
 

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -3342,54 +3342,6 @@ fn typed_async_middleware_registers_and_round_trips_every_surface() {
 }
 
 #[test]
-fn typed_async_llm_sanitize_context_decodes_oci_genai_builtin_identity() {
-    let _guard = begin_test();
-    let host = test_host_v4();
-    let mut ctx = test_context(&host.v3.v1);
-
-    ctx.register_llm_sanitize_request_guardrail(
-        "llm-request-oci-genai",
-        0,
-        |request, context| async move {
-            assert_eq!(
-                context.codec,
-                LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::OCIGenAI)
-            );
-            Ok(Some(request))
-        },
-    )
-    .unwrap();
-
-    let registration =
-        take_async_registration(NemoRelayNativeAsyncMiddlewareKind::LlmSanitizeRequest);
-    assert_eq!(
-        invoke_async_registration(
-            &host,
-            &registration,
-            json!({
-                "request": test_llm_request(),
-                "context": { "codec_kind": "builtin", "codec_id": "oci_genai" }
-            }),
-            None,
-        )
-        .unwrap()["content"],
-        json!({ "prompt": "hello" })
-    );
-    unsafe { registration.free() };
-    // The context's retained codec capability is released on the SDK executor
-    // after the result completion is delivered, so poll instead of asserting
-    // immediately.
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while live_host_strings() != 0 {
-        assert!(
-            Instant::now() < deadline,
-            "host strings were not released after the sanitize invocation"
-        );
-        std::thread::yield_now();
-    }
-}
-
-#[test]
 fn typed_async_llm_sanitize_context_decodes_all_builtin_identities() {
     let _guard = begin_test();
 

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -3342,6 +3342,54 @@ fn typed_async_middleware_registers_and_round_trips_every_surface() {
 }
 
 #[test]
+fn typed_async_llm_sanitize_context_decodes_oci_genai_builtin_identity() {
+    let _guard = begin_test();
+    let host = test_host_v4();
+    let mut ctx = test_context(&host.v3.v1);
+
+    ctx.register_llm_sanitize_request_guardrail(
+        "llm-request-oci-genai",
+        0,
+        |request, context| async move {
+            assert_eq!(
+                context.codec,
+                LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::OCIGenAI)
+            );
+            Ok(Some(request))
+        },
+    )
+    .unwrap();
+
+    let registration =
+        take_async_registration(NemoRelayNativeAsyncMiddlewareKind::LlmSanitizeRequest);
+    assert_eq!(
+        invoke_async_registration(
+            &host,
+            &registration,
+            json!({
+                "request": test_llm_request(),
+                "context": { "codec_kind": "builtin", "codec_id": "oci_genai" }
+            }),
+            None,
+        )
+        .unwrap()["content"],
+        json!({ "prompt": "hello" })
+    );
+    unsafe { registration.free() };
+    // The context's retained codec capability is released on the SDK executor
+    // after the result completion is delivered, so poll instead of asserting
+    // immediately.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while live_host_strings() != 0 {
+        assert!(
+            Instant::now() < deadline,
+            "host strings were not released after the sanitize invocation"
+        );
+        std::thread::yield_now();
+    }
+}
+
+#[test]
 fn typed_async_llm_sanitize_context_decodes_all_builtin_identities() {
     let _guard = begin_test();
 


### PR DESCRIPTION
#### Overview

Serialize the async native-plugin codec-identity tests in CI to prevent Windows ARM64 native test-process aborts.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Both OCI GenAI and table-driven built-in codec identity tests are retained. The CI Nextest profile marks them as heavy, so each runs exclusively instead of contending with the rest of the workspace suite. This addresses the alternating Windows ARM64 `os error 998` process aborts seen in Actions runs 31851000638 and 31852246198.

#### Where should the reviewer start?

`.config/nextest.toml`: the CI override reserves all test threads for the two async native-plugin identity cases.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution for asynchronous LLM sanitization scenarios by grouping related tests and dynamically allocating available CPU resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->