### PR TITLE
fix(node)!: stream Node.js LLM execution intercepts lazily

### DIFF
--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -303,13 +303,16 @@ export interface PluginContext {
   /**
    * Register an LLM streaming execution intercept for this component.
    *
-   * The `next` callback resolves to all downstream chunks. Returning an array
-   * preserves those chunks; any other JSON value produces one chunk.
+   * The `next` callback resolves to a lazy stream. Return that stream to
+   * preserve incremental downstream delivery.
    */
   registerLlmStreamExecutionIntercept(
     name: string,
     priority: number,
-    callback: (request: Json, next: (request: Json) => Promise<Json[]>) => Json | Json[] | Promise<Json | Json[]>,
+    callback: (
+      request: Json,
+      next: (request: Json) => Promise<AsyncIterable<Json>>,
+    ) => AsyncIterable<Json> | Promise<AsyncIterable<Json>>,
   ): void;
   /** Register a tool request intercept for this component. */
   registerToolRequestIntercept(

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -577,6 +577,24 @@ async fn forward_stream_to_channel(
     ));
 }
 
+pub(crate) fn llm_stream_from_rust_stream(rust_stream: RustJsonStream) -> LlmStream {
+    let (tx, rx) = tokio::sync::mpsc::channel(32);
+    let (cancel, cancel_rx) = tokio::sync::watch::channel(false);
+    let (closed, closed_rx) = tokio::sync::watch::channel(None);
+    tokio::spawn(forward_stream_to_channel(
+        rust_stream,
+        tx,
+        cancel_rx,
+        closed,
+    ));
+    LlmStream {
+        receiver: tokio::sync::Mutex::new(rx),
+        cancel,
+        closed: closed_rx,
+        codec_references: Vec::new(),
+    }
+}
+
 struct NodePushStream {
     receiver: tokio_stream::wrappers::UnboundedReceiverStream<FlowResult<Json>>,
     stream_id: u64,
@@ -3613,7 +3631,7 @@ pub fn deregister_llm_execution_intercept(name: String) -> Result<bool> {
 ///
 /// The `callable` receives the request and a `next` function. Call `next(request)` to
 /// invoke the next intercept or original streaming implementation; in Node the
-/// returned promise resolves to an array of downstream JSON chunks. Skip calling
+/// returned promise resolves to a lazy `AsyncIterable`. Return it directly or wrap it
 /// `next` to short-circuit the chain. `next` may be called repeatedly or concurrently
 /// while `callable` is pending; each call receives an isolated scope-stack branch,
 /// and unfinished or later calls reject after the returned interceptor stream settles.
@@ -3624,7 +3642,7 @@ pub fn register_llm_stream_execution_intercept(
     name: String,
     priority: i32,
     #[napi(
-        ts_arg_type = "(request: Json, next: (request: Json) => Promise<Json[]>) => Json | Json[] | Promise<Json | Json[]>"
+        ts_arg_type = "(request: Json, next: (request: Json) => Promise<AsyncIterable<Json>>) => AsyncIterable<Json> | Promise<AsyncIterable<Json>>"
     )]
     callable: JsFunction,
 ) -> Result<()> {
@@ -4271,7 +4289,7 @@ pub fn scope_deregister_llm_execution_intercept(scope_uuid: String, name: String
 ///
 /// The `callable` receives the request and a `next` function. Call `next(request)` to
 /// invoke the next intercept or original streaming implementation; in Node the
-/// returned promise resolves to an array of downstream JSON chunks. Skip calling
+/// returned promise resolves to a lazy `AsyncIterable`. Return it directly or wrap it
 /// `next` to short-circuit the chain. `next` may be called repeatedly or concurrently
 /// while `callable` is pending; each call receives an isolated scope-stack branch,
 /// and unfinished or later calls reject after the returned interceptor stream settles.
@@ -4283,7 +4301,7 @@ pub fn scope_register_llm_stream_execution_intercept(
     name: String,
     priority: i32,
     #[napi(
-        ts_arg_type = "(request: Json, next: (request: Json) => Promise<Json[]>) => Json | Json[] | Promise<Json | Json[]>"
+        ts_arg_type = "(request: Json, next: (request: Json) => Promise<AsyncIterable<Json>>) => AsyncIterable<Json> | Promise<AsyncIterable<Json>>"
     )]
     callable: JsFunction,
 ) -> Result<()> {

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -78,6 +78,8 @@ use nemo_relay_adaptive::plugin_component::register_adaptive_component;
 use nemo_relay_adaptive::{AdaptiveConfig, AdaptiveRuntime as CoreAdaptiveRuntime};
 use nemo_relay_pii_redaction::component::register_pii_redaction_component;
 
+pub(crate) const LLM_STREAM_BRIDGE_CAPACITY: usize = 32;
+
 use crate::callable;
 use crate::callback_factory;
 use crate::convert::{
@@ -578,7 +580,7 @@ async fn forward_stream_to_channel(
 }
 
 pub(crate) fn llm_stream_from_rust_stream(rust_stream: RustJsonStream) -> LlmStream {
-    let (tx, rx) = tokio::sync::mpsc::channel(32);
+    let (tx, rx) = tokio::sync::mpsc::channel(LLM_STREAM_BRIDGE_CAPACITY);
     let (cancel, cancel_rx) = tokio::sync::watch::channel(false);
     let (closed, closed_rx) = tokio::sync::watch::channel(None);
     tokio::spawn(forward_stream_to_channel(

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -30,7 +30,6 @@ use nemo_relay::api::runtime::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
-use tokio_stream::StreamExt;
 
 use nemo_relay::api::event::{
     CategoryProfile, DataSchema, Event, EventCategory,
@@ -1624,9 +1623,9 @@ pub fn wrap_js_llm_exec_intercept_fn(
 /// Wrap a JS function `(request, next) => result` for LLM stream execution intercept.
 ///
 /// The JS callback receives the `LlmRequest` serialized as a plain JSON object
-/// and a real `next(request)` function whose Promise resolves to an array of
-/// downstream JSON chunks. Returning an array preserves streaming semantics;
-/// returning any other JSON value produces a single-chunk stream.
+/// and a real `next(request)` function whose Promise resolves to a lazy
+/// async iterable. The callback can return it directly or wrap it with an async
+/// generator without materializing the downstream stream.
 pub fn wrap_js_llm_stream_exec_intercept_fn(
     func: Arc<PromiseAwareFn>,
 ) -> Arc<
@@ -1649,23 +1648,10 @@ pub fn wrap_js_llm_stream_exec_intercept_fn(
                         .map_err(|e| {
                             FlowError::Internal(format!("invalid LlmRequest from JS next: {e}"))
                         })?;
-                    let mut stream = next(next_request).await?;
-                    let mut chunks = Vec::new();
-                    while let Some(item) = stream.next().await {
-                        chunks.push(item?);
-                    }
-                    Ok(chunks)
+                    next(next_request).await
                 })
             });
-            Box::pin(async move {
-                let result = func.call_with_stream_next(req_json, next_stream).await?;
-                let chunks = match result {
-                    Json::Array(values) => values.into_iter().map(Ok).collect::<Vec<_>>(),
-                    value => vec![Ok(value)],
-                };
-                let stream = tokio_stream::iter(chunks);
-                Ok(LlmJsonStream::new(stream))
-            })
+            Box::pin(async move { func.call_with_stream_next(req_json, next_stream).await })
         },
     )
 }

--- a/crates/node/src/callback_factory.rs
+++ b/crates/node/src/callback_factory.rs
@@ -112,6 +112,9 @@ const CALLBACK_FACTORIES_SOURCE: &str = r#"(() => {
     scopeStack,
     propagationParentUuid,
     registerAbort,
+    streamResult,
+    streamPush,
+    streamEnd,
   ) {
     const controller = new AbortController();
     registerAbort(() => controller.abort());
@@ -148,21 +151,60 @@ const CALLBACK_FACTORIES_SOURCE: &str = r#"(() => {
       }
       expireCallbackStore(token);
     };
+    const invokeNext = (value) => next(
+      jsonValue(value === undefined ? null : value),
+      eventSanitizerContext.getStore()?.scopeStack,
+    );
     const safeNext = next === undefined
       ? undefined
-      : (value) => next(
-        jsonValue(value === undefined ? null : value),
-        eventSanitizerContext.getStore()?.scopeStack,
-      );
+      : !streamResult
+        ? invokeNext
+        : async (value) => {
+        const downstream = await invokeNext(value);
+        return {
+          async *[Symbol.asyncIterator]() {
+            try {
+              for (;;) {
+                const chunk = await downstream.next();
+                if (chunk === null) return;
+                yield chunk;
+              }
+            } finally {
+              await downstream.close();
+            }
+          },
+        };
+      };
     const invoke = () => {
       Promise.resolve().then(() => (
         safeNext === undefined
           ? (spread ? fn(...arg0, controller.signal) : fn(arg0, controller.signal))
           : (spread ? fn(...arg0, safeNext, controller.signal) : fn(arg0, safeNext, controller.signal))
-      )).then((value) => jsonValue(value === undefined ? null : value)).then((value) => {
+      )).then(async (value) => {
+        if (!streamResult) {
+          settlePublication();
+          resolve(jsonValue(value === undefined ? null : value));
+          return;
+        }
+        if (value == null || typeof value[Symbol.asyncIterator] !== 'function') {
+          throw new TypeError('streaming execution intercept must return an AsyncIterable');
+        }
+        resolve();
+        const iterator = value[Symbol.asyncIterator]();
+        try {
+          while (!controller.signal.aborted) {
+            const item = await iterator.next();
+            if (item.done) break;
+            await streamPush(jsonValue(item.value === undefined ? null : item.value));
+          }
+        } finally {
+          if (controller.signal.aborted && typeof iterator.return === 'function') {
+            await iterator.return();
+          }
+        }
+        streamEnd();
         settlePublication();
-        resolve(value);
-      }, (error) => {
+      }).catch((error) => {
         settlePublication();
         let message = 'unknown error';
         let exceptionType = 'Error';
@@ -229,6 +271,9 @@ const CALLBACK_FACTORIES_SOURCE: &str = r#"(() => {
         scopeStack,
         propagationParentUuid,
         registerAbort,
+        streamResult,
+        streamPush,
+        streamEnd,
       ) {
         if (error != null) {
           let message = 'unknown error';
@@ -259,6 +304,9 @@ const CALLBACK_FACTORIES_SOURCE: &str = r#"(() => {
           scopeStack,
           propagationParentUuid,
           registerAbort,
+          streamResult,
+          streamPush,
+          streamEnd,
         );
       };
     },

--- a/crates/node/src/callback_factory.rs
+++ b/crates/node/src/callback_factory.rs
@@ -10,7 +10,7 @@ use nemo_relay::api::runtime::subscriber_dispatcher::PublicationBuffer;
 
 use crate::types::ScopeStack;
 
-const CALLBACK_FACTORIES_PROPERTY: &str = "__nemo_relay_callback_factories_v11";
+const CALLBACK_FACTORIES_PROPERTY: &str = "__nemo_relay_callback_factories_v12";
 
 const CALLBACK_FACTORIES_SOURCE: &str = r#"(() => {
   const { AsyncLocalStorage } = process.getBuiltinModule('node:async_hooks');
@@ -191,14 +191,18 @@ const CALLBACK_FACTORIES_SOURCE: &str = r#"(() => {
         }
         resolve();
         const iterator = value[Symbol.asyncIterator]();
+        let exhausted = false;
         try {
           while (!controller.signal.aborted) {
             const item = await iterator.next();
-            if (item.done) break;
+            if (item.done) {
+              exhausted = true;
+              break;
+            }
             await streamPush(jsonValue(item.value === undefined ? null : item.value));
           }
         } finally {
-          if (controller.signal.aborted && typeof iterator.return === 'function') {
+          if (!exhausted && typeof iterator.return === 'function') {
             await iterator.return();
           }
         }

--- a/crates/node/src/promise_call.rs
+++ b/crates/node/src/promise_call.rs
@@ -15,6 +15,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
 
 use napi::bindgen_prelude::ToNapiValue;
 use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction};
@@ -25,13 +26,14 @@ use nemo_relay::api::runtime::subscriber_dispatcher::{
     PublicationBuffer, capture_nested_publication_buffer, with_task_nested_publication_buffer,
 };
 use nemo_relay::api::runtime::{
-    MiddlewareContinuationContext, ScopeStackHandle, capture_propagation_context,
+    LlmStreamInner, MiddlewareContinuationContext, ScopeStackHandle, capture_propagation_context,
     current_scope_stack,
 };
 use nemo_relay::error::{FlowError, Result as FlowResult};
 
 use crate::callback_factory;
 use crate::types::ScopeStack;
+use tokio_stream::Stream;
 
 tokio::task_local! {
     static PUBLICATION_CALLBACK_CONTEXT_ID: Option<String>;
@@ -57,8 +59,14 @@ fn publication_callback_context_id() -> Option<String> {
 
 pub type JsonNextFn =
     Arc<dyn Fn(Json) -> Pin<Box<dyn Future<Output = FlowResult<Json>> + Send>> + Send + Sync>;
-pub type JsonStreamNextFn =
-    Arc<dyn Fn(Json) -> Pin<Box<dyn Future<Output = FlowResult<Vec<Json>>> + Send>> + Send + Sync>;
+pub type JsonStreamNextFn = Arc<
+    dyn Fn(
+            Json,
+        ) -> Pin<
+            Box<dyn Future<Output = FlowResult<nemo_relay::api::runtime::LlmJsonStream>> + Send>,
+        > + Send
+        + Sync,
+>;
 
 #[derive(Clone)]
 enum NextFn {
@@ -92,6 +100,7 @@ struct CallArgs {
     scope_stack: Option<ScopeStackHandle>,
     propagation_parent_uuid: String,
     publication_buffer: Option<PublicationBuffer>,
+    stream_result: bool,
     continuation_context: Option<MiddlewareContinuationContext>,
     cancellation: CallCancellation,
     completion: CallCompletion,
@@ -118,21 +127,71 @@ impl CallMode {
     };
 }
 
+enum CallCompletionSender {
+    Json(tokio::sync::oneshot::Sender<FlowResult<Json>>),
+    Stream(Arc<StreamCompletion>),
+}
+
+struct StreamCompletion {
+    ready: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<FlowResult<()>>>>,
+    chunks: std::sync::Mutex<Option<tokio::sync::mpsc::Sender<FlowResult<Json>>>>,
+    terminal_error: std::sync::Mutex<Option<FlowError>>,
+}
+
 #[derive(Clone)]
 struct CallCompletion {
-    sender: Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<FlowResult<Json>>>>>,
+    sender: Arc<std::sync::Mutex<Option<CallCompletionSender>>>,
 }
 
 impl CallCompletion {
-    fn new(sender: tokio::sync::oneshot::Sender<FlowResult<Json>>) -> Self {
+    fn json(sender: tokio::sync::oneshot::Sender<FlowResult<Json>>) -> Self {
         Self {
-            sender: Arc::new(std::sync::Mutex::new(Some(sender))),
+            sender: Arc::new(std::sync::Mutex::new(Some(CallCompletionSender::Json(
+                sender,
+            )))),
         }
     }
 
-    fn send(&self, value: FlowResult<Json>) {
-        if let Some(sender) = self.sender.lock().unwrap().take() {
+    fn stream(
+        ready: tokio::sync::oneshot::Sender<FlowResult<()>>,
+        chunks: tokio::sync::mpsc::Sender<FlowResult<Json>>,
+    ) -> (Self, Arc<StreamCompletion>) {
+        let stream = Arc::new(StreamCompletion {
+            ready: std::sync::Mutex::new(Some(ready)),
+            chunks: std::sync::Mutex::new(Some(chunks)),
+            terminal_error: std::sync::Mutex::new(None),
+        });
+        (
+            Self {
+                sender: Arc::new(std::sync::Mutex::new(Some(CallCompletionSender::Stream(
+                    stream.clone(),
+                )))),
+            },
+            stream,
+        )
+    }
+
+    fn send_json(&self, value: FlowResult<Json>) {
+        if let Some(CallCompletionSender::Json(sender)) = self.sender.lock().unwrap().take() {
             let _ = sender.send(value);
+        }
+    }
+
+    fn send_error(&self, error: FlowError) {
+        if let Some(sender) = self.sender.lock().unwrap().take() {
+            match sender {
+                CallCompletionSender::Json(sender) => {
+                    let _ = sender.send(Err(error));
+                }
+                CallCompletionSender::Stream(sender) => {
+                    if let Some(ready) = sender.ready.lock().unwrap().take() {
+                        let _ = ready.send(Err(error));
+                    } else {
+                        *sender.terminal_error.lock().unwrap() = Some(error);
+                    }
+                    sender.chunks.lock().unwrap().take();
+                }
+            }
         }
     }
 }
@@ -193,6 +252,43 @@ impl Drop for CallCancellationGuard {
         if let Some(cancellation) = self.0.take() {
             cancellation.cancel();
         }
+    }
+}
+
+struct JsCallbackStream {
+    receiver: tokio_stream::wrappers::ReceiverStream<FlowResult<Json>>,
+    completion: Arc<StreamCompletion>,
+    cancellation: CallCancellation,
+}
+
+impl Stream for JsCallbackStream {
+    type Item = FlowResult<Json>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.receiver).poll_next(cx) {
+            Poll::Ready(None) => Poll::Ready(
+                self.completion
+                    .terminal_error
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .map(Err),
+            ),
+            poll => poll,
+        }
+    }
+}
+
+impl LlmStreamInner for JsCallbackStream {
+    fn close(self: Pin<&mut Self>) -> Pin<Box<dyn Future<Output = FlowResult<()>> + Send + '_>> {
+        self.cancellation.cancel();
+        Box::pin(async { Ok(()) })
+    }
+}
+
+impl Drop for JsCallbackStream {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
     }
 }
 
@@ -288,7 +384,7 @@ fn build_next_unknown(
                 let publication_context_id = publication_context_id.clone();
                 ctx.env.execute_tokio_future(
                     async move {
-                        with_publication_callback_context(
+                        let stream = with_publication_callback_context(
                             publication_context_id,
                             None,
                             async move {
@@ -301,7 +397,8 @@ fn build_next_unknown(
                                     .await
                             },
                         )
-                        .await
+                        .await?;
+                        Ok(crate::api::llm_stream_from_rust_stream(stream))
                     },
                     |_env, value| Ok(value),
                 )
@@ -315,15 +412,34 @@ fn build_next_unknown(
 fn build_completion_unknowns(
     env: &Env,
     completion: CallCompletion,
-) -> napi::Result<(JsUnknown, JsUnknown)> {
-    let resolve_completion = completion.clone();
-    let resolve = env.create_function_from_closure("__nemo_relay_resolve", move |ctx| {
-        let value = ctx.get::<Json>(0).map_err(|error| {
-            FlowError::Internal(format!(
-                "JavaScript callback result could not be converted to JSON: {error}"
-            ))
+) -> napi::Result<(JsUnknown, JsUnknown, JsUnknown, JsUnknown)> {
+    let stream_completion = completion
+        .sender
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|sender| match sender {
+            CallCompletionSender::Stream(stream) => Some(stream.clone()),
+            CallCompletionSender::Json(_) => None,
         });
-        resolve_completion.send(value);
+    let resolve_completion = completion.clone();
+    let resolve_stream = stream_completion.clone();
+    let resolve = env.create_function_from_closure("__nemo_relay_resolve", move |ctx| {
+        if let Some(stream) = &resolve_stream {
+            if let Some(ready) = stream.ready.lock().unwrap().take() {
+                let _ = ready.send(Ok(()));
+            }
+            return ctx.env.get_undefined();
+        }
+        let sender = resolve_completion.sender.lock().unwrap().take();
+        if let Some(CallCompletionSender::Json(sender)) = sender {
+            let value = ctx.get::<Json>(0).map_err(|error| {
+                FlowError::Internal(format!(
+                    "JavaScript callback result could not be converted to JSON: {error}"
+                ))
+            });
+            let _ = sender.send(value);
+        }
         ctx.env.get_undefined()
     })?;
 
@@ -335,16 +451,46 @@ fn build_completion_unknowns(
             .get::<String>(0)
             .unwrap_or_else(|_| "unknown error".to_string());
         let exception_type = ctx.get::<String>(1).unwrap_or_else(|_| "Error".to_string());
-        completion.send(Err(FlowError::CallbackException {
+        completion.send_error(FlowError::CallbackException {
             message,
             exception_type,
-        }));
+        });
+        ctx.env.get_undefined()
+    })?;
+
+    let push_stream = stream_completion.clone();
+    let push = env.create_function_from_closure("__nemo_relay_stream_push", move |ctx| {
+        let chunk = ctx.get::<Json>(0).map_err(|error| {
+            napi::Error::from_reason(format!("stream chunk is not JSON-compatible: {error}"))
+        })?;
+        let chunks = push_stream
+            .as_ref()
+            .and_then(|stream| stream.chunks.lock().unwrap().as_ref().cloned());
+        ctx.env.execute_tokio_future(
+            async move {
+                if let Some(chunks) = chunks {
+                    chunks.send(Ok(chunk)).await.map_err(|_| {
+                        napi::Error::from_reason("stream consumer closed".to_string())
+                    })?;
+                }
+                Ok(())
+            },
+            |_env, ()| Ok(()),
+        )
+    })?;
+
+    let end = env.create_function_from_closure("__nemo_relay_stream_end", move |ctx| {
+        if let Some(stream) = &stream_completion {
+            stream.chunks.lock().unwrap().take();
+        }
         ctx.env.get_undefined()
     })?;
 
     Ok((
         function_to_unknown(env, &resolve),
         function_to_unknown(env, &reject),
+        function_to_unknown(env, &push),
+        function_to_unknown(env, &end),
     ))
 }
 
@@ -437,10 +583,16 @@ impl PromiseAwareFn {
                         &ctx.env,
                         Json::String(ctx.value.propagation_parent_uuid),
                     )?;
-                    let (resolve, reject) =
+                    let (resolve, reject, stream_push, stream_end) =
                         build_completion_unknowns(&ctx.env, ctx.value.completion)?;
                     let register_abort =
                         build_abort_registration_unknown(&ctx.env, ctx.value.cancellation)?;
+                    let stream_result = unsafe {
+                        JsUnknown::from_raw_unchecked(
+                            ctx.env.raw(),
+                            ctx.env.get_boolean(ctx.value.stream_result)?.raw(),
+                        )
+                    };
                     Ok(vec![
                         arg0,
                         spread,
@@ -452,12 +604,15 @@ impl PromiseAwareFn {
                         scope_stack,
                         propagation_parent_uuid,
                         register_abort,
+                        stream_result,
+                        stream_push,
+                        stream_end,
                     ])
                 })();
                 if let Err(error) = &result {
-                    completion.send(Err(FlowError::Internal(format!(
+                    completion.send_error(FlowError::Internal(format!(
                         "failed to build JavaScript middleware callback arguments: {error}"
-                    ))));
+                    )));
                 }
                 result
             })?;
@@ -538,18 +693,53 @@ impl PromiseAwareFn {
     }
 
     /// Call the JS function with a middleware-style `next(arg)` callback that
-    /// resolves to an array of downstream stream chunks.
+    /// resolves to a lazy downstream stream.
     pub async fn call_with_stream_next(
         &self,
         args: Json,
         next: JsonStreamNextFn,
-    ) -> FlowResult<Json> {
-        self.call_inner(
-            PrimaryArg::Json(args),
-            CallMode::DIRECT,
-            Some(NextFn::Stream(next)),
-        )
-        .await
+    ) -> FlowResult<nemo_relay::api::runtime::LlmJsonStream> {
+        let (ready_sender, ready_receiver) = tokio::sync::oneshot::channel();
+        let (chunk_sender, chunk_receiver) = tokio::sync::mpsc::channel(1);
+        let (completion, stream_completion) = CallCompletion::stream(ready_sender, chunk_sender);
+        let cancellation = CallCancellation::default();
+        let continuation_context = MiddlewareContinuationContext::capture();
+        let propagation_parent_uuid = capture_propagation_context()?.parent_uuid.to_string();
+        let tsfn = self
+            .tsfn
+            .lock()
+            .unwrap()
+            .as_ref()
+            .cloned()
+            .ok_or_else(closed_tsfn_error)?;
+        let status = tsfn.call(
+            Ok(CallArgs {
+                arg0: PrimaryArg::Json(args),
+                spread: false,
+                next: Some(NextFn::Stream(next)),
+                publication: false,
+                publication_context_id: publication_callback_context_id(),
+                scope_stack: Some(current_scope_stack()),
+                propagation_parent_uuid,
+                publication_buffer: capture_nested_publication_buffer(),
+                stream_result: true,
+                continuation_context: Some(continuation_context),
+                cancellation: cancellation.clone(),
+                completion,
+            }),
+            napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+        );
+        queue_status_result(status)?;
+        ready_receiver
+            .await
+            .map_err(|e| FlowError::Internal(e.to_string()))??;
+        Ok(nemo_relay::api::runtime::LlmJsonStream::from_closeable(
+            JsCallbackStream {
+                receiver: tokio_stream::wrappers::ReceiverStream::new(chunk_receiver),
+                completion: stream_completion,
+                cancellation,
+            },
+        ))
     }
 
     /// Release the underlying threadsafe function so it does not outlive its registration.
@@ -592,9 +782,10 @@ impl PromiseAwareFn {
                 scope_stack: Some(current_scope_stack()),
                 propagation_parent_uuid,
                 publication_buffer: capture_nested_publication_buffer(),
+                stream_result: false,
                 continuation_context,
                 cancellation,
-                completion: CallCompletion::new(sender),
+                completion: CallCompletion::json(sender),
             }),
             napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
         );

--- a/crates/node/src/promise_call.rs
+++ b/crates/node/src/promise_call.rs
@@ -136,6 +136,14 @@ struct StreamCompletion {
     ready: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<FlowResult<()>>>>,
     chunks: std::sync::Mutex<Option<tokio::sync::mpsc::Sender<FlowResult<Json>>>>,
     terminal_error: std::sync::Mutex<Option<FlowError>>,
+    closed: tokio::sync::watch::Sender<Option<FlowResult<()>>>,
+}
+
+impl StreamCompletion {
+    fn finish(&self, result: FlowResult<()>) {
+        self.chunks.lock().unwrap().take();
+        self.closed.send_replace(Some(result));
+    }
 }
 
 #[derive(Clone)]
@@ -155,11 +163,17 @@ impl CallCompletion {
     fn stream(
         ready: tokio::sync::oneshot::Sender<FlowResult<()>>,
         chunks: tokio::sync::mpsc::Sender<FlowResult<Json>>,
-    ) -> (Self, Arc<StreamCompletion>) {
+    ) -> (
+        Self,
+        Arc<StreamCompletion>,
+        tokio::sync::watch::Receiver<Option<FlowResult<()>>>,
+    ) {
+        let (closed, closed_rx) = tokio::sync::watch::channel(None);
         let stream = Arc::new(StreamCompletion {
             ready: std::sync::Mutex::new(Some(ready)),
             chunks: std::sync::Mutex::new(Some(chunks)),
             terminal_error: std::sync::Mutex::new(None),
+            closed,
         });
         (
             Self {
@@ -168,6 +182,7 @@ impl CallCompletion {
                 )))),
             },
             stream,
+            closed_rx,
         )
     }
 
@@ -185,11 +200,11 @@ impl CallCompletion {
                 }
                 CallCompletionSender::Stream(sender) => {
                     if let Some(ready) = sender.ready.lock().unwrap().take() {
-                        let _ = ready.send(Err(error));
+                        let _ = ready.send(Err(error.clone()));
                     } else {
-                        *sender.terminal_error.lock().unwrap() = Some(error);
+                        *sender.terminal_error.lock().unwrap() = Some(error.clone());
                     }
-                    sender.chunks.lock().unwrap().take();
+                    sender.finish(Err(error));
                 }
             }
         }
@@ -258,6 +273,7 @@ impl Drop for CallCancellationGuard {
 struct JsCallbackStream {
     receiver: tokio_stream::wrappers::ReceiverStream<FlowResult<Json>>,
     completion: Arc<StreamCompletion>,
+    closed: tokio::sync::watch::Receiver<Option<FlowResult<()>>>,
     cancellation: CallCancellation,
 }
 
@@ -281,8 +297,18 @@ impl Stream for JsCallbackStream {
 
 impl LlmStreamInner for JsCallbackStream {
     fn close(self: Pin<&mut Self>) -> Pin<Box<dyn Future<Output = FlowResult<()>> + Send + '_>> {
-        self.cancellation.cancel();
-        Box::pin(async { Ok(()) })
+        let this = self.get_mut();
+        this.cancellation.cancel();
+        this.receiver.close();
+        let mut closed = this.closed.clone();
+        Box::pin(async move {
+            while closed.borrow().is_none() {
+                closed.changed().await.map_err(|_| {
+                    FlowError::Internal("JavaScript stream cleanup ended early".into())
+                })?;
+            }
+            closed.borrow().clone().expect("close state checked above")
+        })
     }
 }
 
@@ -469,9 +495,7 @@ fn build_completion_unknowns(
         ctx.env.execute_tokio_future(
             async move {
                 if let Some(chunks) = chunks {
-                    chunks.send(Ok(chunk)).await.map_err(|_| {
-                        napi::Error::from_reason("stream consumer closed".to_string())
-                    })?;
+                    let _ = chunks.send(Ok(chunk)).await;
                 }
                 Ok(())
             },
@@ -481,7 +505,7 @@ fn build_completion_unknowns(
 
     let end = env.create_function_from_closure("__nemo_relay_stream_end", move |ctx| {
         if let Some(stream) = &stream_completion {
-            stream.chunks.lock().unwrap().take();
+            stream.finish(Ok(()));
         }
         ctx.env.get_undefined()
     })?;
@@ -700,9 +724,12 @@ impl PromiseAwareFn {
         next: JsonStreamNextFn,
     ) -> FlowResult<nemo_relay::api::runtime::LlmJsonStream> {
         let (ready_sender, ready_receiver) = tokio::sync::oneshot::channel();
-        let (chunk_sender, chunk_receiver) = tokio::sync::mpsc::channel(1);
-        let (completion, stream_completion) = CallCompletion::stream(ready_sender, chunk_sender);
+        let (chunk_sender, chunk_receiver) =
+            tokio::sync::mpsc::channel(crate::api::LLM_STREAM_BRIDGE_CAPACITY);
+        let (completion, stream_completion, closed) =
+            CallCompletion::stream(ready_sender, chunk_sender);
         let cancellation = CallCancellation::default();
+        let mut cancellation_guard = CallCancellationGuard::new(cancellation.clone());
         let continuation_context = MiddlewareContinuationContext::capture();
         let propagation_parent_uuid = capture_propagation_context()?.parent_uuid.to_string();
         let tsfn = self
@@ -733,10 +760,12 @@ impl PromiseAwareFn {
         ready_receiver
             .await
             .map_err(|e| FlowError::Internal(e.to_string()))??;
+        cancellation_guard.disarm();
         Ok(nemo_relay::api::runtime::LlmJsonStream::from_closeable(
             JsCallbackStream {
                 receiver: tokio_stream::wrappers::ReceiverStream::new(chunk_receiver),
                 completion: stream_completion,
+                closed,
                 cancellation,
             },
         ))

--- a/crates/node/tests/llm_tests.mjs
+++ b/crates/node/tests/llm_tests.mjs
@@ -1645,7 +1645,7 @@ describe('LLM intercepts', () => {
     try {
       stream = await llmStreamCallExecute('backpressure_stream_llm', makeNative(), () => {});
       await new Promise((resolve) => setTimeout(resolve, 10));
-      assert.ok(pulls <= 40, `expected bounded read-ahead, observed ${pulls} pulls`);
+      assert.ok(pulls <= 72, `expected bounded read-ahead, observed ${pulls} pulls`);
 
       const chunks = [];
       for (;;) {
@@ -1686,6 +1686,54 @@ describe('LLM intercepts', () => {
       assert.equal(providerEnded, true);
     } finally {
       deregisterLlmStreamExecutionIntercept('node_llm_stream_early_close');
+    }
+  });
+
+  it('stream execution intercept closes its iterator after a chunk conversion error', async () => {
+    let cleaned = false;
+    let stream;
+    registerLlmStreamExecutionIntercept('node_llm_stream_invalid_chunk_cleanup', 10, async () =>
+      (async function* () {
+        try {
+          yield 1n;
+        } finally {
+          cleaned = true;
+        }
+      })(),
+    );
+    try {
+      stream = await llmStreamCallExecute('invalid_chunk_cleanup_stream_llm', makeNative(), () => {});
+      await assert.rejects(() => stream.next(), /unsupported bigint value/i);
+      assert.equal(cleaned, true);
+      await assert.rejects(() => stream.close(), /unsupported bigint value/i);
+    } finally {
+      await stream?.close().catch(() => {});
+      deregisterLlmStreamExecutionIntercept('node_llm_stream_invalid_chunk_cleanup');
+    }
+  });
+
+  it('stream execution intercept close waits for iterator cleanup', async () => {
+    let cleaned = false;
+    registerLlmStreamExecutionIntercept('node_llm_stream_await_cleanup', 10, async (_request, _next, signal) =>
+      (async function* () {
+        try {
+          yield { token: 'first' };
+          if (!signal.aborted) {
+            await new Promise((resolve) => signal.addEventListener('abort', resolve, { once: true }));
+          }
+        } finally {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          cleaned = true;
+        }
+      })(),
+    );
+    try {
+      const stream = await llmStreamCallExecute('await_cleanup_stream_llm', makeNative(), () => {});
+      assert.deepEqual(await stream.next(), { token: 'first' });
+      await stream.close();
+      assert.equal(cleaned, true);
+    } finally {
+      deregisterLlmStreamExecutionIntercept('node_llm_stream_await_cleanup');
     }
   });
 

--- a/crates/node/tests/llm_tests.mjs
+++ b/crates/node/tests/llm_tests.mjs
@@ -1514,13 +1514,11 @@ describe('LLM intercepts', () => {
   it('stream execution intercept composes with next', async () => {
     registerLlmStreamExecutionIntercept('node_llm_stream_exec_repl', 10, async (native, next) => {
       native.content.intercepted = true;
-      const chunks = await next(native);
-      return [
-        ...chunks,
-        {
-          wrapped: native.content.intercepted,
-        },
-      ];
+      const downstream = await next(native);
+      return (async function* () {
+        yield* downstream;
+        yield { wrapped: native.content.intercepted };
+      })();
     });
 
     const native = makeNative();
@@ -1551,14 +1549,7 @@ describe('LLM intercepts', () => {
       seen.push(chunk);
     }
 
-    assert.deepEqual(seen, [
-      {
-        chunk: true,
-      },
-      {
-        wrapped: true,
-      },
-    ]);
+    assert.deepEqual(seen, [{ chunk: true }, { wrapped: true }]);
     deregisterLlmStreamExecutionIntercept('node_llm_stream_exec_repl');
   });
 
@@ -1571,7 +1562,9 @@ describe('LLM intercepts', () => {
     let providerCalls = 0;
     registerLlmStreamExecutionIntercept('node_llm_stream_late_next', 10, async (native, next) => {
       lateNext = lateGate.then(() => next(native));
-      return [{ source: 'intercept' }];
+      return (async function* () {
+        yield { source: 'intercept' };
+      })();
     });
     try {
       const stream = await llmStreamCallExecute('late_next_stream_llm', makeNative(), () => {
@@ -1595,26 +1588,116 @@ describe('LLM intercepts', () => {
     let retainedNext;
     registerLlmStreamExecutionIntercept('node_llm_stream_retained_next_scope', 10, async (native, next) => {
       retainedNext = () => next(native);
-      // Keep the Rust-to-Node forwarding channel backpressured so the
-      // interceptor output stream, and therefore its continuation lease,
-      // remains active after this callback Promise resolves.
-      return Array.from({ length: 64 }, (_, index) => ({ source: 'intercept', index }));
+      return (async function* () {
+        for (let index = 0; index < 64; index += 1) {
+          yield { source: 'intercept', index };
+        }
+      })();
     });
     try {
       const stream = await lib.withScopeStack(invocationStack, () =>
         llmStreamCallExecute('retained_next_scope_stream_llm', makeNative(), (wrapper) => {
-          lib.pushStreamChunk(wrapper.__nemo_relay_stream_id, {
-            scope: lib.getHandle().uuid,
-          });
+          lib.pushStreamChunk(wrapper.__nemo_relay_stream_id, { scope: lib.getHandle().uuid });
           lib.endStream(wrapper.__nemo_relay_stream_id);
         }),
       );
-
-      assert.deepEqual(await retainedNext(), [{ scope: invocationScope }]);
+      const downstream = await retainedNext();
+      const iterator = downstream[Symbol.asyncIterator]();
+      assert.deepEqual(await iterator.next(), { done: false, value: { scope: invocationScope } });
       assert.deepEqual(await stream.next(), { source: 'intercept', index: 0 });
       await stream.close();
     } finally {
       deregisterLlmStreamExecutionIntercept('node_llm_stream_retained_next_scope');
+    }
+  });
+
+  it('stream execution intercept preserves first-chunk delivery before completion', async () => {
+    let releaseCompletion;
+    const completion = new Promise((resolve) => {
+      releaseCompletion = resolve;
+    });
+    registerLlmStreamExecutionIntercept('node_llm_stream_incremental', 10, async (request, next) => next(request));
+    try {
+      const stream = await llmStreamCallExecute('incremental_stream_llm', makeNative(), (wrapper) => {
+        lib.pushStreamChunk(wrapper.__nemo_relay_stream_id, { token: 'first' });
+        completion.then(() => lib.endStream(wrapper.__nemo_relay_stream_id));
+      });
+      assert.deepEqual(await stream.next(), { token: 'first' });
+      releaseCompletion();
+      assert.equal(await stream.next(), null);
+    } finally {
+      releaseCompletion?.();
+      deregisterLlmStreamExecutionIntercept('node_llm_stream_incremental');
+    }
+  });
+
+  it('stream execution intercept applies backpressure to its async iterable', async () => {
+    let pulls = 0;
+    let stream;
+    registerLlmStreamExecutionIntercept('node_llm_stream_backpressure', 10, async () =>
+      (async function* () {
+        for (let index = 0; index < 256; index += 1) {
+          pulls += 1;
+          yield { index };
+        }
+      })(),
+    );
+    try {
+      stream = await llmStreamCallExecute('backpressure_stream_llm', makeNative(), () => {});
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      assert.ok(pulls <= 40, `expected bounded read-ahead, observed ${pulls} pulls`);
+
+      const chunks = [];
+      for (;;) {
+        const chunk = await stream.next();
+        if (chunk === null) break;
+        chunks.push(chunk);
+      }
+      assert.equal(chunks.length, 256);
+      assert.equal(pulls, 256);
+    } finally {
+      await stream?.close();
+      deregisterLlmStreamExecutionIntercept('node_llm_stream_backpressure');
+    }
+  });
+
+  it('stream execution intercept closes a transformed downstream stream early', async () => {
+    let providerEnded = false;
+    registerLlmStreamExecutionIntercept('node_llm_stream_early_close', 10, async (request, next) => {
+      const downstream = await next(request);
+      return (async function* () {
+        yield* downstream;
+      })();
+    });
+    try {
+      const stream = await llmStreamCallExecute('early_close_stream_llm', makeNative(), (wrapper) => {
+        lib.pushStreamChunk(wrapper.__nemo_relay_stream_id, { token: 'first' });
+        const poll = setInterval(() => {
+          if (!lib.pushStreamChunk(wrapper.__nemo_relay_stream_id, { token: 'later' })) {
+            clearInterval(poll);
+            providerEnded = true;
+            lib.endStream(wrapper.__nemo_relay_stream_id);
+          }
+        }, 1);
+      });
+      assert.deepEqual(await stream.next(), { token: 'first' });
+      await stream.close();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      assert.equal(providerEnded, true);
+    } finally {
+      deregisterLlmStreamExecutionIntercept('node_llm_stream_early_close');
+    }
+  });
+
+  it('stream execution intercept rejects non-iterable results', async () => {
+    registerLlmStreamExecutionIntercept('node_llm_stream_non_iterable', 10, async () => ({ invalid: true }));
+    try {
+      await assert.rejects(
+        () => llmStreamCallExecute('non_iterable_stream_llm', makeNative(), () => {}),
+        /must return an AsyncIterable/i,
+      );
+    } finally {
+      deregisterLlmStreamExecutionIntercept('node_llm_stream_non_iterable');
     }
   });
 
@@ -1691,7 +1774,10 @@ describe('LLM intercepts', () => {
           }),
         ),
       ]);
-      return [...first, ...second];
+      return (async function* () {
+        yield* first;
+        yield* second;
+      })();
     });
     try {
       const stream = await llmStreamCallExecute('scoped_next_stream_llm', makeNative(), (wrapper) => {
@@ -1743,10 +1829,13 @@ describe('LLM intercepts', () => {
       releaseBlocker = resolve;
     });
 
-    registerLlmStreamExecutionIntercept('node_llm_stream_snapshot_target', 100, async (request, next) => [
-      ...(await next(request)),
-      { snapshotted: true },
-    ]);
+    registerLlmStreamExecutionIntercept('node_llm_stream_snapshot_target', 100, async (request, next) => {
+      const downstream = await next(request);
+      return (async function* () {
+        yield* downstream;
+        yield { snapshotted: true };
+      })();
+    });
     registerLlmStreamExecutionIntercept('node_llm_stream_snapshot_blocker', -100, async (request, next) => {
       blockerEntered();
       await release;
@@ -1826,43 +1915,6 @@ describe('LLM intercepts', () => {
       stdio: 'inherit',
       timeout: 5_000,
     });
-  });
-
-  it('stream execution intercept can return a single scalar chunk', async () => {
-    registerLlmStreamExecutionIntercept('node_llm_stream_scalar', 10, async () => ({
-      scalar: true,
-    }));
-
-    const seen = [];
-    const stream = await llmStreamCallExecute(
-      'stream_scalar_llm',
-      makeNative(),
-      () => {
-        throw new Error('downstream stream should not be called');
-      },
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-    );
-
-    for (;;) {
-      const chunk = await stream.next();
-      if (chunk === null) {
-        break;
-      }
-      seen.push(chunk);
-    }
-
-    assert.deepEqual(seen, [
-      {
-        scalar: true,
-      },
-    ]);
-    deregisterLlmStreamExecutionIntercept('node_llm_stream_scalar');
   });
 
   it('stream execution intercept rejects invalid next request payloads', async () => {
@@ -2011,14 +2063,12 @@ describe('LLM intercepts', () => {
       assert.match(declaration, /Promise</, `${registration} must expose its Promise callback form`);
     }
     assert.equal(
-      declarations.split('next: (request: Json) => Promise<Json[]>').length - 1,
+      declarations.split('next: (request: Json) => Promise<AsyncIterable<Json>>').length - 1,
       2,
-      'global and scope-local stream intercept declarations must expose the buffered next contract',
+      'global and scope-local stream intercept declarations must expose the lazy next contract',
     );
     assert.equal(
-      declarations.split(
-        'next: (args: Json) => ToolExecutionResult | Promise<ToolExecutionResult>',
-      ).length - 1,
+      declarations.split('next: (args: Json) => ToolExecutionResult | Promise<ToolExecutionResult>').length - 1,
       2,
       'global and scope-local tool intercept declarations must expose canonical tool results',
     );
@@ -2038,9 +2088,8 @@ describe('LLM intercepts', () => {
     assert.match(declarations, /registerLlmRequestIntercept\([\s\S]*?Promise<LlmRequestInterceptOutcome>/);
     assert.match(
       declarations,
-      /registerLlmStreamExecutionIntercept\([\s\S]*?next: \(request: Json\) => Promise<Json\[\]>/,
+      /registerLlmStreamExecutionIntercept\([\s\S]*?next: \(request: Json\) => Promise<AsyncIterable<Json>>/,
     );
-    assert.doesNotMatch(declarations, /registerLlmStreamExecutionIntercept\([\s\S]*?AsyncIterable/);
   });
 
   it('standalone conditional execution helper throws on rejection', async () => {

--- a/crates/node/tests/scope_local_tests.mjs
+++ b/crates/node/tests/scope_local_tests.mjs
@@ -1078,12 +1078,16 @@ describe('Scope-local LLM intercepts', () => {
   it('scope-local llm execution intercept rejects invalid next request payloads', async () => {
     const scope = pushScope('sl_llm_exec_invalid_scope', ScopeType.Agent, null, null);
     scopeRegisterLlmExecutionIntercept(scope.uuid, 'sl_llm_exec_invalid', 10, async (_request, next) => {
-      return next({
+      const downstream = await next({
         headers: 1,
         content: {
           model: 'broken',
         },
       });
+      return (async function* () {
+        yield* downstream;
+        yield { wrappedByScopeStream: true };
+      })();
     });
 
     try {
@@ -1122,19 +1126,17 @@ describe('Scope-local LLM intercepts', () => {
   it('scope-local llm stream execution intercept composes with next', async () => {
     const scope = pushScope('sl_llm_stream_compose_scope', ScopeType.Agent, null, null);
     scopeRegisterLlmStreamExecutionIntercept(scope.uuid, 'sl_llm_stream_compose', 10, async (request, next) => {
-      const chunks = await next({
+      const downstream = await next({
         ...request,
         content: {
           ...request.content,
           touchedByScopeStream: true,
         },
       });
-      return [
-        ...chunks,
-        {
-          wrappedByScopeStream: true,
-        },
-      ];
+      return (async function* () {
+        yield* downstream;
+        yield { wrappedByScopeStream: true };
+      })();
     });
 
     try {
@@ -1165,14 +1167,7 @@ describe('Scope-local LLM intercepts', () => {
         seen.push(chunk);
       }
 
-      assert.deepEqual(seen, [
-        {
-          downstream: true,
-        },
-        {
-          wrappedByScopeStream: true,
-        },
-      ]);
+      assert.deepEqual(seen, [{ downstream: true }, { wrappedByScopeStream: true }]);
     } finally {
       scopeDeregisterLlmStreamExecutionIntercept(scope.uuid, 'sl_llm_stream_compose');
       popScope(scope);

--- a/docs/build-plugins/language-binding/register-behavior.mdx
+++ b/docs/build-plugins/language-binding/register-behavior.mdx
@@ -179,9 +179,11 @@ context.registerLlmRequestIntercept(
 context.registerLlmStreamExecutionIntercept(
   'documentation-stream',
   execution.priority,
-  async (request, next) => (
-    (await next(request)).map((chunk) => ({ ...chunk, plugin_stream: true }))
-  ),
+  async function* (request, next) {
+    for await (const chunk of await next(request)) {
+      yield { ...chunk, plugin_stream: true };
+    }
+  },
 );
 ```
 </Tab>

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -19,6 +19,42 @@ Rust code that constructs `ResponseCacheConfig` with an exhaustive struct
 literal must add `tools: None`. Prefer `..ResponseCacheConfig::default()` when
 the literal should remain compatible with new optional cache surfaces.
 
+### Stream Node.js LLM Execution Intercepts Lazily
+
+<Warning title="Breaking Change">
+NeMo Relay 0.8 changes Node.js LLM streaming execution intercepts from buffered
+JSON values to lazy async iterables. `next(request)` now resolves to an
+`AsyncIterable<Json>`, and the intercept callback must return an async iterable
+or a promise of one. Scalar and array return values are rejected.
+</Warning>
+
+This change applies to global, scope-local, and plugin-owned registrations made
+with `registerLlmStreamExecutionIntercept`,
+`scopeRegisterLlmStreamExecutionIntercept`, and
+`PluginContext.registerLlmStreamExecutionIntercept`.
+
+Replace array transforms such as this pre-0.8 callback:
+
+```js
+async (request, next) =>
+  (await next(request)).map((chunk) => ({ ...chunk, intercepted: true }));
+```
+
+Use an async generator to transform downstream chunks incrementally:
+
+```js
+async function* transformStream(request, next) {
+  for await (const chunk of await next(request)) {
+    yield { ...chunk, intercepted: true };
+  }
+}
+```
+
+Return `next(request)` directly when the intercept only forwards the stream. To
+short-circuit the downstream chain, return an async generator that yields the
+replacement chunks. Do not collect the iterable into an array unless the
+application intentionally needs to buffer the complete response.
+
 ### Move Hermes Agent to Its Native Relay Integration
 
 NeMo Relay 0.8 removes Hermes Agent from the Relay CLI. The `nemo-relay hermes`

--- a/examples/language-binding-plugin/node/main.mjs
+++ b/examples/language-binding-plugin/node/main.mjs
@@ -251,10 +251,14 @@ export const documentationPlugin = {
           pendingMarks: execution.emit_pending_marks ? [{ name: 'documentation-plugin.tool-complete' }] : [],
         };
       });
-      context.registerLlmExecutionIntercept('llm-execution', execution.priority, async (request, next) => next(request));
-      context.registerLlmStreamExecutionIntercept('llm-stream', execution.priority, async (request, next) =>
-        (await next(request)).map((chunk) => ({ ...chunk, plugin_stream: true })),
+      context.registerLlmExecutionIntercept('llm-execution', execution.priority, async (request, next) =>
+        next(request),
       );
+      context.registerLlmStreamExecutionIntercept('llm-stream', execution.priority, async function* (request, next) {
+        for await (const chunk of await next(request)) {
+          yield { ...chunk, plugin_stream: true };
+        }
+      });
     }
   },
 };

--- a/examples/language-binding-plugin/node/test-plugin.mjs
+++ b/examples/language-binding-plugin/node/test-plugin.mjs
@@ -163,10 +163,14 @@ test('LLM policy blocks the configured model', () => {
 test('LLM stream chunks are transformed', async () => {
   const intercept = registeredCallbacks().get('registerLlmStreamExecutionIntercept');
 
-  const chunks = await intercept({ headers: {}, content: { model: 'allowed-model' } }, async () => [
-    { chunk: 1 },
-    { chunk: 2 },
-  ]);
+  const transformed = intercept({ headers: {}, content: { model: 'allowed-model' } }, async () =>
+    (async function* () {
+      yield { chunk: 1 };
+      yield { chunk: 2 };
+    })(),
+  );
+  const chunks = [];
+  for await (const chunk of transformed) chunks.push(chunk);
 
   assert.deepEqual(chunks, [
     { chunk: 1, plugin_stream: true },


### PR DESCRIPTION
> [!WARNING]
> **BREAKING CHANGE:** **[Node.js source compatibility]** LLM streaming execution intercepts no longer receive arrays from `next()` or accept scalar and array return values. `next(request)` now resolves to `AsyncIterable<Json>`, and callbacks must return an async iterable or a promise of one. Update chunk transforms to use async generators and `for await`. Refer to the [Node.js stream-intercept migration guide](https://docs.nvidia.com/nemo/relay/reference/migration-guides#stream-nodejs-llm-execution-intercepts-lazily).

#### Overview

Make Node.js LLM streaming execution intercepts consume and return lazy async iterables instead of buffering downstream chunks into arrays.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Change the Node.js streaming execution-intercept contract so `next(request)` resolves to `AsyncIterable<Json>` and callbacks return `AsyncIterable<Json>`.
- Bridge JavaScript and Rust streams incrementally with bounded backpressure, cancellation, terminal-error propagation, and scope preservation.
- Add regression coverage for stream transformation, incremental delivery, backpressure, early closure, invalid return values, and scope-local behavior.
- Update the plugin API declaration, documentation, and runnable Node.js plugin example.
- Breaking change: remove the previous scalar/array return compatibility for Node.js streaming execution intercepts.

#### Where should the reviewer start?

Start with `crates/node/src/promise_call.rs` for the lazy stream bridge, then review the streaming intercept tests in `crates/node/tests/llm_tests.mjs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-759](https://linear.app/nvidia/issue/RELAY-759/nemo-relay080-node-binding-registering-an-llm-streaming-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - LLM stream interceptors now process and transform chunks incrementally through lazy asynchronous streams.
  - Supports lower-latency delivery, reduced buffering, backpressure, cancellation, early closure, and reliable completion.
  - Scope-local interception continues to support composing and modifying downstream output.
  - Streaming callbacks now require asynchronous iterables, with non-iterable results rejected.

- **Documentation**
  - Updated plugin guidance, examples, and migration documentation for asynchronous stream processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
