### PR TITLE
docs: correct span-drop diagnostic field

### DIFF
--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -4271,7 +4271,7 @@ fn dropped_spans_are_recorded_in_the_active_plugin_report() {
 
     let exporter = BlockingSpanExporter::default();
     let runtime_diagnostics =
-        SignalRuntimeDiagnostics::new(Some("opentelemetry.endpoints[2].endpoint".to_string()));
+        SignalRuntimeDiagnostics::new(Some("opentelemetry.traces[2].endpoint".to_string()));
     let processor = DiagnosticBatchSpanProcessor::new_with_batch_config(
         exporter.clone(),
         "https://collector.example/v1/traces".to_string(),
@@ -4309,7 +4309,7 @@ fn dropped_spans_are_recorded_in_the_active_plugin_report() {
     assert_eq!(diagnostic.count, 2);
     assert_eq!(
         diagnostic.field.as_deref(),
-        Some("opentelemetry.endpoints[2].endpoint")
+        Some("opentelemetry.traces[2].endpoint")
     );
     assert!(
         diagnostic
@@ -4322,6 +4322,50 @@ fn dropped_spans_are_recorded_in_the_active_plugin_report() {
             .get("otel.spans_dropped")
             .map(|diagnostic| diagnostic.count),
         Some(2)
+    );
+}
+
+#[test]
+fn plugin_trace_subscriber_runtime_diagnostics_use_trace_field() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+    let _ = crate::plugin::clear_plugin_configuration();
+    let _clear_guard = ClearPluginConfigurationGuard;
+    futures::executor::block_on(crate::plugin::initialize_plugins_exact(
+        crate::plugin::PluginConfig::default(),
+    ))
+    .unwrap();
+
+    let subscriber = OpenTelemetrySubscriber::new_for_plugin(
+        OpenTelemetryConfig::new(OpenTelemetryType::Full, "http://localhost:4318/v1/traces"),
+        2,
+    )
+    .unwrap();
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .name("invalid-metric")
+            .data(json!({"measurements": []}))
+            .data_schema(
+                DataSchema::builder()
+                    .name(METRIC_DATA_SCHEMA_NAME)
+                    .version("999")
+                    .build(),
+            )
+            .build(),
+        None,
+        None,
+    ));
+
+    (subscriber.subscriber())(&event);
+
+    let report = crate::plugin::active_plugin_report().unwrap();
+    let diagnostic = report
+        .runtime_diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "otel.metric_mark_invalid")
+        .expect("invalid metric diagnostic");
+    assert_eq!(
+        diagnostic.field.as_deref(),
+        Some("opentelemetry.traces[2].endpoint")
     );
 }
 

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -278,7 +278,7 @@ endpoint to avoid a log storm. During graceful shutdown, it logs
 For plugin-managed exporters, NeMo Relay also records `otel.spans_dropped` in the
 active plugin report's `runtime_diagnostics`. Its `count` is the exact number
 of dropped spans, `field` identifies the affected
-`opentelemetry.endpoints[N].endpoint`, and `message` includes the configured
+`opentelemetry.traces[N].endpoint`, and `message` includes the configured
 endpoint URL. If spans were dropped, clearing the plugin returns a delivery
 failure error and retains the diagnostic for inspection. This error does not
 disable later plugin configuration.


### PR DESCRIPTION
#### Overview

Correct the documented runtime diagnostic field for dropped OTLP spans on the 0.8 release branch and cover the production constructor path.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update the `otel.spans_dropped` diagnostic documentation from `opentelemetry.endpoints[N].endpoint` to the emitted `opentelemetry.traces[N].endpoint` field path.
- Align the existing dropped-span diagnostic fixture with that field path.
- Add a focused regression test that constructs the subscriber with `new_for_plugin` and asserts the runtime diagnostic field in the active plugin report.

#### Where should the reviewer start?

`crates/core/tests/unit/observability/otel_tests.rs`, which now verifies the constructor-produced field path; then review the documentation warning in `docs/configure-plugins/observability/opentelemetry.mdx`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenTelemetry diagnostics to reference the appropriate trace endpoint path when reporting dropped spans.
  * Improved metric validation diagnostics for invalid endpoint configurations, including plugin-managed setups.

* **Documentation**
  * Updated observability documentation to reflect the corrected version-4 trace endpoint path used in diagnostic messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->