### PR TITLE
fix: report metadata promotion diagnostics per key

### DIFF
--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -1485,16 +1485,19 @@ impl OtelEventProcessor {
         event: &Event,
         protected_keys: &HashSet<String>,
     ) {
-        let issues = promote_event_metadata_attributes(
+        let mut issues = promote_event_metadata_attributes(
             attributes,
             event,
             &self.promote_metadata_prefixes,
             protected_keys,
         );
 
+        issues.sort_by(|left, right| left.key.cmp(&right.key));
         for issue in issues {
+            let diagnostic_code =
+                format!("otel.metadata_promotion_value_unsupported.{}", issue.key);
             let diagnostic_count = self.runtime_diagnostics.record(
-                "otel.metadata_promotion_value_unsupported",
+                diagnostic_code,
                 format!(
                     "OpenTelemetry metadata attribute {:?} was not promoted: {}",
                     issue.key, issue.reason

--- a/crates/core/src/observability/otel_signal.rs
+++ b/crates/core/src/observability/otel_signal.rs
@@ -57,7 +57,7 @@ impl OpenTelemetryRuntimeDiagnostics {
 
 #[derive(Debug, Default)]
 struct RuntimeDiagnosticState {
-    diagnostics: BTreeMap<&'static str, OpenTelemetryRuntimeDiagnostic>,
+    diagnostics: BTreeMap<String, OpenTelemetryRuntimeDiagnostic>,
 }
 
 /// Shared runtime-diagnostic recorder for one independently owned OTLP subscriber.
@@ -75,21 +75,22 @@ impl SignalRuntimeDiagnostics {
         }
     }
 
-    pub(super) fn record(&self, code: &'static str, message: String, count: u64) -> u64 {
+    pub(super) fn record(&self, code: impl Into<String>, message: String, count: u64) -> u64 {
+        let code = code.into();
         let count = count.max(1);
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let total = if let Some(diagnostic) = state.diagnostics.get_mut(code) {
+        let total = if let Some(diagnostic) = state.diagnostics.get_mut(&code) {
             diagnostic.message = truncate_runtime_diagnostic_message(message.clone());
             diagnostic.count = diagnostic.count.saturating_add(count);
             diagnostic.count
         } else if state.diagnostics.len() < MAX_RUNTIME_DIAGNOSTICS {
             state.diagnostics.insert(
-                code,
+                code.clone(),
                 OpenTelemetryRuntimeDiagnostic {
-                    code: code.to_string(),
+                    code: code.clone(),
                     message: truncate_runtime_diagnostic_message(message.clone()),
                     count,
                 },
@@ -100,7 +101,7 @@ impl SignalRuntimeDiagnostics {
         };
         drop(state);
 
-        record_signal_runtime_diagnostic(code, self.plugin_field.clone(), message, count);
+        record_signal_runtime_diagnostic(&code, self.plugin_field.clone(), message, count);
         total
     }
 

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -709,10 +709,78 @@ fn omits_scope_metadata_when_final_value_is_unsupported_across_trace_projections
 
         let diagnostics = runtime_diagnostics.snapshot();
         let diagnostic = diagnostics
-            .get("otel.metadata_promotion_value_unsupported")
+            .get("otel.metadata_promotion_value_unsupported.nv.source")
             .expect("unsupported final metadata diagnostic");
         assert_eq!(diagnostic.count, 1);
         assert!(diagnostic.message.contains("nv.source"));
+    }
+}
+
+#[test]
+fn reports_each_unsupported_metadata_key_with_a_deterministic_diagnostic_code() {
+    let (provider, exporter) = make_provider();
+    let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);
+    let mut processor =
+        OtelEventProcessor::new_with_mark_projection_and_exclusions_and_mappings_and_runtime_diagnostics(
+            provider,
+            "unsupported-metadata-promotion-keys-test".into(),
+            OpenTelemetryType::Full,
+            MarkProjection::default(),
+            default_mark_exclude_names(),
+            Vec::new(),
+            vec!["tenant.".to_string()],
+            runtime_diagnostics.clone(),
+        );
+    let uuid = Uuid::now_v7();
+    let unsupported_metadata = json!({
+        "tenant.plan": {"name": "enterprise"},
+        "tenant.flags": null,
+        "tenant.tags": [["nested"]],
+        "tenant.mixed": [1, "string"],
+    });
+
+    processor.process(&make_start_event_with_metadata(
+        uuid,
+        None,
+        "unsupported-metadata-promotion-keys-scope",
+        unsupported_metadata.clone(),
+    ));
+    processor.process(&make_end_event_with_metadata(
+        uuid,
+        None,
+        "unsupported-metadata-promotion-keys-scope",
+        ScopeType::Agent,
+        unsupported_metadata,
+    ));
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    let span_attributes = attr_map(&spans[0].attributes);
+    for key in ["tenant.flags", "tenant.mixed", "tenant.plan", "tenant.tags"] {
+        assert!(!span_attributes.contains_key(key));
+    }
+
+    let diagnostics = runtime_diagnostics.snapshot();
+    let expected_keys = ["tenant.flags", "tenant.mixed", "tenant.plan", "tenant.tags"];
+    assert_eq!(
+        diagnostics
+            .entries()
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        expected_keys
+            .iter()
+            .map(|key| format!("otel.metadata_promotion_value_unsupported.{key}"))
+            .collect::<Vec<_>>()
+    );
+    for key in expected_keys {
+        let code = format!("otel.metadata_promotion_value_unsupported.{key}");
+        let diagnostic = diagnostics
+            .get(&code)
+            .expect("metadata-key-specific promotion diagnostic");
+        assert_eq!(diagnostic.count, 2);
+        assert!(diagnostic.message.contains(key));
     }
 }
 

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -179,8 +179,13 @@ Marks.
 
 Promotion supports strings, booleans, signed 64-bit integers, floating-point
 numbers, empty arrays, and homogeneous arrays of those primitive types. Relay
-omits rejected values and records a bounded runtime diagnostic containing the
-key and reason, but it does not record the rejected value or stop trace export.
+omits rejected values and records one bounded runtime diagnostic per rejected
+key. The diagnostic code is
+`otel.metadata_promotion_value_unsupported.<metadata-key>`, its message contains
+the key and rejection reason, and its count is the number of occurrences for
+that key. Relay does not record the rejected value or stop trace export. Match
+the `otel.metadata_promotion_value_unsupported.` prefix to monitor all rejected
+metadata keys.
 
 Projection-owned attributes take precedence over promoted metadata with the
 same key. For `full` and `openinference`, configured attribute-mapping aliases


### PR DESCRIPTION
#### Overview

Preserve the name of every metadata attribute rejected during OpenTelemetry promotion. Runtime reports now expose one stable diagnostic per rejected key instead of collapsing all failures into one entry whose message names only the last key.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Suffix the existing `otel.metadata_promotion_value_unsupported` diagnostic prefix with the rejected metadata key.
- Record rejected keys in deterministic order.
- Allow runtime diagnostic storage to own dynamically generated diagnostic codes.
- Add regression coverage proving that four rejected keys remain independently identifiable across scope start and end events.
- Update the existing unsupported-value test for the key-specific diagnostic code.

This changes exact diagnostic-code matching from:

`otel.metadata_promotion_value_unsupported`

to:

`otel.metadata_promotion_value_unsupported.<metadata-key>`

Consumers that match diagnostic codes exactly should use the key-specific code or match the existing prefix.

Validation:

- Cursor public Python smoke passed with four independently named diagnostics.
- Focused metadata-promotion regression tests passed.
- `cargo fmt --all` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- File-scoped pre-commit checks and commit hooks passed.
- `just test-rust` was not fully green in the local environment:
  - One run had two CLI host-status failures because Claude was observed as running.
  - A later aggregate run had shared plugin-registration failures; 1,502 core tests passed and 24 failed. The metadata-promotion-adjacent failure passed when run independently.
- The Python suite was stopped before completion at the requested push boundary.
- Go, Node.js, and all-file pre-commit validation were not run.

#### Where should the reviewer start?

Start with `OtelEventProcessor::promote_metadata` in `crates/core/src/observability/otel.rs`, then review `reports_each_unsupported_metadata_key_with_a_deterministic_diagnostic_code` in `crates/core/tests/unit/observability/otel_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-763


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observability diagnostics for unsupported metadata.
  * Diagnostics are now consistently ordered and identify the specific metadata key involved.
  * Unsupported metadata continues to be excluded from span attributes while producing clearer diagnostic details.

* **Documentation**
  * Documented diagnostic codes, messages, occurrence counts, and monitoring guidance for rejected metadata values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->