### PR TITLE
fix: synchronize OpenClaw package workspace versions

### DIFF
--- a/justfile
+++ b/justfile
@@ -1802,12 +1802,14 @@ package-openclaw:
         set_npm_package_version crates/node/package.json package-lock.json "$package_version" crates/node
         set_npm_package_version integrations/openclaw/package.json package-lock.json "$package_version" integrations/openclaw
         set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-relay-node "$package_version"
+        set_npm_package_dependency_version examples/language-binding-plugin/node/package.json package-lock.json examples/language-binding-plugin/node nemo-relay-node "$package_version"
     else
         package_version="{{ ref_name }}"
         echo "Using explicit version {{ ref_name }}"
         set_npm_package_version crates/node/package.json package-lock.json "$package_version" crates/node
         set_npm_package_version integrations/openclaw/package.json package-lock.json "$package_version" integrations/openclaw
         set_npm_package_dependency_version integrations/openclaw/package.json package-lock.json integrations/openclaw nemo-relay-node "$package_version"
+        set_npm_package_dependency_version examples/language-binding-plugin/node/package.json package-lock.json examples/language-binding-plugin/node nemo-relay-node "$package_version"
     fi
     npm install --workspace=nemo-relay-node --workspace=nemo-relay-openclaw --ignore-scripts
     if is_true "{{ ci }}"; then


### PR DESCRIPTION
#### Overview

Synchronize the Node language-binding example workspace dependency when packaging the OpenClaw plugin.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Rewrite the example workspace's `nemo-relay-node` dependency and its lockfile entry in both `package-openclaw` version paths.
- This prevents npm from requesting stale `nemo-relay-node@0.8.0` while the OpenClaw release package is built with `0.8.0-rc.1`.

#### Where should the reviewer start?

Review the two dependency-version updates in `justfile`'s `package-openclaw` recipe.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated packaged Node language bindings to use the correct `nemo-relay-node` dependency version in both standard and explicit-release packaging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->