### PR TITLE
fix(cli): validate static components before dynamic plugins

### DIFF
--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -971,6 +971,12 @@ impl PluginActivation {
                 .map_err(|error| CliError::Config(format!("invalid plugin config: {error}")))?,
             None => PluginConfig::default(),
         };
+        if let Some(error) = register_and_validate_plugin_components(&plugin_config)
+            .into_iter()
+            .next()
+        {
+            return Err(CliError::Config(error.to_string()));
+        }
         plugin_config
             .components
             .extend(dynamic_plugins.iter().map(|plugin| PluginComponentSpec {
@@ -978,12 +984,6 @@ impl PluginActivation {
                 enabled: true,
                 config: plugin.config.clone(),
             }));
-        if let Some(error) = register_and_validate_plugin_components(&plugin_config)
-            .into_iter()
-            .next()
-        {
-            return Err(CliError::Config(error.to_string()));
-        }
         for plugin in &dynamic_plugins {
             if let Some(snapshot) = plugin.activation_snapshot.as_ref() {
                 snapshot.verify_current()?;

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -1838,6 +1838,28 @@ async fn static_only_cli_configuration_keeps_the_legacy_lifecycle() {
 }
 
 #[test]
+fn register_and_validate_plugin_components_rejects_legacy_switchyard_components() {
+    for enabled in [true, false] {
+        let config = PluginConfig {
+            components: vec![PluginComponentSpec {
+                kind: "switchyard".into(),
+                enabled,
+                config: Map::new(),
+            }],
+            ..PluginConfig::default()
+        };
+
+        let errors = register_and_validate_plugin_components(&config);
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error, PluginComponentSetupError::RemovedSwitchyard)),
+            "legacy Switchyard components must be rejected when enabled is {enabled}"
+        );
+    }
+}
+
+#[test]
 fn plugin_component_setup_errors_render_every_diagnostic_variant() {
     let adaptive = PluginComponentSetupError::Adaptive("adaptive failure".into());
     assert_eq!(adaptive.check_name(), "Adaptive plugin");

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -1905,17 +1905,19 @@ async fn plugin_activation_covers_empty_invalid_and_missing_manifest_paths() {
     .expect("invalid config should fail activation");
     assert!(invalid.to_string().contains("invalid plugin config"));
 
-    let native = PluginActivation::initialize(
+    let dynamic_switchyard = PluginActivation::initialize(
         None,
         vec![dynamic_component_without_manifest(
-            "acme.native-missing",
+            "switchyard",
             DynamicPluginKind::RustDynamic,
         )],
     )
     .await
     .err()
-    .expect("native plugin without a manifest should fail activation");
-    assert!(native.to_string().contains("native dynamic plugin"));
+    .expect("dynamic Switchyard plugin without a manifest should reach dynamic activation");
+    let dynamic_switchyard = dynamic_switchyard.to_string();
+    assert!(dynamic_switchyard.contains("native dynamic plugin"));
+    assert!(!dynamic_switchyard.contains("removed in NeMo Relay 0.8"));
 
     let worker = PluginActivation::initialize(
         None,


### PR DESCRIPTION
#### Overview

Validate user-authored static components before the CLI synthesizes component specs for dynamic plugins. This prevents a dynamic plugin whose `plugin_id` is `switchyard` from being rejected as the removed legacy static Switchyard component.

This follow-up was rebased onto `main` after #811 merged and now contains only the isolated ordering fix.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Run built-in component registration and legacy static-component validation against the parsed base `PluginConfig`.
- Append synthesized dynamic component specs only after that static validation succeeds.
- Preserve rejection of enabled and disabled legacy `[[components]] kind = "switchyard"` entries, with direct regression coverage for both states.
- Add regression coverage showing dynamic `plugin_id = "switchyard"` reaches dynamic activation and receives its dynamic manifest diagnostic instead of the legacy migration error.

Validation completed successfully:

- `cargo test -p nemo-relay-cli --lib server::tests::register_and_validate_plugin_components_rejects_legacy_switchyard_components -- --exact` (1 passed)
- `cargo test -p nemo-relay-cli --lib server::tests::plugin_activation_covers_empty_invalid_and_missing_manifest_paths -- --exact` (1 passed after rebase)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just build-test-plugin-fixtures`
- `just test-python-plugin` (140 passed)
- `just test-rust`
- `uv run pre-commit run --all-files`

Breaking changes: none. Dynamic plugins continue to validate and activate through their registered plugin kinds; the change only prevents them from being mistaken for user-authored legacy static components.

#### Where should the reviewer start?

Start with the validation ordering in `crates/cli/src/server/mod.rs`, followed by the static and dynamic Switchyard regressions in `crates/cli/tests/coverage/shared/server_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #811
- Relates to NVIDIA-NeMo/Switchyard#270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for plugin configurations before dynamic components are activated.
  * Legacy Switchyard components are now consistently rejected with a clear removal error.
  * Updated error reporting to identify unsupported native dynamic plugins without outdated removal messaging.

* **Tests**
  * Expanded coverage for enabled and disabled legacy Switchyard components.
  * Added coverage for dynamic Rust plugins without manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->