### PR TITLE
fix: price manually observed LLM responses

### DIFF
--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -1074,6 +1074,8 @@ async fn build_llm_end_payload(
 /// Sanitize-response guardrails affect only the emitted end-event payload, not
 /// the caller-owned `response` value. If a sanitizer errors or panics, Relay
 /// omits the payload and response annotation and does not run remaining sanitizers.
+/// When model pricing is configured, Relay estimates missing cost on a supplied
+/// or decoded response annotation that contains matching model and usage data.
 pub fn llm_call_end(params: LlmCallEndParams<'_>) -> Result<()> {
     ensure_runtime_owner()?;
     let scope_stack = params.handle.captured_scope_stack().clone();
@@ -1132,7 +1134,7 @@ pub fn llm_call_end(params: LlmCallEndParams<'_>) -> Result<()> {
                     response_codec,
                     &entries,
                     LlmCallEndBehavior {
-                        attach_estimated_cost: false,
+                        attach_estimated_cost: true,
                     },
                 )
                 .await;
@@ -1286,7 +1288,11 @@ fn resolve_llm_end_annotation(
     provider_name: &str,
 ) -> (Option<AnnotatedLlmResponse>, Option<FlowError>) {
     if let Some(annotated_response) = annotated_response {
-        return (Some((*annotated_response).clone()), None);
+        let mut annotated_response = (*annotated_response).clone();
+        if behavior.attach_estimated_cost {
+            attach_estimated_cost_for_provider(&mut annotated_response, Some(provider_name));
+        }
+        return (Some(annotated_response), None);
     }
     let (Some(codec), Some(response)) = (response_codec, data) else {
         return (None, None);

--- a/crates/core/tests/integration/pipeline_tests.rs
+++ b/crates/core/tests/integration/pipeline_tests.rs
@@ -17,7 +17,8 @@ use serde_json::json;
 
 use nemo_relay::api::event::{Event, PendingMarkSpec, ScopeCategory};
 use nemo_relay::api::llm::{
-    LlmCallExecuteParams, LlmStreamCallExecuteParams, llm_call_execute, llm_stream_call_execute,
+    LlmCallEndParams, LlmCallExecuteParams, LlmCallParams, LlmStreamCallExecuteParams, llm_call,
+    llm_call_end, llm_call_execute, llm_stream_call_execute,
 };
 use nemo_relay::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 use nemo_relay::api::optimization::record_llm_optimization_contribution;
@@ -1401,6 +1402,67 @@ impl LlmResponseCodec for FailingResponseCodec {
     fn decode_response(&self, _response: &Json) -> Result<AnnotatedLlmResponse> {
         Err(FlowError::Internal("decode failed".into()))
     }
+}
+
+#[test]
+fn test_manual_llm_responses_receive_estimated_cost() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let _pricing_guard = ResetPricingResolverGuard;
+    reset_global();
+    setup_isolated_thread();
+    install_mock_response_pricing();
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    register_subscriber(
+        "manual_response_pricing_sub",
+        Arc::new(move |event: &Event| captured.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    let request = make_llm_request(json!({"messages": [{"role": "user", "content": "hello"}]}));
+    let response = json!({"ok": true});
+    for supply_annotation in [false, true] {
+        let handle = llm_call(
+            LlmCallParams::builder()
+                .name("openai")
+                .request(&request)
+                .build(),
+        )
+        .unwrap();
+        let annotated_response = supply_annotation
+            .then(|| Arc::new(MockResponseCodec.decode_response(&response).unwrap()));
+        let response_codec =
+            (!supply_annotation).then(|| Arc::new(MockResponseCodec) as Arc<dyn LlmResponseCodec>);
+        llm_call_end(
+            LlmCallEndParams::builder()
+                .handle(&handle)
+                .response(response.clone())
+                .annotated_response_opt(annotated_response)
+                .response_codec_opt(response_codec)
+                .build(),
+        )
+        .unwrap();
+    }
+
+    let captured = captured_events_snapshot(&events);
+    let end_events = captured
+        .iter()
+        .filter(|event| is_scope_event(event, ScopeType::Llm, ScopeCategory::End))
+        .collect::<Vec<_>>();
+    assert_eq!(end_events.len(), 2);
+    for event in end_events {
+        assert_eq!(
+            event
+                .annotated_response()
+                .and_then(|response| response.usage.as_ref())
+                .and_then(|usage| usage.cost.as_ref())
+                .and_then(|cost| cost.total),
+            Some(0.000_435)
+        );
+    }
+
+    deregister_subscriber("manual_response_pricing_sub").unwrap();
 }
 
 #[tokio::test]

--- a/docs/about-nemo-relay/concepts/plugins.mdx
+++ b/docs/about-nemo-relay/concepts/plugins.mdx
@@ -253,8 +253,9 @@ Configuration](/configure-plugins/pii-redaction/configuration).
 ### Model Pricing
 
 The core crate ships a built-in `pricing` component. It loads catalog sources
-that response codecs can use to annotate managed LLM responses with cost
-estimates. Configure catalog sources through [Model Pricing](/configure-plugins/model-pricing).
+that response codecs can use to annotate managed or manually observed LLM
+responses with cost estimates. Configure catalog sources through
+[Model Pricing](/configure-plugins/model-pricing).
 
 ### Switchyard (Experimental)
 

--- a/docs/configure-plugins/about.mdx
+++ b/docs/configure-plugins/about.mdx
@@ -39,7 +39,7 @@ entries in `plugins.toml`.
   The experimental plugin will be removed in NeMo Relay 0.8 and replaced by a
   Switchyard-owned native plugin.
 - [Model Pricing](/configure-plugins/model-pricing) configures catalog sources
-  for cost estimates on managed LLM responses.
+  for cost estimates on managed or manually observed LLM responses.
 
 ## Guides
 

--- a/docs/configure-plugins/model-pricing.mdx
+++ b/docs/configure-plugins/model-pricing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Model Pricing"
-description: "Configure file and inline pricing catalogs for managed LLM cost estimates."
+description: "Configure file and inline pricing catalogs for LLM cost estimates."
 position: 2
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
@@ -8,8 +8,10 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 
 Use the built-in `pricing` component to configure model pricing catalogs for
-cost estimates on managed LLM responses. Relay leaves cost absent when no
-configured source matches the provider, model, and token usage.
+cost estimates on managed or manually observed LLM responses. Manual lifecycle
+end events must supply a response codec or normalized response annotation with
+model and token usage. Relay leaves cost absent when no configured source
+matches the provider, model, and token usage.
 
 ## Configuration
 

--- a/docs/integrate-into-frameworks/provider-response-codecs.mdx
+++ b/docs/integrate-into-frameworks/provider-response-codecs.mdx
@@ -307,15 +307,16 @@ initialize_plugins(config).await?;
 </Tabs>
 
 Initialize model pricing once during process or harness startup, before the
-managed LLM calls whose responses should be cost-annotated. In tests or
-reusable harnesses, clear plugin configuration during teardown if later cases
-need a different resolver.
+managed LLM calls or manual lifecycle end events whose responses should be
+cost-annotated. In tests or reusable harnesses, clear plugin configuration
+during teardown if later cases need a different resolver.
 
 Built-in response codecs attach estimated cost directly to
 `AnnotatedLlmResponse.usage.cost` when model pricing is known. Managed LLM
-wrappers also enrich decoded custom response-codec output when the custom codec
-returns `model` and `usage` but omits `usage.cost`. Existing cost values are
-preserved, so provider-reported cost remains authoritative in the annotation.
+wrappers and manual lifecycle endings also enrich decoded or supplied response
+annotations when they contain `model` and `usage` but omit `usage.cost`.
+Existing cost values are preserved, so provider-reported cost remains
+authoritative in the annotation.
 
 Observability exporters prefer codec-normalized usage and cost, then fall back to
 raw payload fields and model-pricing estimates, subject to each exporter's

--- a/docs/nemo-relay-cli/basic-usage.mdx
+++ b/docs/nemo-relay-cli/basic-usage.mdx
@@ -327,10 +327,10 @@ Model pricing is configured with the same `plugins.toml` discovery path as
 Observability. The configured sources apply to transparent agent runs,
 standalone gateway runs, and evals or custom agents that initialize the same
 gateway plugin config. Framework integrations, harnesses, and custom hosts do
-not need their own model pricing logic when they emit managed LLM calls with
-response codecs: Relay attaches cost to the annotated response when the
-provider reports cost or when a configured model pricing source matches the
-response model and token usage.
+not need their own model pricing logic when they emit managed LLM calls or
+manual lifecycle events with normalized response annotations: Relay attaches
+cost to the annotated response when the provider reports cost or when a
+configured model pricing source matches the response model and token usage.
 
 Create a Relay model pricing catalog JSON file:
 

--- a/docs/resources/glossary.mdx
+++ b/docs/resources/glossary.mdx
@@ -308,9 +308,9 @@ the rest of the documentation can use them consistently.
 
 **Model Pricing**
 : Model pricing is the built-in `pricing` plugin component that loads catalog
-  sources and annotates managed LLM responses with cost estimates when model and
-  token data are available. The component resolves configured sources through a
-  pricing resolver chain.
+  sources and annotates managed or manually observed LLM responses with cost
+  estimates when model and token data are available. The component resolves
+  configured sources through a pricing resolver chain.
 
 ## N
 

--- a/python/nemo_relay/llm.py
+++ b/python/nemo_relay/llm.py
@@ -171,6 +171,8 @@ def call_end(
         this call. Codec failures retain their documented fallback behavior.
         ``response_codec`` and ``annotated_response`` enrich observability
         output only and do not rewrite the caller-owned response.
+        When model pricing is configured, Relay estimates missing cost when the
+        response annotation contains matching model and token usage data.
         ``timestamp`` must be a timezone-aware ``datetime``; strings and naive
         datetimes are rejected.
     """


### PR DESCRIPTION
#### Overview

Enable configured model pricing for manually observed LLM lifecycle end events.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Apply the existing pricing resolver to supplied or response-codec-decoded annotations passed to `llm.call_end()`.
- Preserve provider-reported cost and leave cost absent when the model, provider, or usage cannot be priced.
- Add core regression coverage for manual lifecycle pricing and document the behavior across the pricing and response-codec references.

#### Where should the reviewer start?

Start with `crates/core/src/api/llm.rs`, where the manual `llm_call_end` publication path now enables the same estimated-cost enrichment already used by managed execution. The regression cases are in `crates/core/tests/integration/pipeline_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model pricing can now estimate missing costs for manually recorded LLM responses.
  * Cost estimates support responses with normalized model and token usage data, including decoded response annotations.
  * Provider-reported costs remain authoritative when available.

* **Documentation**
  * Clarified supported response types, required usage data, and cases where no matching pricing is available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->