### PR TITLE
chore: prepare 0.8 code freeze

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,3 +3,4 @@
 
 branches:
   - main
+  - release/0.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-adaptive"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "log",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-ffi"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-node"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "napi",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-pii-redaction"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "futures",
  "log",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "futures",
  "nemo-relay-types",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-python"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "nemo-relay",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "futures-util",
  "hyper-util",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker-proto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,21 +20,21 @@ exclude = [".tmp", ".uv-cache"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/NeMo-Relay"
 
 [workspace.dependencies]
-nemo-relay = { version = "0.8.0", path = "crates/core", default-features = false }
-nemo-relay-types = { version = "0.8.0", path = "crates/types" }
-nemo-relay-plugin = { version = "0.8.0", path = "crates/plugin" }
-nemo-relay-worker-proto = { version = "0.8.0", path = "crates/worker-proto" }
-nemo-relay-worker = { version = "0.8.0", path = "crates/worker" }
-nemo-relay-adaptive = { version = "0.8.0", path = "crates/adaptive" }
-nemo-relay-pii-redaction = { version = "0.8.0", path = "crates/pii-redaction" }
-nemo-relay-ffi = { version = "0.8.0", path = "crates/ffi" }
-nemo-relay-cli = { version = "0.8.0", path = "crates/cli" }
+nemo-relay = { version = "0.9.0", path = "crates/core", default-features = false }
+nemo-relay-types = { version = "0.9.0", path = "crates/types" }
+nemo-relay-plugin = { version = "0.9.0", path = "crates/plugin" }
+nemo-relay-worker-proto = { version = "0.9.0", path = "crates/worker-proto" }
+nemo-relay-worker = { version = "0.9.0", path = "crates/worker" }
+nemo-relay-adaptive = { version = "0.9.0", path = "crates/adaptive" }
+nemo-relay-pii-redaction = { version = "0.9.0", path = "crates/pii-redaction" }
+nemo-relay-ffi = { version = "0.9.0", path = "crates/ffi" }
+nemo-relay-cli = { version = "0.9.0", path = "crates/cli" }
 opentelemetry = { version = "0.32", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.32.1", default-features = false, features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.32.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ uv add nemo-relay
 
 # Node.js
 # Requires Node.js 24 or newer.
-npm install nemo-relay-node@0.8.0
+npm install nemo-relay-node@0.9.0
 
 # Rust
 cargo add nemo-relay

--- a/crates/core/tests/fixtures/native_plugin/Cargo.lock
+++ b/crates/core/tests/fixtures/native_plugin/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -72,15 +72,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -89,38 +89,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -153,9 +153,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "futures",
  "nemo-relay-types",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/core/tests/fixtures/worker_plugin/Cargo.lock
+++ b/crates/core/tests/fixtures/worker_plugin/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -174,47 +174,47 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -413,9 +413,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -477,7 +477,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "futures-util",
  "hyper-util",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-worker-proto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
 dependencies = [
  "pulldown-cmark",
 ]
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -919,18 +919,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1208,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1218,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/core/tests/unit/plugin_dynamic_tests.rs
+++ b/crates/core/tests/unit/plugin_dynamic_tests.rs
@@ -1943,8 +1943,23 @@ fn dynamic_plugin_relay_compatibility_requires_the_zero_eight_baseline() {
     ] {
         validate_dynamic_plugin_relay_baseline(Some(requirement), "worker")
             .unwrap_or_else(|error| panic!("{requirement} should satisfy the baseline: {error}"));
+    }
+
+    for requirement in [
+        ">=0.8.0",
+        ">=0.8.0,<1.0",
+        ">=0.8.0-alpha,>=0.8.0",
+        ">0.7",
+        ">0.8,<1.0",
+    ] {
         validate_dynamic_plugin_relay_compatibility(Some(requirement), "worker")
             .unwrap_or_else(|error| panic!("{requirement} should be accepted: {error}"));
+    }
+
+    for requirement in ["=0.8", "^0.8", "=0.8.0"] {
+        let error = validate_dynamic_plugin_relay_compatibility(Some(requirement), "worker")
+            .expect_err("a range that excludes the current host should fail");
+        assert!(error.to_string().contains("but host version is"));
     }
 
     for requirement in [

--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-node",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Node.js bindings for the NeMo Relay agent runtime.",
   "keywords": [
     "agents",

--- a/docs/build-plugins/native/build-and-package.mdx
+++ b/docs/build-plugins/native/build-and-package.mdx
@@ -6,7 +6,7 @@ position: 21
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-The repository example builds a `cdylib` against the current 0.8.0 SDK and packages it
+The repository example builds a `cdylib` against the current 0.9.0 SDK and packages it
 with a strict schema. Run every command in this procedure from
 `examples/rust-native-plugin` unless a step says otherwise.
 
@@ -14,10 +14,10 @@ with a strict schema. Run every command in this procedure from
 
 The example crate exposes both `cdylib` and `rlib`. Relay loads the `cdylib`; the `rlib`
 lets the example integration tests call validation helpers without loading an unsafe
-dynamic boundary. The dependencies use the current 0.8.0 public SDK rather than a Git
+dynamic boundary. The dependencies use the current 0.9.0 public SDK rather than a Git
 revision or an older package line. The `path = "../../crates/plugin"` override exists
 only because this checked example builds inside the NeMo Relay repository. A standalone
-plugin depends on the published `nemo-relay-plugin = "0.8.0"` package without `path`.
+plugin depends on the published `nemo-relay-plugin = "0.9.0"` package without `path`.
 
 The checked example uses the following package and dependency configuration:
 
@@ -33,7 +33,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 futures = "0.3"
-nemo-relay-plugin = { version = "0.8.0", path = "../../crates/plugin" }
+nemo-relay-plugin = { version = "0.9.0", path = "../../crates/plugin" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["io-util", "macros", "time"] }

--- a/docs/build-plugins/native/build-and-package.mdx
+++ b/docs/build-plugins/native/build-and-package.mdx
@@ -77,7 +77,7 @@ id = "examples.rust_native_policy"
 kind = "rust_dynamic"
 
 [compat]
-relay = ">=0.8.0,<1.0"
+relay = ">=0.9.0,<1.0"
 native_api = "1"
 
 [defaults]

--- a/docs/build-plugins/workers/rust.mdx
+++ b/docs/build-plugins/workers/rust.mdx
@@ -7,7 +7,7 @@ position: 32
 SPDX-License-Identifier: Apache-2.0 */}
 
 The `examples/rust-grpc-worker-plugin` project is the compiled counterpart to the
-[Python worker](/build-plugins/workers/python). It depends on `nemo-relay-worker` 0.8.0,
+[Python worker](/build-plugins/workers/python). It depends on `nemo-relay-worker` 0.9.0,
 implements `WorkerPlugin`, registers all
 15 [surfaces](/build-plugins/workers/middleware-and-continuations), and lets the SDK
 create the authenticated `grpc-v1` server from the
@@ -120,7 +120,7 @@ publish = false
 
 [dependencies]
 futures-util = "0.3"
-nemo-relay-worker = { version = "0.8.0", path = "../../crates/worker" }
+nemo-relay-worker = { version = "0.9.0", path = "../../crates/worker" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -125,7 +125,7 @@ refer to the [Support Matrix](/reference/support-matrix).
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | NEMO_RELAY_VERSION=0.8.0 sh
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh | NEMO_RELAY_VERSION=0.9.0 sh
 ```
 
 Install into another directory:
@@ -149,7 +149,7 @@ Set the same environment variable before invoking the installer to install a
 specific version:
 
 ```powershell
-$env:NEMO_RELAY_VERSION = '0.8.0'
+$env:NEMO_RELAY_VERSION = '0.9.0'
 irm https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.ps1 | iex
 ```
 
@@ -203,7 +203,7 @@ Install the Python package when your application uses NeMo Relay through the
 Python wrapper and owns the tool or LLM call boundary.
 
 ```bash
-uv add nemo-relay@0.8.0
+uv add nemo-relay@0.9.0
 ```
 
 Use `uv add` from an application project that has a `pyproject.toml`; it records
@@ -226,7 +226,7 @@ Install the Node.js package when your application uses NeMo Relay through the
 JavaScript API and owns the tool or LLM call boundary.
 
 ```bash
-npm install nemo-relay-node@0.8.0
+npm install nemo-relay-node@0.9.0
 ```
 
 On supported x64 and ARM64 Linux systems, npm automatically installs the native
@@ -237,8 +237,8 @@ package for the host C library, including the musl package on Alpine Linux.
 Add the Rust crates when your application uses NeMo Relay directly from Rust.
 
 ```bash
-cargo add nemo-relay@0.8.0
-cargo add nemo-relay-adaptive@0.8.0
+cargo add nemo-relay@0.9.0
+cargo add nemo-relay-adaptive@0.9.0
 ```
 
 - `nemo-relay` provides the core runtime APIs for scopes, middleware, subscribers, plugins, tool calls, and LLM calls.
@@ -255,7 +255,7 @@ Install the OpenClaw plugin through OpenClaw so OpenClaw can register and manage
 the package:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.8.0
+openclaw plugins install npm:nemo-relay-openclaw@0.9.0
 openclaw gateway restart
 ```
 
@@ -278,7 +278,7 @@ Install the Python package with the supported framework extras when your
 application uses LangChain, LangGraph, or Deep Agents.
 
 ```bash
-uv add "nemo-relay[langchain,langgraph,deepagents]@0.8.0"
+uv add "nemo-relay[langchain,langgraph,deepagents]@0.9.0"
 ```
 
 The extras install the NeMo Relay Python package plus the dependencies needed by

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -203,7 +203,7 @@ Install the Python package when your application uses NeMo Relay through the
 Python wrapper and owns the tool or LLM call boundary.
 
 ```bash
-uv add nemo-relay@0.9.0
+uv add nemo-relay==0.9.0
 ```
 
 Use `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -278,7 +278,7 @@ Install the Python package with the supported framework extras when your
 application uses LangChain, LangGraph, or Deep Agents.
 
 ```bash
-uv add "nemo-relay[langchain,langgraph,deepagents]@0.9.0"
+uv add "nemo-relay[langchain,langgraph,deepagents]==0.9.0"
 ```
 
 The extras install the NeMo Relay Python package plus the dependencies needed by

--- a/docs/getting-started/quick-start/nodejs.mdx
+++ b/docs/getting-started/quick-start/nodejs.mdx
@@ -19,7 +19,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-npm install nemo-relay-node@0.8.0
+npm install nemo-relay-node@0.9.0
 ```
 
 ### Install from the Repository

--- a/docs/getting-started/quick-start/python.mdx
+++ b/docs/getting-started/quick-start/python.mdx
@@ -20,7 +20,7 @@ local checkout.
 Use this path when you want the published package for application development.
 
 ```bash
-uv add nemo-relay==0.8.0
+uv add nemo-relay==0.9.0
 ```
 
 Run `uv add` from an application project that has a `pyproject.toml`; it records

--- a/docs/getting-started/quick-start/rust.mdx
+++ b/docs/getting-started/quick-start/rust.mdx
@@ -27,7 +27,7 @@ Install the published NeMo Relay CLI separately when you need coding-agent hook
 and LLM gateway observability:
 
 ```bash
-cargo install nemo-relay-cli@0.30.0
+cargo install nemo-relay-cli@0.9.0
 ```
 
 ### Install from the Repository

--- a/docs/getting-started/quick-start/rust.mdx
+++ b/docs/getting-started/quick-start/rust.mdx
@@ -18,7 +18,7 @@ local checkout.
 Use the published crates when you are consuming a release:
 
 ```bash
-cargo add nemo-relay@0.8.0
+cargo add nemo-relay@0.9.0
 cargo add serde_json
 cargo add tokio --features macros,rt-multi-thread
 ```
@@ -27,7 +27,7 @@ Install the published NeMo Relay CLI separately when you need coding-agent hook
 and LLM gateway observability:
 
 ```bash
-cargo install nemo-relay-cli@0.8.0
+cargo install nemo-relay-cli@0.30.0
 ```
 
 ### Install from the Repository
@@ -47,7 +47,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 - `nemo-relay-adaptive` is a companion crate for adaptive runtime primitives and
   Redis-backed learning components when you need adaptive behavior later, but it
   is not required for this minimal direct-runtime example.
-- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.8.0`
+- `nemo-relay-cli` is a binary crate. Use `cargo install nemo-relay-cli@0.9.0`
   when you need the NeMo Relay CLI.
 
 ## Run One Scope, One Tool Call, and One LLM Call

--- a/docs/supported-integrations/openclaw-plugin.mdx
+++ b/docs/supported-integrations/openclaw-plugin.mdx
@@ -42,7 +42,7 @@ Optional:
 Install the plugin with OpenClaw so OpenClaw can register and manage it:
 
 ```bash
-openclaw plugins install npm:nemo-relay-openclaw@0.8.0
+openclaw plugins install npm:nemo-relay-openclaw@0.9.0
 openclaw gateway restart
 ```
 
@@ -55,7 +55,7 @@ If you manage OpenClaw plugin dependencies directly in a Node.js project,
 install the package with npm:
 
 ```bash
-npm install nemo-relay-openclaw@0.8.0
+npm install nemo-relay-openclaw@0.9.0
 ```
 
 Installing with npm makes the package available to that project. Use

--- a/examples/language-binding-plugin/node/package.json
+++ b/examples/language-binding-plugin/node/package.json
@@ -9,6 +9,6 @@
     "test": "node --test test-plugin.mjs"
   },
   "dependencies": {
-    "nemo-relay-node": "0.8.0"
+    "nemo-relay-node": "0.9.0"
   }
 }

--- a/examples/language-binding-plugin/python/pyproject.toml
+++ b/examples/language-binding-plugin/python/pyproject.toml
@@ -6,7 +6,7 @@ name = "nemo-relay-python-language-binding-plugin-example"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-relay==0.8.0",
+  "nemo-relay==0.9.0",
 ]
 
 [dependency-groups]

--- a/examples/language-binding-plugin/rust/Cargo.lock
+++ b/examples/language-binding-plugin/rust/Cargo.lock
@@ -148,9 +148,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -375,9 +375,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encoding_rs"
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fnv"
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -804,16 +804,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -824,15 +825,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -992,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1052,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1098,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "futures",
  "nemo-relay-types",
@@ -1110,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-relay-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1327,9 +1328,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "portable-atomic"
@@ -1339,9 +1340,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -1428,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2202,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2923,9 +2924,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "yoke"
@@ -2999,9 +3000,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3010,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3021,13 +3022,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/examples/language-binding-plugin/rust/Cargo.toml
+++ b/examples/language-binding-plugin/rust/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 futures = "0.3"
-nemo-relay = { version = "0.8.0", path = "../../../crates/core" }
+nemo-relay = { version = "0.9.0", path = "../../../crates/core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/examples/rust-grpc-worker-plugin/Cargo.toml
+++ b/examples/rust-grpc-worker-plugin/Cargo.toml
@@ -12,13 +12,13 @@ description = "Complete Rust grpc-v1 worker example for NeMo Relay"
 
 [dependencies]
 futures-util = "0.3"
-nemo-relay-worker = { version = "0.8.0", path = "../../crates/worker" }
+nemo-relay-worker = { version = "0.9.0", path = "../../crates/worker" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
-nemo-relay = { version = "0.8.0", path = "../../crates/core", features = ["worker-grpc"] }
+nemo-relay = { version = "0.9.0", path = "../../crates/core", features = ["worker-grpc"] }
 sha2 = "0.11"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/examples/rust-native-plugin/Cargo.toml
+++ b/examples/rust-native-plugin/Cargo.toml
@@ -16,13 +16,13 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 futures = "0.3"
-nemo-relay-plugin = { version = "0.8.0", path = "../../crates/plugin" }
+nemo-relay-plugin = { version = "0.9.0", path = "../../crates/plugin" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["io-util", "macros", "time"] }
 
 [dev-dependencies]
-nemo-relay = { version = "0.8.0", path = "../../crates/core" }
+nemo-relay = { version = "0.9.0", path = "../../crates/core" }
 sha2 = "0.11"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/examples/rust-native-plugin/README.md
+++ b/examples/rust-native-plugin/README.md
@@ -9,7 +9,7 @@ This project is the complete native plugin used by the authoring guide. Its
 configuration, observation, request policy, execution wrappers, and runtime
 helpers live in separate source modules. Together they register the subscriber,
 all three event sanitizers, five tool surfaces, and six LLM surfaces exposed by
-the current typed 0.8.0 SDK.
+the current typed 0.9.0 SDK.
 
 Run the focused tests and build the shared library from this directory. The
 configuration tests isolate validation and schema contracts. The lifecycle test

--- a/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
+++ b/integrations/coding-agents/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Native Relay gateway lifecycle and Claude Code hooks for complete local observability.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/coding-agents/codex/.codex-plugin/plugin.json
+++ b/integrations/coding-agents/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-plugin",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Native Relay gateway lifecycle and Codex hooks for complete local observability.",
   "author": {
     "name": "NVIDIA Corporation and Affiliates",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-relay-openclaw",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "NeMo Relay-authored observability plugin for OpenClaw.",
   "type": "module",
   "repository": {
@@ -63,7 +63,7 @@
     "openclaw": "2026.7.1-2"
   },
   "dependencies": {
-    "nemo-relay-node": "0.8.0"
+    "nemo-relay-node": "0.9.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -466,7 +466,7 @@
       "name": "nemo-relay-node-language-binding-plugin-example",
       "version": "0.1.0",
       "dependencies": {
-        "nemo-relay-node": "0.8.0"
+        "nemo-relay-node": "0.9.0"
       }
     },
     "integrations/openclaw": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
     },
     "crates/node": {
       "name": "nemo-relay-node",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -471,10 +471,10 @@
     },
     "integrations/openclaw": {
       "name": "nemo-relay-openclaw",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "nemo-relay-node": "0.8.0"
+        "nemo-relay-node": "0.9.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ test = [
 
 [project.optional-dependencies]
 cli = [
-    "nemo-relay-cli-bin==0.8.0",
+    "nemo-relay-cli-bin==0.9.0",
 ]
 
 langchain = [

--- a/python/cli-bin/pyproject.toml
+++ b/python/cli-bin/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "nemo-relay-cli-bin"
-version = "0.8.0"
+version = "0.9.0"
 description = "Prebuilt NeMo Relay command-line interface."
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/python/plugin/pyproject.toml
+++ b/python/plugin/pyproject.toml
@@ -8,7 +8,7 @@ backend-path = ["."]
 
 [project]
 name = "nemo-relay-plugin"
-version = "0.8.0"
+version = "0.9.0"
 description = "Python SDK for NeMo Relay dynamic worker plugins."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1273,7 +1273,7 @@ wheels = [
 
 [package.optional-dependencies]
 zig = [
-    { name = "ziglang" },
+    { name = "ziglang", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1508,12 +1508,12 @@ test = [
 
 [[package]]
 name = "nemo-relay-cli-bin"
-version = "0.8.0"
+version = "0.9.0"
 source = { directory = "python/cli-bin" }
 
 [[package]]
 name = "nemo-relay-plugin"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "python/plugin" }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
#### Overview

Prepare `main` for the NeMo Relay 0.8 code freeze and post-freeze 0.9.0 development.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds `release/0.8` to nightly alpha branch configuration.
- Runs `just set-version 0.9.0` across Cargo, Python, Node, OpenClaw, and coding-agent package surfaces.
- Regenerates the worker-plugin fixture lockfile.
- Updates current-version installation and package examples to 0.9.0.

#### Where should the reviewer start?

Start with `.github/nightly-alpha-branches.yaml` and `Cargo.toml`; the remaining changes synchronize versioned package metadata and current-version documentation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Updated packages, plugins, integrations, and SDK components to version 0.9.0.
  - Updated installation guidance for the Rust CLI and other supported platforms.

- **Documentation**
  - Refreshed installation, quick-start, build, and integration instructions for version 0.9.0.
  - Updated Node.js, Python, Rust, OpenClaw, and related integration examples.

- **Chores**
  - Added the `release/0.8` branch to nightly alpha builds.
  - Expanded compatibility coverage for plugins using older Relay version requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->