### PR TITLE
refactor: simplify event metadata number validation

### DIFF
--- a/crates/core/src/api/runtime/state.rs
+++ b/crates/core/src/api/runtime/state.rs
@@ -1800,9 +1800,6 @@ fn otel_compatible_attribute_number_kind(
             .is_ok()
             .then_some(OtelAttributePrimitiveKind::Number);
     }
-    if value.as_i64().is_some() {
-        return Some(OtelAttributePrimitiveKind::Number);
-    }
     value.as_f64().map(|_| OtelAttributePrimitiveKind::Number)
 }
 


### PR DESCRIPTION
#### Overview

Remove a redundant signed-integer classification branch while preserving the existing event-metadata number validation behavior.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Keep the unsigned-integer guard and checked conversion to the signed 64-bit range.
- Let remaining signed integers and floating-point values use the existing floating-point classification path.
- Preserve rejection of unsigned integers larger than the signed 64-bit range.
- Make no API or observable behavior changes.

Focused validation: cargo test -p nemo-relay --lib event_metadata_injection passed 4 tests. Broader repository checks will run after publication.

#### Where should the reviewer start?

Review otel_compatible_attribute_number_kind in crates/core/src/api/runtime/state.rs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenTelemetry-compatible JSON number classification for signed integers.
  * Signed integer values now follow consistent numeric handling when unsigned conversion is not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->