### PR TITLE
test: address Sonar quality findings

### DIFF
--- a/crates/adaptive/src/runtime/validation.rs
+++ b/crates/adaptive/src/runtime/validation.rs
@@ -9,7 +9,7 @@ use nemo_relay::plugin::{
 use serde_json::Value as Json;
 
 use crate::config::{AdaptiveConfig, BackendSpec, ResponseCacheConfig};
-use crate::response_cache::config::{KEY_STRATEGY_EXACT_REQUEST, ToolCacheConfig};
+use crate::response_cache::config::{KEY_STRATEGY_EXACT_REQUEST, ToolCacheConfig, ToolClass};
 use crate::response_cache::tool::{is_supported_tool_pattern, wildcard_patterns_overlap};
 
 pub fn validate_config(config: &AdaptiveConfig) -> ConfigReport {
@@ -235,50 +235,7 @@ fn validate_tool_cache(report: &mut ConfigReport, tools: &ToolCacheConfig) {
 
     let mut owning_class: HashMap<&str, &str> = HashMap::new();
     for (class_name, class) in &tools.classes {
-        validate_tool_policy(
-            report,
-            &format!("classes.{class_name}"),
-            class.ttl_seconds,
-            class.bypass_rate,
-        );
-        for member in &class.members {
-            if !is_supported_tool_pattern(member) {
-                report.diagnostics.push(response_cache_error(
-                    "response_cache.tool_invalid_pattern",
-                    Some("tools.classes"),
-                    format!(
-                        "tool member '{member}' in class '{class_name}' must be an exact name, \
-                         'prefix*', '*suffix', or '*contains*'"
-                    ),
-                ));
-            }
-            if let Some(previous) = owning_class.get(member.as_str()) {
-                if *previous != class_name.as_str() {
-                    report.diagnostics.push(response_cache_error(
-                        "response_cache.tool_multiple_classes",
-                        Some("tools.classes"),
-                        format!(
-                            "tool member '{member}' appears in multiple classes ('{previous}' and \
-                             '{class_name}'); a member — exact name or pattern — may appear in at \
-                             most one class"
-                        ),
-                    ));
-                }
-            } else {
-                owning_class.insert(member.as_str(), class_name.as_str());
-            }
-            if class.cacheable && member == "*" {
-                report.diagnostics.push(response_cache_error(
-                    "response_cache.tool_catch_all_member",
-                    Some("tools.classes"),
-                    format!(
-                        "class '{class_name}' lists the catch-all member '{member}' with \
-                         cacheable = true, which caches every tool; use a named class to \
-                         classify cacheable tools"
-                    ),
-                ));
-            }
-        }
+        validate_tool_cache_class(report, class_name, class, &mut owning_class);
     }
 
     validate_conflicting_tool_class_patterns(report, tools);
@@ -313,6 +270,58 @@ fn validate_tool_cache(report: &mut ConfigReport, tools: &ToolCacheConfig) {
     }
 
     validate_conflicting_tool_override_patterns(report, tools);
+}
+
+fn validate_tool_cache_class<'a>(
+    report: &mut ConfigReport,
+    class_name: &'a str,
+    class: &'a ToolClass,
+    owning_class: &mut HashMap<&'a str, &'a str>,
+) {
+    validate_tool_policy(
+        report,
+        &format!("classes.{class_name}"),
+        class.ttl_seconds,
+        class.bypass_rate,
+    );
+    for member in &class.members {
+        if !is_supported_tool_pattern(member) {
+            report.diagnostics.push(response_cache_error(
+                "response_cache.tool_invalid_pattern",
+                Some("tools.classes"),
+                format!(
+                    "tool member '{member}' in class '{class_name}' must be an exact name, \
+                     'prefix*', '*suffix', or '*contains*'"
+                ),
+            ));
+        }
+        if let Some(previous) = owning_class.get(member.as_str()) {
+            if *previous != class_name {
+                report.diagnostics.push(response_cache_error(
+                    "response_cache.tool_multiple_classes",
+                    Some("tools.classes"),
+                    format!(
+                        "tool member '{member}' appears in multiple classes ('{previous}' and \
+                         '{class_name}'); a member — exact name or pattern — may appear in at \
+                         most one class"
+                    ),
+                ));
+            }
+        } else {
+            owning_class.insert(member.as_str(), class_name);
+        }
+        if class.cacheable && member == "*" {
+            report.diagnostics.push(response_cache_error(
+                "response_cache.tool_catch_all_member",
+                Some("tools.classes"),
+                format!(
+                    "class '{class_name}' lists the catch-all member '{member}' with \
+                     cacheable = true, which caches every tool; use a named class to \
+                     classify cacheable tools"
+                ),
+            ));
+        }
+    }
 }
 
 fn validate_conflicting_tool_class_patterns(report: &mut ConfigReport, tools: &ToolCacheConfig) {

--- a/crates/ffi/src/api/scope.rs
+++ b/crates/ffi/src/api/scope.rs
@@ -441,97 +441,15 @@ pub unsafe extern "C" fn nemo_relay_metric(
     } else {
         unsafe { std::slice::from_raw_parts(measurements, measurements_len) }
     };
-    let mut typed_measurements = Vec::with_capacity(raw_measurements.len());
-    for (index, measurement) in raw_measurements.iter().enumerate() {
-        let measurement_name = match c_str_to_string(measurement.name) {
-            Ok(name) => name,
-            Err(status) => {
-                set_last_error(&format!("measurements[{index}].name is invalid"));
-                return status;
-            }
-        };
-        let Some(kind) = metric_kind_from_ffi(measurement.kind) else {
-            set_metric_discriminator_error(
-                index,
-                "kind",
-                measurement.kind,
-                NEMO_RELAY_METRIC_KIND_UNSPECIFIED,
-                "NEMO_RELAY_METRIC_KIND_COUNTER, NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER, NEMO_RELAY_METRIC_KIND_GAUGE, or NEMO_RELAY_METRIC_KIND_HISTOGRAM",
-            );
-            return NemoRelayStatus::InvalidArg;
-        };
-        let Some(value_type) = metric_value_type_from_ffi(measurement.value_type) else {
-            set_metric_discriminator_error(
-                index,
-                "value_type",
-                measurement.value_type,
-                NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED,
-                "NEMO_RELAY_METRIC_VALUE_TYPE_U64, NEMO_RELAY_METRIC_VALUE_TYPE_I64, or NEMO_RELAY_METRIC_VALUE_TYPE_F64",
-            );
-            return NemoRelayStatus::InvalidArg;
-        };
-        let value = match value_type {
-            nemo_relay::api::event::MetricValueType::U64 => {
-                serde_json::Value::from(measurement.u64_value)
-            }
-            nemo_relay::api::event::MetricValueType::I64 => {
-                serde_json::Value::from(measurement.i64_value)
-            }
-            nemo_relay::api::event::MetricValueType::F64 => {
-                let Some(number) = serde_json::Number::from_f64(measurement.f64_value) else {
-                    set_last_error(&format!("measurements[{index}].f64_value must be finite"));
-                    return NemoRelayStatus::InvalidArg;
-                };
-                serde_json::Value::Number(number)
-            }
-        };
-        let unit = if measurement.unit.is_null() {
-            None
-        } else {
-            match c_str_to_string(measurement.unit) {
-                Ok(value) => Some(value),
-                Err(status) => return status,
-            }
-        };
-        let description = if measurement.description.is_null() {
-            None
-        } else {
-            match c_str_to_string(measurement.description) {
-                Ok(value) => Some(value),
-                Err(status) => return status,
-            }
-        };
-        let attributes = match c_str_to_opt_json(measurement.attributes_json) {
-            Some(value) => value,
-            None => return NemoRelayStatus::InvalidJson,
-        };
-        if measurement.boundaries_len > 0 && measurement.boundaries.is_null() {
-            set_last_error(&format!("measurements[{index}].boundaries pointer is null"));
-            return NemoRelayStatus::NullPointer;
-        }
-        let boundaries = if measurement.boundaries.is_null() {
-            None
-        } else if measurement.boundaries_len == 0 {
-            Some(Vec::new())
-        } else {
-            Some(
-                unsafe {
-                    std::slice::from_raw_parts(measurement.boundaries, measurement.boundaries_len)
-                }
-                .to_vec(),
-            )
-        };
-        typed_measurements.push(nemo_relay::api::event::MetricMeasurement {
-            name: measurement_name,
-            kind,
-            value_type,
-            value,
-            unit,
-            description,
-            attributes,
-            boundaries,
-        });
-    }
+    let typed_measurements = raw_measurements
+        .iter()
+        .enumerate()
+        .map(|(index, measurement)| parse_metric_measurement(index, measurement))
+        .collect::<Result<Vec<_>, _>>();
+    let typed_measurements = match typed_measurements {
+        Ok(measurements) => measurements,
+        Err(status) => return status,
+    };
     let parent_ref = if parent.is_null() {
         None
     } else {
@@ -557,4 +475,98 @@ pub unsafe extern "C" fn nemo_relay_metric(
         Ok(()) => NemoRelayStatus::Ok,
         Err(error) => status_from_error(&error),
     }
+}
+
+fn parse_metric_measurement(
+    index: usize,
+    measurement: &NemoRelayMetricMeasurement,
+) -> Result<nemo_relay::api::event::MetricMeasurement, NemoRelayStatus> {
+    let measurement_name = match c_str_to_string(measurement.name) {
+        Ok(name) => name,
+        Err(status) => {
+            set_last_error(&format!("measurements[{index}].name is invalid"));
+            return Err(status);
+        }
+    };
+    let Some(kind) = metric_kind_from_ffi(measurement.kind) else {
+        set_metric_discriminator_error(
+            index,
+            "kind",
+            measurement.kind,
+            NEMO_RELAY_METRIC_KIND_UNSPECIFIED,
+            "NEMO_RELAY_METRIC_KIND_COUNTER, NEMO_RELAY_METRIC_KIND_UP_DOWN_COUNTER, NEMO_RELAY_METRIC_KIND_GAUGE, or NEMO_RELAY_METRIC_KIND_HISTOGRAM",
+        );
+        return Err(NemoRelayStatus::InvalidArg);
+    };
+    let Some(value_type) = metric_value_type_from_ffi(measurement.value_type) else {
+        set_metric_discriminator_error(
+            index,
+            "value_type",
+            measurement.value_type,
+            NEMO_RELAY_METRIC_VALUE_TYPE_UNSPECIFIED,
+            "NEMO_RELAY_METRIC_VALUE_TYPE_U64, NEMO_RELAY_METRIC_VALUE_TYPE_I64, or NEMO_RELAY_METRIC_VALUE_TYPE_F64",
+        );
+        return Err(NemoRelayStatus::InvalidArg);
+    };
+    let value = match value_type {
+        nemo_relay::api::event::MetricValueType::U64 => {
+            serde_json::Value::from(measurement.u64_value)
+        }
+        nemo_relay::api::event::MetricValueType::I64 => {
+            serde_json::Value::from(measurement.i64_value)
+        }
+        nemo_relay::api::event::MetricValueType::F64 => {
+            let Some(number) = serde_json::Number::from_f64(measurement.f64_value) else {
+                set_last_error(&format!("measurements[{index}].f64_value must be finite"));
+                return Err(NemoRelayStatus::InvalidArg);
+            };
+            serde_json::Value::Number(number)
+        }
+    };
+    let unit = if measurement.unit.is_null() {
+        None
+    } else {
+        match c_str_to_string(measurement.unit) {
+            Ok(value) => Some(value),
+            Err(status) => return Err(status),
+        }
+    };
+    let description = if measurement.description.is_null() {
+        None
+    } else {
+        match c_str_to_string(measurement.description) {
+            Ok(value) => Some(value),
+            Err(status) => return Err(status),
+        }
+    };
+    let attributes = match c_str_to_opt_json(measurement.attributes_json) {
+        Some(value) => value,
+        None => return Err(NemoRelayStatus::InvalidJson),
+    };
+    if measurement.boundaries_len > 0 && measurement.boundaries.is_null() {
+        set_last_error(&format!("measurements[{index}].boundaries pointer is null"));
+        return Err(NemoRelayStatus::NullPointer);
+    }
+    let boundaries = if measurement.boundaries.is_null() {
+        None
+    } else if measurement.boundaries_len == 0 {
+        Some(Vec::new())
+    } else {
+        Some(
+            unsafe {
+                std::slice::from_raw_parts(measurement.boundaries, measurement.boundaries_len)
+            }
+            .to_vec(),
+        )
+    };
+    Ok(nemo_relay::api::event::MetricMeasurement {
+        name: measurement_name,
+        kind,
+        value_type,
+        value,
+        unit,
+        description,
+        attributes,
+        boundaries,
+    })
 }

--- a/crates/node/tests/public_observability_api_fixture.ts
+++ b/crates/node/tests/public_observability_api_fixture.ts
@@ -52,7 +52,6 @@ const metricDeregistered: boolean = metricSubscriber.deregister('fixture-metric-
 metricSubscriber.forceFlush();
 metricSubscriber.shutdown();
 
-void logDiagnostics;
-void metricDiagnostics;
-void logDeregistered;
-void metricDeregistered;
+if (!logDiagnostics || !metricDiagnostics || !logDeregistered || !metricDeregistered) {
+  throw new Error('fixture observability operations failed');
+}

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -1633,23 +1633,28 @@ async fn worker_service_propagates_host_runtime_errors() {
         );
     }
 
-    for (mode, expected) in [
+    for (index, (mode, expected)) in [
         (MockStreamMode::WorkerError, "stream worker failed"),
         (MockStreamMode::EmptyChunk, "empty stream chunk"),
         (MockStreamMode::TransportError, "stream status failed"),
-    ] {
+    ]
+    .into_iter()
+    .enumerate()
+    {
         host.set_failures(MockHostFailures {
             llm_stream_mode: mode,
             ..Default::default()
         });
+        let mut request = llm_invoke(
+            "llm-stream",
+            RegistrationSurface::LlmStreamExecutionIntercept,
+            llm_request(),
+            None,
+            None,
+        );
+        request.invocation_id = format!("llm-stream-{index}");
         let mut stream = client
-            .invoke_stream(Request::new(llm_invoke(
-                "llm-stream",
-                RegistrationSurface::LlmStreamExecutionIntercept,
-                llm_request(),
-                None,
-                None,
-            )))
+            .invoke_stream(Request::new(request))
             .await
             .expect("stream invoke")
             .into_inner();

--- a/go/nemo_relay/adaptive_runtime_test.go
+++ b/go/nemo_relay/adaptive_runtime_test.go
@@ -12,10 +12,13 @@ import (
 
 const (
 	adaptiveRuntimeClosedMessage    = "adaptive runtime is nil or shut down"
+	expectedCleanReportMsg          = "expected clean report, got %#v"
 	forcedAdaptiveMarshalFailure    = "forced adaptive JSON marshal failure"
+	marshalFailedMsg                = "marshal failed: %v"
 	newAdaptiveRuntimeFailedMsg     = "NewAdaptiveRuntime failed: %v"
 	responseCacheTestNamespace      = "go-harness"
 	testAgentID                     = "go-agent"
+	unmarshalFailedMsg              = "unmarshal failed: %v"
 	validateAdaptiveConfigFailedMsg = "ValidateAdaptiveConfig failed: %v"
 )
 
@@ -41,7 +44,7 @@ func TestValidateAdaptiveConfigAndOwnedRuntime(t *testing.T) {
 		t.Fatalf(validateAdaptiveConfigFailedMsg, err)
 	}
 	if len(report.Diagnostics) != 0 {
-		t.Fatalf("expected clean report, got %#v", report.Diagnostics)
+		t.Fatalf(expectedCleanReportMsg, report.Diagnostics)
 	}
 
 	runtime, err := NewAdaptiveRuntime(NewAdaptiveConfig())
@@ -203,11 +206,11 @@ func assertResponseCacheJSONSurface(t *testing.T, responseCache ResponseCacheCon
 	config.ResponseCache = &responseCache
 	payload, err := json.Marshal(config)
 	if err != nil {
-		t.Fatalf("marshal failed: %v", err)
+		t.Fatalf(marshalFailedMsg, err)
 	}
 	var decoded map[string]any
 	if err := json.Unmarshal(payload, &decoded); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
+		t.Fatalf(unmarshalFailedMsg, err)
 	}
 	section, ok := decoded["response_cache"].(map[string]any)
 	if !ok {
@@ -236,7 +239,7 @@ func assertResponseCacheValidation(t *testing.T, responseCache ResponseCacheConf
 		t.Fatalf(validateAdaptiveConfigFailedMsg, err)
 	}
 	if len(report.Diagnostics) != 0 {
-		t.Fatalf("expected clean report, got %#v", report.Diagnostics)
+		t.Fatalf(expectedCleanReportMsg, report.Diagnostics)
 	}
 
 	bad := NewResponseCacheConfig()

--- a/go/nemo_relay/adaptive_runtime_test.go
+++ b/go/nemo_relay/adaptive_runtime_test.go
@@ -285,11 +285,11 @@ func TestResponseCacheToolsConfigReachesTypedSurface(t *testing.T) {
 
 	payload, err := json.Marshal(config)
 	if err != nil {
-		t.Fatalf("marshal failed: %v", err)
+		t.Fatalf(marshalFailedMsg, err)
 	}
 	var decoded map[string]any
 	if err := json.Unmarshal(payload, &decoded); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
+		t.Fatalf(unmarshalFailedMsg, err)
 	}
 	rcSection, ok := decoded["response_cache"].(map[string]any)
 	if !ok {
@@ -338,11 +338,11 @@ func marshalResponseCacheConfig(t *testing.T, responseCache ResponseCacheConfig)
 	t.Helper()
 	payload, err := json.Marshal(responseCache)
 	if err != nil {
-		t.Fatalf("marshal failed: %v", err)
+		t.Fatalf(marshalFailedMsg, err)
 	}
 	var decoded map[string]any
 	if err := json.Unmarshal(payload, &decoded); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
+		t.Fatalf(unmarshalFailedMsg, err)
 	}
 	return decoded
 }

--- a/go/nemo_relay/event_metadata_injectors_test.go
+++ b/go/nemo_relay/event_metadata_injectors_test.go
@@ -221,7 +221,7 @@ func TestEventMetadataInjectorRegistrationErrorsReleaseCallbacks(t *testing.T) {
 	if err := RegisterEventMetadataInjector(eventMetadataDuplicateInjector, 0, callback); err != nil {
 		t.Fatal(err)
 	}
-	if err := RegisterEventMetadataInjector(eventMetadataDuplicateInjector, 0, callback); err == nil {
+	if RegisterEventMetadataInjector(eventMetadataDuplicateInjector, 0, callback) == nil {
 		t.Fatal("expected duplicate event metadata injector registration to fail")
 	}
 	if registeredClosureCount() != baseline+1 {

--- a/go/nemo_relay/event_metadata_injectors_test.go
+++ b/go/nemo_relay/event_metadata_injectors_test.go
@@ -11,6 +11,16 @@ import (
 	"testing"
 )
 
+const (
+	eventMetadataFirstInjector       = "go-event-metadata-first"
+	eventMetadataLaterInjector       = "go-event-metadata-later"
+	eventMetadataFailureInjector     = "go-event-metadata-failure"
+	eventMetadataMixedValuesInjector = "go-event-metadata-mixed-values"
+	eventMetadataDuplicateInjector   = "go-event-metadata-duplicate"
+	injectedCollisionMetadataKey     = "go.injected.collision"
+	injectedLocalMetadataKey         = "go.injected.local"
+)
+
 func TestEventMetadataInjectorGlobalScopeLocalAndFailureBehavior(t *testing.T) {
 	runTestInIsolatedWorkingDirectory(t, func(t *testing.T) {
 		runTestWithScopeStack(t, testEventMetadataInjectorGlobalScopeLocalAndFailureBehavior)
@@ -29,34 +39,34 @@ func testEventMetadataInjectorGlobalScopeLocalAndFailureBehavior(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = DeregisterSubscriber("go-event-metadata-subscriber") })
 
-	if err := RegisterEventMetadataInjector("go-event-metadata-first", 10, func(event Event) (EventMetadata, error) {
+	if err := RegisterEventMetadataInjector(eventMetadataFirstInjector, 10, func(event Event) (EventMetadata, error) {
 		return EventMetadata{
-			"go.injected.global":    event.Kind(),
-			"go.injected.collision": "first",
-			"go.existing":           "replacement",
-			"go.injected.integers":  []int64{1, 2},
-			"go.injected.doubles":   []float64{1, 2.5},
+			"go.injected.global":         event.Kind(),
+			injectedCollisionMetadataKey: "first",
+			"go.existing":                "replacement",
+			"go.injected.integers":       []int64{1, 2},
+			"go.injected.doubles":        []float64{1, 2.5},
 		}, nil
 	}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = DeregisterEventMetadataInjector("go-event-metadata-first") })
+	t.Cleanup(func() { _ = DeregisterEventMetadataInjector(eventMetadataFirstInjector) })
 
-	if err := RegisterEventMetadataInjector("go-event-metadata-later", 20, func(Event) (EventMetadata, error) {
-		return EventMetadata{"go.injected.collision": "later"}, nil
+	if err := RegisterEventMetadataInjector(eventMetadataLaterInjector, 20, func(Event) (EventMetadata, error) {
+		return EventMetadata{injectedCollisionMetadataKey: "later"}, nil
 	}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = DeregisterEventMetadataInjector("go-event-metadata-later") })
+	t.Cleanup(func() { _ = DeregisterEventMetadataInjector(eventMetadataLaterInjector) })
 
-	if err := RegisterEventMetadataInjector("go-event-metadata-failure", 30, func(Event) (EventMetadata, error) {
+	if err := RegisterEventMetadataInjector(eventMetadataFailureInjector, 30, func(Event) (EventMetadata, error) {
 		return nil, errors.New("expected Go injector failure")
 	}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = DeregisterEventMetadataInjector("go-event-metadata-failure") })
+	t.Cleanup(func() { _ = DeregisterEventMetadataInjector(eventMetadataFailureInjector) })
 
-	if err := RegisterEventMetadataInjector("go-event-metadata-mixed-values", 40, func(Event) (EventMetadata, error) {
+	if err := RegisterEventMetadataInjector(eventMetadataMixedValuesInjector, 40, func(Event) (EventMetadata, error) {
 		return EventMetadata{
 			"go.invalid.mixed_values": []any{1, "two"},
 			"go.invalid.sentinel":     "must-be-omitted",
@@ -64,14 +74,14 @@ func testEventMetadataInjectorGlobalScopeLocalAndFailureBehavior(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = DeregisterEventMetadataInjector("go-event-metadata-mixed-values") })
+	t.Cleanup(func() { _ = DeregisterEventMetadataInjector(eventMetadataMixedValuesInjector) })
 
 	scope, err := PushScope("go-event-metadata-scope", ScopeTypeCustom)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := ScopeRegisterEventMetadataInjector(scope.UUID(), "go-event-metadata-local", 5, func(Event) (EventMetadata, error) {
-		return EventMetadata{"go.injected.local": true}, nil
+		return EventMetadata{injectedLocalMetadataKey: true}, nil
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -86,10 +96,10 @@ func testEventMetadataInjectorGlobalScopeLocalAndFailureBehavior(t *testing.T) {
 	}
 
 	for _, name := range []string{
-		"go-event-metadata-mixed-values",
-		"go-event-metadata-failure",
-		"go-event-metadata-later",
-		"go-event-metadata-first",
+		eventMetadataMixedValuesInjector,
+		eventMetadataFailureInjector,
+		eventMetadataLaterInjector,
+		eventMetadataFirstInjector,
 	} {
 		if err := DeregisterEventMetadataInjector(name); err != nil {
 			t.Fatal(err)
@@ -104,23 +114,28 @@ func testEventMetadataInjectorGlobalScopeLocalAndFailureBehavior(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
+	assertEventMetadataInjectorEvents(t, events)
+}
+
+func assertEventMetadataInjectorEvents(t *testing.T, events []Event) {
+	t.Helper()
 	if len(events) != 4 {
 		t.Fatalf("expected four delivered events, got %d", len(events))
 	}
 	for index, event := range events[:3] {
 		metadata := decodeEventMetadata(t, event)
-		if metadata["go.injected.collision"] != "first" {
+		if metadata[injectedCollisionMetadataKey] != "first" {
 			t.Fatalf("event %d did not preserve first-injector precedence: %#v", index, metadata)
 		}
 		if _, ok := metadata["go.injected.global"]; !ok {
 			t.Fatalf("event %d is missing global metadata: %#v", index, metadata)
 		}
 	}
-	if metadata := decodeEventMetadata(t, events[0]); metadata["go.injected.local"] != nil {
+	if metadata := decodeEventMetadata(t, events[0]); metadata[injectedLocalMetadataKey] != nil {
 		t.Fatalf("scope start unexpectedly contains scope-local metadata: %#v", metadata)
 	}
 	for _, event := range events[1:3] {
-		if metadata := decodeEventMetadata(t, event); metadata["go.injected.local"] != true {
+		if metadata := decodeEventMetadata(t, event); metadata[injectedLocalMetadataKey] != true {
 			t.Fatalf("event %s is missing scope-local metadata: %#v", event.Name(), metadata)
 		}
 	}
@@ -147,79 +162,72 @@ func testEventMetadataInjectorGlobalScopeLocalAndFailureBehavior(t *testing.T) {
 
 func TestPluginContextEventMetadataInjectorLifecycle(t *testing.T) {
 	runTestInIsolatedWorkingDirectory(t, func(t *testing.T) {
-		runTestWithScopeStack(t, func(t *testing.T) {
-			const kind = "go.event.metadata.plugin"
-			var mu sync.Mutex
-			var events []Event
+		runTestWithScopeStack(t, testPluginContextEventMetadataInjectorLifecycle)
+	})
+}
 
-			if err := RegisterSubscriber("go-plugin-metadata-subscriber", func(event Event) {
-				mu.Lock()
-				events = append(events, event)
-				mu.Unlock()
-			}); err != nil {
-				t.Fatal(err)
-			}
-			defer DeregisterSubscriber("go-plugin-metadata-subscriber")
-
-			if err := RegisterPlugin(kind, PluginFuncs{RegisterFunc: func(_ map[string]any, ctx *PluginContext) error {
-				return ctx.RegisterEventMetadataInjector("configured", 10, func(Event) (EventMetadata, error) {
-					return EventMetadata{"go.injected.plugin": true}, nil
-				})
-			}}); err != nil {
-				t.Fatal(err)
-			}
-			defer DeregisterPlugin(kind)
-
-			if _, err := InitializePlugins(PluginConfig{
-				Version: 1,
-				Components: []PluginComponentSpec{{
-					Kind:    kind,
-					Enabled: true,
-				}},
-			}); err != nil {
-				t.Fatal(err)
-			}
-			if err := EmitEvent("go-plugin-metadata-active"); err != nil {
-				t.Fatal(err)
-			}
+func testPluginContextEventMetadataInjectorLifecycle(t *testing.T) {
+	const kind = "go.event.metadata.plugin"
+	var mu sync.Mutex
+	var events []Event
+	if err := RegisterSubscriber("go-plugin-metadata-subscriber", func(event Event) {
+		mu.Lock()
+		events = append(events, event)
+		mu.Unlock()
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer DeregisterSubscriber("go-plugin-metadata-subscriber")
+	if err := RegisterPlugin(kind, PluginFuncs{RegisterFunc: func(_ map[string]any, ctx *PluginContext) error {
+		return ctx.RegisterEventMetadataInjector("configured", 10, func(Event) (EventMetadata, error) {
+			return EventMetadata{"go.injected.plugin": true}, nil
+		})
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	defer DeregisterPlugin(kind)
+	if _, err := InitializePlugins(PluginConfig{Version: 1, Components: []PluginComponentSpec{{Kind: kind, Enabled: true}}}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"go-plugin-metadata-active", "go-plugin-metadata-cleanup"} {
+		if name == "go-plugin-metadata-cleanup" {
 			if err := ClearPluginConfiguration(); err != nil {
 				t.Fatal(err)
 			}
-			if err := EmitEvent("go-plugin-metadata-cleanup"); err != nil {
-				t.Fatal(err)
-			}
-			if err := FlushSubscribers(); err != nil {
-				t.Fatal(err)
-			}
-
-			mu.Lock()
-			defer mu.Unlock()
-			if len(events) != 2 {
-				t.Fatalf("expected two delivered events, got %d", len(events))
-			}
-			if metadata := decodeEventMetadata(t, events[0]); metadata["go.injected.plugin"] != true {
-				t.Fatalf("plugin metadata was not injected: %#v", metadata)
-			}
-			if metadata := decodeEventMetadata(t, events[1]); len(metadata) != 0 {
-				t.Fatalf("plugin metadata remained after cleanup: %#v", metadata)
-			}
-		})
-	})
+		}
+		if err := EmitEvent(name); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := FlushSubscribers(); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 2 {
+		t.Fatalf("expected two delivered events, got %d", len(events))
+	}
+	if metadata := decodeEventMetadata(t, events[0]); metadata["go.injected.plugin"] != true {
+		t.Fatalf("plugin metadata was not injected: %#v", metadata)
+	}
+	if metadata := decodeEventMetadata(t, events[1]); len(metadata) != 0 {
+		t.Fatalf("plugin metadata remained after cleanup: %#v", metadata)
+	}
 }
 
 func TestEventMetadataInjectorRegistrationErrorsReleaseCallbacks(t *testing.T) {
 	baseline := registeredClosureCount()
 	callback := func(Event) (EventMetadata, error) { return nil, nil }
-	if err := RegisterEventMetadataInjector("go-event-metadata-duplicate", 0, callback); err != nil {
+	if err := RegisterEventMetadataInjector(eventMetadataDuplicateInjector, 0, callback); err != nil {
 		t.Fatal(err)
 	}
-	if err := RegisterEventMetadataInjector("go-event-metadata-duplicate", 0, callback); err == nil {
+	if err := RegisterEventMetadataInjector(eventMetadataDuplicateInjector, 0, callback); err == nil {
 		t.Fatal("expected duplicate event metadata injector registration to fail")
 	}
 	if current := registeredClosureCount(); current != baseline+1 {
 		t.Fatalf("duplicate registration leaked callback: baseline=%d current=%d", baseline, current)
 	}
-	if err := DeregisterEventMetadataInjector("go-event-metadata-duplicate"); err != nil {
+	if err := DeregisterEventMetadataInjector(eventMetadataDuplicateInjector); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/go/nemo_relay/event_metadata_injectors_test.go
+++ b/go/nemo_relay/event_metadata_injectors_test.go
@@ -224,8 +224,9 @@ func TestEventMetadataInjectorRegistrationErrorsReleaseCallbacks(t *testing.T) {
 	if RegisterEventMetadataInjector(eventMetadataDuplicateInjector, 0, callback) == nil {
 		t.Fatal("expected duplicate event metadata injector registration to fail")
 	}
-	if registeredClosureCount() != baseline+1 {
-		t.Fatalf("duplicate registration leaked callback: baseline=%d current=%d", baseline, registeredClosureCount())
+	current := registeredClosureCount()
+	if current != baseline+1 {
+		t.Fatalf("duplicate registration leaked callback: baseline=%d current=%d", baseline, current)
 	}
 	if err := DeregisterEventMetadataInjector(eventMetadataDuplicateInjector); err != nil {
 		t.Fatal(err)
@@ -250,8 +251,9 @@ func assertNilGlobalEventMetadataInjector(t *testing.T, baseline int) {
 	if err := RegisterEventMetadataInjector("go-event-metadata-nil-global", 0, nil); !errors.Is(err, errEventMetadataInjectorCallbackNil) {
 		t.Fatalf("RegisterEventMetadataInjector() error = %v, want %v", err, errEventMetadataInjectorCallbackNil)
 	}
-	if registeredClosureCount() != baseline {
-		t.Fatalf("nil global callback changed registry size: baseline=%d current=%d", baseline, registeredClosureCount())
+	current := registeredClosureCount()
+	if current != baseline {
+		t.Fatalf("nil global callback changed registry size: baseline=%d current=%d", baseline, current)
 	}
 }
 
@@ -264,8 +266,9 @@ func assertNilScopeEventMetadataInjector(t *testing.T, baseline int) {
 	if err := ScopeRegisterEventMetadataInjector(scope.UUID(), "go-event-metadata-nil-local", 0, nil); !errors.Is(err, errEventMetadataInjectorCallbackNil) {
 		t.Fatalf("ScopeRegisterEventMetadataInjector() error = %v, want %v", err, errEventMetadataInjectorCallbackNil)
 	}
-	if registeredClosureCount() != baseline {
-		t.Fatalf("nil scope callback changed registry size: baseline=%d current=%d", baseline, registeredClosureCount())
+	current := registeredClosureCount()
+	if current != baseline {
+		t.Fatalf("nil scope callback changed registry size: baseline=%d current=%d", baseline, current)
 	}
 	if err := PopScope(scope); err != nil {
 		t.Fatal(err)
@@ -285,8 +288,9 @@ func assertNilPluginEventMetadataInjector(t *testing.T) {
 	if _, err := InitializePlugins(PluginConfig{Version: 1, Components: []PluginComponentSpec{{Kind: kind, Enabled: true}}}); err == nil {
 		t.Fatal("expected nil plugin callback registration to fail")
 	}
-	if registeredClosureCount() != baseline {
-		t.Fatalf("nil plugin callback changed registry size: baseline=%d current=%d", baseline, registeredClosureCount())
+	current := registeredClosureCount()
+	if current != baseline {
+		t.Fatalf("nil plugin callback changed registry size: baseline=%d current=%d", baseline, current)
 	}
 }
 

--- a/go/nemo_relay/event_metadata_injectors_test.go
+++ b/go/nemo_relay/event_metadata_injectors_test.go
@@ -224,8 +224,8 @@ func TestEventMetadataInjectorRegistrationErrorsReleaseCallbacks(t *testing.T) {
 	if err := RegisterEventMetadataInjector(eventMetadataDuplicateInjector, 0, callback); err == nil {
 		t.Fatal("expected duplicate event metadata injector registration to fail")
 	}
-	if current := registeredClosureCount(); current != baseline+1 {
-		t.Fatalf("duplicate registration leaked callback: baseline=%d current=%d", baseline, current)
+	if registeredClosureCount() != baseline+1 {
+		t.Fatalf("duplicate registration leaked callback: baseline=%d current=%d", baseline, registeredClosureCount())
 	}
 	if err := DeregisterEventMetadataInjector(eventMetadataDuplicateInjector); err != nil {
 		t.Fatal(err)
@@ -234,53 +234,60 @@ func TestEventMetadataInjectorRegistrationErrorsReleaseCallbacks(t *testing.T) {
 
 func TestEventMetadataInjectorNilCallbacksDoNotRegister(t *testing.T) {
 	runTestInIsolatedWorkingDirectory(t, func(t *testing.T) {
-		runTestWithScopeStack(t, func(t *testing.T) {
-			baseline := registeredClosureCount()
-
-			if err := RegisterEventMetadataInjector("go-event-metadata-nil-global", 0, nil); !errors.Is(err, errEventMetadataInjectorCallbackNil) {
-				t.Fatalf("RegisterEventMetadataInjector() error = %v, want %v", err, errEventMetadataInjectorCallbackNil)
-			}
-			if current := registeredClosureCount(); current != baseline {
-				t.Fatalf("nil global callback changed registry size: baseline=%d current=%d", baseline, current)
-			}
-
-			scope, err := PushScope("go-event-metadata-nil-scope", ScopeTypeCustom)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := ScopeRegisterEventMetadataInjector(scope.UUID(), "go-event-metadata-nil-local", 0, nil); !errors.Is(err, errEventMetadataInjectorCallbackNil) {
-				t.Fatalf("ScopeRegisterEventMetadataInjector() error = %v, want %v", err, errEventMetadataInjectorCallbackNil)
-			}
-			if current := registeredClosureCount(); current != baseline {
-				t.Fatalf("nil scope callback changed registry size: baseline=%d current=%d", baseline, current)
-			}
-			if err := PopScope(scope); err != nil {
-				t.Fatal(err)
-			}
-
-			const kind = "go.event.metadata.nil.plugin"
-			if err := RegisterPlugin(kind, PluginFuncs{RegisterFunc: func(_ map[string]any, ctx *PluginContext) error {
-				return ctx.RegisterEventMetadataInjector("nil", 0, nil)
-			}}); err != nil {
-				t.Fatal(err)
-			}
-			t.Cleanup(func() { _ = DeregisterPlugin(kind) })
-
-			pluginBaseline := registeredClosureCount()
-			if _, err := InitializePlugins(PluginConfig{
-				Version: 1,
-				Components: []PluginComponentSpec{{
-					Kind:    kind,
-					Enabled: true,
-				}},
-			}); err == nil {
-				t.Fatal("expected nil plugin callback registration to fail")
-			}
-			if current := registeredClosureCount(); current != pluginBaseline {
-				t.Fatalf("nil plugin callback changed registry size: baseline=%d current=%d", pluginBaseline, current)
-			}
-		})
+		runTestWithScopeStack(t, testEventMetadataInjectorNilCallbacksDoNotRegister)
 	})
+}
+
+func testEventMetadataInjectorNilCallbacksDoNotRegister(t *testing.T) {
+	baseline := registeredClosureCount()
+	assertNilGlobalEventMetadataInjector(t, baseline)
+	assertNilScopeEventMetadataInjector(t, baseline)
+	assertNilPluginEventMetadataInjector(t)
+}
+
+func assertNilGlobalEventMetadataInjector(t *testing.T, baseline int) {
+	t.Helper()
+	if err := RegisterEventMetadataInjector("go-event-metadata-nil-global", 0, nil); !errors.Is(err, errEventMetadataInjectorCallbackNil) {
+		t.Fatalf("RegisterEventMetadataInjector() error = %v, want %v", err, errEventMetadataInjectorCallbackNil)
+	}
+	if registeredClosureCount() != baseline {
+		t.Fatalf("nil global callback changed registry size: baseline=%d current=%d", baseline, registeredClosureCount())
+	}
+}
+
+func assertNilScopeEventMetadataInjector(t *testing.T, baseline int) {
+	t.Helper()
+	scope, err := PushScope("go-event-metadata-nil-scope", ScopeTypeCustom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ScopeRegisterEventMetadataInjector(scope.UUID(), "go-event-metadata-nil-local", 0, nil); !errors.Is(err, errEventMetadataInjectorCallbackNil) {
+		t.Fatalf("ScopeRegisterEventMetadataInjector() error = %v, want %v", err, errEventMetadataInjectorCallbackNil)
+	}
+	if registeredClosureCount() != baseline {
+		t.Fatalf("nil scope callback changed registry size: baseline=%d current=%d", baseline, registeredClosureCount())
+	}
+	if err := PopScope(scope); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertNilPluginEventMetadataInjector(t *testing.T) {
+	t.Helper()
+	const kind = "go.event.metadata.nil.plugin"
+	if err := RegisterPlugin(kind, PluginFuncs{RegisterFunc: func(_ map[string]any, ctx *PluginContext) error {
+		return ctx.RegisterEventMetadataInjector("nil", 0, nil)
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = DeregisterPlugin(kind) })
+	baseline := registeredClosureCount()
+	if _, err := InitializePlugins(PluginConfig{Version: 1, Components: []PluginComponentSpec{{Kind: kind, Enabled: true}}}); err == nil {
+		t.Fatal("expected nil plugin callback registration to fail")
+	}
+	if registeredClosureCount() != baseline {
+		t.Fatalf("nil plugin callback changed registry size: baseline=%d current=%d", baseline, registeredClosureCount())
+	}
 }
 
 func decodeEventMetadata(t *testing.T, event Event) map[string]any {

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -2322,6 +2322,8 @@ type OpenTelemetryRuntimeDiagnostic struct {
 	Count   uint64 `json:"count"`
 }
 
+const openTelemetryEndpointRequiredMessage = "endpoint is required"
+
 func decodeOpenTelemetryRuntimeDiagnostics(out *C.char) ([]OpenTelemetryRuntimeDiagnostic, error) {
 	defer C.nemo_relay_string_free(out)
 	var diagnostics []OpenTelemetryRuntimeDiagnostic
@@ -2339,7 +2341,7 @@ func normalizeOpenTelemetryConfig(config OpenTelemetryConfig) (OpenTelemetryConf
 		return config, fmt.Errorf("type is required")
 	}
 	if config.Endpoint == "" {
-		return config, fmt.Errorf("endpoint is required")
+		return config, fmt.Errorf(openTelemetryEndpointRequiredMessage)
 	}
 	if config.ServiceName == "" {
 		config.ServiceName = "unknown_service"
@@ -2606,33 +2608,35 @@ type openTelemetrySignalCStrings struct {
 	instrumentationScope *C.char
 }
 
-func newOpenTelemetrySignalCStrings(
-	transport OpenTelemetryTransport,
-	endpoint string,
-	headers map[string]string,
-	resourceAttributes map[string]string,
-	serviceName string,
-	serviceNamespace string,
-	serviceVersion string,
-	instrumentationScope string,
-) (openTelemetrySignalCStrings, error) {
-	encodedHeaders, err := jsonMarshal(headers)
+type openTelemetrySignalConfig struct {
+	transport            OpenTelemetryTransport
+	endpoint             string
+	headers              map[string]string
+	resourceAttributes   map[string]string
+	serviceName          string
+	serviceNamespace     string
+	serviceVersion       string
+	instrumentationScope string
+}
+
+func newOpenTelemetrySignalCStrings(config openTelemetrySignalConfig) (openTelemetrySignalCStrings, error) {
+	encodedHeaders, err := jsonMarshal(config.headers)
 	if err != nil {
 		return openTelemetrySignalCStrings{}, err
 	}
-	encodedResources, err := jsonMarshal(resourceAttributes)
+	encodedResources, err := jsonMarshal(config.resourceAttributes)
 	if err != nil {
 		return openTelemetrySignalCStrings{}, err
 	}
 	return openTelemetrySignalCStrings{
-		transport:            C.CString(string(transport)),
-		endpoint:             C.CString(endpoint),
+		transport:            C.CString(string(config.transport)),
+		endpoint:             C.CString(config.endpoint),
 		headers:              C.CString(string(encodedHeaders)),
 		resourceAttributes:   C.CString(string(encodedResources)),
-		serviceName:          C.CString(serviceName),
-		serviceNamespace:     optionalCString(serviceNamespace),
-		serviceVersion:       optionalCString(serviceVersion),
-		instrumentationScope: C.CString(instrumentationScope),
+		serviceName:          C.CString(config.serviceName),
+		serviceNamespace:     optionalCString(config.serviceNamespace),
+		serviceVersion:       optionalCString(config.serviceVersion),
+		instrumentationScope: C.CString(config.instrumentationScope),
 	}, nil
 }
 
@@ -2659,7 +2663,7 @@ func normalizeOpenTelemetryLogConfig(config OpenTelemetryLogConfig) (OpenTelemet
 		config.Transport = OpenTelemetryTransportHTTPBinary
 	}
 	if config.Endpoint == "" {
-		return config, fmt.Errorf("endpoint is required")
+		return config, fmt.Errorf(openTelemetryEndpointRequiredMessage)
 	}
 	if config.ServiceName == "" {
 		config.ServiceName = "unknown_service"
@@ -2706,11 +2710,10 @@ func NewOpenTelemetryLogSubscriber(config OpenTelemetryLogConfig) (*OpenTelemetr
 	if err != nil {
 		return nil, err
 	}
-	common, err := newOpenTelemetrySignalCStrings(
+	common, err := newOpenTelemetrySignalCStrings(openTelemetrySignalConfig{
 		config.Transport, config.Endpoint, config.Headers, config.ResourceAttributes,
-		config.ServiceName, config.ServiceNamespace, config.ServiceVersion,
-		config.InstrumentationScope,
-	)
+		config.ServiceName, config.ServiceNamespace, config.ServiceVersion, config.InstrumentationScope,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -2786,7 +2789,7 @@ func normalizeOpenTelemetryMetricConfig(config OpenTelemetryMetricConfig) (OpenT
 		config.Transport = OpenTelemetryTransportHTTPBinary
 	}
 	if config.Endpoint == "" {
-		return config, fmt.Errorf("endpoint is required")
+		return config, fmt.Errorf(openTelemetryEndpointRequiredMessage)
 	}
 	if config.ServiceName == "" {
 		config.ServiceName = "unknown_service"
@@ -2833,11 +2836,10 @@ func NewOpenTelemetryMetricSubscriber(config OpenTelemetryMetricConfig) (*OpenTe
 	if err != nil {
 		return nil, err
 	}
-	common, err := newOpenTelemetrySignalCStrings(
+	common, err := newOpenTelemetrySignalCStrings(openTelemetrySignalConfig{
 		config.Transport, config.Endpoint, config.Headers, config.ResourceAttributes,
-		config.ServiceName, config.ServiceNamespace, config.ServiceVersion,
-		config.InstrumentationScope,
-	)
+		config.ServiceName, config.ServiceNamespace, config.ServiceVersion, config.InstrumentationScope,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/go/nemo_relay/observability_plugin_test.go
+++ b/go/nemo_relay/observability_plugin_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const observabilityDevProject = "observability-dev"
+
 const (
 	ClearPluginConfigurationFailed = "ClearPluginConfiguration failed"
 	InitializePluginsFailed        = "InitializePlugins failed"
@@ -87,8 +89,8 @@ func TestObservabilityConfigHelpers(t *testing.T) {
 	metrics := NewObservabilityOpenTelemetryMetricConfig()
 	metrics.Enabled = true
 	metricEndpoint := NewObservabilityOpenTelemetrySignalEndpointConfig("https://collector.example/custom/metrics")
-	metricEndpoint.Headers["x-nv-project"] = "observability-dev"
-	metricEndpoint.ResourceAttributes["nv.project"] = "observability-dev"
+	metricEndpoint.Headers["x-nv-project"] = observabilityDevProject
+	metricEndpoint.ResourceAttributes["nv.project"] = observabilityDevProject
 	metrics.Endpoints = ObservabilityOpenTelemetrySignalEndpoints(metricEndpoint)
 	otel.Logs = &logs
 	otel.Metrics = &metrics
@@ -185,8 +187,8 @@ func assertWrappedObservabilityConfig(t *testing.T, wrapped PluginComponentSpec)
 	metricEndpoint := metricEndpoints[0].(map[string]any)
 	if metrics["temporality"] != "cumulative" || metrics["cardinality_limit"] != float64(2000) ||
 		metricEndpoint["endpoint"] != "https://collector.example/custom/metrics" ||
-		metricEndpoint["headers"].(map[string]any)["x-nv-project"] != "observability-dev" ||
-		metricEndpoint["resource_attributes"].(map[string]any)["nv.project"] != "observability-dev" {
+		metricEndpoint["headers"].(map[string]any)["x-nv-project"] != observabilityDevProject ||
+		metricEndpoint["resource_attributes"].(map[string]any)["nv.project"] != observabilityDevProject {
 		t.Fatalf("expected OpenTelemetry metric settings in serialized config: %#v", metrics)
 	}
 }

--- a/go/nemo_relay/otel_signals_test.go
+++ b/go/nemo_relay/otel_signals_test.go
@@ -204,7 +204,7 @@ func TestOpenTelemetrySignalConfigRejectsFractionalMillisecondDurations(t *testi
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if err := test.normalize(); err == nil {
+			if test.normalize() == nil {
 				t.Fatal("expected fractional-millisecond duration to fail")
 			}
 		})

--- a/go/nemo_relay/otel_signals_test.go
+++ b/go/nemo_relay/otel_signals_test.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+const (
+	emitEventFailedMsg = "EmitEvent failed"
+	otelEndpoint       = "http://localhost:4318"
+)
+
 func TestEventSchemaSeverityAndMetricParity(t *testing.T) {
 	var (
 		events []Event
@@ -38,7 +43,7 @@ func TestEventSchemaSeverityAndMetricParity(t *testing.T) {
 			WithEventMetadata(json.RawMessage(`{"nemo_relay.log.severity":"debug"}`)),
 			WithEventSeverity(LogSeverityWarn),
 		)
-		requireNoError(t, err, "EmitEvent failed")
+		requireNoError(t, err, emitEventFailedMsg)
 
 		err = EmitMetric("go_metric", []MetricMeasurement{{
 			Name:      "example.tokens.saved",
@@ -159,7 +164,7 @@ func TestOpenTelemetrySignalConfigRejectsFractionalMillisecondDurations(t *testi
 			name: "log timeout",
 			normalize: func() error {
 				_, err := normalizeOpenTelemetryLogConfig(OpenTelemetryLogConfig{
-					Endpoint: "http://localhost:4318",
+					Endpoint: otelEndpoint,
 					Timeout:  time.Nanosecond,
 				})
 				return err
@@ -169,7 +174,7 @@ func TestOpenTelemetrySignalConfigRejectsFractionalMillisecondDurations(t *testi
 			name: "log scheduled delay",
 			normalize: func() error {
 				_, err := normalizeOpenTelemetryLogConfig(OpenTelemetryLogConfig{
-					Endpoint:       "http://localhost:4318",
+					Endpoint:       otelEndpoint,
 					ScheduledDelay: time.Millisecond + 500*time.Microsecond,
 				})
 				return err
@@ -179,7 +184,7 @@ func TestOpenTelemetrySignalConfigRejectsFractionalMillisecondDurations(t *testi
 			name: "metric timeout",
 			normalize: func() error {
 				_, err := normalizeOpenTelemetryMetricConfig(OpenTelemetryMetricConfig{
-					Endpoint: "http://localhost:4318",
+					Endpoint: otelEndpoint,
 					Timeout:  500 * time.Microsecond,
 				})
 				return err
@@ -189,7 +194,7 @@ func TestOpenTelemetrySignalConfigRejectsFractionalMillisecondDurations(t *testi
 			name: "metric export interval",
 			normalize: func() error {
 				_, err := normalizeOpenTelemetryMetricConfig(OpenTelemetryMetricConfig{
-					Endpoint:       "http://localhost:4318",
+					Endpoint:       otelEndpoint,
 					ExportInterval: 2*time.Millisecond + 500*time.Microsecond,
 				})
 				return err
@@ -241,7 +246,7 @@ func TestOpenTelemetrySubscribersExposeRuntimeDiagnostics(t *testing.T) {
 			"invalid_metric",
 			WithEventData(json.RawMessage(`{"measurements":[]}`)),
 			WithEventDataSchema(DataSchema{Name: "nemo.relay.metric_measurements", Version: "999"}),
-		), "EmitEvent failed")
+		), emitEventFailedMsg)
 	})
 	requireNoError(t, FlushSubscribers(), "FlushSubscribers failed")
 
@@ -279,7 +284,7 @@ func TestOpenTelemetryLogSubscriberLifecycleAndDerivation(t *testing.T) {
 	defer func() { _ = subscriber.Deregister(name) }()
 
 	runWithTestScopeStack(t, func() {
-		requireNoError(t, EmitEvent("go_exported_log", WithEventSeverity(LogSeverityError)), "EmitEvent failed")
+		requireNoError(t, EmitEvent("go_exported_log", WithEventSeverity(LogSeverityError)), emitEventFailedMsg)
 	})
 	requireNoError(t, subscriber.ForceFlush(), "log ForceFlush failed")
 

--- a/python/nemo_relay/integrations/langchain/_serialization.py
+++ b/python/nemo_relay/integrations/langchain/_serialization.py
@@ -212,6 +212,30 @@ class LangChainCodec(LlmCodec):
                     provider_tool_calls.append((annotated_messages[0], raw_tool_calls))
         return provider_tool_calls
 
+    def _provider_tool_calls_for_message(
+        self,
+        message: dict[str, Any],
+        original_provider_tool_calls: list[tuple[dict[str, Any], list[dict[str, Any]]]],
+        matched_original_messages: set[int],
+    ) -> list[dict[str, Any]] | None:
+        """Preserve provider tool-call encoding when an assistant message still matches."""
+        for index, (original_message, original_tool_calls) in enumerate(original_provider_tool_calls):
+            if index not in matched_original_messages and message == original_message:
+                matched_original_messages.add(index)
+                return original_tool_calls
+
+        message_without_tool_calls = {key: value for key, value in message.items() if key != "tool_calls"}
+        for index, (original_message, original_tool_calls) in enumerate(original_provider_tool_calls):
+            original_without_tool_calls = {key: value for key, value in original_message.items() if key != "tool_calls"}
+            if index in matched_original_messages or message_without_tool_calls != original_without_tool_calls:
+                continue
+            matched_original_messages.add(index)
+            if message.get("tool_calls") == original_message.get("tool_calls"):
+                return original_tool_calls
+            return self._annotated_tool_calls_to_provider(message.get("tool_calls"))
+
+        return self._annotated_tool_calls_to_provider(message.get("tool_calls"))
+
     def decode(self, request: LLMRequest) -> AnnotatedLLMRequest:
         """Decode a LangChain-shaped request payload into an annotated request."""
         payload = request.content
@@ -244,29 +268,9 @@ class LangChainCodec(LlmCodec):
         for message in annotated.messages:
             provider_tool_calls = None
             if message.get("role") == "assistant":
-                for index, (original_message, original_tool_calls) in enumerate(original_provider_tool_calls):
-                    if index in matched_original_messages or message != original_message:
-                        continue
-                    matched_original_messages.add(index)
-                    provider_tool_calls = original_tool_calls
-                    break
-
-            if message.get("role") == "assistant" and provider_tool_calls is None:
-                message_without_tool_calls = {key: value for key, value in message.items() if key != "tool_calls"}
-                for index, (original_message, original_tool_calls) in enumerate(original_provider_tool_calls):
-                    original_without_tool_calls = {
-                        key: value for key, value in original_message.items() if key != "tool_calls"
-                    }
-                    if index in matched_original_messages or message_without_tool_calls != original_without_tool_calls:
-                        continue
-                    matched_original_messages.add(index)
-                    if message.get("tool_calls") == original_message.get("tool_calls"):
-                        provider_tool_calls = original_tool_calls
-                    else:
-                        provider_tool_calls = self._annotated_tool_calls_to_provider(message.get("tool_calls"))
-                    break
-            if message.get("role") == "assistant" and provider_tool_calls is None:
-                provider_tool_calls = self._annotated_tool_calls_to_provider(message.get("tool_calls"))
+                provider_tool_calls = self._provider_tool_calls_for_message(
+                    message, original_provider_tool_calls, matched_original_messages
+                )
             encoded_messages.append(self._annotated_message_to_langchain(message, provider_tool_calls))
         payload["messages"] = messages_to_dict(encoded_messages)
         if annotated.model is not None:


### PR DESCRIPTION
#### Overview

Resolve the open Sonar quality findings reported on `main` without changing runtime behavior.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Refactor Rust adaptive validation and FFI metric conversion to reduce cognitive complexity.
- Extract LangChain provider tool-call matching logic and simplify Go test and OpenTelemetry helper code.
- Replace repeated test literals and remove unnecessary TypeScript `void` expressions.

#### Where should the reviewer start?

Start with `crates/ffi/src/api/scope.rs` and `crates/adaptive/src/runtime/validation.rs`; both preserve existing behavior while isolating validation and conversion branches.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved observability metric validation and error handling for invalid measurements and configuration issues.
  - Invalid metric data now stops processing cleanly before partial emission.
  - Strengthened diagnostics, deregistration, event, and tool-call failure handling.
  - Improved preservation of provider tool calls when serializing LangChain messages.
  - Improved validation of tool classifications and cache configuration.

- **Tests**
  - Expanded coverage for metadata injector lifecycles, observability integrations, validation failures, cleanup behavior, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->