### PR TITLE
fix: retain distinct OTLP diagnostic causes

### DIFF
--- a/crates/core/src/observability/otel_signal.rs
+++ b/crates/core/src/observability/otel_signal.rs
@@ -4,7 +4,7 @@
 //! Shared infrastructure for independently owned OTLP signal providers.
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -29,7 +29,7 @@ const MAX_RUNTIME_DIAGNOSTIC_MESSAGE_CHARS: usize = 1_024;
 pub struct OpenTelemetryRuntimeDiagnostic {
     /// Stable identifier for the diagnostic condition.
     pub code: String,
-    /// Most recent message recorded for this condition.
+    /// Distinct messages recorded for this condition, retained within a bounded budget.
     pub message: String,
     /// Total number of occurrences recorded for this condition.
     pub count: u64,
@@ -57,7 +57,13 @@ impl OpenTelemetryRuntimeDiagnostics {
 
 #[derive(Debug, Default)]
 struct RuntimeDiagnosticState {
-    diagnostics: BTreeMap<&'static str, OpenTelemetryRuntimeDiagnostic>,
+    diagnostics: BTreeMap<&'static str, RuntimeDiagnosticEntry>,
+}
+
+#[derive(Debug)]
+struct RuntimeDiagnosticEntry {
+    diagnostic: OpenTelemetryRuntimeDiagnostic,
+    messages: BTreeSet<String>,
 }
 
 /// Shared runtime-diagnostic recorder for one independently owned OTLP subscriber.
@@ -77,21 +83,34 @@ impl SignalRuntimeDiagnostics {
 
     pub(super) fn record(&self, code: &'static str, message: String, count: u64) -> u64 {
         let count = count.max(1);
+        let message = truncate_runtime_diagnostic_message(message);
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let total = if let Some(diagnostic) = state.diagnostics.get_mut(code) {
-            diagnostic.message = truncate_runtime_diagnostic_message(message.clone());
-            diagnostic.count = diagnostic.count.saturating_add(count);
-            diagnostic.count
+            diagnostic.diagnostic.count = diagnostic.diagnostic.count.saturating_add(count);
+            if diagnostic.messages.insert(message.clone()) {
+                let combined = combine_runtime_diagnostic_messages(&diagnostic.messages);
+                if combined.chars().count() <= MAX_RUNTIME_DIAGNOSTIC_MESSAGE_CHARS {
+                    diagnostic.diagnostic.message = combined;
+                } else {
+                    diagnostic.messages.remove(&message);
+                }
+            }
+            diagnostic.diagnostic.count
         } else if state.diagnostics.len() < MAX_RUNTIME_DIAGNOSTICS {
+            let mut messages = BTreeSet::new();
+            messages.insert(message.clone());
             state.diagnostics.insert(
                 code,
-                OpenTelemetryRuntimeDiagnostic {
-                    code: code.to_string(),
-                    message: truncate_runtime_diagnostic_message(message.clone()),
-                    count,
+                RuntimeDiagnosticEntry {
+                    diagnostic: OpenTelemetryRuntimeDiagnostic {
+                        code: code.to_string(),
+                        message: message.clone(),
+                        count,
+                    },
+                    messages,
                 },
             );
             count
@@ -110,7 +129,11 @@ impl SignalRuntimeDiagnostics {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         OpenTelemetryRuntimeDiagnostics {
-            diagnostics: state.diagnostics.values().cloned().collect(),
+            diagnostics: state
+                .diagnostics
+                .values()
+                .map(|entry| entry.diagnostic.clone())
+                .collect(),
         }
     }
 
@@ -129,10 +152,22 @@ fn truncate_runtime_diagnostic_message(message: String) -> String {
     }
     let mut truncated = message
         .chars()
-        .take(MAX_RUNTIME_DIAGNOSTIC_MESSAGE_CHARS)
+        .take(MAX_RUNTIME_DIAGNOSTIC_MESSAGE_CHARS - 1)
         .collect::<String>();
     truncated.push('…');
     truncated
+}
+
+fn combine_runtime_diagnostic_messages(messages: &BTreeSet<String>) -> String {
+    messages
+        .iter()
+        .fold(String::new(), |mut combined, message| {
+            if !combined.is_empty() {
+                combined.push('\n');
+            }
+            combined.push_str(message);
+            combined
+        })
 }
 
 pub(super) enum MetricMarkClassification {

--- a/crates/core/tests/unit/observability/otel_metrics_tests.rs
+++ b/crates/core/tests/unit/observability/otel_metrics_tests.rs
@@ -52,9 +52,13 @@ fn measurement(
 }
 
 fn metric_event(version: &str, data: Json) -> Event {
+    metric_event_named("metric.record", version, data)
+}
+
+fn metric_event_named(name: &str, version: &str, data: Json) -> Event {
     Event::Mark(MarkEvent::new(
         BaseEvent::builder()
-            .name("metric.record")
+            .name(name)
             .data(data)
             .data_schema(
                 DataSchema::builder()
@@ -136,6 +140,59 @@ fn direct_metric_subscriber_exposes_runtime_diagnostics() {
             .message
             .contains("unsupported metric schema version")
     );
+}
+
+#[test]
+fn direct_metric_subscriber_retains_distinct_invalid_mark_causes() {
+    let subscriber =
+        OpenTelemetryMetricSubscriber::new(OpenTelemetryMetricConfig::new("http://127.0.0.1:4318"))
+            .unwrap();
+    let events = [
+        metric_event_named("wrong-schema", "999", json!({"measurements": []})),
+        metric_event_named(
+            "empty-measurements",
+            METRIC_DATA_SCHEMA_VERSION,
+            json!({"measurements": []}),
+        ),
+        metric_event_named(
+            "invalid-counter-type",
+            METRIC_DATA_SCHEMA_VERSION,
+            json!({"measurements": [{
+                "name": "example.requests",
+                "kind": "counter",
+                "value_type": "i64",
+                "value": -1
+            }]}),
+        ),
+        metric_event_named(
+            "invalid-instrument-name",
+            METRIC_DATA_SCHEMA_VERSION,
+            json!({"measurements": [{
+                "name": "9bad-name",
+                "kind": "counter",
+                "value_type": "u64",
+                "value": 1
+            }]}),
+        ),
+    ];
+
+    for event in &events {
+        (subscriber.subscriber())(event);
+    }
+
+    let diagnostics = subscriber.runtime_diagnostics();
+    let diagnostic = diagnostics
+        .get("otel.metric_mark_invalid")
+        .expect("invalid metric diagnostic");
+    assert_eq!(diagnostic.count, 4);
+    for mark_name in [
+        "wrong-schema",
+        "empty-measurements",
+        "invalid-counter-type",
+        "invalid-instrument-name",
+    ] {
+        assert!(diagnostic.message.contains(mark_name));
+    }
 }
 
 #[test]


### PR DESCRIPTION
#### Overview

Retain distinct OpenTelemetry diagnostic causes in a bounded subscriber snapshot.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Preserve unique diagnostic messages per code until the existing 1,024-character message budget is reached.
- Keep occurrence counts aggregated by diagnostic code and retain deterministic message ordering.
- Add direct metric subscriber coverage for four distinct invalid metric-mark causes.

#### Where should the reviewer start?

Start with `SignalRuntimeDiagnostics::record` in `crates/core/src/observability/otel_signal.rs`; the neighboring metric-subscriber test shows the expected four-cause snapshot.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime diagnostics now retain and display distinct messages for each diagnostic code.
  - Related diagnostic messages are combined in a stable order without exceeding the existing message-size limit.
  - Corrected message truncation so the final ellipsis remains within the maximum length.
  - Invalid metric marks with different causes are now reported together while preserving each distinct mark name.
  - Diagnostic snapshots now consistently preserve their nested diagnostic details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->