### PR TITLE
test: stabilize integration tests and reduce complexity

### DIFF
--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -4243,6 +4243,9 @@ try:
 
     # Continue Relay's stopped shell job directly. Shell `bg` bookkeeping varies across the
     # macOS runner shell, but Relay only observes the process-group SIGCONT.
+    os.write(master, b"jobs\n")
+    read_until("Stopped")
+    read_until("RELAY_SHELL> ")
     os.killpg(relay_group, signal.SIGCONT)
     time.sleep(0.1)
     assert os.tcgetpgrp(master) == pid, (os.tcgetpgrp(master), pid, buffer)
@@ -4264,6 +4267,9 @@ try:
     read_until("AGENT_DELAY_ARMED")
     read_until("\n")
     os.write(master, b"\x1a")
+    read_until("RELAY_SHELL> ")
+    os.write(master, b"jobs\n")
+    read_until("Stopped")
     read_until("RELAY_SHELL> ")
     os.killpg(relay_group, signal.SIGCONT)
     wait_until_path(delay_marker)
@@ -4918,8 +4924,12 @@ fn read_http_request(stream: &mut impl Read) -> String {
             let headers = String::from_utf8_lossy(&buffer[..header_end]);
             let content_length = headers
                 .lines()
-                .find_map(|line| line.strip_prefix("content-length: "))
-                .and_then(|value| value.trim().parse::<usize>().ok())
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
                 .unwrap_or(0);
             let expected = header_end + 4 + content_length;
             while buffer.len() < expected {
@@ -4930,6 +4940,31 @@ fn read_http_request(stream: &mut impl Read) -> String {
             return String::from_utf8(buffer).unwrap();
         }
     }
+}
+
+#[test]
+fn read_http_request_consumes_title_case_content_length_body_after_headers() {
+    struct ChunkedReader(std::collections::VecDeque<Vec<u8>>);
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let Some(chunk) = self.0.pop_front() else {
+                return Ok(0);
+            };
+            buffer[..chunk.len()].copy_from_slice(&chunk);
+            Ok(chunk.len())
+        }
+    }
+
+    let request = read_http_request(&mut ChunkedReader(
+        [
+            b"POST /hooks/codex HTTP/1.1\r\nContent-Length: 2\r\n\r\n".to_vec(),
+            b"{}".to_vec(),
+        ]
+        .into(),
+    ));
+
+    assert!(request.ends_with("\r\n\r\n{}"));
 }
 
 fn find_header_end(buffer: &[u8]) -> Option<usize> {

--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -1423,35 +1423,15 @@ fn register_opentelemetry(
         warn_skipped_signal_endpoints("metrics", &resolution.endpoints);
     }
     let trace_subscribers = build_opentelemetry_subscribers(endpoints)?;
-    let log_subscribers = match (logs, log_resolution) {
-        (Some(section), Some(resolution)) => {
-            match build_opentelemetry_log_subscribers(section, resolution.endpoints) {
-                Ok(subscribers) => subscribers,
-                Err(error) => {
-                    let _ = shutdown_indexed_opentelemetry_providers(&trace_subscribers);
-                    return Err(error);
-                }
-            }
-        }
-        _ => Vec::new(),
-    };
-    let metric_subscribers = match (metrics, metric_resolution) {
-        (Some(section), Some(resolution)) => {
-            match build_opentelemetry_metric_subscribers(section, resolution.endpoints) {
-                Ok(subscribers) => subscribers,
-                Err(error) => {
-                    let _ = shutdown_indexed_opentelemetry_providers(&trace_subscribers);
-                    for subscriber in &log_subscribers {
-                        if let Some(value) = subscriber.value.as_active() {
-                            let _ = value.shutdown_provider();
-                        }
-                    }
-                    return Err(error);
-                }
-            }
-        }
-        _ => Vec::new(),
-    };
+    let signal_subscribers = build_opentelemetry_signal_subscribers(
+        logs,
+        log_resolution,
+        metrics,
+        metric_resolution,
+        &trace_subscribers,
+    )?;
+    let log_subscribers = signal_subscribers.logs;
+    let metric_subscribers = signal_subscribers.metrics;
     if !has_active_opentelemetry_resource(&trace_subscribers)
         && !has_active_opentelemetry_resource(&log_subscribers)
         && !has_active_opentelemetry_resource(&metric_subscribers)
@@ -1556,6 +1536,46 @@ fn register_opentelemetry(
         }),
     )?;
     Ok(())
+}
+
+struct OpenTelemetrySignalSubscribers {
+    logs: Vec<IndexedOpenTelemetryResource<Arc<OpenTelemetryLogSubscriber>>>,
+    metrics: Vec<IndexedOpenTelemetryResource<Arc<OpenTelemetryMetricSubscriber>>>,
+}
+
+fn build_opentelemetry_signal_subscribers(
+    logs: Option<OpenTelemetryLogSectionConfig>,
+    log_resolution: Option<ResolvedSignalEndpoints>,
+    metrics: Option<OpenTelemetryMetricSectionConfig>,
+    metric_resolution: Option<ResolvedSignalEndpoints>,
+    trace_subscribers: &[IndexedOpenTelemetryResource<Arc<OpenTelemetrySubscriber>>],
+) -> PluginResult<OpenTelemetrySignalSubscribers> {
+    let logs = match (logs, log_resolution) {
+        (Some(section), Some(resolution)) => {
+            build_opentelemetry_log_subscribers(section, resolution.endpoints).inspect_err(
+                |_| {
+                    let _ = shutdown_indexed_opentelemetry_providers(trace_subscribers);
+                },
+            )?
+        }
+        _ => Vec::new(),
+    };
+    let metrics = match (metrics, metric_resolution) {
+        (Some(section), Some(resolution)) => {
+            build_opentelemetry_metric_subscribers(section, resolution.endpoints).inspect_err(
+                |_| {
+                    let _ = shutdown_indexed_opentelemetry_providers(trace_subscribers);
+                    for subscriber in &logs {
+                        if let Some(value) = subscriber.value.as_active() {
+                            let _ = value.shutdown_provider();
+                        }
+                    }
+                },
+            )?
+        }
+        _ => Vec::new(),
+    };
+    Ok(OpenTelemetrySignalSubscribers { logs, metrics })
 }
 
 fn has_active_opentelemetry_resource<T>(resources: &[IndexedOpenTelemetryResource<T>]) -> bool {

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -67,26 +67,7 @@ impl NativePlugin for FixtureNativePlugin {
             .get("event_metadata_injector_error")
             .and_then(Json::as_bool)
             .unwrap_or(false);
-        ctx.register_event_metadata_injector(
-            "fixture_event_metadata_injector",
-            0,
-            move |event| async move {
-                if event_metadata_injector_error {
-                    return Err("fixture Event metadata injector error requested".into());
-                }
-                let mut additions = BTreeMap::new();
-                if event
-                    .name()
-                    .starts_with("external-plugin-event-metadata-injection")
-                {
-                    additions.insert(
-                        "external.injector.transport".into(),
-                        json!("native_dynamic_rust"),
-                    );
-                }
-                Ok(additions)
-            },
-        )?;
+        register_fixture_event_metadata_injector(ctx, event_metadata_injector_error)?;
         if plugin_config
             .get("event_metadata_injector_only")
             .and_then(Json::as_bool)
@@ -331,6 +312,32 @@ impl NativePlugin for FixtureNativePlugin {
 
         Ok(())
     }
+}
+
+fn register_fixture_event_metadata_injector(
+    ctx: &mut PluginContext<'_>,
+    return_error: bool,
+) -> nemo_relay_plugin::Result<()> {
+    ctx.register_event_metadata_injector(
+        "fixture_event_metadata_injector",
+        0,
+        move |event| async move {
+            if return_error {
+                return Err("fixture Event metadata injector error requested".into());
+            }
+            let mut additions = BTreeMap::new();
+            if event
+                .name()
+                .starts_with("external-plugin-event-metadata-injection")
+            {
+                additions.insert(
+                    "external.injector.transport".into(),
+                    json!("native_dynamic_rust"),
+                );
+            }
+            Ok(additions)
+        },
+    )
 }
 
 fn mark_event_fields(mut fields: EventSanitizeFields, marker: &str) -> EventSanitizeFields {

--- a/go/nemo_relay/coverage_gap_test.go
+++ b/go/nemo_relay/coverage_gap_test.go
@@ -192,6 +192,14 @@ func TestGoBindingErrorAndDefaultContracts(t *testing.T) {
 
 func TestRemainingPublicDefaultsAndPropagationCoverage(t *testing.T) {
 	endpoint := "http://127.0.0.1:4318"
+	assertOpenTelemetrySignalDefaults(t, endpoint)
+	assertOpenTelemetrySignalMarshalFailures(t, endpoint)
+	assertPropagationCoverage(t)
+	assertMetricTimestampCoverage(t)
+}
+
+func assertOpenTelemetrySignalDefaults(t *testing.T, endpoint string) {
+	t.Helper()
 	logConfig, err := normalizeOpenTelemetryLogConfig(OpenTelemetryLogConfig{Endpoint: endpoint})
 	if err != nil {
 		t.Fatalf("normalize log defaults failed: %v", err)
@@ -228,11 +236,14 @@ func TestRemainingPublicDefaultsAndPropagationCoverage(t *testing.T) {
 			return err
 		},
 	} {
-		if err := normalize(); err == nil {
+		if normalize() == nil {
 			t.Fatalf("%s should fail", name)
 		}
 	}
+}
 
+func assertOpenTelemetrySignalMarshalFailures(t *testing.T, endpoint string) {
+	t.Helper()
 	oldMarshal := jsonMarshal
 	t.Cleanup(func() { jsonMarshal = oldMarshal })
 	jsonMarshal = func(any) ([]byte, error) {
@@ -253,7 +264,10 @@ func TestRemainingPublicDefaultsAndPropagationCoverage(t *testing.T) {
 		t.Fatal("expected signal resource marshal failure")
 	}
 	jsonMarshal = oldMarshal
+}
 
+func assertPropagationCoverage(t *testing.T) {
+	t.Helper()
 	rootUUID := propagationRootUUID
 	context := PropagationContext{
 		Version:    1,
@@ -271,10 +285,13 @@ func TestRemainingPublicDefaultsAndPropagationCoverage(t *testing.T) {
 		t.Fatal("expected invalid propagation context to fail")
 	}
 
-	if err := ScopeDeregisterEventMetadataInjector(propagationParentUUID, "missing-injector"); err == nil {
+	if ScopeDeregisterEventMetadataInjector(propagationParentUUID, "missing-injector") == nil {
 		t.Fatal("expected missing scope metadata injector deregistration to fail")
 	}
+}
 
+func assertMetricTimestampCoverage(t *testing.T) {
+	t.Helper()
 	expectedMetricTimestamp := time.Unix(1_700_000_000, 0)
 	observedMetricTimestamp := make(chan string, 1)
 	subscriberName := "go_metric_timestamp_coverage_" + time.Now().Format("150405.000000")


### PR DESCRIPTION
#### Overview

Stabilize the reported flaky integration tests and address the SonarQube cognitive-complexity findings.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Make the CLI HTTP fixture consume case-insensitive `Content-Length` headers and add a split-read regression test.
- Synchronize the PTY job-control test with the shell's stopped-job state before resuming it.
- Extract focused helpers from the native-plugin fixture, Go coverage test, and OpenTelemetry registration path to meet SonarQube complexity limits.

Validation: `just test-python`, `just test-go`, `just test-node`, targeted OpenTelemetry Rust tests, `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `uv run pre-commit run --all-files`.

#### Where should the reviewer start?

Start with `crates/core/src/observability/plugin_component.rs`, then review the focused test-fixture refactors and CLI regression coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP request handling for `Content-Length` headers regardless of capitalization, spacing, or whether the body arrives separately.
  - Fixed job-status reporting so suspended Relay jobs appear correctly in `jobs`.

- **Reliability**
  - Improved cleanup behavior during OpenTelemetry setup failures.
  - Expanded validation and coverage for telemetry defaults, propagation, serialization errors, and metric timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->