### PR TITLE
feat: complete conditional middleware plugin support

### DIFF
--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference lib="esnext.disposable" />
 
-import type { EventSanitizeFields, Json, ToolExecutionResult } from './index';
+import type { EventSanitizeFields, Json, RuntimeRegistrationKind, ToolExecutionResult } from './index';
 import type { LlmCodec, LlmResponseCodec } from './typed';
 
 /** Codec identity available while a managed LLM event is sanitized. */
@@ -218,6 +218,13 @@ export type EventMetadata = Record<string, EventMetadataValue>;
 
 /** Component-scoped registration context passed to plugin handlers. */
 export interface PluginContext {
+  /** Register an activation-owned eligibility gate for a global runtime registration. */
+  registerConditionalMiddlewareGuardrail(
+    name: string,
+    kinds: RuntimeRegistrationKind[],
+    registrationName: string,
+    guardrail: (kinds: RuntimeRegistrationKind[], registrationName: string) => string | null,
+  ): void;
   /**
    * Register an event subscriber for this component. Callback failures are isolated and reported
    * through the Node binding's callback-error channel; flushSubscribers waits for returned promises.

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -67,7 +67,7 @@ use nemo_relay::plugin::{
     clear_plugin_configuration as clear_plugin_configuration_impl,
     deregister_plugin as deregister_plugin_impl, initialize_plugins as initialize_plugins_impl,
     list_plugin_kinds as list_plugin_kinds_impl, register_plugin as register_plugin_impl,
-    validate_plugin_config as validate_plugin_config_impl,
+    rollback_registrations, validate_plugin_config as validate_plugin_config_impl,
 };
 use nemo_relay::shared_runtime::initialize_shared_runtime_binding;
 use nemo_relay_adaptive::acg::{
@@ -2013,23 +2013,37 @@ impl Plugin for NodePlugin {
             let status = self.register.call_with_return_value(
                 payload,
                 ThreadsafeFunctionCallMode::NonBlocking,
-                move |_val: JsUnknown| {
-                    let _ = tx.send(Ok(()));
+                move |value: Json| {
+                    let result = callable::unwrap_middleware_result(
+                        callback_json(Some(value)),
+                        "JS plugin register callback failed",
+                    )
+                    .map(|_| ())
+                    .map_err(|error| error.to_string());
+                    let _ = tx.send(result);
                     Ok(())
                 },
             );
-            if status != napi::Status::Ok {
-                return Err(PluginError::RegistrationFailed(format!(
+            let result = if status != napi::Status::Ok {
+                Err(PluginError::RegistrationFailed(format!(
                     "failed to queue JS plugin register callback: {status:?}"
-                )));
+                )))
+            } else {
+                rx.recv()
+                    .map_err(|_| {
+                        PluginError::RegistrationFailed(
+                            "JS plugin register completion channel closed".into(),
+                        )
+                    })?
+                    .map_err(PluginError::RegistrationFailed)
+            };
+            if let Err(error) = result {
+                let mut registrations = registrations
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                rollback_registrations(&mut registrations);
+                return Err(error);
             }
-            rx.recv()
-                .map_err(|_| {
-                    PluginError::RegistrationFailed(
-                        "JS plugin register completion channel closed".into(),
-                    )
-                })?
-                .map_err(PluginError::RegistrationFailed)?;
 
             let drained = std::mem::take(&mut *registrations.lock().map_err(|e| {
                 PluginError::RegistrationFailed(format!("plugin registrations lock poisoned: {e}"))
@@ -5738,6 +5752,7 @@ pub fn register_plugin(
         }
         None => None,
     };
+    let register = callable::safe_middleware_callback(&env, &register)?;
     let mut register_tsfn = register
         .create_threadsafe_function::<NodePluginRegisterCall, JsUnknown, _, ErrorStrategy::Fatal>(
             0,

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -887,6 +887,69 @@ fn build_plugin_context(
 ) -> napi::Result<JsObject> {
     let mut context = env.create_object()?;
 
+    let conditional_gate_regs = registrations.clone();
+    let conditional_gate_namespace = namespace_prefix.clone();
+    let register_conditional_gate = env.create_function_from_closure(
+        "__nemo_relay_plugin_register_conditional_middleware_guardrail",
+        move |ctx| {
+            let name = format!(
+                "{}{}",
+                conditional_gate_namespace,
+                ctx.get::<String>(0)?
+            );
+            let kinds = ctx
+                .get::<Vec<RuntimeRegistrationKind>>(1)?
+                .into_iter()
+                .map(Into::into)
+                .collect::<BTreeSet<_>>();
+            let registration_name = ctx.get::<String>(2)?;
+            let guardrail = ctx.get::<JsFunction>(3)?;
+            let callback = node_conditional_middleware_guardrail(ctx.env, &guardrail)?;
+            core_registry_api::register_conditional_middleware_guardrail(
+                &name,
+                kinds,
+                &registration_name,
+                Arc::new(move |kinds, effective_name| {
+                    callback
+                        .call(
+                            kinds.iter().map(|kind| kind.as_str().to_string()).collect(),
+                            effective_name.to_string(),
+                        )
+                        .unwrap_or_else(|error| {
+                            record_callback_error(format!(
+                                "Node conditional middleware guardrail failed open: {error}"
+                            ));
+                            None
+                        })
+                }),
+            )
+            .map_err(to_napi_err)?;
+
+            let name_clone = name.clone();
+            conditional_gate_regs
+                .lock()
+                .unwrap()
+                .push(PluginRegistration::new(
+                    "plugin",
+                    name_clone.clone(),
+                    Box::new(move || {
+                        core_registry_api::deregister_conditional_middleware_guardrail(&name_clone)
+                            .map(|_| ())
+                            .map_err(|error| {
+                                PluginError::RegistrationFailed(format!(
+                                    "conditional middleware guardrail deregistration failed: {error}"
+                                ))
+                            })
+                    }),
+                ));
+            ctx.env.get_undefined()
+        },
+    )?;
+    context.set_named_property(
+        "registerConditionalMiddlewareGuardrail",
+        register_conditional_gate,
+    )?;
+
     let subscriber_regs = registrations.clone();
     let subscriber_namespace = namespace_prefix.clone();
     let register_subscriber = env.create_function_from_closure(
@@ -1701,6 +1764,37 @@ impl NodeConditionalMiddlewareGuardrail {
         }
         recv_conditional_gate_result(rx, CONDITIONAL_GATE_CALLBACK_TIMEOUT)
     }
+}
+
+fn node_conditional_middleware_guardrail(
+    env: &Env,
+    guardrail: &JsFunction,
+) -> napi::Result<Arc<NodeConditionalMiddlewareGuardrail>> {
+    let guardrail = callable::safe_conditional_gate_callback(env, guardrail)?;
+    let direct = PersistentJsFunction::new(env, &guardrail)?;
+    let registration_thread = std::thread::current().id();
+    let mut thread_safe = guardrail.create_threadsafe_function(
+        0,
+        |ctx: napi::threadsafe_function::ThreadSafeCallContext<(Vec<String>, String)>| {
+            let kinds = unsafe {
+                JsUnknown::from_raw_unchecked(
+                    ctx.env.raw(),
+                    Vec::<String>::to_napi_value(ctx.env.raw(), ctx.value.0)?,
+                )
+            };
+            let registration_name = ctx.env.create_string_from_std(ctx.value.1)?;
+            Ok(vec![
+                kinds,
+                js_unknown_from_raw(&ctx.env, &registration_name),
+            ])
+        },
+    )?;
+    thread_safe.unref(env)?;
+    Ok(Arc::new(NodeConditionalMiddlewareGuardrail {
+        direct,
+        thread_safe,
+        registration_thread,
+    }))
 }
 
 #[cfg(test)]
@@ -3465,31 +3559,7 @@ pub fn register_conditional_middleware_guardrail(
     guardrail: JsFunction,
 ) -> Result<()> {
     let selected = kinds.into_iter().map(Into::into).collect::<BTreeSet<_>>();
-    let guardrail = callable::safe_conditional_gate_callback(&env, &guardrail)?;
-    let direct = PersistentJsFunction::new(&env, &guardrail)?;
-    let registration_thread = std::thread::current().id();
-    let mut thread_safe = guardrail.create_threadsafe_function(
-        0,
-        |ctx: napi::threadsafe_function::ThreadSafeCallContext<(Vec<String>, String)>| {
-            let kinds = unsafe {
-                JsUnknown::from_raw_unchecked(
-                    ctx.env.raw(),
-                    Vec::<String>::to_napi_value(ctx.env.raw(), ctx.value.0)?,
-                )
-            };
-            let registration_name = ctx.env.create_string_from_std(ctx.value.1)?;
-            Ok(vec![
-                kinds,
-                js_unknown_from_raw(&ctx.env, &registration_name),
-            ])
-        },
-    )?;
-    thread_safe.unref(&env)?;
-    let callback = Arc::new(NodeConditionalMiddlewareGuardrail {
-        direct,
-        thread_safe,
-        registration_thread,
-    });
+    let callback = node_conditional_middleware_guardrail(&env, &guardrail)?;
     core_registry_api::register_conditional_middleware_guardrail(
         &name,
         selected,

--- a/crates/node/tests/adaptive_tests.mjs
+++ b/crates/node/tests/adaptive_tests.mjs
@@ -342,6 +342,37 @@ describe('core plugins', () => {
   });
 });
 
+describe('plugin context conditional middleware guardrails', () => {
+  it('fails open and is removed during clear', async () => {
+    const suffix = `${process.pid}-${Date.now()}`;
+    const pluginKind = `node.context_gate.${suffix}`;
+    const target = `node-context-gate-target-${suffix}`;
+    const observed = [];
+    lib.registerSubscriber(target, (event) => observed.push(event.name));
+    plugin.register(pluginKind, {
+      register(_config, context) {
+        context.registerConditionalMiddlewareGuardrail('failing-gate', ['subscriber'], target, () => {
+          throw new Error('expected gate failure');
+        });
+      },
+    });
+    try {
+      await plugin.initialize({ version: 1, components: [plugin.ComponentSpec(pluginKind)] });
+      lib.event('node-context-gate-fail-open', null, null);
+      await lib.flushSubscribers();
+      assert.equal(observed.at(-1), 'node-context-gate-fail-open');
+      plugin.clear();
+      lib.event('node-context-gate-cleared', null, null);
+      await lib.flushSubscribers();
+      assert.equal(observed.at(-1), 'node-context-gate-cleared');
+    } finally {
+      plugin.clear();
+      plugin.deregister(pluginKind);
+      lib.deregisterSubscriber(target);
+    }
+  });
+});
+
 describe('adaptive helpers', () => {
   it('builds a redis backend with the default key prefix', () => {
     assert.deepEqual(adaptive.redisBackend('redis://127.0.0.1:6379'), {

--- a/crates/node/tests/adaptive_tests.mjs
+++ b/crates/node/tests/adaptive_tests.mjs
@@ -348,10 +348,12 @@ describe('plugin context conditional middleware guardrails', () => {
     const pluginKind = `node.context_gate.${suffix}`;
     const target = `node-context-gate-target-${suffix}`;
     const observed = [];
+    let guardrailCalls = 0;
     lib.registerSubscriber(target, (event) => observed.push(event.name));
     plugin.register(pluginKind, {
       register(_config, context) {
         context.registerConditionalMiddlewareGuardrail('failing-gate', ['subscriber'], target, () => {
+          guardrailCalls += 1;
           throw new Error('expected gate failure');
         });
       },
@@ -361,10 +363,46 @@ describe('plugin context conditional middleware guardrails', () => {
       lib.event('node-context-gate-fail-open', null, null);
       await lib.flushSubscribers();
       assert.equal(observed.at(-1), 'node-context-gate-fail-open');
+      assert.ok(guardrailCalls > 0);
       plugin.clear();
+      const callsBeforeClear = guardrailCalls;
       lib.event('node-context-gate-cleared', null, null);
       await lib.flushSubscribers();
       assert.equal(observed.at(-1), 'node-context-gate-cleared');
+      assert.equal(guardrailCalls, callsBeforeClear);
+    } finally {
+      plugin.clear();
+      plugin.deregister(pluginKind);
+      lib.deregisterSubscriber(target);
+    }
+  });
+
+  it('rolls back a gate when plugin registration throws', async () => {
+    const suffix = `${process.pid}-${Date.now()}`;
+    const pluginKind = `node.context_gate_rollback.${suffix}`;
+    const target = `node-context-gate-rollback-target-${suffix}`;
+    const observed = [];
+    let guardrailCalls = 0;
+    lib.registerSubscriber(target, (event) => observed.push(event.name));
+    plugin.register(pluginKind, {
+      register(_config, context) {
+        context.registerConditionalMiddlewareGuardrail('rollback-gate', ['subscriber'], target, () => {
+          guardrailCalls += 1;
+          return 'activation in progress';
+        });
+        throw new Error('expected activation failure');
+      },
+    });
+    try {
+      await assert.rejects(
+        () => plugin.initialize({ version: 1, components: [plugin.ComponentSpec(pluginKind)] }),
+        /expected activation failure/,
+      );
+      const callsAfterFailure = guardrailCalls;
+      lib.event('node-context-gate-rolled-back', null, null);
+      await lib.flushSubscribers();
+      assert.equal(observed.at(-1), 'node-context-gate-rolled-back');
+      assert.equal(guardrailCalls, callsAfterFailure);
     } finally {
       plugin.clear();
       plugin.deregister(pluginKind);

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -2239,6 +2239,112 @@ unsafe extern "C" fn unavailable_plugin_context_register_gate(
     NemoRelayStatus::NotFound
 }
 
+unsafe extern "C" fn capture_plugin_context_runtime(
+    _ctx: *mut NemoRelayNativePluginContext,
+    out: *mut *const NemoRelayNativePluginRuntime,
+) -> NemoRelayStatus {
+    if out.is_null() {
+        return NemoRelayStatus::NullPointer;
+    }
+    unsafe { *out = NonNull::<NemoRelayNativePluginRuntime>::dangling().as_ptr() };
+    NemoRelayStatus::Ok
+}
+
+unsafe extern "C" fn capture_plugin_runtime_retain(
+    _runtime: *const NemoRelayNativePluginRuntime,
+) -> NemoRelayStatus {
+    UNAVAILABLE_RUNTIME_RETAINS.fetch_add(1, Ordering::SeqCst);
+    NemoRelayStatus::Ok
+}
+
+unsafe extern "C" fn capture_plugin_runtime_release(_runtime: *const NemoRelayNativePluginRuntime) {
+    UNAVAILABLE_RUNTIME_RELEASES.fetch_add(1, Ordering::SeqCst);
+}
+
+unsafe extern "C" fn capture_plugin_runtime_list_registrations(
+    _runtime: *const NemoRelayNativePluginRuntime,
+    kinds_json: *const NemoRelayNativeString,
+    out_json: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    if out_json.is_null() {
+        return NemoRelayStatus::NullPointer;
+    }
+    let kinds = read_host_string(&test_host(), kinds_json).unwrap();
+    RUNTIME_CALLS.lock().unwrap().push(format!("list:{kinds}"));
+    unsafe {
+        *out_json = json_host_string(
+            &test_host(),
+            json!([{
+                "kind": "subscriber",
+                "local_name": "target",
+                "effective_name": "plugin::0::target",
+                "owner": {
+                    "kind": "plugin",
+                    "plugin_kind": "example",
+                    "component_ordinal": 0
+                }
+            }]),
+        )
+    };
+    NemoRelayStatus::Ok
+}
+
+unsafe extern "C" fn capture_plugin_runtime_register_gate(
+    _runtime: *const NemoRelayNativePluginRuntime,
+    name: *const NemoRelayNativeString,
+    kinds_json: *const NemoRelayNativeString,
+    registration_name: *const NemoRelayNativeString,
+    reason: *const NemoRelayNativeString,
+    out_handle: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    if out_handle.is_null() {
+        return NemoRelayStatus::NullPointer;
+    }
+    let host = test_host();
+    let values = [name, kinds_json, registration_name, reason]
+        .map(|value| read_host_string(&host, value).unwrap());
+    RUNTIME_CALLS.lock().unwrap().push(format!(
+        "register:{}:{}:{}:{}",
+        values[0], values[1], values[2], values[3]
+    ));
+    unsafe { *out_handle = host_string(&host, "gate-handle") };
+    NemoRelayStatus::Ok
+}
+
+unsafe extern "C" fn capture_plugin_runtime_deregister_gate(
+    _runtime: *const NemoRelayNativePluginRuntime,
+    handle: *const NemoRelayNativeString,
+    out_removed: *mut bool,
+) -> NemoRelayStatus {
+    if out_removed.is_null() {
+        return NemoRelayStatus::NullPointer;
+    }
+    let handle = read_host_string(&test_host(), handle).unwrap();
+    RUNTIME_CALLS
+        .lock()
+        .unwrap()
+        .push(format!("deregister:{handle}"));
+    unsafe { *out_removed = true };
+    NemoRelayStatus::Ok
+}
+
+unsafe extern "C" fn capture_plugin_context_register_gate(
+    _ctx: *mut NemoRelayNativePluginContext,
+    name: *const NemoRelayNativeString,
+    kinds_json: *const NemoRelayNativeString,
+    registration_name: *const NemoRelayNativeString,
+    reason: *const NemoRelayNativeString,
+) -> NemoRelayStatus {
+    let host = test_host();
+    let values = [name, kinds_json, registration_name, reason]
+        .map(|value| read_host_string(&host, value).unwrap());
+    RUNTIME_CALLS.lock().unwrap().push(format!(
+        "initial:{}:{}:{}:{}",
+        values[0], values[1], values[2], values[3]
+    ));
+    NemoRelayStatus::Ok
+}
+
 fn test_host_v4() -> NemoRelayNativeHostApiV4 {
     let mut v1 = test_host();
     v1.abi_version = 4;
@@ -2871,6 +2977,72 @@ fn plugin_context_handles_an_unavailable_runtime_capability() {
         .unwrap_err();
     assert!(error.contains("NotFound"), "{error}");
     assert_eq!(UNAVAILABLE_CONTEXT_GATE_CALLS.load(Ordering::SeqCst), 1);
+    assert_eq!(STRING_LIVE_COUNT.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn plugin_runtime_registration_controls_cover_success_and_lifecycle() {
+    let _guard = begin_test();
+    let mut host = test_host_v4();
+    host.plugin_context_runtime = capture_plugin_context_runtime;
+    host.plugin_runtime_retain = capture_plugin_runtime_retain;
+    host.plugin_runtime_release = capture_plugin_runtime_release;
+    host.plugin_runtime_list_registrations = capture_plugin_runtime_list_registrations;
+    host.plugin_runtime_register_conditional_middleware_guardrail =
+        capture_plugin_runtime_register_gate;
+    host.plugin_runtime_deregister_conditional_middleware_guardrail =
+        capture_plugin_runtime_deregister_gate;
+    host.plugin_context_register_conditional_middleware_guardrail =
+        capture_plugin_context_register_gate;
+    let mut context = test_context(&host.v3.v1);
+    let runtime = context.runtime();
+    let kinds = BTreeSet::from([nemo_relay_plugin::RuntimeRegistrationKind::Subscriber]);
+
+    let registrations = runtime
+        .list_runtime_registrations(Some(&kinds))
+        .expect("runtime registrations should decode");
+    assert_eq!(registrations[0].effective_name, "plugin::0::target");
+    let handle = runtime
+        .register_conditional_middleware_guardrail(
+            "timer-gate",
+            &kinds,
+            "plugin::0::target",
+            "timer active",
+        )
+        .expect("dynamic gate should register");
+    assert!(
+        runtime
+            .deregister_conditional_middleware_guardrail(&handle)
+            .unwrap()
+    );
+    context
+        .register_conditional_middleware_guardrail(
+            "startup-gate",
+            &kinds,
+            "plugin::0::target",
+            "startup disabled",
+        )
+        .expect("initial gate should register");
+
+    let clone = runtime.clone();
+    drop(clone);
+    drop(runtime);
+    assert_eq!(UNAVAILABLE_RUNTIME_RETAINS.load(Ordering::SeqCst), 1);
+    assert_eq!(UNAVAILABLE_RUNTIME_RELEASES.load(Ordering::SeqCst), 2);
+    let calls = RUNTIME_CALLS.lock().unwrap();
+    assert!(calls.iter().any(|call| call.starts_with("list:")));
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.starts_with("register:timer-gate:"))
+    );
+    assert!(calls.iter().any(|call| call == "deregister:gate-handle"));
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.starts_with("initial:startup-gate:"))
+    );
+    drop(calls);
     assert_eq!(STRING_LIVE_COUNT.load(Ordering::SeqCst), 0);
 }
 

--- a/crates/python/src/py_plugin.rs
+++ b/crates/python/src/py_plugin.rs
@@ -3,6 +3,7 @@
 
 //! Python-facing generic plugin configuration and registration helpers.
 
+use std::collections::BTreeSet;
 #[cfg(test)]
 use std::collections::HashSet;
 use std::future::Future;
@@ -10,9 +11,11 @@ use std::pin::Pin;
 use std::sync::{Arc, LazyLock, Mutex};
 
 use pyo3::prelude::*;
+use pyo3::types::PySet;
 use serde_json::{Map, Value as Json};
 
 use nemo_relay::api::registry::{
+    RuntimeRegistrationKind, deregister_conditional_middleware_guardrail,
     deregister_event_metadata_injector, deregister_llm_conditional_execution_guardrail,
     deregister_llm_execution_intercept, deregister_llm_request_intercept,
     deregister_llm_sanitize_request_guardrail, deregister_llm_sanitize_response_guardrail,
@@ -20,14 +23,15 @@ use nemo_relay::api::registry::{
     deregister_scope_sanitize_end_guardrail, deregister_scope_sanitize_start_guardrail,
     deregister_tool_conditional_execution_guardrail, deregister_tool_execution_intercept,
     deregister_tool_request_intercept, deregister_tool_sanitize_request_guardrail,
-    deregister_tool_sanitize_response_guardrail, register_event_metadata_injector,
-    register_llm_conditional_execution_guardrail, register_llm_execution_intercept,
-    register_llm_request_intercept, register_llm_sanitize_request_guardrail,
-    register_llm_sanitize_response_guardrail, register_llm_stream_execution_intercept,
-    register_mark_sanitize_guardrail, register_scope_sanitize_end_guardrail,
-    register_scope_sanitize_start_guardrail, register_tool_conditional_execution_guardrail,
-    register_tool_execution_intercept, register_tool_request_intercept,
-    register_tool_sanitize_request_guardrail, register_tool_sanitize_response_guardrail,
+    deregister_tool_sanitize_response_guardrail, register_conditional_middleware_guardrail,
+    register_event_metadata_injector, register_llm_conditional_execution_guardrail,
+    register_llm_execution_intercept, register_llm_request_intercept,
+    register_llm_sanitize_request_guardrail, register_llm_sanitize_response_guardrail,
+    register_llm_stream_execution_intercept, register_mark_sanitize_guardrail,
+    register_scope_sanitize_end_guardrail, register_scope_sanitize_start_guardrail,
+    register_tool_conditional_execution_guardrail, register_tool_execution_intercept,
+    register_tool_request_intercept, register_tool_sanitize_request_guardrail,
+    register_tool_sanitize_response_guardrail,
 };
 use nemo_relay::api::subscriber::{deregister_subscriber, register_subscriber};
 use nemo_relay::error::Result as FlowResult;
@@ -239,8 +243,66 @@ impl PyPluginContext {
     }
 }
 
+fn runtime_registration_kind(kind: &str) -> PyResult<RuntimeRegistrationKind> {
+    serde_json::from_value(Json::String(kind.to_string())).map_err(|_| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "unknown runtime registration kind: {kind}"
+        ))
+    })
+}
+
 #[pymethods]
 impl PyPluginContext {
+    #[pyo3(signature = (
+        name: "str",
+        kinds: "set[str]",
+        registration_name: "str",
+        guardrail: "object"
+    ) -> "None", text_signature = "(name: str, kinds: set[str], registration_name: str, guardrail: object) -> None")]
+    fn register_conditional_middleware_guardrail(
+        &self,
+        name: &str,
+        kinds: BTreeSet<String>,
+        registration_name: &str,
+        guardrail: Py<PyAny>,
+    ) -> PyResult<()> {
+        let kinds = kinds
+            .iter()
+            .map(|kind| runtime_registration_kind(kind))
+            .collect::<PyResult<BTreeSet<_>>>()?;
+        let registration_name = registration_name.to_string();
+        self.register_callback(
+            name,
+            move |qualified_name| {
+                register_conditional_middleware_guardrail(
+                    qualified_name,
+                    kinds,
+                    &registration_name,
+                    Arc::new(move |kinds, effective_name| {
+                        Python::attach(|py| {
+                            let registration_kind = py
+                                .import("nemo_relay.runtime_registrations")?
+                                .getattr("RuntimeRegistrationKind")?;
+                            let python_kinds = PySet::empty(py)?;
+                            for kind in kinds {
+                                python_kinds.add(registration_kind.call1((kind.as_str(),))?)?;
+                            }
+                            guardrail
+                                .call1(py, (python_kinds, effective_name))?
+                                .extract::<Option<String>>(py)
+                        })
+                        .unwrap_or_else(|error| {
+                            Python::attach(|py| error.print(py));
+                            None
+                        })
+                    }),
+                )
+            },
+            deregister_conditional_middleware_guardrail,
+            "conditional middleware guardrail",
+        )
+    }
+
     #[pyo3(signature = (name: "str", priority: "int", callback: "object") -> "None", text_signature = "(name: str, priority: int, callback: object) -> None")]
     fn register_event_metadata_injector(
         &self,

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -336,6 +336,38 @@ async fn worker_service_rejects_duplicate_registration_names_on_one_surface() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn worker_service_validates_initial_conditional_middleware_guardrails() {
+    for (mode, expected) in [
+        (InvalidInitialGate::EmptyKinds, "has no registration kinds"),
+        (InvalidInitialGate::EmptyTarget, "names must not be empty"),
+        (
+            InvalidInitialGate::Duplicate,
+            "duplicate conditional middleware guardrail",
+        ),
+    ] {
+        let (handle, mut client) = spawn_worker(
+            Arc::new(InvalidInitialGatePlugin(mode)),
+            "http://127.0.0.1:9".into(),
+        )
+        .await;
+        let response = client
+            .register(Request::new(RegisterRequest {
+                activation_id: ACTIVATION_ID.into(),
+                plugin_id: PLUGIN_ID.into(),
+                auth_token: AUTH_TOKEN.into(),
+                config: Some(json_env(json!({}))),
+            }))
+            .await
+            .expect("invalid initial gate should return protocol data")
+            .into_inner();
+        assert!(response.registrations.is_empty());
+        assert!(response.conditional_middleware_guardrails.is_empty());
+        assert!(response.error.unwrap().message.contains(expected));
+        handle.abort();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn worker_service_cancels_unary_and_stream_invocations_by_id() {
     let timeout = WORKER_TEST_TIMEOUT;
     let plugin = Arc::new(CancellationPlugin::default());
@@ -1759,6 +1791,50 @@ impl WorkerPlugin for DuplicateEventSanitizerPlugin {
     }
 }
 
+#[derive(Clone, Copy)]
+enum InvalidInitialGate {
+    EmptyKinds,
+    EmptyTarget,
+    Duplicate,
+}
+
+struct InvalidInitialGatePlugin(InvalidInitialGate);
+
+impl WorkerPlugin for InvalidInitialGatePlugin {
+    fn plugin_id(&self) -> &str {
+        PLUGIN_ID
+    }
+
+    fn register(&self, ctx: &mut PluginContext, _config: &Json) -> Result<()> {
+        let kinds = match self.0 {
+            InvalidInitialGate::EmptyKinds => BTreeSet::new(),
+            InvalidInitialGate::EmptyTarget | InvalidInitialGate::Duplicate => {
+                BTreeSet::from([RuntimeRegistrationKind::Subscriber])
+            }
+        };
+        let target = if matches!(self.0, InvalidInitialGate::EmptyTarget) {
+            ""
+        } else {
+            "target-subscriber"
+        };
+        ctx.register_conditional_middleware_guardrail(
+            "initial-gate",
+            kinds.clone(),
+            target,
+            "disabled",
+        );
+        if matches!(self.0, InvalidInitialGate::Duplicate) {
+            ctx.register_conditional_middleware_guardrail(
+                "initial-gate",
+                kinds,
+                target,
+                "also disabled",
+            );
+        }
+        Ok(())
+    }
+}
+
 #[derive(Default)]
 struct CancellationPlugin {
     unary_started: Arc<tokio::sync::Notify>,
@@ -1890,6 +1966,12 @@ impl WorkerPlugin for SurfacePlugin {
 
     fn register(&self, ctx: &mut PluginContext, _config: &Json) -> Result<()> {
         let runtime = ctx.runtime().expect("worker service provides runtime");
+        ctx.register_conditional_middleware_guardrail(
+            "initial-gate",
+            BTreeSet::from([RuntimeRegistrationKind::Subscriber]),
+            "missing-target",
+            "initial gate",
+        );
         let events = self.events.clone();
         ctx.register_subscriber("subscriber", move |event| {
             events

--- a/docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx
+++ b/docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx
@@ -1,0 +1,102 @@
+---
+title: "Conditional Middleware Guardrails"
+description: "Understand how Relay controls the eligibility of global runtime registrations."
+position: 4
+---
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+A conditional middleware guardrail temporarily excludes an existing global runtime
+registration from future middleware snapshots. The target remains registered and keeps
+its original owner. When no gate suppresses the target, Relay includes it again without
+recreating it.
+
+This control is useful for operational decisions. For example, an application can pause
+an exporter during an outage or exclude an expensive intercept while a dependency is
+unhealthy. A conditional middleware guardrail does not approve or reject a tool or LLM
+call. Use a conditional-execution guardrail for call-level policy.
+
+## Registration Identity
+
+Relay describes each gateable global registration with four identity fields:
+
+- `kind` identifies the subscriber, metadata injector, guardrail, or intercept family.
+- `local_name` is the name that the registration owner supplied.
+- `effective_name` is the runtime name that a conditional middleware guardrail targets.
+- `owner` identifies core, global API, or plugin ownership. Plugin ownership also
+  includes the plugin kind and component ordinal when available.
+
+Applications and plugins must discover the effective name from the active runtime.
+Plugin contexts qualify local names, and that qualification can change after a process
+restart or plugin configuration reload. A controller must not persist an effective name
+or construct one from a plugin kind, local name, or component position.
+
+Discovery reports global registrations even when a gate currently suppresses them. This
+behavior lets another controller inspect or manage an ineligible target. Discovery does
+not report scope-local registrations because global gates never control scope-local
+behavior.
+
+## Matching and Ordering
+
+A gate selects an effective registration name and one or more registration kinds. Relay
+evaluates every matching gate in gate-name order when it creates a middleware or event
+publication snapshot. The target is eligible only when every matching gate returns no
+reason. One gate cannot override another gate that suppresses the target.
+
+A reason describes why the target is ineligible for the snapshot. The reason does not
+deregister the target, transfer its ownership, or change its configuration.
+
+## Failure and Snapshot Semantics
+
+Conditional middleware guardrails fail open. If a callback fails or panics, Relay keeps
+the target eligible and records a bounded runtime diagnostic. This behavior prevents a
+faulty operational control from silently removing observability or execution behavior.
+
+Gate changes affect future snapshots. An in-flight execution chain keeps the decision
+from the snapshot that created it. An event that already entered the queued publication
+path also keeps its existing decision. Registering or removing a gate does not rewrite
+those snapshots.
+
+Relay never applies a gate to gate registration, gate deregistration, target
+deregistration, or plugin teardown. These operations must remain available so the host
+can recover and clean up.
+
+## Ownership Models
+
+An activation-owned gate belongs to one plugin component. The component context
+qualifies the gate name, includes registration in the activation transaction, rolls the
+gate back after failed activation, and removes it during teardown. This model is
+appropriate when configuration determines the target and the gate must exist for the
+component's complete active lifetime.
+
+A runtime-discovered dynamic gate belongs to the application or active dynamic plugin
+that creates it. A timer, health check, or controller can discover a target and add or
+remove the gate while the process runs. The owner must retain the gate handle or name and
+provide an explicit cleanup path. Dynamic plugin hosts also enforce activation ownership
+so one plugin cannot remove another plugin's gate.
+
+Language-binding gates can evaluate a callback against current in-process state. Native
+and worker plugins instead install a host-resident constant reason. This distinction
+keeps snapshot construction in the host and avoids a native-library or worker round trip
+for every eligibility decision.
+
+## Callback Safety
+
+Gate callbacks run while Relay constructs a snapshot. They must be fast, deterministic,
+and side-effect free. A callback can read state that is already available, such as an
+atomic timer flag or a cached health result.
+
+A callback must not make a reentrant Relay call that produces middleware, flushes
+subscribers, waits for an exporter, or clears plugins. A background task can update the
+state that the callback reads or can register and deregister a host-resident dynamic
+gate.
+
+## Binding Support
+
+Rust, Python, and Node.js expose the primary language-binding APIs. The native Rust SDK,
+Rust worker SDK, and Python worker SDK expose activation-owned and runtime-discovered
+host-resident controls.
+
+Refer to [Add Middleware](/instrument-applications/advanced-guide) for application
+guidance and [PluginContext](/build-plugins/fundamentals/plugin-context) for plugin
+ownership. The corresponding code-example pages provide binding-specific APIs.

--- a/docs/about-nemo-relay/concepts/middleware.mdx
+++ b/docs/about-nemo-relay/concepts/middleware.mdx
@@ -32,12 +32,6 @@ callbacks observe earlier middleware output. Event payload transformations,
 event metadata injectors, and event sanitizer chains run on the queued
 publication path and do not delay managed execution.
 
-The experimental raw C FFI and Go binding retain synchronous middleware
-callbacks. Relay invokes each callback on a native thread and waits for it to
-return, so blocking I/O or other long-running work occupies that thread and can
-reduce middleware throughput. There is no completion-based C or Go middleware
-registration API.
-
 Synchronous standalone Python calls cannot drive an awaitable callback. Call
 the same standalone helper from a running event loop and await the returned
 value instead.
@@ -110,66 +104,12 @@ everything in application code.
 
 ## Control Global Registration Eligibility
 
-A conditional middleware guardrail can dynamically disable an existing global
-subscriber, metadata injector, guardrail, or intercept. The target remains
-registered and owned by its original component. Relay omits the target from new
-runtime snapshots while a matching gate returns a reason string, then includes
-the target again after the gate returns `None` or is deregistered.
-
-Use `list_runtime_registrations` to discover a target's structured identity.
-Match the `RuntimeRegistrationKind` and `effective_name` fields rather than
-guessing a plugin-qualified name. Effective names remain stable for the current
-runtime activation, but callers must not persist them across process restarts
-or plugin configuration reloads.
-
-The following Python example disables the OpenTelemetry subscriber until a
-background policy removes the gate:
-
-```python
-from nemo_relay.runtime_registrations import (
-    RuntimeRegistrationKind,
-    deregister_conditional_middleware_guardrail,
-    list_runtime_registrations,
-    register_conditional_middleware_guardrail,
-)
-
-subscribers = list_runtime_registrations({RuntimeRegistrationKind.SUBSCRIBER})
-opentelemetry = next(
-    registration
-    for registration in subscribers
-    if registration.local_name == "opentelemetry"
-    and registration.owner.plugin_kind == "observability"
-)
-
-register_conditional_middleware_guardrail(
-    "pause-opentelemetry",
-    {RuntimeRegistrationKind.SUBSCRIBER},
-    opentelemetry.effective_name,
-    lambda _kinds, _name: "export paused",
-)
-
-# A timer, health check, or other background policy can enable future
-# subscriber snapshots without recreating the OpenTelemetry exporter.
-deregister_conditional_middleware_guardrail("pause-opentelemetry")
-```
-
-Conditional middleware guardrails have these runtime properties:
-
-- They apply only to global registrations. A global gate does not disable a
-  same-named scope-local registration.
-- Relay evaluates matching gates in gate-name order. Every matching gate must
-  return `None` for the target to remain eligible.
-- Gate callback failures and panics fail open. Relay continues with the target
-  and records a runtime diagnostic.
-- Gate changes affect future middleware and event-publication snapshots.
-  Queued events and in-flight execution chains keep their existing decisions.
-- Gate registration, gate deregistration, target deregistration, and plugin
-  teardown are never gated.
-
-Direct SDK integrations can register a synchronous callable that reads shared
-state. Rust-native and gRPC worker plugins use host-resident gates. Their async
-tasks can register and deregister gates through `PluginRuntime` without a
-callback across the dynamic-plugin boundary.
+A conditional middleware guardrail can temporarily exclude an existing global
+subscriber, metadata injector, guardrail, or intercept from future runtime snapshots
+without changing its ownership or registration. Discover the target's effective name,
+choose activation-owned or dynamic lifecycle management, and understand ordering,
+fail-open behavior, and snapshot timing in
+[Conditional Middleware Guardrails](/about-nemo-relay/concepts/conditional-middleware-guardrails).
 
 ## Middleware Families
 

--- a/docs/about-nemo-relay/concepts/plugins.mdx
+++ b/docs/about-nemo-relay/concepts/plugins.mdx
@@ -150,6 +150,9 @@ It connects plugin configuration to the active runtime.
 Depending on the component, a plugin can register middleware, subscribers, and
 runtime helpers. These are the same execution surfaces available elsewhere in
 Relay, but the component context gives them shared configuration and ownership.
+This includes activation-owned
+[conditional middleware guardrails](/about-nemo-relay/concepts/conditional-middleware-guardrails)
+that temporarily control the eligibility of an existing global registration.
 
 This is what makes plugins a packaging mechanism rather than a separate runtime
 model. Plugins do not replace scopes, middleware, or subscribers. They install

--- a/docs/build-plugins/about.mdx
+++ b/docs/build-plugins/about.mdx
@@ -89,3 +89,8 @@ defines the operator-facing boundary, and [PluginContext](/build-plugins/fundame
 describes every registration surface. Each model-specific section then follows a
 complete path from invalid configuration through activation, representative execution,
 observable verification, and teardown.
+
+Plugins can also own gates that control whether another global runtime registration is
+included in future snapshots. Read
+[Conditional Middleware Guardrails](/about-nemo-relay/concepts/conditional-middleware-guardrails)
+before adding this operational control to any delivery model.

--- a/docs/build-plugins/language-binding/advanced-configuration.mdx
+++ b/docs/build-plugins/language-binding/advanced-configuration.mdx
@@ -34,6 +34,11 @@ configuration. A cleanup failure is more serious: the process can retain a runti
 diagnostic report and refuse later mutation because it can no longer prove that stale
 callbacks are gone.
 
+An activation-owned conditional middleware guardrail participates in the same
+transaction. Relay removes a partially registered gate if later component registration
+fails. A successful replacement removes the previous component's gate during teardown
+and installs the replacement gate with the new component.
+
 The report accessor is a snapshot, not a live inspection of every registry. The kind-listing
 accessor answers a different question: which implementations can future component
 documents reference? An inactive or disabled kind can appear in that list, and an active
@@ -155,3 +160,24 @@ Use the following order so active callbacks cannot outlive their implementation:
 Success means instance multiplicity is intentional, reports are interpreted separately
 from registry state, async teardown never blocks its event loop, and the application can
 prove both active registrations and future kind lookup have been removed.
+
+## Configure Registration Control
+
+The complete language-binding examples define the following optional group:
+
+| Field | Default | Validation |
+|---|---|---|
+| `enabled` | `false` | Must be a Boolean value. |
+| `kinds` | `["subscriber"]` | Must contain at least one supported global registration kind. |
+| `registration_name` | `"documentation-controlled-subscriber"` | Must be a nonempty effective target name. |
+| `reason` | `"disabled by documentation plugin"` | Must be a nonempty operator-facing explanation. |
+
+Keep the feature disabled unless the host deliberately supplies a target from
+runtime-registration discovery. Do not copy an effective name into long-lived
+configuration or reuse it after a process restart or plugin configuration reload. A host
+that generates plugin configuration dynamically can discover the target, insert its
+effective name, and initialize the component in the same runtime activation.
+
+The example uses a constant-result callback because the component owns the gate for its
+complete activation. Use the application-level API for a timer or health check that
+changes eligibility without replacing plugin configuration.

--- a/docs/build-plugins/language-binding/code-examples.mdx
+++ b/docs/build-plugins/language-binding/code-examples.mdx
@@ -16,6 +16,27 @@ needs, asserts one behavior, and cleans up its registrations. You can therefore 
 test by name without relying on test order or on another example having prepared files,
 configuration, or process state.
 
+## Shared Registration-Control Configuration
+
+All three hosts include the same disabled-by-default configuration group:
+
+```json
+{
+  "registration_control": {
+    "enabled": false,
+    "kinds": ["subscriber"],
+    "registration_name": "documentation-controlled-subscriber",
+    "reason": "disabled by documentation plugin"
+  }
+}
+```
+
+The atomic tests confirm that the default is valid, each required value has a
+field-specific diagnostic, enabling the group registers the expected gate, and clearing
+the plugin restores the target for future snapshots. The host must replace the example
+target with an effective name discovered in the current activation before enabling the
+group against application middleware.
+
 ## Python Host
 
 Run and inspect the Python host as follows:

--- a/docs/build-plugins/language-binding/register-behavior.mdx
+++ b/docs/build-plugins/language-binding/register-behavior.mdx
@@ -12,6 +12,67 @@ example installs only the feature groups whose `enabled` values are true and rea
 configuration. It never calls a process-global middleware registrar from inside the
 plugin.
 
+An optional `registration_control` group in each complete example demonstrates an
+activation-owned conditional middleware guardrail. It is disabled by default. When
+enabled, the context qualifies the gate name and removes the gate automatically during
+rollback or teardown. Refer to
+[Conditional Middleware Guardrails](/about-nemo-relay/concepts/conditional-middleware-guardrails)
+before selecting and storing the target name.
+
+## Register an Activation-Owned Gate
+
+The following examples register the same constant-result gate after configuration has
+supplied a discovered effective target name:
+
+<Tabs>
+<Tab title="Python" language="python">
+```python
+from nemo_relay.runtime_registrations import RuntimeRegistrationKind
+
+control = settings["registration_control"]
+if control["enabled"]:
+    context.register_conditional_middleware_guardrail(
+        "documentation-registration-control",
+        {RuntimeRegistrationKind(kind) for kind in control["kinds"]},
+        control["registration_name"],
+        lambda _kinds, _name: control["reason"],
+    )
+```
+</Tab>
+
+<Tab title="Node.js" language="node">
+```js
+const control = settings.registration_control;
+if (control.enabled) {
+  context.registerConditionalMiddlewareGuardrail(
+    'documentation-registration-control',
+    control.kinds,
+    control.registration_name,
+    () => control.reason,
+  );
+}
+```
+</Tab>
+
+<Tab title="Rust" language="rust">
+```rust
+if config.registration_control.enabled {
+    let reason = config.registration_control.reason.clone();
+    ctx.register_conditional_middleware_guardrail(
+        "documentation-registration-control",
+        config.registration_control.kinds.iter().copied().collect(),
+        &config.registration_control.registration_name,
+        Arc::new(move |_kinds, _name| Some(reason.clone())),
+    )?;
+}
+```
+</Tab>
+</Tabs>
+
+The component-local gate name does not need a plugin prefix. Relay qualifies the name
+and records its rollback operation. The target name is different: it must already be the
+effective name that discovery returned for the current runtime activation.
+
 ## Register Event Metadata Injectors
 
 An event metadata injector receives an event snapshot and returns flat metadata

--- a/docs/build-plugins/native/runtime-events-and-scopes.mdx
+++ b/docs/build-plugins/native/runtime-events-and-scopes.mdx
@@ -125,6 +125,25 @@ owned by its activation, and Relay removes remaining gates during activation
 teardown. Use `PluginContext::register_conditional_middleware_guardrail` for a
 gate that must exist as part of the initial registration transaction.
 
+The following registration uses the example's validated, disabled-by-default
+`registration_control` group:
+
+```rust
+if config.registration_control.enabled {
+    context.register_conditional_middleware_guardrail(
+        "documentation_registration_control",
+        &config.registration_control.kinds.iter().copied().collect(),
+        &config.registration_control.registration_name,
+        &config.registration_control.reason,
+    )?;
+}
+```
+
+The native SDK installs the constant reason in the host. Relay does not enter the native
+library while it evaluates future snapshots. Refer to
+[Conditional Middleware Guardrails](/about-nemo-relay/concepts/conditional-middleware-guardrails)
+for the complete discovery, ordering, snapshot, and cleanup contract.
+
 ## Configure the SDK Executor
 
 `NativePlugin::executor_config` supplies the plugin-wide default. The SDK default and the

--- a/docs/build-plugins/plugin-context.mdx
+++ b/docs/build-plugins/plugin-context.mdx
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 `PluginContext` is the component-scoped bridge between validated configuration and the
 Relay runtime. It qualifies each registration name, applies priority and chain controls,
-tracks ownership for rollback, and exposes the same 16 registration surfaces to
+tracks ownership for rollback, and exposes the same 17 registration surfaces to
 language-binding, native typed, and worker plugins.
 
 ## Registration Surface
@@ -20,6 +20,7 @@ language-binding, native typed, and worker plugins.
 | Events | Mark sanitizer | Return replacement `data`, `category_profile`, and `metadata` fields for the emitted mark event. |
 | Events | Scope-start sanitizer | Return replacement observability fields for the emitted scope-start event. |
 | Events | Scope-end sanitizer | Return replacement observability fields for the emitted scope-end event. |
+| Runtime control | Conditional middleware guardrail | Make a matching global registration ineligible for future snapshots. Language bindings use a callback; native and worker SDKs install a host-resident constant reason. |
 | Tool | Request sanitizer | Sanitize the request recorded in start events without changing the request passed to real execution. |
 | Tool | Response sanitizer | Sanitize the result recorded in end events without changing the application result. |
 | Tool | Conditional guardrail | Allow or block real execution from the tool name and request. |
@@ -37,6 +38,29 @@ arguments given to a tool or model and do not change the value returned to the
 application. Request and execution intercepts are different: they participate in the
 real call path. Use a sanitizer for redaction and an intercept for policy or routing that
 must affect execution.
+
+Conditional middleware guardrails are also lifecycle-owned. `PluginContext` qualifies
+their local gate names and removes them during failed activation or component teardown.
+Their target must be a discovered effective global registration name. Refer to
+[Conditional Middleware Guardrails](/about-nemo-relay/concepts/conditional-middleware-guardrails)
+for discovery, snapshot timing, and dynamic runtime controls.
+
+The registration method differs by SDK, as shown in the following table:
+
+| SDK | Method | Gate Decision |
+|---|---|---|
+| Python language binding | `register_conditional_middleware_guardrail` | Callback returns a reason or `None`. |
+| Node.js language binding | `registerConditionalMiddlewareGuardrail` | Callback returns a reason or `null`. |
+| Rust language binding | `register_conditional_middleware_guardrail` | Callback returns an optional reason. |
+| Rust native plugin | `register_conditional_middleware_guardrail` | Host-resident constant reason. |
+| Python worker | `register_conditional_middleware_guardrail` | Host-resident constant reason. |
+| Rust worker | `register_conditional_middleware_guardrail` | Host-resident constant reason. |
+
+Each method accepts a component-local gate name, a nonempty set of registration kinds,
+the target's effective global name, and the callback or constant reason. Context methods
+do not return a deregistration handle because Relay owns cleanup. Runtime-level native
+and worker methods return an activation-owned handle for explicit dynamic
+deregistration.
 
 ## Names, Priority, and `break_chain`
 

--- a/docs/build-plugins/workers/runtime-events-and-scopes.mdx
+++ b/docs/build-plugins/workers/runtime-events-and-scopes.mdx
@@ -50,11 +50,16 @@ subscribers = await ctx.runtime.list_runtime_registrations(
     {RuntimeRegistrationKind.SUBSCRIBER}
 )
 opentelemetry = next(
-    registration
-    for registration in subscribers
-    if registration.local_name == "opentelemetry"
-    and registration.owner.plugin_kind == "observability"
+    (
+        registration
+        for registration in subscribers
+        if registration.local_name == "opentelemetry"
+        and registration.owner.plugin_kind == "observability"
+    ),
+    None,
 )
+if opentelemetry is None:
+    raise RuntimeError("OpenTelemetry subscriber was not found")
 
 gate = await ctx.runtime.register_conditional_middleware_guardrail(
     "pause-opentelemetry",

--- a/docs/build-plugins/workers/runtime-events-and-scopes.mdx
+++ b/docs/build-plugins/workers/runtime-events-and-scopes.mdx
@@ -36,9 +36,11 @@ a middleware chain or publishes an event. A worker timer or health monitor can
 therefore register a constant-reason gate, retain its activation-owned handle,
 and deregister it later.
 
-The following Python worker flow discovers the observability plugin's
-OpenTelemetry subscriber and disables it for one timer interval:
+The following worker flows discover the observability plugin's OpenTelemetry subscriber
+and disable it for one timer interval:
 
+<Tabs>
+<Tab title="Python" language="python">
 ```python
 import asyncio
 
@@ -65,12 +67,84 @@ try:
 finally:
     await ctx.runtime.deregister_conditional_middleware_guardrail(gate)
 ```
+</Tab>
+
+<Tab title="Rust" language="rust">
+```rust
+use std::collections::BTreeSet;
+use std::time::Duration;
+use nemo_relay_worker::{RuntimeRegistrationKind, WorkerSdkError};
+
+let kinds = BTreeSet::from([RuntimeRegistrationKind::Subscriber]);
+let opentelemetry = runtime
+    .list_runtime_registrations(Some(kinds.clone()))
+    .await?
+    .into_iter()
+    .find(|registration| {
+        registration.local_name == "opentelemetry"
+            && registration.owner.plugin_kind.as_deref() == Some("observability")
+    })
+    .ok_or_else(|| WorkerSdkError::Callback(
+        "OpenTelemetry subscriber was not found".into()
+    ))?;
+
+let gate = runtime
+    .register_conditional_middleware_guardrail(
+        "pause-opentelemetry",
+        kinds,
+        &opentelemetry.effective_name,
+        "worker timer active",
+    )
+    .await?;
+tokio::time::sleep(Duration::from_secs(30)).await;
+runtime.deregister_conditional_middleware_guardrail(&gate).await?;
+```
+</Tab>
+</Tabs>
 
 The worker can remove only gates owned by its activation. Relay removes any
 remaining owned gates during ordinary activation teardown. A worker can also
 call `PluginContext.register_conditional_middleware_guardrail` during
 registration to declare an initial host-resident gate; use `PluginRuntime` for
 timer-controlled changes after activation.
+
+Refer to [Conditional Middleware Guardrails](/about-nemo-relay/concepts/conditional-middleware-guardrails)
+for global-only behavior, effective-name discovery, all-matching-gate semantics, and
+the distinction between activation-owned and runtime-discovered gates.
+
+## Declare an Initial Gate
+
+Use the component context when the validated configuration requires the gate for the
+complete worker activation. The following examples install the same host-resident
+constant reason:
+
+<Tabs>
+<Tab title="Python" language="python">
+```python
+ctx.register_conditional_middleware_guardrail(
+    "documentation_registration_control",
+    {RuntimeRegistrationKind.SUBSCRIBER},
+    registration_name,
+    "disabled by documentation plugin",
+)
+```
+</Tab>
+
+<Tab title="Rust" language="rust">
+```rust
+ctx.register_conditional_middleware_guardrail(
+    "documentation_registration_control",
+    BTreeSet::from([RuntimeRegistrationKind::Subscriber]),
+    registration_name,
+    "disabled by documentation plugin",
+);
+```
+</Tab>
+</Tabs>
+
+Relay validates initial gate names, kinds, targets, and duplicate names before it commits
+the worker registrations. Failed registration returns no initial gates. Ordinary
+teardown removes every gate that remains owned by the worker activation.
 
 Use typed [mark](/about-nemo-relay/concepts/events) options when an exported mark needs
 a data schema or log severity. Use

--- a/docs/instrument-applications/advanced-guide.mdx
+++ b/docs/instrument-applications/advanced-guide.mdx
@@ -36,6 +36,32 @@ Use this table to match the behavior you need with the correct middleware family
 
 Use the narrowest middleware type that matches the behavior. For example, do not use a request intercept when you only need to hide a secret from exported events.
 
+## Control a Global Registration
+
+Use a conditional middleware guardrail when an operational policy must temporarily
+exclude existing global middleware or a subscriber. Discover the target from the active
+runtime, and match its registration kind and effective name. Do not persist or construct
+the effective name.
+
+The gate affects future middleware and event-publication snapshots. It does not change
+an in-flight chain, a queued event, the target's ownership, or a same-named scope-local
+registration. Every matching gate must allow the target. If a gate callback fails, Relay
+fails open and keeps the target eligible.
+
+Choose one of the following lifecycle patterns:
+
+- Register a global gate when application code owns the timer, health check, or
+  operational control. Remove the gate in a guaranteed cleanup path.
+- Register an activation-owned gate when a plugin component owns the control for its
+  complete active lifetime. Relay removes the gate during rollback or teardown.
+
+Gate callbacks must read already-available state. They must not make reentrant Relay
+calls that produce middleware, flush subscribers, wait for exporters, or clear plugins.
+Refer to
+[Conditional Middleware Guardrails](/about-nemo-relay/concepts/conditional-middleware-guardrails)
+for the complete semantic model and [Code Examples](/instrument-applications/code-examples)
+for binding-specific registration and cleanup.
+
 ## Add a Tool Policy
 
 This example adds three behaviors around a `search` tool:

--- a/docs/instrument-applications/code-examples.mdx
+++ b/docs/instrument-applications/code-examples.mdx
@@ -288,13 +288,18 @@ from nemo_relay.runtime_registrations import (
 )
 
 target = next(
-    registration
-    for registration in list_runtime_registrations(
-        {RuntimeRegistrationKind.SUBSCRIBER}
-    )
-    if registration.local_name == "opentelemetry"
-    and registration.owner.plugin_kind == "observability"
+    (
+        registration
+        for registration in list_runtime_registrations(
+            {RuntimeRegistrationKind.SUBSCRIBER}
+        )
+        if registration.local_name == "opentelemetry"
+        and registration.owner.plugin_kind == "observability"
+    ),
+    None,
 )
+if target is None:
+    raise RuntimeError("OpenTelemetry subscriber was not found")
 
 paused = True
 register_conditional_middleware_guardrail(

--- a/docs/instrument-applications/code-examples.mdx
+++ b/docs/instrument-applications/code-examples.mdx
@@ -28,7 +28,7 @@ The following table shows which API to use based on your integration need:
 
 Use manual lifecycle calls only when the surrounding code owns the real tool invocation and only exposes reliable start and finish hooks.
 If you are replaying events or bridging a framework clock, pass an explicit timestamp to the manual start, end, or mark helpers.
-Python accepts timezone-aware `datetime` values, Node.js accepts Unix microseconds since epoch, Rust accepts `DateTime<Utc>`, and Go accepts `time.Time`.
+Python accepts timezone-aware `datetime` values, Node.js accepts Unix microseconds since epoch, and Rust accepts `DateTime<Utc>`.
 Every manual tool end helper accepts the canonical `ToolExecutionResult`; wrap
 the business payload and add an optional opaque annotation when needed.
 
@@ -270,6 +270,119 @@ stream.close().await?;
 </Tab>
 
 </Tabs>
+
+## Temporarily Exclude a Global Registration
+
+The following examples discover a global subscriber, register a state-driven gate, and
+remove the gate in a guaranteed cleanup path. Use the same registration kind during
+discovery and gate registration.
+
+<Tabs>
+<Tab title="Python" language="python">
+```python
+from nemo_relay.runtime_registrations import (
+    RuntimeRegistrationKind,
+    deregister_conditional_middleware_guardrail,
+    list_runtime_registrations,
+    register_conditional_middleware_guardrail,
+)
+
+target = next(
+    registration
+    for registration in list_runtime_registrations(
+        {RuntimeRegistrationKind.SUBSCRIBER}
+    )
+    if registration.local_name == "opentelemetry"
+    and registration.owner.plugin_kind == "observability"
+)
+
+paused = True
+register_conditional_middleware_guardrail(
+    "pause-opentelemetry",
+    {RuntimeRegistrationKind.SUBSCRIBER},
+    target.effective_name,
+    lambda _kinds, _name: "export paused" if paused else None,
+)
+try:
+    await run_application()
+finally:
+    deregister_conditional_middleware_guardrail("pause-opentelemetry")
+```
+</Tab>
+
+<Tab title="Node.js" language="node">
+```js
+import {
+  deregisterConditionalMiddlewareGuardrail,
+  listRuntimeRegistrations,
+  registerConditionalMiddlewareGuardrail,
+} from 'nemo-relay-node';
+
+const target = listRuntimeRegistrations(['subscriber']).find(
+  (registration) => registration.localName === 'opentelemetry'
+    && registration.owner.pluginKind === 'observability',
+);
+if (!target) throw new Error('OpenTelemetry subscriber was not found');
+
+let paused = true;
+registerConditionalMiddlewareGuardrail(
+  'pause-opentelemetry',
+  ['subscriber'],
+  target.effectiveName,
+  () => paused ? 'export paused' : null,
+);
+try {
+  await runApplication();
+} finally {
+  deregisterConditionalMiddlewareGuardrail('pause-opentelemetry');
+}
+```
+</Tab>
+
+<Tab title="Rust" language="rust">
+```rust
+use std::collections::BTreeSet;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use nemo_relay::api::registry::{
+    RuntimeRegistrationKind,
+    deregister_conditional_middleware_guardrail,
+    list_runtime_registrations,
+    register_conditional_middleware_guardrail,
+};
+
+let kinds = BTreeSet::from([RuntimeRegistrationKind::Subscriber]);
+let target = list_runtime_registrations(Some(&kinds))?
+    .into_iter()
+    .find(|registration| {
+        registration.local_name == "opentelemetry"
+            && registration.owner.plugin_kind.as_deref() == Some("observability")
+    })
+    .ok_or("OpenTelemetry subscriber was not found")?;
+
+let paused = Arc::new(AtomicBool::new(true));
+let callback_state = Arc::clone(&paused);
+register_conditional_middleware_guardrail(
+    "pause-opentelemetry",
+    kinds,
+    &target.effective_name,
+    Arc::new(move |_kinds, _name| {
+        callback_state
+            .load(Ordering::Acquire)
+            .then(|| "export paused".to_string())
+    }),
+)?;
+
+let application_result = run_application().await;
+deregister_conditional_middleware_guardrail("pause-opentelemetry")?;
+application_result?;
+```
+</Tab>
+</Tabs>
+
+Python and Node.js use `try` and `finally` for cleanup. Rust must preserve both the
+application result and deregistration result, as shown, or use an owning guard in the
+host application. A callback failure keeps the target eligible and adds a runtime
+diagnostic.
 
 ## Partial Middleware Calls
 

--- a/examples/language-binding-plugin/README.md
+++ b/examples/language-binding-plugin/README.md
@@ -21,3 +21,17 @@ The test names separate validation, activation, tool and model policies, request
 rewrites, streaming, subscription, and teardown. The `main` program in each
 directory is the end-to-end demonstration, while its atomic tests identify the
 exact contract that failed.
+
+Each implementation accepts the same optional registration control:
+
+| Field | Default | Meaning |
+|---|---|---|
+| `registration_control.enabled` | `false` | Install one activation-owned conditional middleware guardrail. |
+| `registration_control.kinds` | `["subscriber"]` | Nonempty runtime registration kinds eligible for suppression. |
+| `registration_control.registration_name` | `"documentation-controlled-subscriber"` | Effective global target name discovered for the current activation. |
+| `registration_control.reason` | `"disabled by documentation plugin"` | Nonempty reason returned while the gate is active. |
+
+The disabled default prevents the runnable example from suppressing unrelated
+application middleware. Refer to
+[Conditional Middleware Guardrails](../../docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx)
+for discovery, ownership, snapshot timing, and cleanup.

--- a/examples/language-binding-plugin/node/main.mjs
+++ b/examples/language-binding-plugin/node/main.mjs
@@ -32,6 +32,12 @@ export const DEFAULT_CONFIG = {
   },
   execution: { enabled: true, priority: 30, emit_pending_marks: true },
   runtime: { emit_marks: true, emit_isolated_scope: true },
+  registration_control: {
+    enabled: false,
+    kinds: ['subscriber'],
+    registration_name: 'documentation-controlled-subscriber',
+    reason: 'disabled by documentation plugin',
+  },
 };
 
 const GROUP_FIELDS = {
@@ -48,6 +54,7 @@ const GROUP_FIELDS = {
   ]),
   execution: new Set(['enabled', 'priority', 'emit_pending_marks']),
   runtime: new Set(['emit_marks', 'emit_isolated_scope']),
+  registration_control: new Set(['enabled', 'kinds', 'registration_name', 'reason']),
 };
 
 function diagnostic(level, code, field, message) {
@@ -143,9 +150,25 @@ function validateDocumentationConfig(config) {
     'execution.emit_pending_marks': settings.execution.emit_pending_marks,
     'runtime.emit_marks': settings.runtime.emit_marks,
     'runtime.emit_isolated_scope': settings.runtime.emit_isolated_scope,
+    'registration_control.enabled': settings.registration_control.enabled,
+    'registration_control.kinds': settings.registration_control.kinds,
+    'registration_control.registration_name': settings.registration_control.registration_name,
+    'registration_control.reason': settings.registration_control.reason,
   };
-  const stringFields = new Set(['tag', 'requests.mode', 'requests.header_name', 'requests.header_value']);
-  const arrayFields = new Set(['observe.redact_keys', 'requests.blocked_tools', 'requests.blocked_models']);
+  const stringFields = new Set([
+    'tag',
+    'requests.mode',
+    'requests.header_name',
+    'requests.header_value',
+    'registration_control.registration_name',
+    'registration_control.reason',
+  ]);
+  const arrayFields = new Set([
+    'observe.redact_keys',
+    'requests.blocked_tools',
+    'requests.blocked_models',
+    'registration_control.kinds',
+  ]);
   const integerFields = new Set(['requests.priority', 'execution.priority']);
   for (const [field, value] of Object.entries(fields)) {
     const valid = stringFields.has(field)
@@ -162,10 +185,31 @@ function validateDocumentationConfig(config) {
   if (typeof settings.tag === 'string' && settings.tag.length === 0) {
     diagnostics.push(diagnostic('error', 'invalid_tag', 'tag', 'tag must be a non-empty string'));
   }
+  const supportedKinds = new Set(Object.values(relay.RuntimeRegistrationKind));
+  if (
+    Array.isArray(settings.registration_control.kinds) &&
+    (settings.registration_control.kinds.length === 0 ||
+      !settings.registration_control.kinds.every((kind) => supportedKinds.has(kind)))
+  ) {
+    diagnostics.push(
+      diagnostic(
+        'error',
+        'invalid_config',
+        'registration_control.kinds',
+        'registration_control.kinds must be a non-empty array of supported registration kinds',
+      ),
+    );
+  }
   for (const field of ['requests.header_name', 'requests.header_value']) {
     const value = fields[field];
     if (typeof value === 'string' && value.length === 0) {
       diagnostics.push(diagnostic('error', 'invalid_header', field, `${field} must be a non-empty string`));
+    }
+  }
+  for (const field of ['registration_control.registration_name', 'registration_control.reason']) {
+    const value = fields[field];
+    if (typeof value === 'string' && value.length === 0) {
+      diagnostics.push(diagnostic('error', 'invalid_config', field, `${field} must be a non-empty string`));
     }
   }
   if (typeof settings.requests.mode === 'string' && !new Set(['observe', 'enforce']).has(settings.requests.mode)) {
@@ -183,7 +227,15 @@ export const documentationPlugin = {
   },
   register(config, context) {
     const settings = normalizedConfig(config);
-    const { observe, requests, execution, runtime } = settings;
+    const { observe, requests, execution, runtime, registration_control: registrationControl } = settings;
+    if (registrationControl.enabled) {
+      context.registerConditionalMiddlewareGuardrail(
+        'documentation-registration-control',
+        registrationControl.kinds,
+        registrationControl.registration_name,
+        () => registrationControl.reason,
+      );
+    }
     if (observe.enabled) {
       context.registerSubscriber('events', (event) => documentationPlugin.events.push(event.name));
       const sanitizeEvent = (_event, fields) => ({

--- a/examples/language-binding-plugin/node/test-plugin.mjs
+++ b/examples/language-binding-plugin/node/test-plugin.mjs
@@ -43,6 +43,11 @@ test('validation accepts a supported mode', () => {
   assert.deepEqual(documentationPlugin.validate({ requests: { mode: 'enforce' } }), []);
 });
 
+test('default registration control is disabled and valid', () => {
+  assert.equal(DEFAULT_CONFIG.registration_control.enabled, false);
+  assert.deepEqual(documentationPlugin.validate(structuredClone(DEFAULT_CONFIG)), []);
+});
+
 test('validation rejects an unsupported mode', () => {
   const diagnostics = documentationPlugin.validate({ requests: { mode: 'invalid' } });
 
@@ -66,6 +71,13 @@ for (const [config, field, code] of [
   [{ tag: '' }, 'tag', 'documentation-plugin.invalid_tag'],
   [{ requests: { header_name: '' } }, 'requests.header_name', 'documentation-plugin.invalid_header'],
   [{ requests: { header_value: '' } }, 'requests.header_value', 'documentation-plugin.invalid_header'],
+  [{ registration_control: { kinds: [] } }, 'registration_control.kinds', 'documentation-plugin.invalid_config'],
+  [
+    { registration_control: { registration_name: '' } },
+    'registration_control.registration_name',
+    'documentation-plugin.invalid_config',
+  ],
+  [{ registration_control: { reason: '' } }, 'registration_control.reason', 'documentation-plugin.invalid_config'],
 ]) {
   test(`validation rejects an empty ${field}`, () => {
     const diagnostics = documentationPlugin.validate(config);
@@ -114,6 +126,35 @@ test('registers every safe plugin surface', () => {
     'registerToolSanitizeRequestGuardrail',
     'registerToolSanitizeResponseGuardrail',
   ]);
+
+  const enabled = structuredClone(DEFAULT_CONFIG);
+  enabled.registration_control.enabled = true;
+  const methods = new Set();
+  documentationPlugin.register(enabled, new Proxy({}, { get: (_target, method) => () => methods.add(method) }));
+  assert.ok(methods.has('registerConditionalMiddlewareGuardrail'));
+});
+
+test('registration control is owned by activation', async () => {
+  const target = 'documentation-controlled-subscriber';
+  const observed = [];
+  const controlled = config('enforce');
+  controlled.components[0].config.registration_control.enabled = true;
+  relay.registerSubscriber(target, (event) => observed.push(event.name));
+  try {
+    const before = relay.listRuntimeRegistrations(['subscriber']);
+    assert.ok(before.some((registration) => registration.effectiveName === target));
+    await withActivePlugin(async () => {
+      const baseline = observed.length;
+      relay.event('registration-control-active', null, null);
+      await relay.flushSubscribers();
+      assert.equal(observed.length, baseline);
+    }, controlled);
+    relay.event('registration-control-cleared', null, null);
+    await relay.flushSubscribers();
+    assert.equal(observed.at(-1), 'registration-control-cleared');
+  } finally {
+    relay.deregisterSubscriber(target);
+  }
 });
 
 test('activation reports no diagnostics', async () => {

--- a/examples/language-binding-plugin/python/main.py
+++ b/examples/language-binding-plugin/python/main.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import nemo_relay
 from nemo_relay import llm, plugin, scope, subscribers, tools
+from nemo_relay.runtime_registrations import RuntimeRegistrationKind
 
 DEFAULT_CONFIG: dict[str, Any] = {
     "tag": "documentation",
@@ -29,6 +30,12 @@ DEFAULT_CONFIG: dict[str, Any] = {
     },
     "execution": {"enabled": True, "priority": 30, "emit_pending_marks": True},
     "runtime": {"emit_marks": True, "emit_isolated_scope": True},
+    "registration_control": {
+        "enabled": False,
+        "kinds": [RuntimeRegistrationKind.SUBSCRIBER],
+        "registration_name": "documentation-controlled-subscriber",
+        "reason": "disabled by documentation plugin",
+    },
 }
 
 GROUP_FIELDS = {
@@ -45,6 +52,7 @@ GROUP_FIELDS = {
     },
     "execution": {"enabled", "priority", "emit_pending_marks"},
     "runtime": {"emit_marks", "emit_isolated_scope"},
+    "registration_control": {"enabled", "kinds", "registration_name", "reason"},
 }
 
 
@@ -139,6 +147,10 @@ def validate_documentation_config(config: dict[str, Any]) -> list[dict[str, str]
         "execution.emit_pending_marks": bool,
         "runtime.emit_marks": bool,
         "runtime.emit_isolated_scope": bool,
+        "registration_control.enabled": bool,
+        "registration_control.kinds": list,
+        "registration_control.registration_name": str,
+        "registration_control.reason": str,
     }
     for field, expected in expected_types.items():
         group, separator, key = field.partition(".")
@@ -165,6 +177,18 @@ def validate_documentation_config(config: dict[str, Any]) -> list[dict[str, str]
                     f"{field} must contain only strings",
                 )
             )
+    kinds = settings["registration_control"]["kinds"]
+    if isinstance(kinds, list):
+        supported_kinds = {kind.value for kind in RuntimeRegistrationKind}
+        if not kinds or not all(isinstance(item, str) and item in supported_kinds for item in kinds):
+            diagnostics.append(
+                _diagnostic(
+                    "error",
+                    "invalid_config",
+                    "registration_control.kinds",
+                    "registration_control.kinds must be a non-empty array of supported registration kinds",
+                )
+            )
     if isinstance(settings["tag"], str) and not settings["tag"]:
         diagnostics.append(_diagnostic("error", "invalid_tag", "tag", "tag must be a non-empty string"))
     for field in ("requests.header_name", "requests.header_value"):
@@ -172,6 +196,11 @@ def validate_documentation_config(config: dict[str, Any]) -> list[dict[str, str]
         value = settings[group][key]
         if isinstance(value, str) and not value:
             diagnostics.append(_diagnostic("error", "invalid_header", field, f"{field} must be a non-empty string"))
+    for field in ("registration_control.registration_name", "registration_control.reason"):
+        group, key = field.split(".")
+        value = settings[group][key]
+        if isinstance(value, str) and not value:
+            diagnostics.append(_diagnostic("error", "invalid_config", field, f"{field} must be a non-empty string"))
     requests = settings["requests"]
     if isinstance(requests["mode"], str) and requests["mode"] not in {"observe", "enforce"}:
         diagnostics.append(
@@ -198,6 +227,14 @@ class DocumentationPlugin:
         observe = settings["observe"]
         requests = settings["requests"]
         execution = settings["execution"]
+        registration_control = settings["registration_control"]
+        if registration_control["enabled"]:
+            context.register_conditional_middleware_guardrail(
+                "documentation-registration-control",
+                {RuntimeRegistrationKind(kind) for kind in registration_control["kinds"]},
+                registration_control["registration_name"],
+                lambda _kinds, _registration_name: registration_control["reason"],
+            )
         if observe["enabled"]:
             context.register_subscriber("events", lambda event: self.events.append(event.name))
 

--- a/examples/language-binding-plugin/python/test_plugin.py
+++ b/examples/language-binding-plugin/python/test_plugin.py
@@ -14,7 +14,8 @@ import pytest_asyncio
 from main import DocumentationPlugin, component
 
 import nemo_relay
-from nemo_relay import llm, plugin, subscribers, tools
+from nemo_relay import llm, plugin, runtime_registrations, scope, subscribers, tools
+from nemo_relay.runtime_registrations import RuntimeRegistrationKind
 
 
 @dataclass
@@ -59,6 +60,13 @@ def test_validation_accepts_supported_mode() -> None:
     assert DocumentationPlugin().validate({"requests": {"mode": "enforce"}}) == []
 
 
+def test_default_registration_control_is_disabled_and_valid() -> None:
+    configuration = component("enforce").components[0].config
+
+    assert configuration["registration_control"]["enabled"] is False
+    assert DocumentationPlugin().validate(configuration) == []
+
+
 def test_validation_rejects_unsupported_mode() -> None:
     diagnostics = DocumentationPlugin().validate({"requests": {"mode": "invalid"}})
 
@@ -87,6 +95,17 @@ def test_registration_rejects_a_duplicate_kind_and_missing_deregistration_is_fal
         ({"tag": ""}, "tag", "documentation-plugin.invalid_tag"),
         ({"requests": {"header_name": ""}}, "requests.header_name", "documentation-plugin.invalid_header"),
         ({"requests": {"header_value": ""}}, "requests.header_value", "documentation-plugin.invalid_header"),
+        ({"registration_control": {"kinds": []}}, "registration_control.kinds", "documentation-plugin.invalid_config"),
+        (
+            {"registration_control": {"registration_name": ""}},
+            "registration_control.registration_name",
+            "documentation-plugin.invalid_config",
+        ),
+        (
+            {"registration_control": {"reason": ""}},
+            "registration_control.reason",
+            "documentation-plugin.invalid_config",
+        ),
     ],
 )
 def test_validation_rejects_empty_required_strings(config: dict[str, Any], field: str, code: str) -> None:
@@ -133,6 +152,39 @@ def test_registers_each_safe_plugin_surface() -> None:
         "register_llm_execution_intercept",
         "register_llm_stream_execution_intercept",
     }
+
+    configuration = component("enforce").components[0].config
+    configuration["registration_control"]["enabled"] = True
+    context = RecordingContext()
+    DocumentationPlugin().register(configuration, context)  # type: ignore[arg-type]
+    assert "register_conditional_middleware_guardrail" in context.registrations
+
+
+async def test_registration_control_is_owned_by_activation(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = "documentation-controlled-subscriber"
+    observed: list[str] = []
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    subscribers.register(target, lambda event: observed.append(event.name))
+    configuration = component("enforce")
+    configuration.components[0].config["registration_control"]["enabled"] = True
+    plugin.register("documentation-plugin", DocumentationPlugin())
+    try:
+        before = runtime_registrations.list_runtime_registrations({RuntimeRegistrationKind.SUBSCRIBER})
+        assert any(item.effective_name == target for item in before)
+        await plugin.initialize(configuration)
+        baseline = len(observed)
+        scope.event("registration-control-active")
+        await subscribers.flush_async()
+        assert len(observed) == baseline
+        await plugin.clear_async()
+        scope.event("registration-control-cleared")
+        await subscribers.flush_async()
+        assert observed[-1] == "registration-control-cleared"
+    finally:
+        await plugin.clear_async()
+        plugin.deregister("documentation-plugin")
+        subscribers.deregister(target)
 
 
 async def test_activation_reports_no_diagnostics(active_plugin: ActivatedExample) -> None:

--- a/examples/language-binding-plugin/rust/src/config.rs
+++ b/examples/language-binding-plugin/rust/src/config.rs
@@ -3,6 +3,8 @@
 
 use std::collections::HashSet;
 
+use nemo_relay::api::registry::RuntimeRegistrationKind;
+
 use nemo_relay::plugin::{ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, UnsupportedBehavior};
 use serde::Deserialize;
 use serde_json::{Map, Value as Json};
@@ -15,6 +17,7 @@ pub(crate) struct Settings {
     pub requests: Requests,
     pub execution: Execution,
     pub runtime: Runtime,
+    pub registration_control: RegistrationControl,
 }
 
 #[derive(Clone, Deserialize)]
@@ -52,6 +55,15 @@ pub(crate) struct Runtime {
     pub emit_isolated_scope: bool,
 }
 
+#[derive(Clone, Deserialize)]
+#[serde(default)]
+pub(crate) struct RegistrationControl {
+    pub enabled: bool,
+    pub kinds: Vec<RuntimeRegistrationKind>,
+    pub registration_name: String,
+    pub reason: String,
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
@@ -60,6 +72,7 @@ impl Default for Settings {
             requests: Requests::default(),
             execution: Execution::default(),
             runtime: Runtime::default(),
+            registration_control: RegistrationControl::default(),
         }
     }
 }
@@ -103,6 +116,17 @@ impl Default for Runtime {
         Self {
             emit_marks: true,
             emit_isolated_scope: true,
+        }
+    }
+}
+
+impl Default for RegistrationControl {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            kinds: vec![RuntimeRegistrationKind::Subscriber],
+            registration_name: "documentation-controlled-subscriber".into(),
+            reason: "disabled by documentation plugin".into(),
         }
     }
 }
@@ -158,6 +182,30 @@ pub(crate) fn validate(config: &Map<String, Json>, policy: &ConfigPolicy) -> Vec
             "requests.header_value must be a non-empty string",
         ));
     }
+    if settings.registration_control.kinds.is_empty() {
+        diagnostics.push(diagnostic(
+            DiagnosticLevel::Error,
+            "invalid_registration_control",
+            Some("registration_control.kinds"),
+            "registration_control.kinds must not be empty",
+        ));
+    }
+    for (field, value) in [
+        (
+            "registration_control.registration_name",
+            &settings.registration_control.registration_name,
+        ),
+        ("registration_control.reason", &settings.registration_control.reason),
+    ] {
+        if value.is_empty() {
+            diagnostics.push(diagnostic(
+                DiagnosticLevel::Error,
+                "invalid_registration_control",
+                Some(field),
+                format!("{field} must not be empty"),
+            ));
+        }
+    }
     diagnostics
 }
 
@@ -171,7 +219,14 @@ fn report_unknown_fields(
         UnsupportedBehavior::Warn => DiagnosticLevel::Warning,
         UnsupportedBehavior::Error => DiagnosticLevel::Error,
     };
-    const TOP_LEVEL: &[&str] = &["tag", "observe", "requests", "execution", "runtime"];
+    const TOP_LEVEL: &[&str] = &[
+        "tag",
+        "observe",
+        "requests",
+        "execution",
+        "runtime",
+        "registration_control",
+    ];
     const OBSERVE: &[&str] = &["enabled", "redact_keys"];
     const REQUESTS: &[&str] = &[
         "enabled",
@@ -185,12 +240,14 @@ fn report_unknown_fields(
     ];
     const EXECUTION: &[&str] = &["enabled", "priority", "emit_pending_marks"];
     const RUNTIME: &[&str] = &["emit_marks", "emit_isolated_scope"];
+    const REGISTRATION_CONTROL: &[&str] = &["enabled", "kinds", "registration_name", "reason"];
     report_unknown(config, "", TOP_LEVEL, level, diagnostics);
     for (group, allowed) in [
         ("observe", OBSERVE),
         ("requests", REQUESTS),
         ("execution", EXECUTION),
         ("runtime", RUNTIME),
+        ("registration_control", REGISTRATION_CONTROL),
     ] {
         if let Some(object) = config.get(group).and_then(Json::as_object) {
             report_unknown(object, group, allowed, level, diagnostics);

--- a/examples/language-binding-plugin/rust/src/lib.rs
+++ b/examples/language-binding-plugin/rust/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod config;
 
+use std::collections::BTreeSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -62,6 +63,15 @@ impl Plugin for DocumentationPlugin {
         Box::pin(async move {
             let settings =
                 config::parse(&config).map_err(nemo_relay::plugin::PluginError::InvalidConfig)?;
+            if settings.registration_control.enabled {
+                let reason = settings.registration_control.reason.clone();
+                context.register_conditional_middleware_guardrail(
+                    "registration-control",
+                    settings.registration_control.kinds.iter().copied().collect::<BTreeSet<_>>(),
+                    &settings.registration_control.registration_name,
+                    Arc::new(move |_, _| Some(reason.clone())),
+                )?;
+            }
             if settings.observe.enabled {
                 context.register_subscriber(
                     "events",
@@ -320,7 +330,13 @@ pub fn config_with_enabled(mode: &str, enabled: bool) -> PluginConfig {
             "break_chain": false
         },
         "execution": { "enabled": true, "priority": 30, "emit_pending_marks": true },
-        "runtime": { "emit_marks": true, "emit_isolated_scope": true }
+        "runtime": { "emit_marks": true, "emit_isolated_scope": true },
+        "registration_control": {
+            "enabled": false,
+            "kinds": ["subscriber"],
+            "registration_name": "documentation-controlled-subscriber",
+            "reason": "disabled by documentation plugin"
+        }
     })
     .as_object()
     .expect("config object")

--- a/examples/language-binding-plugin/rust/tests/plugin.rs
+++ b/examples/language-binding-plugin/rust/tests/plugin.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
 
 use futures::{StreamExt, stream};
 use nemo_relay::api::llm::{
@@ -108,6 +108,21 @@ fn validation_reports_each_empty_required_string_at_its_field() {
             "documentation-plugin.invalid_header",
             "requests.header_value",
         ),
+        (
+            json!({ "registration_control": { "kinds": [] } }),
+            "documentation-plugin.invalid_registration_control",
+            "registration_control.kinds",
+        ),
+        (
+            json!({ "registration_control": { "registration_name": "" } }),
+            "documentation-plugin.invalid_registration_control",
+            "registration_control.registration_name",
+        ),
+        (
+            json!({ "registration_control": { "reason": "" } }),
+            "documentation-plugin.invalid_registration_control",
+            "registration_control.reason",
+        ),
     ] {
         let diagnostics = DocumentationPlugin.validate(&configuration.as_object().unwrap().clone());
         assert!(diagnostics.iter().any(|diagnostic| {
@@ -149,11 +164,12 @@ fn implementation_registers_each_safe_plugin_surface() {
             "register_llm_request_intercept",
             "register_llm_execution_intercept",
             "register_llm_stream_execution_intercept",
+            "register_conditional_middleware_guardrail",
         ]
         .iter()
         .filter(|method| source.contains(**method))
         .count(),
-        15
+        16
     );
 }
 
@@ -182,6 +198,52 @@ async fn activation_reports_no_diagnostics() {
     let active = activate().await;
 
     assert!(active.report.diagnostics.is_empty());
+}
+
+#[tokio::test]
+async fn registration_control_is_owned_by_activation() {
+    const TARGET: &str = "documentation-controlled-subscriber";
+    let observed = Arc::new(AtomicUsize::new(0));
+    let captured = Arc::clone(&observed);
+    nemo_relay::api::subscriber::register_subscriber(
+        TARGET,
+        Arc::new(move |_| {
+            captured.fetch_add(1, Ordering::SeqCst);
+        }),
+    )
+    .expect("controlled subscriber should register");
+    let mut configuration = config("enforce");
+    configuration.components[0].config["registration_control"]["enabled"] = json!(true);
+
+    let active = activate_with(configuration).await;
+    flush_subscribers().expect("activation events should flush");
+    let baseline = observed.load(Ordering::SeqCst);
+    tool_call_execute(
+        ToolCallExecuteParams::builder()
+            .name("controlled-tool")
+            .args(json!({}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(ToolExecutionResult::new(args)) })))
+            .build(),
+    )
+    .await
+    .expect("managed call should complete");
+    flush_subscribers().expect("active events should flush");
+    assert_eq!(observed.load(Ordering::SeqCst), baseline);
+
+    drop(active);
+    tool_call_execute(
+        ToolCallExecuteParams::builder()
+            .name("restored-tool")
+            .args(json!({}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(ToolExecutionResult::new(args)) })))
+            .build(),
+    )
+    .await
+    .expect("managed call should complete after clear");
+    flush_subscribers().expect("restored events should flush");
+    assert!(observed.load(Ordering::SeqCst) > baseline);
+    nemo_relay::api::subscriber::deregister_subscriber(TARGET)
+        .expect("controlled subscriber should deregister");
 }
 
 #[tokio::test]

--- a/examples/language-binding-plugin/rust/tests/plugin.rs
+++ b/examples/language-binding-plugin/rust/tests/plugin.rs
@@ -57,6 +57,13 @@ async fn register_only() -> RegisteredPlugin {
 
 async fn activate_with(plugin_config: nemo_relay::plugin::PluginConfig) -> ActivePlugin {
     let registration = register_only().await;
+    activate_registered(registration, plugin_config).await
+}
+
+async fn activate_registered(
+    registration: RegisteredPlugin,
+    plugin_config: nemo_relay::plugin::PluginConfig,
+) -> ActivePlugin {
     let report = initialize_plugins_exact(plugin_config)
         .await
         .unwrap_or_else(|error| panic!("plugin activation should succeed: {error}"));
@@ -211,6 +218,7 @@ async fn activation_reports_no_diagnostics() {
 #[tokio::test]
 async fn registration_control_is_owned_by_activation() {
     const TARGET: &str = "documentation-controlled-subscriber";
+    let registration = register_only().await;
     let observed = Arc::new(AtomicUsize::new(0));
     let captured = Arc::clone(&observed);
     register_subscriber(
@@ -224,7 +232,7 @@ async fn registration_control_is_owned_by_activation() {
     let mut configuration = config("enforce");
     configuration.components[0].config["registration_control"]["enabled"] = json!(true);
 
-    let active = activate_with(configuration).await;
+    let active = activate_registered(registration, configuration).await;
     flush_subscribers().expect("activation events should flush");
     let baseline = observed.load(Ordering::SeqCst);
     tool_call_execute(

--- a/examples/language-binding-plugin/rust/tests/plugin.rs
+++ b/examples/language-binding-plugin/rust/tests/plugin.rs
@@ -9,7 +9,7 @@ use nemo_relay::api::llm::{
     llm_stream_call_execute,
 };
 use nemo_relay::api::runtime::callbacks::LlmJsonStream;
-use nemo_relay::api::subscriber::flush_subscribers;
+use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
 use nemo_relay::api::tool::{ToolCallExecuteParams, ToolExecutionResult, tool_call_execute};
 use nemo_relay::plugin::{
     ConfigReport, DiagnosticLevel, Plugin, clear_plugin_configuration, deregister_plugin,
@@ -38,6 +38,14 @@ impl Drop for RegisteredPlugin {
 struct ActivePlugin {
     report: ConfigReport,
     _registration: RegisteredPlugin,
+}
+
+struct RegisteredSubscriber(&'static str);
+
+impl Drop for RegisteredSubscriber {
+    fn drop(&mut self) {
+        let _ = deregister_subscriber(self.0);
+    }
 }
 
 async fn register_only() -> RegisteredPlugin {
@@ -205,13 +213,14 @@ async fn registration_control_is_owned_by_activation() {
     const TARGET: &str = "documentation-controlled-subscriber";
     let observed = Arc::new(AtomicUsize::new(0));
     let captured = Arc::clone(&observed);
-    nemo_relay::api::subscriber::register_subscriber(
+    register_subscriber(
         TARGET,
         Arc::new(move |_| {
             captured.fetch_add(1, Ordering::SeqCst);
         }),
     )
     .expect("controlled subscriber should register");
+    let _subscriber = RegisteredSubscriber(TARGET);
     let mut configuration = config("enforce");
     configuration.components[0].config["registration_control"]["enabled"] = json!(true);
 
@@ -242,8 +251,6 @@ async fn registration_control_is_owned_by_activation() {
     .expect("managed call should complete after clear");
     flush_subscribers().expect("restored events should flush");
     assert!(observed.load(Ordering::SeqCst) > baseline);
-    nemo_relay::api::subscriber::deregister_subscriber(TARGET)
-        .expect("controlled subscriber should deregister");
 }
 
 #[tokio::test]

--- a/examples/python-grpc-worker-plugin/README.md
+++ b/examples/python-grpc-worker-plugin/README.md
@@ -23,9 +23,17 @@ uv run --locked --group test pytest
 
 Each test owns one contract and can be selected independently. The suite builds
 this directory as a wheel in a clean temporary project, checks the mandatory
-source digest and JSON Schema, validates configuration, asserts all 16
+source digest and JSON Schema, validates configuration, asserts all 17
 registrations, and then exercises each policy, sanitizer, request rewrite,
 continuation, stream, mark, and scope behavior separately.
+
+The seventeenth surface is an optional activation-owned conditional middleware
+guardrail. `registration_control.enabled` defaults to `false`; its remaining defaults
+are `kinds: ["subscriber"]`, target `documentation-controlled-subscriber`, and reason
+`disabled by documentation plugin`. The kinds, effective target, and reason must be
+nonempty. Refer to
+[Conditional Middleware Guardrails](../../docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx)
+for the full runtime and ownership contract.
 
 To run the managed-environment lifecycle from this directory, create temporary
 Relay state, add the manifest, and enable the plugin:

--- a/examples/python-grpc-worker-plugin/config.schema.json
+++ b/examples/python-grpc-worker-plugin/config.schema.json
@@ -120,6 +120,30 @@
           "default": true
         }
       }
+    },
+    "registration_control": {
+      "description": "Optionally suppresses a matching global runtime registration for this component's activation lifetime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "kinds": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "enum": ["subscriber", "event_metadata_injector", "mark_sanitize_guardrail", "scope_sanitize_start_guardrail", "scope_sanitize_end_guardrail", "tool_sanitize_request_guardrail", "tool_sanitize_response_guardrail", "tool_conditional_execution_guardrail", "tool_request_intercept", "tool_execution_intercept", "llm_sanitize_request_guardrail", "llm_sanitize_response_guardrail", "llm_conditional_execution_guardrail", "llm_request_intercept", "llm_execution_intercept", "llm_stream_execution_intercept"] },
+          "default": ["subscriber"]
+        },
+        "registration_name": {
+          "type": "string",
+          "minLength": 1,
+          "default": "documentation-controlled-subscriber"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "default": "disabled by documentation plugin"
+        }
+      }
     }
   }
 }

--- a/examples/python-grpc-worker-plugin/nemo_relay_python_grpc_worker_example/worker.py
+++ b/examples/python-grpc-worker-plugin/nemo_relay_python_grpc_worker_example/worker.py
@@ -19,6 +19,7 @@ from nemo_relay_plugin import (
     LlmRequestInterceptOutcome,
     PendingMarkSpec,
     PluginContext,
+    RuntimeRegistrationKind,
     ScopeType,
     ToolExecutionInterceptOutcome,
     ToolExecutionResult,
@@ -41,6 +42,12 @@ DEFAULT_CONFIG: dict[str, Json] = {
     },
     "execution": {"enabled": True, "priority": 30, "emit_pending_marks": True},
     "runtime": {"emit_marks": True, "emit_isolated_scope": True},
+    "registration_control": {
+        "enabled": False,
+        "kinds": [RuntimeRegistrationKind.SUBSCRIBER.value],
+        "registration_name": "documentation-controlled-subscriber",
+        "reason": "disabled by documentation plugin",
+    },
 }
 
 GROUP_FIELDS = {
@@ -57,6 +64,7 @@ GROUP_FIELDS = {
     },
     "execution": {"enabled", "priority", "emit_pending_marks"},
     "runtime": {"emit_marks", "emit_isolated_scope"},
+    "registration_control": {"enabled", "kinds", "registration_name", "reason"},
 }
 
 
@@ -82,6 +90,15 @@ class ExamplePythonWorker(WorkerPlugin):
         requests = cast(dict[str, Json], settings["requests"])
         execution = cast(dict[str, Json], settings["execution"])
         runtime_settings = cast(dict[str, Json], settings["runtime"])
+        registration_control = cast(dict[str, Json], settings["registration_control"])
+
+        if registration_control["enabled"]:
+            ctx.register_conditional_middleware_guardrail(
+                "documentation_registration_control",
+                {RuntimeRegistrationKind(kind) for kind in cast(list[str], registration_control["kinds"])},
+                cast(str, registration_control["registration_name"]),
+                cast(str, registration_control["reason"]),
+            )
 
         if observe["enabled"]:
             self._register_observation(ctx, tag, observe)
@@ -331,6 +348,7 @@ def validate_config(config: Json) -> list[ConfigDiagnostic]:
         "execution.emit_pending_marks",
         "runtime.emit_marks",
         "runtime.emit_isolated_scope",
+        "registration_control.enabled",
     ):
         if not isinstance(_path(settings, path), bool):
             diagnostics.append(_diagnostic(DiagnosticLevel.ERROR, "invalid_type", path, f"{path} must be a boolean"))
@@ -344,7 +362,27 @@ def validate_config(config: Json) -> list[ConfigDiagnostic]:
             diagnostics.append(
                 _diagnostic(DiagnosticLevel.ERROR, "invalid_type", path, f"{path} must be an array of strings")
             )
+    kinds = _path(settings, "registration_control.kinds")
+    if (
+        not isinstance(kinds, list)
+        or not kinds
+        or not all(isinstance(item, str) and item in {kind.value for kind in RuntimeRegistrationKind} for item in kinds)
+    ):
+        diagnostics.append(
+            _diagnostic(
+                DiagnosticLevel.ERROR,
+                "invalid_type",
+                "registration_control.kinds",
+                "registration_control.kinds must be a non-empty array of supported registration kinds",
+            )
+        )
     for path in ("requests.header_name", "requests.header_value"):
+        value = _path(settings, path)
+        if not isinstance(value, str) or not value:
+            diagnostics.append(
+                _diagnostic(DiagnosticLevel.ERROR, "invalid_type", path, f"{path} must be a non-empty string")
+            )
+    for path in ("registration_control.registration_name", "registration_control.reason"):
         value = _path(settings, path)
         if not isinstance(value, str) or not value:
             diagnostics.append(

--- a/examples/python-grpc-worker-plugin/relay-plugin.toml
+++ b/examples/python-grpc-worker-plugin/relay-plugin.toml
@@ -25,7 +25,7 @@ manifest_root = "."
 artifact = "nemo_relay_python_grpc_worker_example/worker.py"
 
 [integrity]
-sha256 = "sha256:8fe6ded5b590bd6a712c2ee2ac7d8da2620fdab1d5de05f212197372f0ab2b8d"
+sha256 = "sha256:e024d3e6bdf50dad41de4b5319689c680565ae2a70a4eb077cfa1ec9a7d4f0f0"
 
 [load]
 runtime = "python"

--- a/examples/python-grpc-worker-plugin/tests/test_worker.py
+++ b/examples/python-grpc-worker-plugin/tests/test_worker.py
@@ -147,6 +147,11 @@ def test_project_builds_an_importable_wheel(tmp_path: Path) -> None:
 def test_default_configuration_is_valid(example: Any) -> None:
     assert example.ExamplePythonWorker().validate(example.DEFAULT_CONFIG) == []
     assert example.DEFAULT_CONFIG["registration_control"]["enabled"] is False
+    context, _runtime = configured_context()
+
+    example.ExamplePythonWorker().register(context, example.DEFAULT_CONFIG)
+
+    context.register_conditional_middleware_guardrail.assert_not_called()
 
 
 def test_non_object_configuration_is_rejected(example: Any) -> None:
@@ -175,7 +180,7 @@ def test_wrong_type_is_rejected(example: Any) -> None:
         ({"registration_control": {"reason": ""}}, "registration_control.reason"),
     ],
 )
-def test_invalid_registration_control_is_rejected(example: Any, config: dict[str, Any], field: str) -> None:
+def test_invalid_registration_control_is_rejected(example: Any, config: dict[str, Any], field: str):
     diagnostics = example.ExamplePythonWorker().validate(config)
 
     assert any(item.code == "examples.python_grpc_worker.invalid_type" and item.field == field for item in diagnostics)
@@ -234,7 +239,7 @@ def test_register_installs_all_protocol_surfaces(example: Any) -> None:
     assert all(getattr(context, method).call_count >= 1 for method in registration_methods)
 
 
-def test_enabled_registration_control_registers_expected_gate(example: Any) -> None:
+def test_enabled_registration_control_registers_expected_gate(example: Any):
     context, _runtime = configured_context()
     config = deepcopy(example.DEFAULT_CONFIG)
     config["registration_control"]["enabled"] = True

--- a/examples/python-grpc-worker-plugin/tests/test_worker.py
+++ b/examples/python-grpc-worker-plugin/tests/test_worker.py
@@ -107,7 +107,14 @@ def test_schema_declares_only_supported_groups() -> None:
     schema = json.loads((EXAMPLE_ROOT / manifest["config_schema"]["path"]).read_text(encoding="utf-8"))
 
     assert schema["additionalProperties"] is False
-    assert set(schema["properties"]) == {"tag", "observe", "requests", "execution", "runtime"}
+    assert set(schema["properties"]) == {
+        "tag",
+        "observe",
+        "requests",
+        "execution",
+        "runtime",
+        "registration_control",
+    }
 
 
 def test_project_builds_an_importable_wheel(tmp_path: Path) -> None:
@@ -139,6 +146,7 @@ def test_project_builds_an_importable_wheel(tmp_path: Path) -> None:
 
 def test_default_configuration_is_valid(example: Any) -> None:
     assert example.ExamplePythonWorker().validate(example.DEFAULT_CONFIG) == []
+    assert example.DEFAULT_CONFIG["registration_control"]["enabled"] is False
 
 
 def test_non_object_configuration_is_rejected(example: Any) -> None:
@@ -157,6 +165,20 @@ def test_wrong_type_is_rejected(example: Any) -> None:
     diagnostics = example.ExamplePythonWorker().validate({"requests": {"priority": "high"}})
 
     assert any(item.code == "examples.python_grpc_worker.invalid_type" for item in diagnostics)
+
+
+@pytest.mark.parametrize(
+    ("config", "field"),
+    [
+        ({"registration_control": {"kinds": []}}, "registration_control.kinds"),
+        ({"registration_control": {"registration_name": ""}}, "registration_control.registration_name"),
+        ({"registration_control": {"reason": ""}}, "registration_control.reason"),
+    ],
+)
+def test_invalid_registration_control_is_rejected(example: Any, config: dict[str, Any], field: str) -> None:
+    diagnostics = example.ExamplePythonWorker().validate(config)
+
+    assert any(item.code == "examples.python_grpc_worker.invalid_type" and item.field == field for item in diagnostics)
 
 
 def test_unknown_field_is_rejected(example: Any) -> None:
@@ -210,6 +232,21 @@ def test_register_installs_all_protocol_surfaces(example: Any) -> None:
     }
 
     assert all(getattr(context, method).call_count >= 1 for method in registration_methods)
+
+
+def test_enabled_registration_control_registers_expected_gate(example: Any) -> None:
+    context, _runtime = configured_context()
+    config = deepcopy(example.DEFAULT_CONFIG)
+    config["registration_control"]["enabled"] = True
+
+    example.ExamplePythonWorker().register(context, config)
+
+    context.register_conditional_middleware_guardrail.assert_called_once_with(
+        "documentation_registration_control",
+        {example.RuntimeRegistrationKind.SUBSCRIBER},
+        "documentation-controlled-subscriber",
+        "disabled by documentation plugin",
+    )
 
 
 async def test_event_metadata_injector_adds_transport_metadata(example: Any) -> None:

--- a/examples/rust-grpc-worker-plugin/README.md
+++ b/examples/rust-grpc-worker-plugin/README.md
@@ -19,3 +19,10 @@ placeholder with the built executable name, and replace only `<artifact-sha256>`
 with the lowercase hexadecimal digest of the built executable. The manifest value
 keeps its `sha256:` prefix; omit the filename column printed by `shasum -a 256`,
 `sha256sum`, or `Get-FileHash`.
+
+The optional `registration_control` group installs one host-resident gate for the
+worker activation. It defaults to disabled, with `kinds: ["subscriber"]`, target
+`documentation-controlled-subscriber`, and reason
+`disabled by documentation plugin`. All three values must be nonempty. Refer to
+[Conditional Middleware Guardrails](../../docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx)
+for effective-name discovery and automatic teardown behavior.

--- a/examples/rust-grpc-worker-plugin/config.schema.json
+++ b/examples/rust-grpc-worker-plugin/config.schema.json
@@ -119,6 +119,30 @@
           "default": true
         }
       }
+    },
+    "registration_control": {
+      "description": "Optionally suppresses a matching global runtime registration for this component's activation lifetime.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "kinds": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "enum": ["subscriber", "event_metadata_injector", "mark_sanitize_guardrail", "scope_sanitize_start_guardrail", "scope_sanitize_end_guardrail", "tool_sanitize_request_guardrail", "tool_sanitize_response_guardrail", "tool_conditional_execution_guardrail", "tool_request_intercept", "tool_execution_intercept", "llm_sanitize_request_guardrail", "llm_sanitize_response_guardrail", "llm_conditional_execution_guardrail", "llm_request_intercept", "llm_execution_intercept", "llm_stream_execution_intercept"] },
+          "default": ["subscriber"]
+        },
+        "registration_name": {
+          "type": "string",
+          "minLength": 1,
+          "default": "documentation-controlled-subscriber"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "default": "disabled by documentation plugin"
+        }
+      }
     }
   }
 }

--- a/examples/rust-grpc-worker-plugin/src/config.rs
+++ b/examples/rust-grpc-worker-plugin/src/config.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use nemo_relay_worker::{ConfigDiagnostic, DiagnosticLevel, Json};
+use nemo_relay_worker::{ConfigDiagnostic, DiagnosticLevel, Json, RuntimeRegistrationKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
 
@@ -15,6 +15,7 @@ pub(crate) struct ExampleConfig {
     pub requests: RequestsConfig,
     pub execution: ExecutionConfig,
     pub runtime: RuntimeConfig,
+    pub registration_control: RegistrationControlConfig,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -52,6 +53,15 @@ pub(crate) struct RuntimeConfig {
     pub emit_isolated_scope: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
+pub(crate) struct RegistrationControlConfig {
+    pub enabled: bool,
+    pub kinds: Vec<RuntimeRegistrationKind>,
+    pub registration_name: String,
+    pub reason: String,
+}
+
 impl Default for ExampleConfig {
     fn default() -> Self {
         Self {
@@ -60,6 +70,7 @@ impl Default for ExampleConfig {
             requests: RequestsConfig::default(),
             execution: ExecutionConfig::default(),
             runtime: RuntimeConfig::default(),
+            registration_control: RegistrationControlConfig::default(),
         }
     }
 }
@@ -103,6 +114,17 @@ impl Default for RuntimeConfig {
         Self {
             emit_marks: true,
             emit_isolated_scope: true,
+        }
+    }
+}
+
+impl Default for RegistrationControlConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            kinds: vec![RuntimeRegistrationKind::Subscriber],
+            registration_name: "documentation-controlled-subscriber".into(),
+            reason: "disabled by documentation plugin".into(),
         }
     }
 }
@@ -160,6 +182,30 @@ pub(crate) fn validate(config: &Json) -> Vec<ConfigDiagnostic> {
             "requests.header_value must not be empty",
         ));
     }
+    if parsed.registration_control.kinds.is_empty() {
+        diagnostics.push(diagnostic(
+            DiagnosticLevel::Error,
+            "invalid_registration_control",
+            Some("registration_control.kinds"),
+            "registration_control.kinds must not be empty",
+        ));
+    }
+    for (field, value) in [
+        (
+            "registration_control.registration_name",
+            &parsed.registration_control.registration_name,
+        ),
+        ("registration_control.reason", &parsed.registration_control.reason),
+    ] {
+        if value.is_empty() {
+            diagnostics.push(diagnostic(
+                DiagnosticLevel::Error,
+                "invalid_registration_control",
+                Some(field),
+                format!("{field} must not be empty"),
+            ));
+        }
+    }
     diagnostics
 }
 
@@ -167,7 +213,14 @@ fn validate_unknown_fields(config: &Json, diagnostics: &mut Vec<ConfigDiagnostic
     let Some(config) = config.as_object() else {
         return;
     };
-    const TOP_LEVEL: &[&str] = &["tag", "observe", "requests", "execution", "runtime"];
+    const TOP_LEVEL: &[&str] = &[
+        "tag",
+        "observe",
+        "requests",
+        "execution",
+        "runtime",
+        "registration_control",
+    ];
     const OBSERVE: &[&str] = &["enabled", "redact_keys"];
     const REQUESTS: &[&str] = &[
         "enabled",
@@ -181,6 +234,7 @@ fn validate_unknown_fields(config: &Json, diagnostics: &mut Vec<ConfigDiagnostic
     ];
     const EXECUTION: &[&str] = &["enabled", "priority", "emit_pending_marks"];
     const RUNTIME: &[&str] = &["emit_marks", "emit_isolated_scope"];
+    const REGISTRATION_CONTROL: &[&str] = &["enabled", "kinds", "registration_name", "reason"];
 
     report_unknown(config, "", TOP_LEVEL, diagnostics);
     for (field, allowed) in [
@@ -188,6 +242,7 @@ fn validate_unknown_fields(config: &Json, diagnostics: &mut Vec<ConfigDiagnostic
         ("requests", REQUESTS),
         ("execution", EXECUTION),
         ("runtime", RUNTIME),
+        ("registration_control", REGISTRATION_CONTROL),
     ] {
         if let Some(object) = config.get(field).and_then(Json::as_object) {
             report_unknown(object, field, allowed, diagnostics);

--- a/examples/rust-grpc-worker-plugin/src/lib.rs
+++ b/examples/rust-grpc-worker-plugin/src/lib.rs
@@ -33,6 +33,14 @@ impl WorkerPlugin for DocumentationWorker {
 
     fn register(&self, context: &mut PluginContext, config: &Json) -> Result<()> {
         let config = ExampleConfig::parse(config).map_err(WorkerSdkError::InvalidInput)?;
+        if config.registration_control.enabled {
+            context.register_conditional_middleware_guardrail(
+                "documentation_registration_control",
+                config.registration_control.kinds.iter().copied().collect(),
+                &config.registration_control.registration_name,
+                &config.registration_control.reason,
+            );
+        }
         if config.observe.enabled {
             register_observation(context, &config);
         }

--- a/examples/rust-grpc-worker-plugin/src/lib.rs
+++ b/examples/rust-grpc-worker-plugin/src/lib.rs
@@ -7,9 +7,9 @@ use std::collections::BTreeMap;
 
 use futures_util::StreamExt;
 use nemo_relay_worker::{
-    ConfigDiagnostic, EventSanitizeFields, Json, JsonStream, LlmOptimizationContribution,
-    LlmRequestInterceptOutcome, PendingMarkSpec, PluginContext, PluginRuntime, Result, ScopeType,
-    ToolExecutionInterceptOutcome, WorkerPlugin, WorkerSdkError,
+    ConfigDiagnostic, DiagnosticLevel, EventSanitizeFields, Json, JsonStream,
+    LlmOptimizationContribution, LlmRequestInterceptOutcome, PendingMarkSpec, PluginContext,
+    PluginRuntime, Result, ScopeType, ToolExecutionInterceptOutcome, WorkerPlugin, WorkerSdkError,
 };
 use serde_json::json;
 
@@ -32,6 +32,16 @@ impl WorkerPlugin for DocumentationWorker {
     }
 
     fn register(&self, context: &mut PluginContext, config: &Json) -> Result<()> {
+        if let Some(diagnostic) = config::validate(config)
+            .into_iter()
+            .find(|diagnostic| diagnostic.level == DiagnosticLevel::Error)
+        {
+            let location = diagnostic.field.unwrap_or(diagnostic.code);
+            return Err(WorkerSdkError::InvalidInput(format!(
+                "{location}: {}",
+                diagnostic.message
+            )));
+        }
         let config = ExampleConfig::parse(config).map_err(WorkerSdkError::InvalidInput)?;
         if config.registration_control.enabled {
             context.register_conditional_middleware_guardrail(

--- a/examples/rust-grpc-worker-plugin/tests/config.rs
+++ b/examples/rust-grpc-worker-plugin/tests/config.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use nemo_relay_rust_grpc_worker_plugin_example::{default_example_config, validate_example_config};
+use nemo_relay_rust_grpc_worker_plugin_example::{
+    DocumentationWorker, default_example_config, validate_example_config,
+};
+use nemo_relay_worker::{PluginContext, WorkerPlugin};
 use serde_json::{Value as Json, json};
 
 #[test]
@@ -69,6 +72,20 @@ fn wrong_types_are_rejected() {
 }
 
 #[test]
+fn registration_control_parse_errors_are_rejected() {
+    for config in [
+        json!({ "registration_control": { "enabled": "yes" } }),
+        json!({ "registration_control": { "kinds": ["unsupported"] } }),
+    ] {
+        let diagnostics = validate_example_config(&config);
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "examples.rust_grpc_worker.invalid_config"
+                && diagnostic.field.is_none()
+        }));
+    }
+}
+
+#[test]
 fn empty_headers_are_reported_at_their_individual_fields() {
     for (config, field) in [
         (
@@ -110,6 +127,23 @@ fn invalid_registration_control_is_reported_at_its_field() {
                 && diagnostic.field.as_deref() == Some(field)
         }));
     }
+}
+
+#[test]
+fn register_rejects_invalid_registration_control() {
+    let mut context = PluginContext::new();
+    let error = DocumentationWorker
+        .register(
+            &mut context,
+            &json!({ "registration_control": { "enabled": true, "reason": "" } }),
+        )
+        .expect_err("register should validate the raw configuration");
+
+    assert!(
+        error
+            .to_string()
+            .contains("registration_control.reason must not be empty")
+    );
 }
 
 #[test]

--- a/examples/rust-grpc-worker-plugin/tests/config.rs
+++ b/examples/rust-grpc-worker-plugin/tests/config.rs
@@ -20,7 +20,13 @@ fn shared_configuration_is_valid() {
             "break_chain": false
         },
         "execution": { "enabled": true, "priority": 30, "emit_pending_marks": true },
-        "runtime": { "emit_marks": true, "emit_isolated_scope": true }
+        "runtime": { "emit_marks": true, "emit_isolated_scope": true },
+        "registration_control": {
+            "enabled": false,
+            "kinds": ["subscriber"],
+            "registration_name": "documentation-controlled-subscriber",
+            "reason": "disabled by documentation plugin"
+        }
     }));
     assert!(diagnostics.is_empty(), "{diagnostics:?}");
 }
@@ -83,13 +89,44 @@ fn empty_headers_are_reported_at_their_individual_fields() {
 }
 
 #[test]
+fn invalid_registration_control_is_reported_at_its_field() {
+    for (config, field) in [
+        (
+            json!({ "registration_control": { "kinds": [] } }),
+            "registration_control.kinds",
+        ),
+        (
+            json!({ "registration_control": { "registration_name": "" } }),
+            "registration_control.registration_name",
+        ),
+        (
+            json!({ "registration_control": { "reason": "" } }),
+            "registration_control.reason",
+        ),
+    ] {
+        let diagnostics = validate_example_config(&config);
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "examples.rust_grpc_worker.invalid_registration_control"
+                && diagnostic.field.as_deref() == Some(field)
+        }));
+    }
+}
+
+#[test]
 fn schema_contains_every_feature_group() {
     let schema: Json = serde_json::from_str(include_str!("../config.schema.json"))
         .expect("schema should be valid JSON");
     let fields = schema["properties"].as_object().expect("properties object");
     assert_eq!(schema["additionalProperties"], Json::Bool(true));
-    assert_eq!(fields.len(), 5);
-    for field in ["tag", "observe", "requests", "execution", "runtime"] {
+    assert_eq!(fields.len(), 6);
+    for field in [
+        "tag",
+        "observe",
+        "requests",
+        "execution",
+        "runtime",
+        "registration_control",
+    ] {
         assert!(fields.contains_key(field));
     }
 }

--- a/examples/rust-grpc-worker-plugin/tests/lifecycle.rs
+++ b/examples/rust-grpc-worker-plugin/tests/lifecycle.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic::{AtomicUsize, Ordering}};
 
 use nemo_relay::api::event::Event;
 use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
@@ -22,6 +22,7 @@ use tokio::sync::Mutex as AsyncMutex;
 static TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 const PLUGIN_ID: &str = "examples.rust_grpc_worker";
 const SUBSCRIBER: &str = "rust_grpc_worker_example_lifecycle_events";
+const CONTROLLED_SUBSCRIBER: &str = "documentation-controlled-subscriber";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn built_worker_validates_registers_executes_and_shuts_down() {
@@ -41,6 +42,15 @@ async fn built_worker_validates_registers_executes_and_shuts_down() {
         }),
     )
     .expect("test subscriber should register");
+    let controlled_events = Arc::new(AtomicUsize::new(0));
+    let captured_controlled_events = Arc::clone(&controlled_events);
+    register_subscriber(
+        CONTROLLED_SUBSCRIBER,
+        Arc::new(move |_| {
+            captured_controlled_events.fetch_add(1, Ordering::SeqCst);
+        }),
+    )
+    .expect("controlled subscriber should register");
 
     let (activation, report) = PluginHostActivation::activate(
         PluginConfig::default(),
@@ -55,6 +65,8 @@ async fn built_worker_validates_registers_executes_and_shuts_down() {
     .await
     .expect("the materialized worker manifest should activate");
     assert!(report.diagnostics.is_empty(), "{report:?}");
+    flush_subscribers().expect("activation events should flush");
+    let controlled_baseline = controlled_events.load(Ordering::SeqCst);
 
     let result = tool_call_execute(
         ToolCallExecuteParams::builder()
@@ -77,6 +89,7 @@ async fn built_worker_validates_registers_executes_and_shuts_down() {
     assert_eq!(result.annotation, Some(json!({"source": "application"})));
 
     flush_subscribers().expect("worker events should flush");
+    assert_eq!(controlled_events.load(Ordering::SeqCst), controlled_baseline);
     assert!(
         events
             .lock()
@@ -94,6 +107,19 @@ async fn built_worker_validates_registers_executes_and_shuts_down() {
     activation
         .clear()
         .expect("worker shutdown should follow callback cleanup");
+    tool_call_execute(
+        ToolCallExecuteParams::builder()
+            .name("restored_tool")
+            .args(json!({}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(ToolExecutionResult::new(args)) })))
+            .build(),
+    )
+    .await
+    .expect("managed execution should continue after worker clear");
+    flush_subscribers().expect("restored subscriber events should flush");
+    assert!(controlled_events.load(Ordering::SeqCst) > controlled_baseline);
+    deregister_subscriber(CONTROLLED_SUBSCRIBER)
+        .expect("controlled subscriber should deregister");
     deregister_subscriber(SUBSCRIBER).expect("test subscriber should deregister");
 }
 
@@ -112,7 +138,13 @@ fn documented_config() -> Map<String, serde_json::Value> {
             "break_chain": false
         },
         "execution": { "enabled": true, "priority": 30, "emit_pending_marks": true },
-        "runtime": { "emit_marks": true, "emit_isolated_scope": true }
+        "runtime": { "emit_marks": true, "emit_isolated_scope": true },
+        "registration_control": {
+            "enabled": true,
+            "kinds": ["subscriber"],
+            "registration_name": "documentation-controlled-subscriber",
+            "reason": "disabled by documentation plugin"
+        }
     })
     .as_object()
     .expect("documented configuration is an object")

--- a/examples/rust-native-plugin/README.md
+++ b/examples/rust-native-plugin/README.md
@@ -38,3 +38,11 @@ the `sha256:` prefix. The same relative artifact path must appear in
 
 The strict schema documents every feature group and the SDK-owned
 `executor.worker_threads` override.
+
+The optional `registration_control` group demonstrates a host-resident,
+activation-owned gate. It defaults to `enabled: false`, `kinds: ["subscriber"]`,
+`registration_name: "documentation-controlled-subscriber"`, and
+`reason: "disabled by documentation plugin"`. The kinds, effective target name,
+and reason must be nonempty. Refer to
+[Conditional Middleware Guardrails](../../docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx)
+before enabling it against a discovered runtime target.

--- a/examples/rust-native-plugin/config.schema.json
+++ b/examples/rust-native-plugin/config.schema.json
@@ -2,10 +2,10 @@
   "$comment": "SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Rust Native Documentation Plugin",
-  "description": "Configures the observation, request policy, execution, runtime, and SDK executor groups demonstrated by the native example.",
+  "description": "Configures the observation, request policy, execution, runtime, conditional registration control, and SDK executor groups demonstrated by the native example.",
   "type": "object",
   "additionalProperties": false,
-  "x-nemo-relay-order": ["tag", "observe", "requests", "execution", "runtime", "executor"],
+  "x-nemo-relay-order": ["tag", "observe", "requests", "execution", "runtime", "registration_control", "executor"],
   "properties": {
     "tag": {
       "description": "Non-empty label attached to plugin-created metadata and runtime events.",
@@ -119,6 +119,37 @@
           "description": "Creates, binds, and drops an isolated scope stack during the tool request intercept.",
           "type": "boolean",
           "default": true
+        }
+      }
+    },
+    "registration_control": {
+      "description": "Optionally suppresses a matching global runtime registration for this component's activation lifetime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Registers the activation-owned conditional middleware guardrail.",
+          "type": "boolean",
+          "default": false
+        },
+        "kinds": {
+          "description": "Non-empty set of runtime registration kinds eligible for suppression.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "enum": ["subscriber", "event_metadata_injector", "mark_sanitize_guardrail", "scope_sanitize_start_guardrail", "scope_sanitize_end_guardrail", "tool_sanitize_request_guardrail", "tool_sanitize_response_guardrail", "tool_conditional_execution_guardrail", "tool_request_intercept", "tool_execution_intercept", "llm_sanitize_request_guardrail", "llm_sanitize_response_guardrail", "llm_conditional_execution_guardrail", "llm_request_intercept", "llm_execution_intercept", "llm_stream_execution_intercept"] },
+          "default": ["subscriber"]
+        },
+        "registration_name": {
+          "description": "Effective name of the global registration to suppress.",
+          "type": "string",
+          "minLength": 1,
+          "default": "documentation-controlled-subscriber"
+        },
+        "reason": {
+          "description": "Non-empty constant reason returned while the registration is suppressed.",
+          "type": "string",
+          "minLength": 1,
+          "default": "disabled by documentation plugin"
         }
       }
     },

--- a/examples/rust-native-plugin/src/config.rs
+++ b/examples/rust-native-plugin/src/config.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use nemo_relay_plugin::{ConfigDiagnostic, DiagnosticLevel, Json};
+use nemo_relay_plugin::{ConfigDiagnostic, DiagnosticLevel, Json, RuntimeRegistrationKind};
 use serde::Deserialize;
 use serde_json::Map;
 
@@ -17,6 +17,7 @@ pub(crate) struct ExampleConfig {
     pub requests: RequestsConfig,
     pub execution: ExecutionConfig,
     pub runtime: RuntimeConfig,
+    pub registration_control: RegistrationControlConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -54,6 +55,15 @@ pub(crate) struct RuntimeConfig {
     pub emit_isolated_scope: bool,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub(crate) struct RegistrationControlConfig {
+    pub enabled: bool,
+    pub kinds: Vec<RuntimeRegistrationKind>,
+    pub registration_name: String,
+    pub reason: String,
+}
+
 impl Default for ExampleConfig {
     fn default() -> Self {
         Self {
@@ -62,6 +72,7 @@ impl Default for ExampleConfig {
             requests: RequestsConfig::default(),
             execution: ExecutionConfig::default(),
             runtime: RuntimeConfig::default(),
+            registration_control: RegistrationControlConfig::default(),
         }
     }
 }
@@ -105,6 +116,17 @@ impl Default for RuntimeConfig {
         Self {
             emit_marks: true,
             emit_isolated_scope: true,
+        }
+    }
+}
+
+impl Default for RegistrationControlConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            kinds: vec![RuntimeRegistrationKind::Subscriber],
+            registration_name: "documentation-controlled-subscriber".into(),
+            reason: "disabled by documentation plugin".into(),
         }
     }
 }
@@ -157,6 +179,30 @@ pub(crate) fn validate(plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnosti
                     "requests.header_value must not be empty",
                 ));
             }
+            if config.registration_control.kinds.is_empty() {
+                diagnostics.push(diagnostic(
+                    DiagnosticLevel::Error,
+                    "examples.rust_native_policy.invalid_registration_control",
+                    Some("registration_control.kinds"),
+                    "registration_control.kinds must not be empty",
+                ));
+            }
+            for (field, value) in [
+                (
+                    "registration_control.registration_name",
+                    &config.registration_control.registration_name,
+                ),
+                ("registration_control.reason", &config.registration_control.reason),
+            ] {
+                if value.is_empty() {
+                    diagnostics.push(diagnostic(
+                        DiagnosticLevel::Error,
+                        "examples.rust_native_policy.invalid_registration_control",
+                        Some(field),
+                        format!("{field} must not be empty"),
+                    ));
+                }
+            }
         }
         Err(error) => diagnostics.push(diagnostic(
             DiagnosticLevel::Error,
@@ -179,6 +225,7 @@ fn validate_unknown_fields(
         "requests",
         "execution",
         "runtime",
+        "registration_control",
         "executor",
     ];
     const OBSERVE: &[&str] = &["enabled", "redact_keys"];
@@ -194,6 +241,7 @@ fn validate_unknown_fields(
     ];
     const EXECUTION: &[&str] = &["enabled", "priority", "emit_pending_marks"];
     const RUNTIME: &[&str] = &["emit_marks", "emit_isolated_scope"];
+    const REGISTRATION_CONTROL: &[&str] = &["enabled", "kinds", "registration_name", "reason"];
 
     report_unknown(plugin_config, "", TOP_LEVEL, diagnostics);
     for (field, allowed) in [
@@ -201,6 +249,7 @@ fn validate_unknown_fields(
         ("requests", REQUESTS),
         ("execution", EXECUTION),
         ("runtime", RUNTIME),
+        ("registration_control", REGISTRATION_CONTROL),
     ] {
         if let Some(object) = plugin_config.get(field).and_then(Json::as_object) {
             report_unknown(object, field, allowed, diagnostics);

--- a/examples/rust-native-plugin/src/lib.rs
+++ b/examples/rust-native-plugin/src/lib.rs
@@ -56,6 +56,15 @@ impl NativePlugin for ExampleNativePlugin {
         let config = ExampleConfig::parse(plugin_config)?;
         let plugin_runtime = context.runtime();
 
+        if config.registration_control.enabled {
+            context.register_conditional_middleware_guardrail(
+                "documentation_registration_control",
+                &config.registration_control.kinds.iter().copied().collect(),
+                &config.registration_control.registration_name,
+                &config.registration_control.reason,
+            )?;
+        }
+
         observe::register(context, &config, &plugin_runtime)?;
         requests::register(context, &config)?;
         execution::register(context, &config, &plugin_runtime)?;

--- a/examples/rust-native-plugin/tests/config.rs
+++ b/examples/rust-native-plugin/tests/config.rs
@@ -25,6 +25,12 @@ fn shared_configuration_is_valid() {
         },
         "execution": { "enabled": true, "priority": 30, "emit_pending_marks": true },
         "runtime": { "emit_marks": true, "emit_isolated_scope": true },
+        "registration_control": {
+            "enabled": false,
+            "kinds": ["subscriber"],
+            "registration_name": "documentation-controlled-subscriber",
+            "reason": "disabled by documentation plugin"
+        },
         "executor": { "worker_threads": 2 }
     })));
 
@@ -87,6 +93,21 @@ fn invalid_values_are_rejected_at_their_fields() {
             "examples.rust_native_policy.invalid_header",
             "requests.header_name",
         ),
+        (
+            json!({ "registration_control": { "kinds": [] } }),
+            "examples.rust_native_policy.invalid_registration_control",
+            "registration_control.kinds",
+        ),
+        (
+            json!({ "registration_control": { "registration_name": "" } }),
+            "examples.rust_native_policy.invalid_registration_control",
+            "registration_control.registration_name",
+        ),
+        (
+            json!({ "registration_control": { "reason": "" } }),
+            "examples.rust_native_policy.invalid_registration_control",
+            "registration_control.reason",
+        ),
     ] {
         let diagnostics = validate_example_config(&object(config));
         assert!(diagnostics.iter().any(|diagnostic| {
@@ -109,6 +130,7 @@ fn schema_declares_every_feature_group_and_executor() {
         "requests",
         "execution",
         "runtime",
+        "registration_control",
         "executor",
     ] {
         assert!(properties.contains_key(field), "schema is missing {field}");

--- a/examples/rust-native-plugin/tests/config.rs
+++ b/examples/rust-native-plugin/tests/config.rs
@@ -76,6 +76,20 @@ fn wrong_types_are_rejected() {
 }
 
 #[test]
+fn registration_control_parse_errors_are_rejected() {
+    for config in [
+        json!({ "registration_control": { "enabled": "yes" } }),
+        json!({ "registration_control": { "kinds": ["unsupported"] } }),
+    ] {
+        let diagnostics = validate_example_config(&object(config));
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "examples.rust_native_policy.invalid_config"
+                && diagnostic.field.is_none()
+        }));
+    }
+}
+
+#[test]
 fn invalid_values_are_rejected_at_their_fields() {
     for (config, code, field) in [
         (

--- a/examples/rust-native-plugin/tests/lifecycle.rs
+++ b/examples/rust-native-plugin/tests/lifecycle.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic::{AtomicUsize, Ordering}};
 
 use nemo_relay::api::event::Event;
 use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
@@ -22,6 +22,7 @@ use tokio::sync::Mutex as AsyncMutex;
 static TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 const PLUGIN_ID: &str = "examples.rust_native_policy";
 const SUBSCRIBER: &str = "rust_native_example_lifecycle_events";
+const CONTROLLED_SUBSCRIBER: &str = "documentation-controlled-subscriber";
 
 #[tokio::test]
 async fn built_cdylib_validates_activates_runs_and_unloads() {
@@ -41,6 +42,15 @@ async fn built_cdylib_validates_activates_runs_and_unloads() {
         }),
     )
     .expect("test subscriber should register");
+    let controlled_events = Arc::new(AtomicUsize::new(0));
+    let captured_controlled_events = Arc::clone(&controlled_events);
+    register_subscriber(
+        CONTROLLED_SUBSCRIBER,
+        Arc::new(move |_| {
+            captured_controlled_events.fetch_add(1, Ordering::SeqCst);
+        }),
+    )
+    .expect("controlled subscriber should register");
 
     let config = documented_config();
     let (activation, report) = PluginHostActivation::activate(
@@ -56,6 +66,8 @@ async fn built_cdylib_validates_activates_runs_and_unloads() {
     .await
     .expect("the materialized native manifest should activate");
     assert!(report.diagnostics.is_empty(), "{report:?}");
+    flush_subscribers().expect("activation events should flush");
+    let controlled_baseline = controlled_events.load(Ordering::SeqCst);
 
     let result = tool_call_execute(
         ToolCallExecuteParams::builder()
@@ -78,6 +90,11 @@ async fn built_cdylib_validates_activates_runs_and_unloads() {
     assert_eq!(result.annotation, Some(json!({"source": "application"})));
 
     flush_subscribers().expect("native events should flush");
+    assert_eq!(
+        controlled_events.load(Ordering::SeqCst),
+        controlled_baseline,
+        "the activation-owned gate should suppress future subscriber snapshots"
+    );
     assert!(
         events
             .lock()
@@ -95,6 +112,19 @@ async fn built_cdylib_validates_activates_runs_and_unloads() {
     activation
         .clear()
         .expect("callbacks should clear before the library unloads");
+    tool_call_execute(
+        ToolCallExecuteParams::builder()
+            .name("restored_tool")
+            .args(json!({}))
+            .func(Arc::new(|args| Box::pin(async move { Ok(ToolExecutionResult::new(args)) })))
+            .build(),
+    )
+    .await
+    .expect("managed execution should continue after plugin clear");
+    flush_subscribers().expect("restored subscriber events should flush");
+    assert!(controlled_events.load(Ordering::SeqCst) > controlled_baseline);
+    deregister_subscriber(CONTROLLED_SUBSCRIBER)
+        .expect("controlled subscriber should deregister");
     deregister_subscriber(SUBSCRIBER).expect("test subscriber should deregister");
     assert!(!list_plugin_kinds().contains(&PLUGIN_ID.to_owned()));
 }
@@ -115,6 +145,12 @@ fn documented_config() -> Map<String, serde_json::Value> {
         },
         "execution": { "enabled": false, "priority": 30, "emit_pending_marks": true },
         "runtime": { "emit_marks": true, "emit_isolated_scope": true },
+        "registration_control": {
+            "enabled": true,
+            "kinds": ["subscriber"],
+            "registration_name": "documentation-controlled-subscriber",
+            "reason": "disabled by documentation plugin"
+        },
         "executor": { "worker_threads": 2 }
     })
     .as_object()

--- a/python/nemo_relay/plugin.py
+++ b/python/nemo_relay/plugin.py
@@ -66,6 +66,7 @@ from nemo_relay._native import (
 from nemo_relay._native import (
     validate_plugin_config as _validate_plugin_config,
 )
+from nemo_relay.runtime_registrations import ConditionalMiddlewareGuardrail, RuntimeRegistrationKind
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -116,6 +117,16 @@ class PluginContext(Protocol):
 
     def register_subscriber(self, name: str, callback: Callable[[Event], None]) -> None:
         """Register an infallible event subscriber for this component."""
+        ...
+
+    def register_conditional_middleware_guardrail(
+        self,
+        name: str,
+        kinds: set[RuntimeRegistrationKind],
+        registration_name: str,
+        guardrail: ConditionalMiddlewareGuardrail,
+    ) -> None:
+        """Register an activation-owned gate for a global runtime registration."""
         ...
 
     def register_event_metadata_injector(

--- a/python/nemo_relay/plugin.pyi
+++ b/python/nemo_relay/plugin.pyi
@@ -22,6 +22,7 @@ from nemo_relay import (
     ToolRequestIntercept,
     ToolSanitizeGuardrail,
 )
+from nemo_relay.runtime_registrations import ConditionalMiddlewareGuardrail, RuntimeRegistrationKind
 
 UnsupportedBehavior = Literal["ignore", "warn", "error"]
 DynamicPluginKind = Literal["rust_dynamic", "worker"]
@@ -51,6 +52,13 @@ class ConfigReport(TypedDict):
 
 class PluginContext(Protocol):
     def register_subscriber(self, name: str, callback: Callable[[Event], None]) -> None: ...
+    def register_conditional_middleware_guardrail(
+        self,
+        name: str,
+        kinds: set[RuntimeRegistrationKind],
+        registration_name: str,
+        guardrail: ConditionalMiddlewareGuardrail,
+    ) -> None: ...
     def register_event_metadata_injector(
         self, name: str, priority: int, callback: EventMetadataInjectorCallback
     ) -> None: ...

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -400,6 +400,19 @@ class RecordingHostStub:
 
     async def ListRuntimeRegistrations(self, request: Any) -> Any:
         self.requests.append(request)
+        if self.failures.get("ListRuntimeRegistrations") == "error":
+            return pb.ListRuntimeRegistrationsResponse(error=_worker_error("list failed"))
+        if self.failures.get("ListRuntimeRegistrations") == "unknown_kind":
+            return pb.ListRuntimeRegistrationsResponse(registrations=[pb.RuntimeRegistrationIdentity(kind=999)])
+        if self.failures.get("ListRuntimeRegistrations") == "unknown_owner":
+            return pb.ListRuntimeRegistrationsResponse(
+                registrations=[
+                    pb.RuntimeRegistrationIdentity(
+                        kind=pb.SUBSCRIBER,
+                        owner=pb.RuntimeRegistrationOwner(kind=999),
+                    )
+                ]
+            )
         return pb.ListRuntimeRegistrationsResponse(
             registrations=[
                 pb.RuntimeRegistrationIdentity(
@@ -416,10 +429,14 @@ class RecordingHostStub:
 
     async def RegisterConditionalMiddlewareGuardrail(self, request: Any) -> Any:
         self.requests.append(request)
+        if self.failures.get("RegisterConditionalMiddlewareGuardrail") == "error":
+            return pb.RegisterConditionalMiddlewareGuardrailResponse(error=_worker_error("register failed"))
         return pb.RegisterConditionalMiddlewareGuardrailResponse(handle="gate-1")
 
     async def DeregisterConditionalMiddlewareGuardrail(self, request: Any) -> Any:
         self.requests.append(request)
+        if self.failures.get("DeregisterConditionalMiddlewareGuardrail") == "error":
+            return pb.DeregisterConditionalMiddlewareGuardrailResponse(error=_worker_error("deregister failed"))
         return pb.DeregisterConditionalMiddlewareGuardrailResponse(removed=True)
 
     async def CreateScopeStack(self, request: Any) -> Any:
@@ -2273,6 +2290,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         assert runtime.current_scope_stack_id() == stack_id
     assert runtime.current_scope_stack_id() is None
     assert tool_next.result["next_tool"]["value"] == 1
+
     assert tool_next.annotation == {"source": "host"}
     assert llm_next["next_llm"]["content"]["prompt"] == "hello"
     assert stream_next[0]["next_stream"]["content"]["prompt"] == "hello"
@@ -2354,6 +2372,44 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         await runtime.emit_mark("invalid-schema", data_schema={"name": "schema"})
     with pytest.raises(TypeError, match="measurements must contain mappings"):
         await runtime.emit_metric("invalid-metric", cast(Any, [42]))
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        ("error", "list failed"),
+        ("unknown_kind", "unknown runtime registration kind"),
+        ("unknown_owner", "unknown runtime registration owner kind"),
+    ],
+)
+async def test_runtime_registration_discovery_rejects_host_and_malformed_responses(
+    host_stub: RecordingHostStub, failure: str, message: str
+) -> None:
+    host_stub.failures["ListRuntimeRegistrations"] = failure
+    runtime = PluginRuntime(activation_id=ACTIVATION_ID, auth_token=AUTH_TOKEN, host_stub=host_stub)
+
+    with pytest.raises(WorkerSdkError, match=message):
+        await runtime.list_runtime_registrations()
+
+
+async def test_runtime_gate_operations_propagate_host_errors(host_stub: RecordingHostStub) -> None:
+    runtime = PluginRuntime(activation_id=ACTIVATION_ID, auth_token=AUTH_TOKEN, host_stub=host_stub)
+    host_stub.failures["RegisterConditionalMiddlewareGuardrail"] = "error"
+    with pytest.raises(WorkerSdkError, match="register failed"):
+        await runtime.register_conditional_middleware_guardrail(
+            "gate",
+            {RuntimeRegistrationKind.SUBSCRIBER},
+            "target",
+            "disabled",
+        )
+
+    host_stub.failures["DeregisterConditionalMiddlewareGuardrail"] = "error"
+    with pytest.raises(WorkerSdkError, match="deregister failed"):
+        await runtime.deregister_conditional_middleware_guardrail(ConditionalMiddlewareGuardrailHandle("gate-1"))
+    with pytest.raises(TypeError, match="ConditionalMiddlewareGuardrailHandle"):
+        await runtime.deregister_conditional_middleware_guardrail(
+            "gate-1"  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
+        )
 
 
 async def test_invocation_scope_context_is_isolated_across_concurrent_requests(host_stub: RecordingHostStub):

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -2384,7 +2384,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
 )
 async def test_runtime_registration_discovery_rejects_host_and_malformed_responses(
     host_stub: RecordingHostStub, failure: str, message: str
-) -> None:
+):
     host_stub.failures["ListRuntimeRegistrations"] = failure
     runtime = PluginRuntime(activation_id=ACTIVATION_ID, auth_token=AUTH_TOKEN, host_stub=host_stub)
 

--- a/python/tests/test_adaptive.py
+++ b/python/tests/test_adaptive.py
@@ -6,6 +6,7 @@
 from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import cast
+from uuid import uuid4
 
 import pytest
 
@@ -19,6 +20,7 @@ from nemo_relay import (
     llm,
     plugin,
     scope,
+    subscribers,
     tools,
 )
 from nemo_relay import adaptive as adaptive_module
@@ -34,6 +36,7 @@ from nemo_relay.adaptive import (
     TelemetryConfig,
     ToolParallelismConfig,
 )
+from nemo_relay.runtime_registrations import RuntimeRegistrationKind
 
 
 class TestAdaptiveConfigHelpers:
@@ -416,3 +419,78 @@ class TestAdaptivePluginConfiguration:
             assert "python.list_kinds_plugin" in plugin.list_kinds()
         finally:
             plugin.deregister("python.list_kinds_plugin")
+
+
+async def test_plugin_context_conditional_gate_fails_open_and_clears() -> None:
+    suffix = uuid4().hex
+    kind = f"python.context_gate.{suffix}"
+    target = f"python-context-gate-target-{suffix}"
+    observed: list[str] = []
+    observed_kinds: list[set[RuntimeRegistrationKind]] = []
+
+    class GatePlugin(plugin.Plugin):
+        def validate(self, plugin_config: JsonObject) -> list[plugin.ConfigDiagnostic] | None:
+            return None
+
+        def register(self, plugin_config: JsonObject, context: plugin.PluginContext) -> None:
+            def fail(kinds: set[RuntimeRegistrationKind], _name: str) -> str | None:
+                observed_kinds.append(kinds)
+                raise RuntimeError("expected gate failure")
+
+            context.register_conditional_middleware_guardrail(
+                "failing-gate",
+                {RuntimeRegistrationKind.SUBSCRIBER},
+                target,
+                fail,
+            )
+
+    subscribers.register(target, lambda event: observed.append(event.name))
+    plugin.register(kind, GatePlugin())
+    try:
+        await plugin.initialize(plugin.PluginConfig(components=[plugin.ComponentSpec(kind=kind)]))
+        scope.event("python-context-gate-fail-open")
+        await subscribers.flush_async()
+        assert observed[-1] == "python-context-gate-fail-open"
+        assert observed_kinds[-1] == {RuntimeRegistrationKind.SUBSCRIBER}
+        assert all(type(kind) is RuntimeRegistrationKind for kind in observed_kinds[-1])
+        await plugin.clear_async()
+        scope.event("python-context-gate-cleared")
+        await subscribers.flush_async()
+        assert observed[-1] == "python-context-gate-cleared"
+    finally:
+        await plugin.clear_async()
+        plugin.deregister(kind)
+        subscribers.deregister(target)
+
+
+async def test_failed_plugin_activation_rolls_back_conditional_gate() -> None:
+    suffix = uuid4().hex
+    kind = f"python.context_gate_rollback.{suffix}"
+    target = f"python-context-gate-rollback-target-{suffix}"
+    observed: list[str] = []
+
+    class FailingPlugin(plugin.Plugin):
+        def validate(self, plugin_config: JsonObject) -> list[plugin.ConfigDiagnostic] | None:
+            return None
+
+        def register(self, plugin_config: JsonObject, context: plugin.PluginContext) -> None:
+            context.register_conditional_middleware_guardrail(
+                "rollback-gate",
+                {RuntimeRegistrationKind.SUBSCRIBER},
+                target,
+                lambda _kinds, _name: "activation in progress",
+            )
+            raise RuntimeError("expected activation failure")
+
+    subscribers.register(target, lambda event: observed.append(event.name))
+    plugin.register(kind, FailingPlugin())
+    try:
+        with pytest.raises(RuntimeError, match="expected activation failure"):
+            await plugin.initialize(plugin.PluginConfig(components=[plugin.ComponentSpec(kind=kind)]))
+        scope.event("python-context-gate-rolled-back")
+        await subscribers.flush_async()
+        assert observed[-1] == "python-context-gate-rolled-back"
+    finally:
+        await plugin.clear_async()
+        plugin.deregister(kind)
+        subscribers.deregister(target)

--- a/python/tests/test_adaptive.py
+++ b/python/tests/test_adaptive.py
@@ -421,7 +421,7 @@ class TestAdaptivePluginConfiguration:
             plugin.deregister("python.list_kinds_plugin")
 
 
-async def test_plugin_context_conditional_gate_fails_open_and_clears() -> None:
+async def test_plugin_context_conditional_gate_fails_open_and_clears():
     suffix = uuid4().hex
     kind = f"python.context_gate.{suffix}"
     target = f"python-context-gate-target-{suffix}"
@@ -463,7 +463,7 @@ async def test_plugin_context_conditional_gate_fails_open_and_clears() -> None:
         subscribers.deregister(target)
 
 
-async def test_failed_plugin_activation_rolls_back_conditional_gate() -> None:
+async def test_failed_plugin_activation_rolls_back_conditional_gate():
     suffix = uuid4().hex
     kind = f"python.context_gate_rollback.{suffix}"
     target = f"python-context-gate-rollback-target-{suffix}"


### PR DESCRIPTION
#### Overview

Complete conditional middleware guardrail support across plugin contexts, executable plugin examples, SDK coverage, and user documentation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add lifecycle-owned conditional middleware guardrail registration to the Python and Node.js language-binding `PluginContext` APIs.
- Add validated, disabled-by-default `registration_control` configuration to all six language-binding, native, and worker example implementations.
- Cover discovery, registration, deregistration, ownership, rollback, malformed responses, unavailable capabilities, and callback fail-open behavior across the native, worker, Python, and Node.js SDKs.
- Add a code-free Conditional Middleware Guardrails concepts guide and place binding-specific examples in the application, language-binding, native, and worker documentation.
- Update every example README, schema, configuration table, and registration-surface assertion consistently.
- Preserve the existing coverage thresholds.

Validation completed:

- `just build-test-plugin-fixtures`
- `just test-plugin-examples`
- `cargo test -p nemo-relay-plugin -p nemo-relay-worker -p nemo-relay-types`
- `just test-python-plugin`
- `just test-rust`
- `just test-python`
- `just test-node`
- `just test-go`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --all-files`
- `just docs`
- `just docs-linkcheck`
- Dynamic SDK LLVM coverage generation

#### Where should the reviewer start?

Start with `docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx` for the semantic contract, then review the Python and Node.js context implementations in `crates/python/src/py_plugin.rs` and `crates/node/src/api/mod.rs`. The example configuration pattern is implemented consistently under `examples/language-binding-plugin`, `examples/rust-native-plugin`, `examples/rust-grpc-worker-plugin`, and `examples/python-grpc-worker-plugin`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plugins can conditionally suppress matching global middleware and runtime registrations.
  - Added support across Python, Node.js, and Rust with disabled-by-default configuration.
  - Added validation, lifecycle cleanup, rollback, and safe callback handling.

- **Documentation**
  - Added guidance and examples for configuration, naming, ordering, snapshots, failure handling, and ownership.

- **Tests**
  - Expanded coverage for validation, cleanup, rollback, callback failures, and cross-language behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->