### PR TITLE
fix: synchronize Node example package version

### DIFF
--- a/justfile
+++ b/justfile
@@ -1719,11 +1719,13 @@ package-node:
         echo "Non-release build: appending commit hash to version"
         set_npm_package_version crates/node/package.json package-lock.json "$package_version" crates/node
         set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-relay-node "$package_version"
+        set_npm_package_dependency_version examples/language-binding-plugin/node/package.json package-lock.json examples/language-binding-plugin/node nemo-relay-node "$package_version"
     else
         package_version="{{ ref_name }}"
         echo "Using explicit version {{ ref_name }}"
         set_npm_package_version crates/node/package.json package-lock.json "$package_version" crates/node
         set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-relay-node "$package_version"
+        set_npm_package_dependency_version examples/language-binding-plugin/node/package.json package-lock.json examples/language-binding-plugin/node nemo-relay-node "$package_version"
     fi
     build_args=(build --)
     if [[ -n "$node_target" ]]; then


### PR DESCRIPTION
#### Overview

Synchronize the Node language-binding example workspace dependency with the package version selected by `package-node`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Rewrite the example workspace's `nemo-relay-node` dependency and matching lockfile entry for both release and snapshot Node packaging.
- This prevents npm from requesting the stale `nemo-relay-node@0.8.0` registry package while packaging `0.8.0-rc.1`.

#### Where should the reviewer start?

Review the two dependency-version updates in `justfile`'s `package-node` recipe.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Node packages now consistently reference the correct `nemo-relay-node` dependency version during both standard and explicit-release packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->