### PR TITLE
chore: update h2 security patch

### DIFF
--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -18276,7 +18276,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## h2 - 0.4.13
+## h2 - 0.4.16
 **Repository URL**: https://github.com/hyperium/h2
 **License Type(s)**: MIT
 ### License: https://spdx.org/licenses/MIT.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
#### Overview

Update the locked `h2` dependency to the release that addresses RUSTSEC-2026-0258.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update `h2` from 0.4.13 to 0.4.16 in `Cargo.lock`.
- Regenerate the corresponding `h2` attribution version.

Validation:

- `cargo deny check` — passed (advisories, bans, licenses, and sources).
- Commit-time pre-commit hooks — passed.

#### Where should the reviewer start?

Review the `h2` resolution in `Cargo.lock` and its matching entry in `ATTRIBUTIONS-Rust.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the listed `h2` component attribution to version 0.4.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->