### PR TITLE
fix: identify OTLP signal provider errors

### DIFF
--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -145,7 +145,13 @@ pub enum OpenTelemetryError {
     ExporterBuild(String),
     /// The underlying tracer provider returned an error.
     #[error("OpenTelemetry tracer provider error: {0}")]
-    Provider(String),
+    TraceProvider(String),
+    /// The underlying logger provider returned an error.
+    #[error("OpenTelemetry log provider error: {0}")]
+    LogProvider(String),
+    /// The underlying meter provider returned an error.
+    #[error("OpenTelemetry metric provider error: {0}")]
+    MetricProvider(String),
     /// Attribute mapping configuration was invalid.
     #[error("invalid attribute mappings: {0}")]
     InvalidAttributeMappings(String),
@@ -693,7 +699,7 @@ impl OpenTelemetrySubscriber {
     pub fn force_flush(&self) -> Result<()> {
         flush_subscribers()?;
         let guard = self.inner.processor.lock().map_err(|_| {
-            OpenTelemetryError::Provider("the subscriber state lock was poisoned".to_string())
+            OpenTelemetryError::TraceProvider("the subscriber state lock was poisoned".to_string())
         })?;
         guard.force_flush()
     }
@@ -712,7 +718,7 @@ impl OpenTelemetrySubscriber {
 
     pub(crate) fn shutdown_provider(&self) -> Result<()> {
         let guard = self.inner.processor.lock().map_err(|_| {
-            OpenTelemetryError::Provider("the subscriber state lock was poisoned".to_string())
+            OpenTelemetryError::TraceProvider("the subscriber state lock was poisoned".to_string())
         })?;
         let result = guard.shutdown();
         if result.is_ok() {
@@ -1194,13 +1200,13 @@ impl OtelEventProcessor {
     pub(super) fn force_flush(&self) -> Result<()> {
         self.provider
             .force_flush()
-            .map_err(|e| OpenTelemetryError::Provider(e.to_string()))
+            .map_err(|e| OpenTelemetryError::TraceProvider(e.to_string()))
     }
 
     fn shutdown(&self) -> Result<()> {
         self.provider
             .shutdown()
-            .map_err(|e| OpenTelemetryError::Provider(e.to_string()))
+            .map_err(|e| OpenTelemetryError::TraceProvider(e.to_string()))
     }
 
     fn process_start(&mut self, event: &Event) {

--- a/crates/core/src/observability/otel_logs.rs
+++ b/crates/core/src/observability/otel_logs.rs
@@ -304,7 +304,7 @@ impl OpenTelemetryLogSubscriber {
         self.inner
             .provider
             .force_flush()
-            .map_err(|error| OpenTelemetryError::Provider(error.to_string()))
+            .map_err(|error| OpenTelemetryError::LogProvider(error.to_string()))
     }
 
     /// Shut down the OTLP logger provider.
@@ -316,7 +316,7 @@ impl OpenTelemetryLogSubscriber {
             .inner
             .provider
             .shutdown()
-            .map_err(|error| OpenTelemetryError::Provider(error.to_string()));
+            .map_err(|error| OpenTelemetryError::LogProvider(error.to_string()));
         barrier.and(provider)
     }
 
@@ -324,7 +324,7 @@ impl OpenTelemetryLogSubscriber {
         self.inner
             .provider
             .shutdown()
-            .map_err(|error| OpenTelemetryError::Provider(error.to_string()))
+            .map_err(|error| OpenTelemetryError::LogProvider(error.to_string()))
     }
 
     pub(crate) fn delivery_failure_summary(&self) -> Option<String> {

--- a/crates/core/src/observability/otel_metrics.rs
+++ b/crates/core/src/observability/otel_metrics.rs
@@ -369,7 +369,7 @@ impl OpenTelemetryMetricSubscriber {
         self.inner
             .provider
             .force_flush()
-            .map_err(|error| OpenTelemetryError::Provider(error.to_string()))
+            .map_err(|error| OpenTelemetryError::MetricProvider(error.to_string()))
     }
 
     /// Shut down the meter provider, including its final collection.
@@ -381,7 +381,7 @@ impl OpenTelemetryMetricSubscriber {
             .inner
             .provider
             .shutdown()
-            .map_err(|error| OpenTelemetryError::Provider(error.to_string()));
+            .map_err(|error| OpenTelemetryError::MetricProvider(error.to_string()));
         barrier.and(provider)
     }
 
@@ -389,7 +389,7 @@ impl OpenTelemetryMetricSubscriber {
         self.inner
             .provider
             .shutdown()
-            .map_err(|error| OpenTelemetryError::Provider(error.to_string()))
+            .map_err(|error| OpenTelemetryError::MetricProvider(error.to_string()))
     }
 
     pub(crate) fn delivery_failure_summary(&self) -> Option<String> {

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -53,6 +53,26 @@ impl Drop for ClearPluginConfigurationGuard {
     }
 }
 
+#[test]
+fn provider_errors_identify_their_telemetry_signal() {
+    for (error, expected) in [
+        (
+            OpenTelemetryError::TraceProvider("trace failure".to_string()),
+            "OpenTelemetry tracer provider error: trace failure",
+        ),
+        (
+            OpenTelemetryError::LogProvider("log failure".to_string()),
+            "OpenTelemetry log provider error: log failure",
+        ),
+        (
+            OpenTelemetryError::MetricProvider("metric failure".to_string()),
+            "OpenTelemetry metric provider error: metric failure",
+        ),
+    ] {
+        assert_eq!(error.to_string(), expected);
+    }
+}
+
 struct RestoreThreadScopeStackGuard(ThreadScopeStackBinding);
 
 impl Drop for RestoreThreadScopeStackGuard {

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -3684,9 +3684,11 @@ fn opentelemetry_shutdown_helper_retains_every_endpoint_failure() {
 #[test]
 fn signal_delivery_state_classifies_generic_sdk_shutdown_error_as_delivery() {
     let issue = signal_shutdown_issue(
-        Err(crate::observability::otel::OpenTelemetryError::Provider(
-            "generic SDK final-export failure".to_string(),
-        )),
+        Err(
+            crate::observability::otel::OpenTelemetryError::MetricProvider(
+                "generic SDK final-export failure".to_string(),
+            ),
+        ),
         Some("otel.metrics_export_failed (1)".to_string()),
     )
     .expect("delivery failure should produce a shutdown issue");


### PR DESCRIPTION
#### Overview

Correct OTLP log and metric provider failures so they identify their own telemetry signal instead of reporting a tracer-provider error.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Split shared OpenTelemetry provider failures into trace, log, and metric variants.
- Map log and metric flush/shutdown failures to their signal-specific variant.
- Add regression coverage for the public error messages and preserve plugin shutdown classification.
- Validation passed: `just test-rust`, `cargo clippy --workspace --all-targets -- -D warnings`, `just test-python`, `just test-node`, and `uv run pre-commit run --all-files`.
- `just test-go` was attempted twice; an unchanged OTLP plugin test timed out waiting for `/v1/logs` export (`TestObservabilityPluginActivatesDerivedLogsAndExplicitMetrics`).

#### Where should the reviewer start?

Start with `crates/core/src/observability/otel.rs`, then review the log and metric subscriber mappings and the new display-contract test.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenTelemetry error reporting by identifying whether failures come from trace, log, or metric providers.
  * Trace flushing and shutdown failures now report more specific error details.
  * Log and metric provider shutdown errors now use signal-specific messages.

* **Tests**
  * Added coverage confirming distinct messages for trace, log, and metric provider errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->