### PR TITLE
fix: report direct OTLP log queue drops

### DIFF
--- a/crates/core/src/observability/otel_logs.rs
+++ b/crates/core/src/observability/otel_logs.rs
@@ -502,10 +502,12 @@ impl LogProcessor for DiagnosticBatchLogProcessor {
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         let result = self.inner.shutdown_with_timeout(timeout);
-        if result.is_ok() && self.diagnostics.runtime_diagnostics.has_plugin_mirror() {
+        if result.is_ok() {
             let dropped = self.diagnostics.record_queue_drops();
             let export_failures = self.diagnostics.export_failures.load(Ordering::Relaxed);
-            if dropped > 0 || export_failures > 0 {
+            if (dropped > 0 || export_failures > 0)
+                && self.diagnostics.runtime_diagnostics.has_plugin_mirror()
+            {
                 return Err(opentelemetry_sdk::error::OTelSdkError::InternalFailure(
                     format!(
                         "{OTEL_RUNTIME_DELIVERY_FAILURE_MARKER}: otel.logs_dropped ({dropped}), otel.logs_export_failed ({export_failures})"

--- a/crates/core/tests/unit/observability/otel_logs_tests.rs
+++ b/crates/core/tests/unit/observability/otel_logs_tests.rs
@@ -298,6 +298,36 @@ fn log_delivery_state_reports_queue_and_export_failures_independently() {
 }
 
 #[test]
+fn direct_log_processor_records_queue_drops_on_shutdown() {
+    let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);
+    let delivery_diagnostics = Arc::new(LogDeliveryDiagnostics::new(
+        "https://collector.example/v1/logs".to_string(),
+        runtime_diagnostics.clone(),
+    ));
+    delivery_diagnostics.emitted.store(3, Ordering::Relaxed);
+    delivery_diagnostics.accepted.store(1, Ordering::Relaxed);
+    let processor = DiagnosticBatchLogProcessor {
+        inner: BatchLogProcessor::builder(InMemoryLogExporter::default()).build(),
+        diagnostics: delivery_diagnostics,
+    };
+
+    processor
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let diagnostics = runtime_diagnostics.snapshot();
+    let diagnostic = diagnostics
+        .get("otel.logs_dropped")
+        .expect("direct subscriber drop diagnostic");
+    assert_eq!(diagnostic.count, 2);
+    assert!(
+        diagnostic
+            .message
+            .contains("https://collector.example/v1/logs")
+    );
+}
+
+#[test]
 fn non_metric_mark_maps_structured_body_attributes_and_scope_context() {
     let (mut processor, exporter, provider) = processor(LogSeverity::Info);
     let parent_uuid = Uuid::now_v7();


### PR DESCRIPTION
#### Overview

Report OTLP log queue drops through direct subscriber diagnostics after a successful shutdown.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Record `otel.logs_dropped` for direct OTLP log subscribers during successful shutdown.
- Preserve the plugin-managed shutdown error behavior.
- Add a regression test for direct subscriber queue-drop diagnostics.

#### Where should the reviewer start?

Start with `DiagnosticBatchLogProcessor::shutdown_with_timeout` in `crates/core/src/observability/otel_logs.rs`; the adjacent regression test verifies the direct construction path.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown diagnostics by recording queued log drops and export failures when log delivery does not complete.
  * Diagnostic messages now include the affected endpoint for clearer troubleshooting.

* **Tests**
  * Added coverage to verify that queued log drops are reported during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->