### PR TITLE
test: raise binding coverage above 95 percent

### DIFF
--- a/crates/core/tests/unit/subscriber_dispatcher_tests.rs
+++ b/crates/core/tests/unit/subscriber_dispatcher_tests.rs
@@ -708,6 +708,9 @@ fn detached_publications_share_one_background_executor_thread() {
 
 #[test]
 fn event_metadata_injection_applies_to_every_canonical_event_record() {
+    let _lock = crate::shared_runtime::runtime_owner_test_mutex()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
     let invocations = Arc::new(AtomicUsize::new(0));
     let injector: EventMetadataInjectorFn = {
         let invocations = Arc::clone(&invocations);

--- a/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
@@ -1200,3 +1200,839 @@ fn test_ffi_adaptive_and_observability_entry_points_from_integration_binary() {
         );
     }
 }
+
+#[test]
+fn test_ffi_lifecycle_validation_paths_from_integration_binary() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let stack = fresh_scope_stack();
+        let invalid_utf8 = [0xffu8, 0];
+        let invalid = invalid_utf8.as_ptr() as *const c_char;
+        let malformed_json = cstring("{");
+        let invalid_timestamp = i64::MAX;
+        let scope_name = cstring("ffi_integration_validation_scope");
+
+        assert_status!(
+            api::nemo_relay_get_handle(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            api::nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Custom,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+
+        let mut scope = ptr::null_mut();
+        assert_status!(
+            api::nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Custom,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                &mut scope,
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_status!(
+            api::nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Custom,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+                &mut scope,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_status!(
+            api::nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Custom,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut scope,
+            ),
+            NemoRelayStatus::Ok
+        );
+        for (output, metadata, timestamp, expected) in [
+            (
+                malformed_json.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ] {
+            assert_status!(
+                api::nemo_relay_pop_scope(scope, output, metadata, timestamp),
+                expected
+            );
+        }
+
+        let event_name = cstring("ffi_integration_validation_event");
+        let invalid_schema = cstring(r#"{"name":1,"version":false}"#);
+        for (schema, metadata) in [
+            (malformed_json.as_ptr(), ptr::null()),
+            (invalid_schema.as_ptr(), ptr::null()),
+            (ptr::null(), malformed_json.as_ptr()),
+        ] {
+            assert_status!(
+                api::nemo_relay_event_v2(
+                    event_name.as_ptr(),
+                    scope,
+                    ptr::null(),
+                    schema,
+                    metadata,
+                    ptr::null(),
+                    ptr::null(),
+                ),
+                NemoRelayStatus::InvalidJson
+            );
+        }
+        assert_status!(
+            api::nemo_relay_event_v2(
+                event_name.as_ptr(),
+                scope,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+
+        let metric_name = cstring("ffi_integration_validation_metric");
+        let measurements = cstring(
+            r#"[{"name":"example.validation.value","kind":"counter","value_type":"u64","value":1}]"#,
+        );
+        let wrong_shape = cstring(r#"{"name":"not-an-array"}"#);
+        for (name, values, metadata, timestamp, expected) in [
+            (
+                invalid,
+                measurements.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidUtf8,
+            ),
+            (
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::NullPointer,
+            ),
+            (
+                metric_name.as_ptr(),
+                wrong_shape.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                metric_name.as_ptr(),
+                measurements.as_ptr(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                metric_name.as_ptr(),
+                measurements.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ] {
+            assert_status!(
+                api::nemo_relay_metric_json(name, scope, values, metadata, timestamp),
+                expected
+            );
+        }
+
+        let instrument_name = cstring("example.integration.validation");
+        let unit = cstring("{item}");
+        let description = cstring("integration validation");
+        let attributes = cstring(r#"{"source":"integration"}"#);
+        let base_measurement = types::NemoRelayMetricMeasurement {
+            name: instrument_name.as_ptr(),
+            kind: types::NEMO_RELAY_METRIC_KIND_COUNTER,
+            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_I64,
+            u64_value: 0,
+            i64_value: -7,
+            f64_value: 0.0,
+            unit: unit.as_ptr(),
+            description: description.as_ptr(),
+            attributes_json: attributes.as_ptr(),
+            boundaries: ptr::null(),
+            boundaries_len: 0,
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        for measurement in [
+            types::NemoRelayMetricMeasurement {
+                name: invalid,
+                ..base_measurement
+            },
+            types::NemoRelayMetricMeasurement {
+                unit: invalid,
+                ..base_measurement
+            },
+            types::NemoRelayMetricMeasurement {
+                description: invalid,
+                ..base_measurement
+            },
+        ] {
+            assert_status!(
+                api::nemo_relay_metric(
+                    metric_name.as_ptr(),
+                    scope,
+                    ptr::from_ref(&measurement),
+                    1,
+                    ptr::null(),
+                    ptr::null(),
+                ),
+                NemoRelayStatus::InvalidUtf8
+            );
+        }
+        let boundaries = [0.0, 1.0, 10.0];
+        let histogram = types::NemoRelayMetricMeasurement {
+            kind: types::NEMO_RELAY_METRIC_KIND_HISTOGRAM,
+            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_F64,
+            f64_value: 2.5,
+            boundaries: boundaries.as_ptr(),
+            boundaries_len: boundaries.len(),
+            ..base_measurement
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                scope,
+                ptr::from_ref(&histogram),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+        for (metadata, timestamp, expected) in [
+            (
+                malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ] {
+            assert_status!(
+                api::nemo_relay_metric(
+                    metric_name.as_ptr(),
+                    scope,
+                    ptr::from_ref(&base_measurement),
+                    1,
+                    metadata,
+                    timestamp,
+                ),
+                expected
+            );
+        }
+
+        let invalid_attributes = types::NemoRelayMetricMeasurement {
+            attributes_json: malformed_json.as_ptr(),
+            ..base_measurement
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                scope,
+                ptr::from_ref(&invalid_attributes),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                scope,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_status!(
+            api::nemo_relay_metric_json(
+                metric_name.as_ptr(),
+                scope,
+                measurements.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let tool_name = cstring("ffi_integration_validation_tool");
+        let tool_args = cstring(r#"{"value":1}"#);
+        let tool_result = cstring(r#"{"result":{"ok":true}}"#);
+        let mut tool = ptr::null_mut();
+        assert_status!(
+            api::nemo_relay_tool_call(
+                tool_name.as_ptr(),
+                tool_args.as_ptr(),
+                scope,
+                0,
+                ptr::null(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                &mut tool,
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_status!(
+            api::nemo_relay_tool_call(
+                tool_name.as_ptr(),
+                tool_args.as_ptr(),
+                scope,
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut tool,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            api::nemo_relay_tool_call_end(
+                tool,
+                tool_result.as_ptr(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_status!(
+            api::nemo_relay_tool_call_end(
+                tool,
+                tool_result.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            api::nemo_relay_tool_call_end(
+                tool,
+                tool_result.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_tool_handle_free(tool);
+
+        let llm_name = cstring("ffi_integration_validation_llm");
+        let llm_request =
+            cstring(r#"{"headers":{},"content":{"model":"ffi-model","messages":[]}}"#);
+        let llm_response = cstring(r#"{"content":"ok","role":"assistant","tool_calls":[]}"#);
+        let invalid_llm_shape = cstring(r#"{"content":{"model":"ffi-model"}}"#);
+        let mut llm = ptr::null_mut();
+        for (data, metadata) in [
+            (malformed_json.as_ptr(), ptr::null()),
+            (ptr::null(), malformed_json.as_ptr()),
+        ] {
+            assert_status!(
+                api::nemo_relay_llm_call(
+                    llm_name.as_ptr(),
+                    llm_request.as_ptr(),
+                    scope,
+                    0,
+                    data,
+                    metadata,
+                    ptr::null(),
+                    ptr::null(),
+                    &mut llm,
+                ),
+                NemoRelayStatus::InvalidJson
+            );
+        }
+        assert_status!(
+            api::nemo_relay_llm_call(
+                llm_name.as_ptr(),
+                llm_request.as_ptr(),
+                scope,
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut llm,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            api::nemo_relay_llm_call_end(
+                llm,
+                llm_response.as_ptr(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_status!(
+            api::nemo_relay_llm_call_end(
+                llm,
+                llm_response.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            api::nemo_relay_llm_call_end(
+                llm,
+                llm_response.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_llm_handle_free(llm);
+
+        let mut out = ptr::null_mut();
+        assert_status!(
+            api::nemo_relay_llm_request_intercepts(
+                llm_name.as_ptr(),
+                invalid_llm_shape.as_ptr(),
+                &mut out,
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_status!(
+            api::nemo_relay_llm_conditional_execution(invalid_llm_shape.as_ptr()),
+            NemoRelayStatus::InvalidJson
+        );
+
+        assert!(
+            api::nemo_relay_llm_sanitize_request_codec_decode(ptr::null(), ptr::null()).is_null()
+        );
+        assert!(
+            api::nemo_relay_llm_sanitize_request_codec_encode(
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            )
+            .is_null()
+        );
+        assert!(
+            api::nemo_relay_llm_sanitize_response_codec_decode(ptr::null(), ptr::null()).is_null()
+        );
+        assert_status!(
+            api::nemo_relay_stream_close(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+
+        assert_status!(
+            api::nemo_relay_pop_scope(scope, ptr::null(), ptr::null(), ptr::null()),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_scope_handle_free(scope);
+        nemo_relay_scope_stack_free(stack);
+    }
+}
+
+#[test]
+fn test_ffi_otel_projection_validation_from_integration_binary() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let otel_type = cstring("full");
+        let transport = cstring("http_binary");
+        let endpoint = cstring("http://127.0.0.1:4318/v1/traces");
+        let headers = cstring(r#"{"authorization":"test-token"}"#);
+        let resources = cstring(r#"{"service.instance.id":"ffi-integration"}"#);
+        let service_name = cstring("ffi-integration");
+        let service_namespace = cstring("nemo-relay");
+        let service_version = cstring("test");
+        let instrumentation_scope = cstring("ffi.integration");
+        let malformed_json = cstring("{");
+        let wrong_shape = cstring(r#"{"not":"an-array"}"#);
+        let invalid_projection = cstring("invalid");
+        let invalid_prefixes = cstring(r#"[""]"#);
+        let projection = cstring("event");
+        let excluded_names = cstring(r#"["llm.chunk"]"#);
+        let mappings = cstring(r#"[{"key":"gen_ai.request.model","alias":"relay.request.model"}]"#);
+        let prefixes = cstring(r#"["nv."]"#);
+        let mut subscriber = ptr::null_mut();
+
+        macro_rules! assert_projection_status {
+            ($projection:expr, $excluded:expr, $mappings:expr, $prefixes:expr, $expected:expr) => {
+                assert_status!(
+                    nemo_relay_otel_subscriber_create_with_projection_options_v2(
+                        otel_type.as_ptr(),
+                        transport.as_ptr(),
+                        endpoint.as_ptr(),
+                        headers.as_ptr(),
+                        resources.as_ptr(),
+                        service_name.as_ptr(),
+                        service_namespace.as_ptr(),
+                        service_version.as_ptr(),
+                        instrumentation_scope.as_ptr(),
+                        250,
+                        $projection,
+                        $excluded,
+                        $mappings,
+                        $prefixes,
+                        &mut subscriber,
+                    ),
+                    $expected
+                )
+            };
+        }
+
+        assert_projection_status!(
+            invalid_projection.as_ptr(),
+            ptr::null(),
+            ptr::null(),
+            ptr::null(),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_projection_status!(
+            projection.as_ptr(),
+            malformed_json.as_ptr(),
+            ptr::null(),
+            ptr::null(),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_projection_status!(
+            projection.as_ptr(),
+            wrong_shape.as_ptr(),
+            ptr::null(),
+            ptr::null(),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_projection_status!(
+            projection.as_ptr(),
+            excluded_names.as_ptr(),
+            malformed_json.as_ptr(),
+            ptr::null(),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_projection_status!(
+            projection.as_ptr(),
+            excluded_names.as_ptr(),
+            wrong_shape.as_ptr(),
+            ptr::null(),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_projection_status!(
+            projection.as_ptr(),
+            excluded_names.as_ptr(),
+            mappings.as_ptr(),
+            malformed_json.as_ptr(),
+            NemoRelayStatus::InvalidJson
+        );
+        assert_projection_status!(
+            projection.as_ptr(),
+            excluded_names.as_ptr(),
+            mappings.as_ptr(),
+            wrong_shape.as_ptr(),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_projection_status!(
+            projection.as_ptr(),
+            excluded_names.as_ptr(),
+            mappings.as_ptr(),
+            invalid_prefixes.as_ptr(),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_projection_status!(
+            projection.as_ptr(),
+            excluded_names.as_ptr(),
+            mappings.as_ptr(),
+            prefixes.as_ptr(),
+            NemoRelayStatus::Ok
+        );
+        assert!(!subscriber.is_null());
+
+        let subscriber_name = cstring(&unique_name("ffi_projection_integration"));
+        assert_status!(
+            nemo_relay_otel_subscriber_register(subscriber, subscriber_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_subscriber_register(subscriber, subscriber_name.as_ptr()),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_subscriber_deregister(subscriber_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        let mut diagnostics = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_subscriber_runtime_diagnostics_json(ptr::null(), &mut diagnostics),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_subscriber_runtime_diagnostics_json(subscriber, ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_otel_subscriber_shutdown(subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_subscriber_force_flush(subscriber),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_subscriber_shutdown(subscriber),
+            NemoRelayStatus::Internal
+        );
+        nemo_relay_otel_subscriber_free(subscriber);
+    }
+}
+
+#[test]
+fn test_ffi_observability_component_and_atof_validation_from_integration_binary() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let mut out_json = ptr::null_mut();
+        assert_status!(
+            nemo_relay_observability_component_spec_json(ptr::null(), true, ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        let invalid_config = cstring(r#"{"version":"invalid"}"#);
+        assert_status!(
+            nemo_relay_observability_component_spec_json(
+                invalid_config.as_ptr(),
+                true,
+                &mut out_json,
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+
+        let valid_atof_config = cstring(r#"{"type":"file","filename":"events.jsonl"}"#);
+        let invalid_atof_config = cstring(r#"{"mode":17}"#);
+        let mut exporter = ptr::null_mut();
+        assert_status!(
+            nemo_relay_atof_exporter_create_from_json(valid_atof_config.as_ptr(), ptr::null_mut(),),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_atof_exporter_create_from_json(invalid_atof_config.as_ptr(), &mut exporter),
+            NemoRelayStatus::InvalidJson
+        );
+
+        let directory = temp_dir("ffi-atof-integration-validation");
+        let directory = cstring(&directory.to_string_lossy());
+        let mode = cstring("overwrite");
+        let filename = cstring("events.jsonl");
+        assert_status!(
+            nemo_relay_atof_exporter_create(
+                directory.as_ptr(),
+                mode.as_ptr(),
+                filename.as_ptr(),
+                &mut exporter,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_atof_exporter_path(exporter, ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        let invalid_utf8 = [0xffu8, 0];
+        let invalid = invalid_utf8.as_ptr() as *const c_char;
+        assert_status!(
+            nemo_relay_atof_exporter_register(exporter, invalid),
+            NemoRelayStatus::InvalidUtf8
+        );
+        assert_status!(
+            nemo_relay_atof_exporter_deregister(invalid),
+            NemoRelayStatus::InvalidUtf8
+        );
+        types::nemo_relay_atof_exporter_free(exporter);
+    }
+}
+
+#[test]
+fn test_ffi_typed_otel_signal_options_from_integration_binary() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let transport = cstring("http_binary");
+        let log_endpoint = cstring("http://127.0.0.1:4318/v1/logs");
+        let metric_endpoint = cstring("http://127.0.0.1:4318/v1/metrics");
+        let headers = cstring(r#"{"authorization":"test-token"}"#);
+        let resources = cstring(r#"{"service.instance.id":"ffi-integration"}"#);
+        let service_name = cstring("ffi-integration");
+        let service_namespace = cstring("nemo-relay");
+        let service_version = cstring("test");
+        let instrumentation_scope = cstring("ffi.integration");
+        let minimum_severity = cstring("warn");
+        let temporality = cstring("delta");
+        let invalid_utf8 = [0xffu8, 0];
+        let invalid = invalid_utf8.as_ptr() as *const c_char;
+
+        let mut log_subscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_log_subscriber_create(
+                transport.as_ptr(),
+                log_endpoint.as_ptr(),
+                headers.as_ptr(),
+                resources.as_ptr(),
+                service_name.as_ptr(),
+                service_namespace.as_ptr(),
+                service_version.as_ptr(),
+                instrumentation_scope.as_ptr(),
+                250,
+                minimum_severity.as_ptr(),
+                64,
+                16,
+                10,
+                &mut log_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_register(log_subscriber, invalid),
+            NemoRelayStatus::InvalidUtf8
+        );
+        let log_name = cstring(&unique_name("ffi_typed_log_integration"));
+        assert_status!(
+            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_deregister(log_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_force_flush(log_subscriber),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
+            NemoRelayStatus::Internal
+        );
+        types::nemo_relay_otel_log_subscriber_free(log_subscriber);
+
+        let mut metric_subscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_create(
+                transport.as_ptr(),
+                metric_endpoint.as_ptr(),
+                headers.as_ptr(),
+                resources.as_ptr(),
+                service_name.as_ptr(),
+                service_namespace.as_ptr(),
+                service_version.as_ptr(),
+                instrumentation_scope.as_ptr(),
+                250,
+                20,
+                temporality.as_ptr(),
+                256,
+                128,
+                &mut metric_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_register(metric_subscriber, invalid),
+            NemoRelayStatus::InvalidUtf8
+        );
+        let metric_name = cstring(&unique_name("ffi_typed_metric_integration"));
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_deregister(metric_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_force_flush(metric_subscriber),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
+            NemoRelayStatus::Internal
+        );
+        types::nemo_relay_otel_metric_subscriber_free(metric_subscriber);
+    }
+}

--- a/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for coverage sweeps in the NeMo Relay FFI crate.
 
+use super::ffi_coverage_support::{ValidationFixtures, assert_otel_signal_lifecycle};
 use super::*;
 use std::ptr;
 
@@ -1208,11 +1209,11 @@ fn test_ffi_lifecycle_validation_paths_from_integration_binary() {
 
     unsafe {
         let stack = fresh_scope_stack();
-        let invalid_utf8 = [0xffu8, 0];
-        let invalid = invalid_utf8.as_ptr() as *const c_char;
-        let malformed_json = cstring("{");
-        let invalid_timestamp = i64::MAX;
-        let scope_name = cstring("ffi_integration_validation_scope");
+        let fixtures = ValidationFixtures::new("integration");
+        let invalid = fixtures.invalid_utf8();
+        let malformed_json = &fixtures.malformed_json;
+        let invalid_timestamp = fixtures.invalid_timestamp;
+        let scope_name = &fixtures.scope_name;
 
         assert_status!(
             api::nemo_relay_get_handle(ptr::null_mut()),
@@ -1234,20 +1235,22 @@ fn test_ffi_lifecycle_validation_paths_from_integration_binary() {
         );
 
         let mut scope = ptr::null_mut();
-        assert_status!(
-            api::nemo_relay_push_scope(
-                scope_name.as_ptr(),
-                NemoRelayScopeType::Custom,
-                ptr::null(),
-                0,
-                ptr::null(),
-                ptr::null(),
-                malformed_json.as_ptr(),
-                ptr::null(),
-                &mut scope,
-            ),
-            NemoRelayStatus::InvalidJson
-        );
+        for (data, metadata, input) in fixtures.push_scope_json_cases() {
+            assert_status!(
+                api::nemo_relay_push_scope(
+                    scope_name.as_ptr(),
+                    NemoRelayScopeType::Custom,
+                    ptr::null(),
+                    0,
+                    data,
+                    metadata,
+                    input,
+                    ptr::null(),
+                    &mut scope,
+                ),
+                NemoRelayStatus::InvalidJson
+            );
+        }
         assert_status!(
             api::nemo_relay_push_scope(
                 scope_name.as_ptr(),
@@ -1276,44 +1279,32 @@ fn test_ffi_lifecycle_validation_paths_from_integration_binary() {
             ),
             NemoRelayStatus::Ok
         );
-        for (output, metadata, timestamp, expected) in [
-            (
-                malformed_json.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                ptr::null(),
-                malformed_json.as_ptr(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                ptr::null(),
-                ptr::null(),
-                ptr::from_ref(&invalid_timestamp),
-                NemoRelayStatus::InvalidArg,
-            ),
-        ] {
+        for (output, metadata, timestamp, expected) in fixtures.pop_scope_cases() {
             assert_status!(
                 api::nemo_relay_pop_scope(scope, output, metadata, timestamp),
                 expected
             );
         }
 
-        let event_name = cstring("ffi_integration_validation_event");
-        let invalid_schema = cstring(r#"{"name":1,"version":false}"#);
-        for (schema, metadata) in [
-            (malformed_json.as_ptr(), ptr::null()),
-            (invalid_schema.as_ptr(), ptr::null()),
-            (ptr::null(), malformed_json.as_ptr()),
-        ] {
+        let event_name = &fixtures.event_name;
+        assert_status!(
+            api::nemo_relay_event_v2(
+                invalid,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidUtf8
+        );
+        for (data, schema, metadata) in fixtures.event_json_cases() {
             assert_status!(
                 api::nemo_relay_event_v2(
                     event_name.as_ptr(),
                     scope,
-                    ptr::null(),
+                    data,
                     schema,
                     metadata,
                     ptr::null(),
@@ -1335,71 +1326,15 @@ fn test_ffi_lifecycle_validation_paths_from_integration_binary() {
             NemoRelayStatus::InvalidArg
         );
 
-        let metric_name = cstring("ffi_integration_validation_metric");
-        let measurements = cstring(
-            r#"[{"name":"example.validation.value","kind":"counter","value_type":"u64","value":1}]"#,
-        );
-        let wrong_shape = cstring(r#"{"name":"not-an-array"}"#);
-        for (name, values, metadata, timestamp, expected) in [
-            (
-                invalid,
-                measurements.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::InvalidUtf8,
-            ),
-            (
-                metric_name.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::NullPointer,
-            ),
-            (
-                metric_name.as_ptr(),
-                wrong_shape.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                metric_name.as_ptr(),
-                measurements.as_ptr(),
-                malformed_json.as_ptr(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                metric_name.as_ptr(),
-                measurements.as_ptr(),
-                ptr::null(),
-                ptr::from_ref(&invalid_timestamp),
-                NemoRelayStatus::InvalidArg,
-            ),
-        ] {
+        let metric_name = &fixtures.metric_name;
+        for (name, values, metadata, timestamp, expected) in fixtures.metric_json_cases() {
             assert_status!(
                 api::nemo_relay_metric_json(name, scope, values, metadata, timestamp),
                 expected
             );
         }
 
-        let instrument_name = cstring("example.integration.validation");
-        let unit = cstring("{item}");
-        let description = cstring("integration validation");
-        let attributes = cstring(r#"{"source":"integration"}"#);
-        let base_measurement = types::NemoRelayMetricMeasurement {
-            name: instrument_name.as_ptr(),
-            kind: types::NEMO_RELAY_METRIC_KIND_COUNTER,
-            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_I64,
-            u64_value: 0,
-            i64_value: -7,
-            f64_value: 0.0,
-            unit: unit.as_ptr(),
-            description: description.as_ptr(),
-            attributes_json: attributes.as_ptr(),
-            boundaries: ptr::null(),
-            boundaries_len: 0,
-        };
+        let base_measurement = fixtures.base_measurement();
         assert_status!(
             api::nemo_relay_metric(
                 metric_name.as_ptr(),
@@ -1437,13 +1372,12 @@ fn test_ffi_lifecycle_validation_paths_from_integration_binary() {
                 NemoRelayStatus::InvalidUtf8
             );
         }
-        let boundaries = [0.0, 1.0, 10.0];
         let histogram = types::NemoRelayMetricMeasurement {
             kind: types::NEMO_RELAY_METRIC_KIND_HISTOGRAM,
             value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_F64,
             f64_value: 2.5,
-            boundaries: boundaries.as_ptr(),
-            boundaries_len: boundaries.len(),
+            boundaries: fixtures.boundaries.as_ptr(),
+            boundaries_len: fixtures.boundaries.len(),
             ..base_measurement
         };
         assert_status!(
@@ -1457,18 +1391,7 @@ fn test_ffi_lifecycle_validation_paths_from_integration_binary() {
             ),
             NemoRelayStatus::Ok
         );
-        for (metadata, timestamp, expected) in [
-            (
-                malformed_json.as_ptr(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                ptr::null(),
-                ptr::from_ref(&invalid_timestamp),
-                NemoRelayStatus::InvalidArg,
-            ),
-        ] {
+        for (metadata, timestamp, expected) in fixtures.native_metric_status_cases() {
             assert_status!(
                 api::nemo_relay_metric(
                     metric_name.as_ptr(),
@@ -1512,8 +1435,8 @@ fn test_ffi_lifecycle_validation_paths_from_integration_binary() {
             api::nemo_relay_metric_json(
                 metric_name.as_ptr(),
                 scope,
-                measurements.as_ptr(),
-                ptr::null(),
+                fixtures.measurements.as_ptr(),
+                fixtures.metadata.as_ptr(),
                 ptr::null(),
             ),
             NemoRelayStatus::Ok
@@ -1834,6 +1757,11 @@ fn test_ffi_otel_projection_validation_from_integration_binary() {
             NemoRelayStatus::NullPointer
         );
         assert_status!(
+            nemo_relay_otel_subscriber_runtime_diagnostics_json(subscriber, &mut diagnostics),
+            NemoRelayStatus::Ok
+        );
+        assert!(returned_json(diagnostics).is_array());
+        assert_status!(
             nemo_relay_otel_subscriber_shutdown(subscriber),
             NemoRelayStatus::Ok
         );
@@ -1869,6 +1797,20 @@ fn test_ffi_observability_component_and_atof_validation_from_integration_binary(
             ),
             NemoRelayStatus::InvalidJson
         );
+        assert_status!(
+            nemo_relay_observability_default_config_json(&mut out_json),
+            NemoRelayStatus::Ok
+        );
+        let valid_config = cstring(&take_string(out_json).expect("expected default config JSON"));
+        assert_status!(
+            nemo_relay_observability_component_spec_json(
+                valid_config.as_ptr(),
+                true,
+                &mut out_json,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert_eq!(returned_json(out_json)["kind"], json!("observability"));
 
         let valid_atof_config = cstring(r#"{"type":"file","filename":"events.jsonl"}"#);
         let invalid_atof_config = cstring(r#"{"mode":17}"#);
@@ -1898,6 +1840,16 @@ fn test_ffi_observability_component_and_atof_validation_from_integration_binary(
         assert_status!(
             nemo_relay_atof_exporter_path(exporter, ptr::null_mut()),
             NemoRelayStatus::NullPointer
+        );
+        let mut path = ptr::null_mut();
+        assert_status!(
+            nemo_relay_atof_exporter_path(exporter, &mut path),
+            NemoRelayStatus::Ok
+        );
+        let path = take_string(path).expect("expected ATOF exporter path");
+        assert!(
+            path.ends_with("events.jsonl"),
+            "unexpected exporter path: {path}"
         );
         let invalid_utf8 = [0xffu8, 0];
         let invalid = invalid_utf8.as_ptr() as *const c_char;
@@ -1930,109 +1882,74 @@ fn test_ffi_typed_otel_signal_options_from_integration_binary() {
         let instrumentation_scope = cstring("ffi.integration");
         let minimum_severity = cstring("warn");
         let temporality = cstring("delta");
-        let invalid_utf8 = [0xffu8, 0];
-        let invalid = invalid_utf8.as_ptr() as *const c_char;
-
-        let mut log_subscriber = ptr::null_mut();
-        assert_status!(
-            nemo_relay_otel_log_subscriber_create(
-                transport.as_ptr(),
-                log_endpoint.as_ptr(),
-                headers.as_ptr(),
-                resources.as_ptr(),
-                service_name.as_ptr(),
-                service_namespace.as_ptr(),
-                service_version.as_ptr(),
-                instrumentation_scope.as_ptr(),
-                250,
-                minimum_severity.as_ptr(),
-                64,
-                16,
-                10,
-                &mut log_subscriber,
-            ),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_register(log_subscriber, invalid),
-            NemoRelayStatus::InvalidUtf8
-        );
+        let fixtures = ValidationFixtures::new("typed_otel_integration");
+        let invalid = fixtures.invalid_utf8();
         let log_name = cstring(&unique_name("ffi_typed_log_integration"));
-        assert_status!(
-            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
-            NemoRelayStatus::Ok
+        assert_otel_signal_lifecycle(
+            &log_name,
+            |out| {
+                nemo_relay_otel_log_subscriber_create(
+                    transport.as_ptr(),
+                    log_endpoint.as_ptr(),
+                    headers.as_ptr(),
+                    resources.as_ptr(),
+                    service_name.as_ptr(),
+                    service_namespace.as_ptr(),
+                    service_version.as_ptr(),
+                    instrumentation_scope.as_ptr(),
+                    250,
+                    minimum_severity.as_ptr(),
+                    64,
+                    16,
+                    10,
+                    out,
+                )
+            },
+            |subscriber| {
+                assert_status!(
+                    nemo_relay_otel_log_subscriber_register(subscriber, invalid),
+                    NemoRelayStatus::InvalidUtf8
+                );
+            },
+            |subscriber, name| nemo_relay_otel_log_subscriber_register(subscriber, name),
+            |name| nemo_relay_otel_log_subscriber_deregister(name),
+            |subscriber| nemo_relay_otel_log_subscriber_shutdown(subscriber),
+            |subscriber| nemo_relay_otel_log_subscriber_force_flush(subscriber),
+            |subscriber| types::nemo_relay_otel_log_subscriber_free(subscriber),
         );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
-            NemoRelayStatus::Internal
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_deregister(log_name.as_ptr()),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_force_flush(log_subscriber),
-            NemoRelayStatus::Internal
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
-            NemoRelayStatus::Internal
-        );
-        types::nemo_relay_otel_log_subscriber_free(log_subscriber);
 
-        let mut metric_subscriber = ptr::null_mut();
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_create(
-                transport.as_ptr(),
-                metric_endpoint.as_ptr(),
-                headers.as_ptr(),
-                resources.as_ptr(),
-                service_name.as_ptr(),
-                service_namespace.as_ptr(),
-                service_version.as_ptr(),
-                instrumentation_scope.as_ptr(),
-                250,
-                20,
-                temporality.as_ptr(),
-                256,
-                128,
-                &mut metric_subscriber,
-            ),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_register(metric_subscriber, invalid),
-            NemoRelayStatus::InvalidUtf8
-        );
         let metric_name = cstring(&unique_name("ffi_typed_metric_integration"));
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
-            NemoRelayStatus::Ok
+        assert_otel_signal_lifecycle(
+            &metric_name,
+            |out| {
+                nemo_relay_otel_metric_subscriber_create(
+                    transport.as_ptr(),
+                    metric_endpoint.as_ptr(),
+                    headers.as_ptr(),
+                    resources.as_ptr(),
+                    service_name.as_ptr(),
+                    service_namespace.as_ptr(),
+                    service_version.as_ptr(),
+                    instrumentation_scope.as_ptr(),
+                    250,
+                    20,
+                    temporality.as_ptr(),
+                    256,
+                    128,
+                    out,
+                )
+            },
+            |subscriber| {
+                assert_status!(
+                    nemo_relay_otel_metric_subscriber_register(subscriber, invalid),
+                    NemoRelayStatus::InvalidUtf8
+                );
+            },
+            |subscriber, name| nemo_relay_otel_metric_subscriber_register(subscriber, name),
+            |name| nemo_relay_otel_metric_subscriber_deregister(name),
+            |subscriber| nemo_relay_otel_metric_subscriber_shutdown(subscriber),
+            |subscriber| nemo_relay_otel_metric_subscriber_force_flush(subscriber),
+            |subscriber| types::nemo_relay_otel_metric_subscriber_free(subscriber),
         );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
-            NemoRelayStatus::Internal
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_deregister(metric_name.as_ptr()),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_force_flush(metric_subscriber),
-            NemoRelayStatus::Internal
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
-            NemoRelayStatus::Internal
-        );
-        types::nemo_relay_otel_metric_subscriber_free(metric_subscriber);
     }
 }

--- a/crates/ffi/tests/integration/api_tests.rs
+++ b/crates/ffi/tests/integration/api_tests.rs
@@ -649,6 +649,9 @@ unsafe extern "C" fn plugin_register_fail_with_last_error(
 
 #[path = "../unit/api/core_tests.rs"]
 mod core_tests;
+#[path = "../support/ffi_coverage.rs"]
+mod ffi_coverage_support;
+
 #[path = "api/coverage_sweeps_tests.rs"]
 mod coverage_sweeps_tests;
 #[path = "../unit/api/execution_tests.rs"]

--- a/crates/ffi/tests/support/ffi_coverage.rs
+++ b/crates/ffi/tests/support/ffi_coverage.rs
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared fixtures and lifecycle assertions for FFI coverage tests.
+
+use std::ffi::{CStr, CString, c_char};
+use std::ptr;
+
+use super::{NemoRelayStatus, types};
+
+pub(crate) struct ValidationFixtures {
+    pub(crate) scope_name: CString,
+    pub(crate) event_name: CString,
+    pub(crate) metric_name: CString,
+    pub(crate) instrument_name: CString,
+    pub(crate) unit: CString,
+    pub(crate) description: CString,
+    pub(crate) attributes: CString,
+    pub(crate) metadata: CString,
+    pub(crate) malformed_json: CString,
+    pub(crate) invalid_schema: CString,
+    pub(crate) measurements: CString,
+    pub(crate) invalid_measurements_shape: CString,
+    invalid_utf8: [u8; 2],
+    pub(crate) invalid_timestamp: i64,
+    pub(crate) boundaries: [f64; 3],
+}
+
+impl ValidationFixtures {
+    pub(crate) fn new(label: &str) -> Self {
+        Self {
+            scope_name: CString::new(format!("ffi_{label}_validation_scope")).unwrap(),
+            event_name: CString::new(format!("ffi_{label}_validation_event")).unwrap(),
+            metric_name: CString::new(format!("ffi_{label}_validation_metric")).unwrap(),
+            instrument_name: CString::new("example.validation.value").unwrap(),
+            unit: CString::new("{item}").unwrap(),
+            description: CString::new("validation sweep").unwrap(),
+            attributes: CString::new(r#"{"source":"ffi"}"#).unwrap(),
+            metadata: CString::new(r#"{"test":true}"#).unwrap(),
+            malformed_json: CString::new("{").unwrap(),
+            invalid_schema: CString::new(r#"{"name":1,"version":false}"#).unwrap(),
+            measurements: CString::new(
+                r#"[{"name":"example.validation.value","kind":"counter","value_type":"u64","value":1}]"#,
+            )
+            .unwrap(),
+            invalid_measurements_shape: CString::new(r#"{"name":"not-an-array"}"#).unwrap(),
+            invalid_utf8: [0xff, 0],
+            invalid_timestamp: i64::MAX,
+            boundaries: [0.0, 1.0, 10.0],
+        }
+    }
+
+    pub(crate) fn invalid_utf8(&self) -> *const c_char {
+        self.invalid_utf8.as_ptr().cast()
+    }
+
+    pub(crate) fn push_scope_json_cases(
+        &self,
+    ) -> [(*const c_char, *const c_char, *const c_char); 3] {
+        [
+            (self.malformed_json.as_ptr(), ptr::null(), ptr::null()),
+            (ptr::null(), self.malformed_json.as_ptr(), ptr::null()),
+            (ptr::null(), ptr::null(), self.malformed_json.as_ptr()),
+        ]
+    }
+
+    pub(crate) fn pop_scope_cases(
+        &self,
+    ) -> [(*const c_char, *const c_char, *const i64, NemoRelayStatus); 3] {
+        [
+            (
+                self.malformed_json.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                self.malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&self.invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ]
+    }
+
+    pub(crate) fn event_json_cases(&self) -> [(*const c_char, *const c_char, *const c_char); 4] {
+        [
+            (self.malformed_json.as_ptr(), ptr::null(), ptr::null()),
+            (ptr::null(), self.malformed_json.as_ptr(), ptr::null()),
+            (ptr::null(), self.invalid_schema.as_ptr(), ptr::null()),
+            (ptr::null(), ptr::null(), self.malformed_json.as_ptr()),
+        ]
+    }
+
+    pub(crate) fn metric_json_cases(
+        &self,
+    ) -> [(
+        *const c_char,
+        *const c_char,
+        *const c_char,
+        *const i64,
+        NemoRelayStatus,
+    ); 6] {
+        [
+            (
+                self.invalid_utf8(),
+                self.measurements.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidUtf8,
+            ),
+            (
+                self.metric_name.as_ptr(),
+                self.malformed_json.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                self.metric_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::NullPointer,
+            ),
+            (
+                self.metric_name.as_ptr(),
+                self.invalid_measurements_shape.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                self.metric_name.as_ptr(),
+                self.measurements.as_ptr(),
+                self.malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                self.metric_name.as_ptr(),
+                self.measurements.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&self.invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ]
+    }
+
+    pub(crate) fn base_measurement(&self) -> types::NemoRelayMetricMeasurement {
+        types::NemoRelayMetricMeasurement {
+            name: self.instrument_name.as_ptr(),
+            kind: types::NEMO_RELAY_METRIC_KIND_COUNTER,
+            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_I64,
+            u64_value: 0,
+            i64_value: -7,
+            f64_value: 0.0,
+            unit: self.unit.as_ptr(),
+            description: self.description.as_ptr(),
+            attributes_json: self.attributes.as_ptr(),
+            boundaries: ptr::null(),
+            boundaries_len: 0,
+        }
+    }
+
+    pub(crate) fn native_metric_status_cases(
+        &self,
+    ) -> [(*const c_char, *const i64, NemoRelayStatus); 2] {
+        [
+            (
+                self.malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                ptr::from_ref(&self.invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ]
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn assert_otel_signal_lifecycle<H>(
+    name: &CStr,
+    create: impl FnOnce(*mut *mut H) -> NemoRelayStatus,
+    after_create: impl FnOnce(*mut H),
+    register: impl Fn(*const H, *const c_char) -> NemoRelayStatus,
+    deregister: impl Fn(*const c_char) -> NemoRelayStatus,
+    shutdown: impl Fn(*const H) -> NemoRelayStatus,
+    force_flush: impl Fn(*const H) -> NemoRelayStatus,
+    free: impl FnOnce(*mut H),
+) {
+    let mut subscriber = ptr::null_mut();
+    assert_eq!(create(&mut subscriber), NemoRelayStatus::Ok);
+    assert!(!subscriber.is_null());
+    after_create(subscriber);
+    assert_eq!(register(subscriber, name.as_ptr()), NemoRelayStatus::Ok);
+    assert_eq!(
+        register(subscriber, name.as_ptr()),
+        NemoRelayStatus::Internal
+    );
+    assert_eq!(deregister(name.as_ptr()), NemoRelayStatus::Ok);
+    assert_eq!(shutdown(subscriber), NemoRelayStatus::Ok);
+    assert_eq!(force_flush(subscriber), NemoRelayStatus::Internal);
+    assert_eq!(shutdown(subscriber), NemoRelayStatus::Internal);
+    free(subscriber);
+}

--- a/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
@@ -3,6 +3,7 @@
 
 //! Unit tests for coverage sweeps in the NeMo Relay FFI crate.
 
+use super::ffi_coverage_support::{ValidationFixtures, assert_otel_signal_lifecycle};
 use super::*;
 
 const RUNTIME_OWNER_ENV: &str = "NEMO_RELAY_RUNTIME_OWNER";
@@ -2808,17 +2809,20 @@ fn test_ffi_adaptive_runtime_and_cache_helper_paths() {
             ),
             NemoRelayStatus::Ok
         );
+        let facts = returned_json(out_json);
+        assert_eq!(facts["provider"], "openai");
+        assert_eq!(facts["missing_facts"][0], "acg_stability_unavailable");
+
+        let mut null_runtime_json = ptr::null_mut();
         assert_status!(
             nemo_relay_adaptive_runtime_build_cache_request_facts(
                 ptr::null_mut(),
                 cache_facts_options.as_ptr(),
-                &mut out_json,
+                &mut null_runtime_json,
             ),
             NemoRelayStatus::NullPointer
         );
-        let facts = returned_json(out_json);
-        assert_eq!(facts["provider"], "openai");
-        assert_eq!(facts["missing_facts"][0], "acg_stability_unavailable");
+        assert!(null_runtime_json.is_null());
 
         for (options, expected) in [
             (
@@ -3478,18 +3482,14 @@ fn test_ffi_scope_event_and_metric_validation_sweeps() {
 
     unsafe {
         let stack = fresh_scope_stack();
-        let invalid_utf8 = [0xffu8, 0];
-        let invalid = invalid_utf8.as_ptr() as *const c_char;
-        let malformed_json = cstring("{");
-        let metric_name = cstring("ffi_metric_validation_sweep");
-        let event_name = cstring("ffi_event_validation_sweep");
-        let scope_name = cstring("ffi_scope_validation_sweep");
-        let instrument_name = cstring("example.validation.value");
-        let unit = cstring("{item}");
-        let description = cstring("validation sweep");
-        let attributes = cstring(r#"{"source":"ffi"}"#);
-        let metadata = cstring(r#"{"test":true}"#);
-        let invalid_timestamp = i64::MAX;
+        let fixtures = ValidationFixtures::new("unit");
+        let invalid = fixtures.invalid_utf8();
+        let malformed_json = &fixtures.malformed_json;
+        let metric_name = &fixtures.metric_name;
+        let event_name = &fixtures.event_name;
+        let scope_name = &fixtures.scope_name;
+        let metadata = &fixtures.metadata;
+        let invalid_timestamp = fixtures.invalid_timestamp;
 
         assert_status!(
             api::nemo_relay_get_handle(ptr::null_mut()),
@@ -3511,11 +3511,7 @@ fn test_ffi_scope_event_and_metric_validation_sweeps() {
         );
 
         let mut scope = ptr::null_mut();
-        for (data, metadata, input) in [
-            (malformed_json.as_ptr(), ptr::null(), ptr::null()),
-            (ptr::null(), malformed_json.as_ptr(), ptr::null()),
-            (ptr::null(), ptr::null(), malformed_json.as_ptr()),
-        ] {
+        for (data, metadata, input) in fixtures.push_scope_json_cases() {
             assert_status!(
                 api::nemo_relay_push_scope(
                     scope_name.as_ptr(),
@@ -3564,33 +3560,13 @@ fn test_ffi_scope_event_and_metric_validation_sweeps() {
             api::nemo_relay_pop_scope(ptr::null(), ptr::null(), ptr::null(), ptr::null()),
             NemoRelayStatus::NullPointer
         );
-        for (output, metadata, timestamp, expected) in [
-            (
-                malformed_json.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                ptr::null(),
-                malformed_json.as_ptr(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                ptr::null(),
-                ptr::null(),
-                ptr::from_ref(&invalid_timestamp),
-                NemoRelayStatus::InvalidArg,
-            ),
-        ] {
+        for (output, metadata, timestamp, expected) in fixtures.pop_scope_cases() {
             assert_status!(
                 api::nemo_relay_pop_scope(scope, output, metadata, timestamp),
                 expected
             );
         }
 
-        let invalid_schema = cstring(r#"{"name":1,"version":false}"#);
         assert_status!(
             api::nemo_relay_event_v2(
                 invalid,
@@ -3603,12 +3579,7 @@ fn test_ffi_scope_event_and_metric_validation_sweeps() {
             ),
             NemoRelayStatus::InvalidUtf8
         );
-        for (data, schema, event_metadata) in [
-            (malformed_json.as_ptr(), ptr::null(), ptr::null()),
-            (ptr::null(), malformed_json.as_ptr(), ptr::null()),
-            (ptr::null(), invalid_schema.as_ptr(), ptr::null()),
-            (ptr::null(), ptr::null(), malformed_json.as_ptr()),
-        ] {
+        for (data, schema, event_metadata) in fixtures.event_json_cases() {
             assert_status!(
                 api::nemo_relay_event_v2(
                     event_name.as_ptr(),
@@ -3635,54 +3606,7 @@ fn test_ffi_scope_event_and_metric_validation_sweeps() {
             NemoRelayStatus::InvalidArg
         );
 
-        let measurements = cstring(
-            r#"[{"name":"example.validation.value","kind":"counter","value_type":"u64","value":1}]"#,
-        );
-        let invalid_measurements_shape = cstring(r#"{"name":"not-an-array"}"#);
-        for (name, values, metric_metadata, timestamp, expected) in [
-            (
-                invalid,
-                measurements.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::InvalidUtf8,
-            ),
-            (
-                metric_name.as_ptr(),
-                malformed_json.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                metric_name.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::NullPointer,
-            ),
-            (
-                metric_name.as_ptr(),
-                invalid_measurements_shape.as_ptr(),
-                ptr::null(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                metric_name.as_ptr(),
-                measurements.as_ptr(),
-                malformed_json.as_ptr(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                metric_name.as_ptr(),
-                measurements.as_ptr(),
-                ptr::null(),
-                ptr::from_ref(&invalid_timestamp),
-                NemoRelayStatus::InvalidArg,
-            ),
-        ] {
+        for (name, values, metric_metadata, timestamp, expected) in fixtures.metric_json_cases() {
             assert_status!(
                 api::nemo_relay_metric_json(name, ptr::null(), values, metric_metadata, timestamp),
                 expected
@@ -3692,26 +3616,14 @@ fn test_ffi_scope_event_and_metric_validation_sweeps() {
             api::nemo_relay_metric_json(
                 metric_name.as_ptr(),
                 scope,
-                measurements.as_ptr(),
+                fixtures.measurements.as_ptr(),
                 metadata.as_ptr(),
                 ptr::null(),
             ),
             NemoRelayStatus::Ok
         );
 
-        let base_measurement = types::NemoRelayMetricMeasurement {
-            name: instrument_name.as_ptr(),
-            kind: types::NEMO_RELAY_METRIC_KIND_COUNTER,
-            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_I64,
-            u64_value: 0,
-            i64_value: -7,
-            f64_value: 0.0,
-            unit: unit.as_ptr(),
-            description: description.as_ptr(),
-            attributes_json: attributes.as_ptr(),
-            boundaries: ptr::null(),
-            boundaries_len: 0,
-        };
+        let base_measurement = fixtures.base_measurement();
         assert_status!(
             api::nemo_relay_metric(
                 invalid,
@@ -3788,13 +3700,12 @@ fn test_ffi_scope_event_and_metric_validation_sweeps() {
             NemoRelayStatus::InvalidJson
         );
 
-        let boundaries = [0.0, 1.0, 10.0];
         let histogram_measurement = types::NemoRelayMetricMeasurement {
             kind: types::NEMO_RELAY_METRIC_KIND_HISTOGRAM,
             value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_F64,
             f64_value: 2.5,
-            boundaries: boundaries.as_ptr(),
-            boundaries_len: boundaries.len(),
+            boundaries: fixtures.boundaries.as_ptr(),
+            boundaries_len: fixtures.boundaries.len(),
             ..base_measurement
         };
         assert_status!(
@@ -3808,18 +3719,7 @@ fn test_ffi_scope_event_and_metric_validation_sweeps() {
             ),
             NemoRelayStatus::Ok
         );
-        for (metric_metadata, timestamp, expected) in [
-            (
-                malformed_json.as_ptr(),
-                ptr::null(),
-                NemoRelayStatus::InvalidJson,
-            ),
-            (
-                ptr::null(),
-                ptr::from_ref(&invalid_timestamp),
-                NemoRelayStatus::InvalidArg,
-            ),
-        ] {
+        for (metric_metadata, timestamp, expected) in fixtures.native_metric_status_cases() {
             assert_status!(
                 api::nemo_relay_metric(
                     metric_name.as_ptr(),
@@ -3860,102 +3760,62 @@ fn test_ffi_otel_signal_subscribers_apply_all_typed_options() {
         let minimum_severity = cstring("warn");
         let temporality = cstring("delta");
 
-        let mut log_subscriber = ptr::null_mut();
-        assert_status!(
-            nemo_relay_otel_log_subscriber_create(
-                transport.as_ptr(),
-                log_endpoint.as_ptr(),
-                headers.as_ptr(),
-                resources.as_ptr(),
-                service_name.as_ptr(),
-                service_namespace.as_ptr(),
-                service_version.as_ptr(),
-                instrumentation_scope.as_ptr(),
-                250,
-                minimum_severity.as_ptr(),
-                64,
-                16,
-                10,
-                &mut log_subscriber,
-            ),
-            NemoRelayStatus::Ok
-        );
-        assert!(!log_subscriber.is_null());
-
         let log_name = cstring(&unique_name("ffi_typed_log_subscriber"));
-        assert_status!(
-            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
-            NemoRelayStatus::Ok
+        assert_otel_signal_lifecycle(
+            &log_name,
+            |out| {
+                nemo_relay_otel_log_subscriber_create(
+                    transport.as_ptr(),
+                    log_endpoint.as_ptr(),
+                    headers.as_ptr(),
+                    resources.as_ptr(),
+                    service_name.as_ptr(),
+                    service_namespace.as_ptr(),
+                    service_version.as_ptr(),
+                    instrumentation_scope.as_ptr(),
+                    250,
+                    minimum_severity.as_ptr(),
+                    64,
+                    16,
+                    10,
+                    out,
+                )
+            },
+            |_| {},
+            |subscriber, name| nemo_relay_otel_log_subscriber_register(subscriber, name),
+            |name| nemo_relay_otel_log_subscriber_deregister(name),
+            |subscriber| nemo_relay_otel_log_subscriber_shutdown(subscriber),
+            |subscriber| nemo_relay_otel_log_subscriber_force_flush(subscriber),
+            |subscriber| types::nemo_relay_otel_log_subscriber_free(subscriber),
         );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
-            NemoRelayStatus::Internal
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_deregister(log_name.as_ptr()),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_force_flush(log_subscriber),
-            NemoRelayStatus::Internal
-        );
-        assert_status!(
-            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
-            NemoRelayStatus::Internal
-        );
-        types::nemo_relay_otel_log_subscriber_free(log_subscriber);
-
-        let mut metric_subscriber = ptr::null_mut();
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_create(
-                transport.as_ptr(),
-                metric_endpoint.as_ptr(),
-                headers.as_ptr(),
-                resources.as_ptr(),
-                service_name.as_ptr(),
-                service_namespace.as_ptr(),
-                service_version.as_ptr(),
-                instrumentation_scope.as_ptr(),
-                250,
-                20,
-                temporality.as_ptr(),
-                256,
-                128,
-                &mut metric_subscriber,
-            ),
-            NemoRelayStatus::Ok
-        );
-        assert!(!metric_subscriber.is_null());
 
         let metric_name = cstring(&unique_name("ffi_typed_metric_subscriber"));
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
-            NemoRelayStatus::Ok
+        assert_otel_signal_lifecycle(
+            &metric_name,
+            |out| {
+                nemo_relay_otel_metric_subscriber_create(
+                    transport.as_ptr(),
+                    metric_endpoint.as_ptr(),
+                    headers.as_ptr(),
+                    resources.as_ptr(),
+                    service_name.as_ptr(),
+                    service_namespace.as_ptr(),
+                    service_version.as_ptr(),
+                    instrumentation_scope.as_ptr(),
+                    250,
+                    20,
+                    temporality.as_ptr(),
+                    256,
+                    128,
+                    out,
+                )
+            },
+            |_| {},
+            |subscriber, name| nemo_relay_otel_metric_subscriber_register(subscriber, name),
+            |name| nemo_relay_otel_metric_subscriber_deregister(name),
+            |subscriber| nemo_relay_otel_metric_subscriber_shutdown(subscriber),
+            |subscriber| nemo_relay_otel_metric_subscriber_force_flush(subscriber),
+            |subscriber| types::nemo_relay_otel_metric_subscriber_free(subscriber),
         );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
-            NemoRelayStatus::Internal
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_deregister(metric_name.as_ptr()),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
-            NemoRelayStatus::Ok
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_force_flush(metric_subscriber),
-            NemoRelayStatus::Internal
-        );
-        assert_status!(
-            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
-            NemoRelayStatus::Internal
-        );
-        types::nemo_relay_otel_metric_subscriber_free(metric_subscriber);
     }
 }

--- a/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
@@ -2682,6 +2682,27 @@ fn test_ffi_adaptive_runtime_and_cache_helper_paths() {
         let mut out_json = ptr::null_mut();
 
         assert_status!(
+            nemo_relay_adaptive_runtime_register(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_adaptive_runtime_deregister(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_adaptive_runtime_shutdown(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_adaptive_runtime_wait_for_idle(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            nemo_relay_adaptive_runtime_report_json(ptr::null_mut(), &mut out_json),
+            NemoRelayStatus::NullPointer
+        );
+
+        assert_status!(
             nemo_relay_adaptive_validate_config(ptr::null(), &mut out_json),
             NemoRelayStatus::InvalidJson
         );
@@ -2756,6 +2777,10 @@ fn test_ffi_adaptive_runtime_and_cache_helper_paths() {
             nemo_relay_adaptive_runtime_bind_scope(runtime, scope),
             NemoRelayStatus::Ok
         );
+        assert_status!(
+            nemo_relay_adaptive_runtime_bind_scope(ptr::null_mut(), scope),
+            NemoRelayStatus::NullPointer
+        );
 
         let cache_facts_options = cstring(
             &json!({
@@ -2782,6 +2807,14 @@ fn test_ffi_adaptive_runtime_and_cache_helper_paths() {
                 &mut out_json,
             ),
             NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_adaptive_runtime_build_cache_request_facts(
+                ptr::null_mut(),
+                cache_facts_options.as_ptr(),
+                &mut out_json,
+            ),
+            NemoRelayStatus::NullPointer
         );
         let facts = returned_json(out_json);
         assert_eq!(facts["provider"], "openai");
@@ -3435,5 +3468,494 @@ fn test_ffi_observability_component_and_constructor_error_paths() {
             ),
             NemoRelayStatus::InvalidArg
         );
+    }
+}
+
+#[test]
+fn test_ffi_scope_event_and_metric_validation_sweeps() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let stack = fresh_scope_stack();
+        let invalid_utf8 = [0xffu8, 0];
+        let invalid = invalid_utf8.as_ptr() as *const c_char;
+        let malformed_json = cstring("{");
+        let metric_name = cstring("ffi_metric_validation_sweep");
+        let event_name = cstring("ffi_event_validation_sweep");
+        let scope_name = cstring("ffi_scope_validation_sweep");
+        let instrument_name = cstring("example.validation.value");
+        let unit = cstring("{item}");
+        let description = cstring("validation sweep");
+        let attributes = cstring(r#"{"source":"ffi"}"#);
+        let metadata = cstring(r#"{"test":true}"#);
+        let invalid_timestamp = i64::MAX;
+
+        assert_status!(
+            api::nemo_relay_get_handle(ptr::null_mut()),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            api::nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Custom,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null_mut(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+
+        let mut scope = ptr::null_mut();
+        for (data, metadata, input) in [
+            (malformed_json.as_ptr(), ptr::null(), ptr::null()),
+            (ptr::null(), malformed_json.as_ptr(), ptr::null()),
+            (ptr::null(), ptr::null(), malformed_json.as_ptr()),
+        ] {
+            assert_status!(
+                api::nemo_relay_push_scope(
+                    scope_name.as_ptr(),
+                    NemoRelayScopeType::Custom,
+                    ptr::null(),
+                    0,
+                    data,
+                    metadata,
+                    input,
+                    ptr::null(),
+                    &mut scope,
+                ),
+                NemoRelayStatus::InvalidJson
+            );
+        }
+        assert_status!(
+            api::nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Custom,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+                &mut scope,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+        assert_status!(
+            api::nemo_relay_push_scope(
+                scope_name.as_ptr(),
+                NemoRelayScopeType::Custom,
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut scope,
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        assert_status!(
+            api::nemo_relay_pop_scope(ptr::null(), ptr::null(), ptr::null(), ptr::null()),
+            NemoRelayStatus::NullPointer
+        );
+        for (output, metadata, timestamp, expected) in [
+            (
+                malformed_json.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ] {
+            assert_status!(
+                api::nemo_relay_pop_scope(scope, output, metadata, timestamp),
+                expected
+            );
+        }
+
+        let invalid_schema = cstring(r#"{"name":1,"version":false}"#);
+        assert_status!(
+            api::nemo_relay_event_v2(
+                invalid,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidUtf8
+        );
+        for (data, schema, event_metadata) in [
+            (malformed_json.as_ptr(), ptr::null(), ptr::null()),
+            (ptr::null(), malformed_json.as_ptr(), ptr::null()),
+            (ptr::null(), invalid_schema.as_ptr(), ptr::null()),
+            (ptr::null(), ptr::null(), malformed_json.as_ptr()),
+        ] {
+            assert_status!(
+                api::nemo_relay_event_v2(
+                    event_name.as_ptr(),
+                    scope,
+                    data,
+                    schema,
+                    event_metadata,
+                    ptr::null(),
+                    ptr::null(),
+                ),
+                NemoRelayStatus::InvalidJson
+            );
+        }
+        assert_status!(
+            api::nemo_relay_event_v2(
+                event_name.as_ptr(),
+                scope,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+
+        let measurements = cstring(
+            r#"[{"name":"example.validation.value","kind":"counter","value_type":"u64","value":1}]"#,
+        );
+        let invalid_measurements_shape = cstring(r#"{"name":"not-an-array"}"#);
+        for (name, values, metric_metadata, timestamp, expected) in [
+            (
+                invalid,
+                measurements.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidUtf8,
+            ),
+            (
+                metric_name.as_ptr(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::NullPointer,
+            ),
+            (
+                metric_name.as_ptr(),
+                invalid_measurements_shape.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                metric_name.as_ptr(),
+                measurements.as_ptr(),
+                malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                metric_name.as_ptr(),
+                measurements.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ] {
+            assert_status!(
+                api::nemo_relay_metric_json(name, ptr::null(), values, metric_metadata, timestamp),
+                expected
+            );
+        }
+        assert_status!(
+            api::nemo_relay_metric_json(
+                metric_name.as_ptr(),
+                scope,
+                measurements.as_ptr(),
+                metadata.as_ptr(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+
+        let base_measurement = types::NemoRelayMetricMeasurement {
+            name: instrument_name.as_ptr(),
+            kind: types::NEMO_RELAY_METRIC_KIND_COUNTER,
+            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_I64,
+            u64_value: 0,
+            i64_value: -7,
+            f64_value: 0.0,
+            unit: unit.as_ptr(),
+            description: description.as_ptr(),
+            attributes_json: attributes.as_ptr(),
+            boundaries: ptr::null(),
+            boundaries_len: 0,
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                invalid,
+                ptr::null(),
+                ptr::from_ref(&base_measurement),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidUtf8
+        );
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::NullPointer
+        );
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                0,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+
+        for measurement in [
+            types::NemoRelayMetricMeasurement {
+                name: invalid,
+                ..base_measurement
+            },
+            types::NemoRelayMetricMeasurement {
+                unit: invalid,
+                ..base_measurement
+            },
+            types::NemoRelayMetricMeasurement {
+                description: invalid,
+                ..base_measurement
+            },
+        ] {
+            assert_status!(
+                api::nemo_relay_metric(
+                    metric_name.as_ptr(),
+                    ptr::null(),
+                    ptr::from_ref(&measurement),
+                    1,
+                    ptr::null(),
+                    ptr::null(),
+                ),
+                NemoRelayStatus::InvalidUtf8
+            );
+        }
+        let invalid_attributes = types::NemoRelayMetricMeasurement {
+            attributes_json: malformed_json.as_ptr(),
+            ..base_measurement
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                ptr::null(),
+                ptr::from_ref(&invalid_attributes),
+                1,
+                ptr::null(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::InvalidJson
+        );
+
+        let boundaries = [0.0, 1.0, 10.0];
+        let histogram_measurement = types::NemoRelayMetricMeasurement {
+            kind: types::NEMO_RELAY_METRIC_KIND_HISTOGRAM,
+            value_type: types::NEMO_RELAY_METRIC_VALUE_TYPE_F64,
+            f64_value: 2.5,
+            boundaries: boundaries.as_ptr(),
+            boundaries_len: boundaries.len(),
+            ..base_measurement
+        };
+        assert_status!(
+            api::nemo_relay_metric(
+                metric_name.as_ptr(),
+                scope,
+                ptr::from_ref(&histogram_measurement),
+                1,
+                metadata.as_ptr(),
+                ptr::null(),
+            ),
+            NemoRelayStatus::Ok
+        );
+        for (metric_metadata, timestamp, expected) in [
+            (
+                malformed_json.as_ptr(),
+                ptr::null(),
+                NemoRelayStatus::InvalidJson,
+            ),
+            (
+                ptr::null(),
+                ptr::from_ref(&invalid_timestamp),
+                NemoRelayStatus::InvalidArg,
+            ),
+        ] {
+            assert_status!(
+                api::nemo_relay_metric(
+                    metric_name.as_ptr(),
+                    ptr::null(),
+                    ptr::from_ref(&base_measurement),
+                    1,
+                    metric_metadata,
+                    timestamp,
+                ),
+                expected
+            );
+        }
+
+        assert_status!(
+            api::nemo_relay_pop_scope(scope, ptr::null(), ptr::null(), ptr::null()),
+            NemoRelayStatus::Ok
+        );
+        nemo_relay_scope_handle_free(scope);
+        nemo_relay_scope_stack_free(stack);
+    }
+}
+
+#[test]
+fn test_ffi_otel_signal_subscribers_apply_all_typed_options() {
+    let _lock = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    reset_globals();
+
+    unsafe {
+        let transport = cstring("http_binary");
+        let log_endpoint = cstring("http://127.0.0.1:4318/v1/logs");
+        let metric_endpoint = cstring("http://127.0.0.1:4318/v1/metrics");
+        let headers = cstring(r#"{"authorization":"test-token"}"#);
+        let resources = cstring(r#"{"service.instance.id":"ffi-test"}"#);
+        let service_name = cstring("ffi-coverage");
+        let service_namespace = cstring("nemo-relay");
+        let service_version = cstring("test");
+        let instrumentation_scope = cstring("ffi.coverage");
+        let minimum_severity = cstring("warn");
+        let temporality = cstring("delta");
+
+        let mut log_subscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_log_subscriber_create(
+                transport.as_ptr(),
+                log_endpoint.as_ptr(),
+                headers.as_ptr(),
+                resources.as_ptr(),
+                service_name.as_ptr(),
+                service_namespace.as_ptr(),
+                service_version.as_ptr(),
+                instrumentation_scope.as_ptr(),
+                250,
+                minimum_severity.as_ptr(),
+                64,
+                16,
+                10,
+                &mut log_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert!(!log_subscriber.is_null());
+
+        let log_name = cstring(&unique_name("ffi_typed_log_subscriber"));
+        assert_status!(
+            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_register(log_subscriber, log_name.as_ptr()),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_deregister(log_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_force_flush(log_subscriber),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_log_subscriber_shutdown(log_subscriber),
+            NemoRelayStatus::Internal
+        );
+        types::nemo_relay_otel_log_subscriber_free(log_subscriber);
+
+        let mut metric_subscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_create(
+                transport.as_ptr(),
+                metric_endpoint.as_ptr(),
+                headers.as_ptr(),
+                resources.as_ptr(),
+                service_name.as_ptr(),
+                service_namespace.as_ptr(),
+                service_version.as_ptr(),
+                instrumentation_scope.as_ptr(),
+                250,
+                20,
+                temporality.as_ptr(),
+                256,
+                128,
+                &mut metric_subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert!(!metric_subscriber.is_null());
+
+        let metric_name = cstring(&unique_name("ffi_typed_metric_subscriber"));
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_register(metric_subscriber, metric_name.as_ptr()),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_deregister(metric_name.as_ptr()),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
+            NemoRelayStatus::Ok
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_force_flush(metric_subscriber),
+            NemoRelayStatus::Internal
+        );
+        assert_status!(
+            nemo_relay_otel_metric_subscriber_shutdown(metric_subscriber),
+            NemoRelayStatus::Internal
+        );
+        types::nemo_relay_otel_metric_subscriber_free(metric_subscriber);
     }
 }

--- a/crates/ffi/tests/unit/api_tests.rs
+++ b/crates/ffi/tests/unit/api_tests.rs
@@ -804,6 +804,9 @@ fn ffi_sanitizer_codec_entrypoints_contain_codec_panics() {
 
 #[path = "api/core_tests.rs"]
 mod core_tests;
+#[path = "../support/ffi_coverage.rs"]
+mod ffi_coverage_support;
+
 #[path = "api/coverage_sweeps_tests.rs"]
 mod coverage_sweeps_tests;
 #[path = "api/execution_tests.rs"]

--- a/crates/python/tests/coverage/py_types_coverage_tests.rs
+++ b/crates/python/tests/coverage/py_types_coverage_tests.rs
@@ -7,8 +7,9 @@ use super::*;
 use std::ffi::CString;
 
 use nemo_relay::api::event::{
-    BaseEvent, CategoryProfile, Event, EventCategory, MarkEvent, ScopeCategory, ScopeEvent,
-    llm_attributes_to_strings, scope_attributes_to_strings, tool_attributes_to_strings,
+    BaseEvent, CategoryProfile, Event, EventCategory, LogSeverity, MarkEvent, MetricKind,
+    MetricValueType, ScopeCategory, ScopeEvent, llm_attributes_to_strings,
+    scope_attributes_to_strings, tool_attributes_to_strings,
 };
 use nemo_relay::api::llm::{LlmAttributes, LlmHandle};
 use nemo_relay::api::llm::{LlmCallParams, llm_call, llm_call_end};
@@ -260,6 +261,7 @@ fn test_bitflags_handles_and_event_wrappers_expose_expected_fields() {
                 None,
             )));
             assert_eq!(event.kind(), "mark");
+            assert_eq!(event.atof_version(), "0.1");
             assert_eq!(event.parent_uuid(), Some(parent_uuid.to_string()));
             assert_eq!(
                 py_to_json(event.data(py).unwrap().bind(py)).unwrap(),
@@ -284,6 +286,7 @@ fn test_bitflags_handles_and_event_wrappers_expose_expected_fields() {
                 Some(CategoryProfile::builder().tool_call_id("tool-1").build()),
             )));
             assert_eq!(tool_event.kind(), "scope");
+            assert_eq!(tool_event.atof_version(), "0.1");
             assert_eq!(tool_event.scope_category(), "start");
             assert_eq!(tool_event.category(), "tool");
             assert_eq!(
@@ -1085,6 +1088,221 @@ fn test_python_side_core_type_constructors_cover_exposed_entrypoints() {
             .call1((bad_headers, py.None()))
             .unwrap_err();
         assert!(err.to_string().contains("not an instance of 'dict'"));
+    });
+}
+
+#[test]
+fn test_metric_measurement_and_pending_mark_getters_cover_python_surface() {
+    let _python = crate::test_support::init_python_test();
+    Python::attach(|py| {
+        let module = PyModule::new(py, "_types_metric_mark_getters").unwrap();
+        register(&module).unwrap();
+
+        let metric_kwargs = PyDict::new(py);
+        metric_kwargs.set_item("unit", "tokens").unwrap();
+        metric_kwargs
+            .set_item("description", "generated tokens")
+            .unwrap();
+        metric_kwargs
+            .set_item(
+                "attributes",
+                json_to_py(py, &json!({"model": "demo"})).unwrap(),
+            )
+            .unwrap();
+        metric_kwargs
+            .set_item("boundaries", vec![1.0_f64, 10.0])
+            .unwrap();
+        let metric = module
+            .getattr("MetricMeasurement")
+            .unwrap()
+            .call(
+                (
+                    "relay.tokens",
+                    module
+                        .getattr("MetricKind")
+                        .unwrap()
+                        .getattr("Histogram")
+                        .unwrap(),
+                    module
+                        .getattr("MetricValueType")
+                        .unwrap()
+                        .getattr("U64")
+                        .unwrap(),
+                    7_u64,
+                ),
+                Some(&metric_kwargs),
+            )
+            .unwrap();
+        assert_eq!(
+            metric.getattr("name").unwrap().extract::<String>().unwrap(),
+            "relay.tokens"
+        );
+        assert_eq!(
+            metric.getattr("value").unwrap().extract::<u64>().unwrap(),
+            7
+        );
+        assert_eq!(
+            metric.getattr("unit").unwrap().extract::<String>().unwrap(),
+            "tokens"
+        );
+        assert_eq!(
+            metric
+                .getattr("description")
+                .unwrap()
+                .extract::<String>()
+                .unwrap(),
+            "generated tokens"
+        );
+        assert_eq!(
+            py_to_json(metric.getattr("attributes").unwrap().as_any()).unwrap(),
+            json!({"model": "demo"})
+        );
+        assert_eq!(
+            metric
+                .getattr("boundaries")
+                .unwrap()
+                .extract::<Vec<f64>>()
+                .unwrap(),
+            vec![1.0, 10.0]
+        );
+        assert!(metric.getattr("kind").is_ok());
+        assert!(metric.getattr("value_type").is_ok());
+        assert!(
+            metric
+                .repr()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("relay.tokens")
+        );
+
+        let mark_kwargs = PyDict::new(py);
+        mark_kwargs
+            .set_item(
+                "data",
+                json_to_py(py, &json!({"phase": "execute"})).unwrap(),
+            )
+            .unwrap();
+        mark_kwargs
+            .set_item(
+                "metadata",
+                json_to_py(py, &json!({"trace": "abc"})).unwrap(),
+            )
+            .unwrap();
+        mark_kwargs
+            .set_item(
+                "data_schema",
+                json_to_py(py, &json!({"name": "relay.mark", "version": "1"})).unwrap(),
+            )
+            .unwrap();
+        mark_kwargs
+            .set_item(
+                "severity",
+                module
+                    .getattr("LogSeverity")
+                    .unwrap()
+                    .getattr("Info")
+                    .unwrap(),
+            )
+            .unwrap();
+        let mark = module
+            .getattr("PendingMarkSpec")
+            .unwrap()
+            .call(("relay.execute",), Some(&mark_kwargs))
+            .unwrap();
+        assert_eq!(
+            mark.getattr("name").unwrap().extract::<String>().unwrap(),
+            "relay.execute"
+        );
+        assert!(mark.getattr("category").unwrap().is_none());
+        assert!(mark.getattr("category_profile").unwrap().is_none());
+        assert_eq!(
+            py_to_json(mark.getattr("data").unwrap().as_any()).unwrap(),
+            json!({"phase": "execute"})
+        );
+        assert_eq!(
+            py_to_json(mark.getattr("metadata").unwrap().as_any()).unwrap(),
+            json!({"trace": "abc"})
+        );
+        assert_eq!(
+            py_to_json(mark.getattr("data_schema").unwrap().as_any()).unwrap(),
+            json!({"name": "relay.mark", "version": "1"})
+        );
+        assert!(mark.getattr("severity").is_ok());
+    });
+}
+
+#[test]
+fn test_metric_enum_conversions_and_tool_execution_outcome_getters() {
+    let _python = crate::test_support::init_python_test();
+    for (python, native) in [
+        (PyLogSeverity::Trace, LogSeverity::Trace),
+        (PyLogSeverity::Debug, LogSeverity::Debug),
+        (PyLogSeverity::Error, LogSeverity::Error),
+    ] {
+        assert!(PyLogSeverity::from(native) == python);
+        assert!(LogSeverity::from(python) == native);
+    }
+    for (python, native) in [
+        (PyMetricKind::UpDownCounter, MetricKind::UpDownCounter),
+        (PyMetricKind::Gauge, MetricKind::Gauge),
+        (PyMetricKind::Histogram, MetricKind::Histogram),
+    ] {
+        assert!(PyMetricKind::from(native) == python);
+        assert!(MetricKind::from(python) == native);
+    }
+    for (python, native) in [
+        (PyMetricValueType::I64, MetricValueType::I64),
+        (PyMetricValueType::F64, MetricValueType::F64),
+    ] {
+        assert!(PyMetricValueType::from(native) == python);
+        assert!(MetricValueType::from(python) == native);
+    }
+
+    Python::attach(|py| {
+        let module = PyModule::new(py, "_types_tool_execution_outcome").unwrap();
+        register(&module).unwrap();
+        let mark = module
+            .getattr("PendingMarkSpec")
+            .unwrap()
+            .call1(("relay.execute",))
+            .unwrap();
+        let outcome_kwargs = PyDict::new(py);
+        outcome_kwargs
+            .set_item(
+                "annotation",
+                json_to_py(py, &json!({"source": "coverage"})).unwrap(),
+            )
+            .unwrap();
+        let pending_marks = PyList::new(py, [mark]).unwrap();
+        let outcome = module
+            .getattr("ToolExecutionInterceptOutcome")
+            .unwrap()
+            .call(
+                (json_to_py(py, &json!({"ok": true})).unwrap(), pending_marks),
+                Some(&outcome_kwargs),
+            )
+            .unwrap();
+        assert_eq!(
+            py_to_json(outcome.getattr("result").unwrap().as_any()).unwrap(),
+            json!({"ok": true})
+        );
+        assert_eq!(
+            py_to_json(outcome.getattr("annotation").unwrap().as_any()).unwrap(),
+            json!({"source": "coverage"})
+        );
+        let returned_marks = outcome.getattr("pending_marks").unwrap();
+        assert_eq!(returned_marks.len().unwrap(), 1);
+        assert_eq!(
+            returned_marks
+                .get_item(0)
+                .unwrap()
+                .getattr("name")
+                .unwrap()
+                .extract::<String>()
+                .unwrap(),
+            "relay.execute"
+        );
     });
 }
 

--- a/go/nemo_relay/coverage_gap_test.go
+++ b/go/nemo_relay/coverage_gap_test.go
@@ -275,17 +275,45 @@ func TestRemainingPublicDefaultsAndPropagationCoverage(t *testing.T) {
 		t.Fatal("expected missing scope metadata injector deregistration to fail")
 	}
 
+	expectedMetricTimestamp := time.Unix(1_700_000_000, 0)
+	observedMetricTimestamp := make(chan string, 1)
+	subscriberName := "go_metric_timestamp_coverage_" + time.Now().Format("150405.000000")
+	if err := RegisterSubscriber(subscriberName, func(event Event) {
+		if event.Name() == "go_metric_timestamp_coverage" {
+			observedMetricTimestamp <- event.Timestamp()
+		}
+	}); err != nil {
+		t.Fatalf("RegisterSubscriber failed: %v", err)
+	}
+	defer DeregisterSubscriber(subscriberName)
+
 	runTestWithScopeStack(t, func(t *testing.T) {
 		err := EmitMetric("go_metric_timestamp_coverage", []MetricMeasurement{{
 			Name:      "example.go.timestamp",
 			Kind:      MetricKindCounter,
 			ValueType: MetricValueTypeU64,
 			Value:     uint64(1),
-		}}, WithMetricTimestamp(time.Unix(1_700_000_000, 0)))
+		}}, WithMetricTimestamp(expectedMetricTimestamp))
 		if err != nil {
 			t.Fatalf("EmitMetric with timestamp failed: %v", err)
 		}
+		if err := FlushSubscribers(); err != nil {
+			t.Fatalf("FlushSubscribers failed: %v", err)
+		}
 	})
+
+	select {
+	case timestamp := <-observedMetricTimestamp:
+		observed, err := time.Parse(time.RFC3339Nano, timestamp)
+		if err != nil {
+			t.Fatalf("failed to parse metric timestamp %q: %v", timestamp, err)
+		}
+		if !observed.Equal(expectedMetricTimestamp) {
+			t.Fatalf("metric timestamp = %s, expected %s", observed, expectedMetricTimestamp)
+		}
+	default:
+		t.Fatal("expected metric event with supplied timestamp")
+	}
 }
 
 func assertAdaptiveJSONUnmarshalFailures(t *testing.T) {

--- a/go/nemo_relay/coverage_gap_test.go
+++ b/go/nemo_relay/coverage_gap_test.go
@@ -190,6 +190,104 @@ func TestGoBindingErrorAndDefaultContracts(t *testing.T) {
 	assertOptimizationContributionValidation(t)
 }
 
+func TestRemainingPublicDefaultsAndPropagationCoverage(t *testing.T) {
+	endpoint := "http://127.0.0.1:4318"
+	logConfig, err := normalizeOpenTelemetryLogConfig(OpenTelemetryLogConfig{Endpoint: endpoint})
+	if err != nil {
+		t.Fatalf("normalize log defaults failed: %v", err)
+	}
+	if logConfig.MinimumSeverity != LogSeverityInfo || logConfig.MaxQueueSize != 2048 ||
+		logConfig.MaxExportBatchSize != 512 || logConfig.ScheduledDelay != time.Second ||
+		logConfig.Headers == nil || logConfig.ResourceAttributes == nil {
+		t.Fatalf("log defaults were not applied: %#v", logConfig)
+	}
+
+	metricConfig, err := normalizeOpenTelemetryMetricConfig(OpenTelemetryMetricConfig{Endpoint: endpoint})
+	if err != nil {
+		t.Fatalf("normalize metric defaults failed: %v", err)
+	}
+	if metricConfig.Temporality != OpenTelemetryMetricTemporalityCumulative ||
+		metricConfig.MaxInstruments != 256 || metricConfig.CardinalityLimit != 2000 ||
+		metricConfig.Headers == nil || metricConfig.ResourceAttributes == nil {
+		t.Fatalf("metric defaults were not applied: %#v", metricConfig)
+	}
+
+	for name, normalize := range map[string]func() error{
+		"negative log duration": func() error {
+			_, err := normalizeOpenTelemetryLogConfig(OpenTelemetryLogConfig{
+				Endpoint: endpoint,
+				Timeout:  -time.Millisecond,
+			})
+			return err
+		},
+		"negative metric duration": func() error {
+			_, err := normalizeOpenTelemetryMetricConfig(OpenTelemetryMetricConfig{
+				Endpoint:       endpoint,
+				ExportInterval: -time.Millisecond,
+			})
+			return err
+		},
+	} {
+		if err := normalize(); err == nil {
+			t.Fatalf("%s should fail", name)
+		}
+	}
+
+	oldMarshal := jsonMarshal
+	t.Cleanup(func() { jsonMarshal = oldMarshal })
+	jsonMarshal = func(any) ([]byte, error) {
+		return nil, errors.New("forced signal header marshal failure")
+	}
+	if _, err := newOpenTelemetrySignalCStrings(openTelemetrySignalConfig{endpoint: endpoint}); err == nil {
+		t.Fatal("expected signal header marshal failure")
+	}
+	callCount := 0
+	jsonMarshal = func(value any) ([]byte, error) {
+		callCount++
+		if callCount == 2 {
+			return nil, errors.New("forced signal resource marshal failure")
+		}
+		return oldMarshal(value)
+	}
+	if _, err := newOpenTelemetrySignalCStrings(openTelemetrySignalConfig{endpoint: endpoint}); err == nil {
+		t.Fatal("expected signal resource marshal failure")
+	}
+	jsonMarshal = oldMarshal
+
+	rootUUID := propagationRootUUID
+	context := PropagationContext{
+		Version:    1,
+		RootUUID:   &rootUUID,
+		ParentUUID: propagationParentUUID,
+	}
+	traceparent, err := context.ToTraceparent()
+	if err != nil {
+		t.Fatalf("ToTraceparent failed: %v", err)
+	}
+	if traceparent == "" {
+		t.Fatal("ToTraceparent returned an empty value")
+	}
+	if _, err := (PropagationContext{Version: 2, ParentUUID: propagationParentUUID}).ToTraceparent(); err == nil {
+		t.Fatal("expected invalid propagation context to fail")
+	}
+
+	if err := ScopeDeregisterEventMetadataInjector(propagationParentUUID, "missing-injector"); err == nil {
+		t.Fatal("expected missing scope metadata injector deregistration to fail")
+	}
+
+	runTestWithScopeStack(t, func(t *testing.T) {
+		err := EmitMetric("go_metric_timestamp_coverage", []MetricMeasurement{{
+			Name:      "example.go.timestamp",
+			Kind:      MetricKindCounter,
+			ValueType: MetricValueTypeU64,
+			Value:     uint64(1),
+		}}, WithMetricTimestamp(time.Unix(1_700_000_000, 0)))
+		if err != nil {
+			t.Fatalf("EmitMetric with timestamp failed: %v", err)
+		}
+	})
+}
+
 func assertAdaptiveJSONUnmarshalFailures(t *testing.T) {
 	t.Helper()
 	runtime, err := NewAdaptiveRuntime(testAdaptiveRuntimeConfig("openai"))

--- a/justfile
+++ b/justfile
@@ -1506,7 +1506,10 @@ test-go:
     if is_true "{{ ci }}"; then
         coverage_out="$(prepare_artifact go-coverage.xml)"
         junit_out="$(prepare_artifact go-junit.xml)"
-        go_test_cmd+=(-coverprofile=coverage.out)
+        # Include the root binding package when shorthand-package tests exercise
+        # its delegated implementation so those calls are represented once the
+        # per-package profiles are merged.
+        go_test_cmd+=(-coverprofile=coverage.out -coverpkg=./...)
         if [[ "$is_windows" == true ]]; then
             go_ldflags+=(-w)
         fi


### PR DESCRIPTION
#### Overview

Raises the Codecov Go Binding and Python Binding components above the required 95% gate and stabilizes a concurrency-sensitive core dispatcher test discovered during validation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Expands FFI unit and integration coverage across lifecycle validation, scope and event handling, metrics, observability, and typed OpenTelemetry options.
- Adds Go tests for public defaults, propagation, error paths, metadata injection, and metric timestamps.
- Updates CI Go coverage collection to include delegated package implementations with -coverpkg=./....
- Adds Python native binding coverage for event versions, metric and mark getters, enum conversions, and tool execution outcomes.
- Serializes the metadata-injection coverage test with the existing runtime failure hook to eliminate an intermittent cross-test race.
- Measures the rebased Go Binding component at 95.11% and the Python Binding component at 95.11%.

#### Where should the reviewer start?

Start with the CI coverage command in justfile, then review go/nemo_relay/coverage_gap_test.go and crates/python/tests/coverage/py_types_coverage_tests.rs. The FFI coverage sweeps exercise the native half of the Go Binding component.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for FFI lifecycle operations, validation, error handling, OpenTelemetry, observability, scopes, events, metrics, and subscriber options.
  * Added Python coverage for metric measurements, pending marks, event metadata versions, enum conversions, and tool outcomes.
  * Added Go coverage for propagation, defaults, metadata handling, invalid inputs, and metric emission.
  * Improved test stability for event metadata scenarios.

* **Chores**
  * Updated Go coverage reporting to include the full package surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->