### PR TITLE
fix: report failed trace exports

### DIFF
--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -895,13 +895,20 @@ fn build_tracer_provider(
 struct CountingSpanExporter<E> {
     inner: E,
     accepted_spans: Arc<AtomicU64>,
+    diagnostics: Arc<TraceDeliveryDiagnostics>,
 }
 
 impl<E: SpanExporter> SpanExporter for CountingSpanExporter<E> {
     async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
         self.accepted_spans
             .fetch_add(batch.len() as u64, Ordering::Relaxed);
-        self.inner.export(batch).await
+        let result = self.inner.export(batch).await;
+        if let Err(error) = &result {
+            self.diagnostics.record_export_failure(error);
+        } else {
+            self.diagnostics.record_export_success();
+        }
+        result
     }
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
@@ -918,12 +925,61 @@ impl<E: SpanExporter> SpanExporter for CountingSpanExporter<E> {
 }
 
 #[derive(Debug)]
+struct TraceDeliveryDiagnostics {
+    endpoint: String,
+    runtime_diagnostics: SignalRuntimeDiagnostics,
+    export_failures: AtomicU64,
+    unresolved_export_failure: AtomicBool,
+}
+
+impl TraceDeliveryDiagnostics {
+    fn new(endpoint: String, runtime_diagnostics: SignalRuntimeDiagnostics) -> Self {
+        Self {
+            endpoint,
+            runtime_diagnostics,
+            export_failures: AtomicU64::new(0),
+            unresolved_export_failure: AtomicBool::new(false),
+        }
+    }
+
+    fn record_export_failure(&self, error: &impl std::fmt::Display) {
+        self.export_failures.fetch_add(1, Ordering::Relaxed);
+        self.unresolved_export_failure
+            .store(true, Ordering::Relaxed);
+        self.runtime_diagnostics.record(
+            "otel.traces_export_failed",
+            format!(
+                "OpenTelemetry trace export to endpoint {} failed: {error}",
+                self.endpoint
+            ),
+            1,
+        );
+    }
+
+    fn record_export_success(&self) {
+        self.unresolved_export_failure
+            .store(false, Ordering::Relaxed);
+    }
+
+    fn unresolved_failure_summary(&self) -> Option<String> {
+        self.unresolved_export_failure
+            .load(Ordering::Relaxed)
+            .then(|| {
+                let failures = self.export_failures.load(Ordering::Relaxed);
+                format!(
+                    "otel.traces_export_failed ({failures}): export to endpoint {} has not recovered",
+                    self.endpoint
+                )
+            })
+    }
+}
+
+#[derive(Debug)]
 struct DiagnosticBatchSpanProcessor {
     inner: BatchSpanProcessor,
     completed_spans: AtomicU64,
     accepted_spans: Arc<AtomicU64>,
-    endpoint: String,
-    runtime_diagnostics: SignalRuntimeDiagnostics,
+    diagnostics: Arc<TraceDeliveryDiagnostics>,
     diagnostic_reported: AtomicBool,
 }
 
@@ -935,9 +991,11 @@ impl DiagnosticBatchSpanProcessor {
         batch_config: opentelemetry_sdk::trace::BatchConfig,
     ) -> Self {
         let accepted_spans = Arc::new(AtomicU64::new(0));
+        let diagnostics = Arc::new(TraceDeliveryDiagnostics::new(endpoint, runtime_diagnostics));
         let exporter = CountingSpanExporter {
             inner: exporter,
             accepted_spans: Arc::clone(&accepted_spans),
+            diagnostics: Arc::clone(&diagnostics),
         };
         Self {
             inner: BatchSpanProcessor::builder(exporter)
@@ -945,8 +1003,7 @@ impl DiagnosticBatchSpanProcessor {
                 .build(),
             completed_spans: AtomicU64::new(0),
             accepted_spans,
-            endpoint,
-            runtime_diagnostics,
+            diagnostics,
             diagnostic_reported: AtomicBool::new(false),
         }
     }
@@ -959,11 +1016,11 @@ impl DiagnosticBatchSpanProcessor {
         if dropped == 0 || self.diagnostic_reported.swap(true, Ordering::Relaxed) {
             return dropped;
         }
-        self.runtime_diagnostics.record(
+        self.diagnostics.runtime_diagnostics.record(
             "otel.spans_dropped",
             format!(
                 "OpenTelemetry dropped {dropped} spans before export to endpoint {} because the batch queue was full",
-                self.endpoint
+                self.diagnostics.endpoint
             ),
             dropped,
         );
@@ -982,16 +1039,33 @@ impl SpanProcessor for DiagnosticBatchSpanProcessor {
     }
 
     fn force_flush(&self) -> OTelSdkResult {
-        self.inner.force_flush()
+        let result = self.inner.force_flush();
+        if result.is_ok()
+            && let Some(summary) = self.diagnostics.unresolved_failure_summary()
+        {
+            return Err(OTelSdkError::InternalFailure(summary));
+        }
+        result
     }
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         let result = self.inner.shutdown_with_timeout(timeout);
         if result.is_ok() {
             let dropped = self.record_dropped_spans();
-            if dropped > 0 && self.runtime_diagnostics.has_plugin_mirror() {
+            let export_failure = self.diagnostics.unresolved_failure_summary();
+            if (dropped > 0 || export_failure.is_some())
+                && self.diagnostics.runtime_diagnostics.has_plugin_mirror()
+            {
+                let mut diagnostics = Vec::new();
+                if dropped > 0 {
+                    diagnostics.push(format!("otel.spans_dropped ({dropped})"));
+                }
+                if let Some(export_failure) = export_failure {
+                    diagnostics.push(export_failure);
+                }
                 return Err(OTelSdkError::InternalFailure(format!(
-                    "{OTEL_RUNTIME_DELIVERY_FAILURE_MARKER}: otel.spans_dropped ({dropped})"
+                    "{OTEL_RUNTIME_DELIVERY_FAILURE_MARKER}: {}",
+                    diagnostics.join(", ")
                 )));
             }
         }

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -4387,6 +4387,65 @@ fn trace_export_failures_are_diagnosed_until_a_later_export_recovers() {
 }
 
 #[test]
+fn unrecovered_trace_export_failure_is_retained_in_the_active_plugin_report() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+    let _ = crate::plugin::clear_plugin_configuration();
+    let _clear_guard = ClearPluginConfigurationGuard;
+    futures::executor::block_on(crate::plugin::initialize_plugins_exact(
+        crate::plugin::PluginConfig::default(),
+    ))
+    .unwrap();
+
+    let runtime_diagnostics =
+        SignalRuntimeDiagnostics::new(Some("opentelemetry.traces[2].endpoint".to_string()));
+    let processor = DiagnosticBatchSpanProcessor::new_with_batch_config(
+        FailingThenRecoveringSpanExporter::default(),
+        "https://collector.example/v1/traces".to_string(),
+        runtime_diagnostics.clone(),
+        BatchConfigBuilder::default()
+            .with_max_export_batch_size(1)
+            .build(),
+    );
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+    let tracer = provider.tracer("unrecovered-trace-export-failure-test");
+
+    tracer.start("export-fails").end();
+    assert!(provider.force_flush().is_err());
+
+    let shutdown = provider.shutdown().unwrap_err();
+    assert!(
+        shutdown
+            .to_string()
+            .contains(OTEL_RUNTIME_DELIVERY_FAILURE_MARKER)
+    );
+    assert!(
+        shutdown
+            .to_string()
+            .contains("otel.traces_export_failed (1)")
+    );
+
+    let report = crate::plugin::active_plugin_report().unwrap();
+    let diagnostic = report
+        .runtime_diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "otel.traces_export_failed")
+        .expect("trace export failure diagnostic");
+    assert_eq!(diagnostic.count, 1);
+    assert_eq!(
+        diagnostic.field.as_deref(),
+        Some("opentelemetry.traces[2].endpoint")
+    );
+    assert!(
+        diagnostic
+            .message
+            .contains("https://collector.example/v1/traces")
+    );
+    assert!(diagnostic.message.contains("collector unavailable"));
+}
+
+#[test]
 fn grpc_metadata_and_runtime_builder_paths_succeed() {
     let metadata = build_grpc_metadata(&HashMap::from([(
         "authorization".to_string(),

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -32,6 +32,7 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::TcpListener;
+use std::sync::atomic::AtomicUsize;
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
@@ -105,6 +106,23 @@ impl SpanExporter for BlockingSpanExporter {
             state = changed.wait(state).unwrap();
         }
         Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct FailingThenRecoveringSpanExporter {
+    attempts: Arc<AtomicUsize>,
+}
+
+impl SpanExporter for FailingThenRecoveringSpanExporter {
+    async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+        if self.attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+            Err(OTelSdkError::InternalFailure(
+                "collector unavailable".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -4323,6 +4341,49 @@ fn dropped_spans_are_recorded_in_the_active_plugin_report() {
             .map(|diagnostic| diagnostic.count),
         Some(2)
     );
+}
+
+#[test]
+fn trace_export_failures_are_diagnosed_until_a_later_export_recovers() {
+    let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);
+    let processor = DiagnosticBatchSpanProcessor::new_with_batch_config(
+        FailingThenRecoveringSpanExporter::default(),
+        "https://collector.example/v1/traces".to_string(),
+        runtime_diagnostics.clone(),
+        BatchConfigBuilder::default()
+            .with_max_export_batch_size(1)
+            .build(),
+    );
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+    let tracer = provider.tracer("trace-export-failure-diagnostics-test");
+
+    tracer.start("first-export-fails").end();
+    assert!(provider.force_flush().is_err());
+
+    let diagnostics = runtime_diagnostics.snapshot();
+    let diagnostic = diagnostics
+        .get("otel.traces_export_failed")
+        .expect("trace export failure diagnostic");
+    assert_eq!(diagnostic.count, 1);
+    assert!(
+        diagnostic
+            .message
+            .contains("https://collector.example/v1/traces")
+    );
+    assert!(diagnostic.message.contains("collector unavailable"));
+
+    let repeated_flush = provider.force_flush().unwrap_err();
+    assert!(
+        repeated_flush
+            .to_string()
+            .contains("otel.traces_export_failed (1)")
+    );
+
+    tracer.start("recovery-export").end();
+    provider.force_flush().unwrap();
+    provider.shutdown().unwrap();
 }
 
 #[test]

--- a/python/nemo_relay/README.md
+++ b/python/nemo_relay/README.md
@@ -53,6 +53,9 @@ The Python package provides the following capabilities:
   resolve to `/v1/traces`, `/v1/logs`, or `/v1/metrics` for the selected signal.
   Each direct OTLP subscriber exposes `runtime_diagnostics()` for bounded
   exporter and event-processing failure summaries.
+  Trace export failures use `otel.traces_export_failed`; after a trace export
+  fails, `force_flush()` continues to return an error until a later trace batch
+  exports successfully.
   The `nemo_relay.observability` helpers configure plugin-owned endpoint fan-out.
 - **Plugin and typed helpers**: Public modules for plugins, codecs, typed
   wrappers, adaptive runtime behavior, and observability plugin configuration.

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -57,7 +57,7 @@ class _OtelCollectorHandler(http.server.BaseHTTPRequestHandler):
             }
         )
         server.request_event.set()
-        self.send_response(200)
+        self.send_response(server.response_status)
         self.end_headers()
 
     def log_message(self, format: str, *args: object) -> None:  # noqa: ARG002
@@ -73,10 +73,14 @@ class _CollectorRequest(TypedDict):
 class _OtelCollector:
     server: "_OtelCollectorServer"
 
+    def __init__(self, response_status: int = 200) -> None:
+        self.response_status = response_status
+
     def __enter__(self) -> "_OtelCollector":
         self.server = _OtelCollectorServer(("127.0.0.1", 0), _OtelCollectorHandler)
         self.server.requests = []
         self.server.request_event = threading.Event()
+        self.server.response_status = self.response_status
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()
         return self
@@ -98,6 +102,7 @@ class _OtelCollector:
 class _OtelCollectorServer(http.server.ThreadingHTTPServer):
     requests: list[_CollectorRequest]
     request_event: threading.Event
+    response_status: int
 
 
 def _encode_varint(value: int) -> bytes:
@@ -819,6 +824,33 @@ class TestOpenTelemetryTypes:
                 assert request["body"]
                 assert b"nemo_relay.mark.metadata.source" in request["body"]
                 assert _otlp_string_attribute("nv.binding", "python") in request["body"]
+            finally:
+                subscriber.deregister(subscriber_name)
+                subscriber.shutdown()
+
+    def test_trace_export_failure_stays_unhealthy_until_a_later_export_succeeds(self):
+        with _OtelCollector(response_status=503) as collector:
+            subscriber = OpenTelemetrySubscriber(OpenTelemetryConfig("full", collector.endpoint))
+            subscriber_name = f"py_otel_trace_failure_{uuid4().hex}"
+            subscriber.register(subscriber_name)
+            try:
+                failed_scope = scope.push("trace-export-failure", ScopeType.Agent)
+                scope.pop(failed_scope)
+                with pytest.raises(RuntimeError):
+                    subscriber.force_flush()
+
+                diagnostic = subscriber.runtime_diagnostics().get("otel.traces_export_failed")
+                assert diagnostic is not None
+                assert diagnostic.count == 1
+                assert collector.endpoint in diagnostic.message
+
+                with pytest.raises(RuntimeError, match=r"otel\.traces_export_failed \(1\)"):
+                    subscriber.force_flush()
+
+                collector.server.response_status = 200
+                recovered_scope = scope.push("trace-export-recovery", ScopeType.Agent)
+                scope.pop(recovered_scope)
+                subscriber.force_flush()
             finally:
                 subscriber.deregister(subscriber_name)
                 subscriber.shutdown()


### PR DESCRIPTION
#### Overview

Report failed OpenTelemetry trace exports through direct subscriber diagnostics and keep trace flushes unhealthy until a later export succeeds.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Record `otel.traces_export_failed` with the failed endpoint and exporter error.
- Preserve the failure across an otherwise-empty `force_flush()`; a successful later export clears the unhealthy state.
- Preserve unresolved trace failures in plugin shutdown delivery summaries.
- Add Rust and Python HTTP 503/recovery regression coverage and document the direct-subscriber behavior.

Validation:

- `cargo test -p nemo-relay observability::otel::tests --lib` (61 passed)
- `.venv/bin/pytest python/tests/test_types.py` (50 passed)
- `cargo clippy -p nemo-relay --lib --tests -- -D warnings`, `cargo fmt --all -- --check`, and Ruff passed.
- The full `just test-rust` run was stopped during compilation to protect the workstation when free disk space fell to 26 GiB. Full Rust, Go, Node.js, and Python-matrix validation remain for CI.

#### Where should the reviewer start?

Start with `TraceDeliveryDiagnostics` and `DiagnosticBatchSpanProcessor::force_flush` in `crates/core/src/observability/otel.rs`; the neighboring Rust test captures the failed-flush, repeated-flush, and recovery sequence.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trace export failures now produce runtime diagnostics and remain visible during subsequent flushes.
  * Export health recovers after a later successful trace batch, allowing clean shutdown.
  * Shutdown reporting now includes both dropped spans and unrecovered export failures.

* **Documentation**
  * Documented the `otel.traces_export_failed` diagnostic and `force_flush()` behavior during export failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->