### PR TITLE
ci: remove Switchyard from Artifactory publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -268,7 +268,7 @@ publish:artifactory:cargo:
       artifactory = { index = "sparse+${NEMO_RELAY_CI_ARTIFACTORY_CARGO_URL}" }
       EOF
       export CARGO_REGISTRIES_ARTIFACTORY_TOKEN="Bearer ${NEMO_RELAY_CI_ARTIFACTORY_KEY}"
-      export NEMO_RELAY_ARTIFACTORY_CRATE_DIRS="types plugin worker-proto worker core adaptive pii-redaction switchyard ffi cli"
+      export NEMO_RELAY_ARTIFACTORY_CRATE_DIRS="types plugin worker-proto worker core adaptive pii-redaction ffi cli"
 
       crates="$(
         uv run --no-project python - <<'PY'


### PR DESCRIPTION
#### Overview

Remove the stale Switchyard crate from GitLab Artifactory publishing for the 0.8 release branch. GitHub publishing already excludes it.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Removes `switchyard` from `NEMO_RELAY_ARTIFACTORY_CRATE_DIRS`.
- Leaves the remaining release crate order unchanged.

#### Where should the reviewer start?

Review `.gitlab-ci.yml` in the `publish:artifactory:cargo` job, alongside the existing GitHub crates.io package list.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing configuration to exclude the `switchyard` crate while continuing to publish the remaining configured crates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->