### PR TITLE
fix(observability): isolate trace flush from event delivery

### DIFF
--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -445,10 +445,10 @@ impl Default for OpenTelemetrySubscriberOptions {
 }
 
 struct Inner {
-    // Keep `processor` before `_runtime`: the processor owns the
-    // `SdkTracerProvider` and must be dropped before `ExporterRuntime` joins
-    // and tears down its Tokio runtime. Do not reorder these fields.
-    processor: Arc<Mutex<OtelEventProcessor>>,
+    // Keep `provider` before `_runtime`: the provider must be dropped before
+    // `ExporterRuntime` joins and tears down its Tokio runtime. Do not reorder
+    // these fields.
+    provider: SdkTracerProvider,
     runtime_diagnostics: SignalRuntimeDiagnostics,
     subscriber: EventSubscriberFn,
     _runtime: Option<ExporterRuntime>,
@@ -628,7 +628,7 @@ impl OpenTelemetrySubscriber {
             .unwrap_or_else(|| SignalRuntimeDiagnostics::new(None));
         let processor = Arc::new(Mutex::new(
             OtelEventProcessor::new_with_mark_projection_and_exclusions_and_mappings_and_runtime_diagnostics(
-                provider,
+                provider.clone(),
                 instrumentation_scope,
                 otel_type,
                 mark_projection,
@@ -650,7 +650,7 @@ impl OpenTelemetrySubscriber {
 
         Self {
             inner: Arc::new(Inner {
-                processor,
+                provider,
                 runtime_diagnostics,
                 subscriber,
                 _runtime: runtime,
@@ -698,10 +698,10 @@ impl OpenTelemetrySubscriber {
     /// Flushes finished spans through the underlying tracer provider.
     pub fn force_flush(&self) -> Result<()> {
         flush_subscribers()?;
-        let guard = self.inner.processor.lock().map_err(|_| {
-            OpenTelemetryError::TraceProvider("the subscriber state lock was poisoned".to_string())
-        })?;
-        guard.force_flush()
+        self.inner
+            .provider
+            .force_flush()
+            .map_err(|error| OpenTelemetryError::TraceProvider(error.to_string()))
     }
 
     /// Shuts down the underlying tracer provider.
@@ -717,10 +717,11 @@ impl OpenTelemetrySubscriber {
     }
 
     pub(crate) fn shutdown_provider(&self) -> Result<()> {
-        let guard = self.inner.processor.lock().map_err(|_| {
-            OpenTelemetryError::TraceProvider("the subscriber state lock was poisoned".to_string())
-        })?;
-        let result = guard.shutdown();
+        let result = self
+            .inner
+            .provider
+            .shutdown()
+            .map_err(|error| OpenTelemetryError::TraceProvider(error.to_string()));
         if result.is_ok() {
             log::info!(
                 target: "nemo_relay.observability",
@@ -1118,6 +1119,7 @@ pub(super) struct OtelEventProcessor {
     pub(super) active_spans: HashMap<Uuid, ActiveSpan>,
     pub(super) completed_span_contexts: HashMap<Uuid, SpanContext>,
     pub(super) completed_span_order: VecDeque<Uuid>,
+    #[cfg(test)]
     provider: SdkTracerProvider,
     tracer: SdkTracer,
     otel_type: OpenTelemetryType,
@@ -1251,6 +1253,7 @@ impl OtelEventProcessor {
             active_spans: HashMap::new(),
             completed_span_contexts: HashMap::new(),
             completed_span_order: VecDeque::new(),
+            #[cfg(test)]
             provider,
             tracer,
             otel_type,
@@ -1271,15 +1274,10 @@ impl OtelEventProcessor {
         }
     }
 
+    #[cfg(test)]
     pub(super) fn force_flush(&self) -> Result<()> {
         self.provider
             .force_flush()
-            .map_err(|e| OpenTelemetryError::TraceProvider(e.to_string()))
-    }
-
-    fn shutdown(&self) -> Result<()> {
-        self.provider
-            .shutdown()
             .map_err(|e| OpenTelemetryError::TraceProvider(e.to_string()))
     }
 

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -129,6 +129,92 @@ impl SpanExporter for BlockingSpanExporter {
     }
 }
 
+#[test]
+fn slow_trace_flush_does_not_block_other_subscribers_or_lifecycle_barriers() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+    reset_global();
+
+    let exporter = BlockingSpanExporter::default();
+    let processor = DiagnosticBatchSpanProcessor::new_with_batch_config(
+        exporter.clone(),
+        "https://collector.example/v1/traces".to_string(),
+        SignalRuntimeDiagnostics::new(None),
+        BatchConfigBuilder::default()
+            .with_max_queue_size(1)
+            .with_max_export_batch_size(1)
+            .with_scheduled_delay(Duration::from_secs(60))
+            .build(),
+    );
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+    let trace_subscriber = OpenTelemetrySubscriber::from_tracer_provider(provider, "trace");
+    let trace_name = format!("slow-trace-{}", Uuid::now_v7().simple());
+    trace_subscriber.register(&trace_name).unwrap();
+
+    let (healthy_tx, healthy_rx) = mpsc::channel();
+    let healthy_name = format!("healthy-{}", Uuid::now_v7().simple());
+    crate::api::subscriber::register_subscriber(
+        &healthy_name,
+        Arc::new(move |event| {
+            if event.name() == "healthy-event" {
+                healthy_tx.send(()).unwrap();
+            }
+        }),
+    )
+    .unwrap();
+
+    let trace_callback = trace_subscriber.subscriber();
+    let trace_uuid = Uuid::now_v7();
+    trace_callback(&make_start_event(
+        trace_uuid,
+        None,
+        "slow-trace",
+        ScopeType::Agent,
+        None,
+    ));
+    trace_callback(&make_end_event(
+        trace_uuid,
+        None,
+        "slow-trace",
+        ScopeType::Agent,
+        None,
+    ));
+
+    let flush_trace = trace_subscriber.clone();
+    let trace_flush = thread::spawn(move || flush_trace.force_flush());
+    exporter.wait_until_export_starts();
+
+    crate::api::scope::event(
+        crate::api::scope::EmitMarkEventParams::builder()
+            .name("healthy-event")
+            .build(),
+    )
+    .unwrap();
+
+    let (barrier_tx, barrier_rx) = mpsc::channel();
+    let barrier = thread::spawn(move || {
+        barrier_tx
+            .send(crate::api::subscriber::flush_subscribers())
+            .unwrap();
+    });
+
+    healthy_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("a slow trace flush must not delay another subscriber");
+    barrier_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("a slow trace flush must not delay the subscriber lifecycle barrier")
+        .unwrap();
+
+    exporter.release();
+    trace_flush.join().unwrap().unwrap();
+    barrier.join().unwrap();
+    trace_subscriber.deregister(&trace_name).unwrap();
+    crate::api::subscriber::deregister_subscriber(&healthy_name).unwrap();
+    trace_subscriber.shutdown().unwrap();
+}
+
 #[derive(Clone, Debug, Default)]
 struct FailingThenRecoveringSpanExporter {
     attempts: Arc<AtomicUsize>,


### PR DESCRIPTION
#### Overview

Prevent a slow OTLP trace flush from blocking event delivery and lifecycle barriers for other subscribers.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Retain the trace provider outside the event processor mutex so flush and shutdown do not block queued event processing.
- Add a deterministic regression test that holds trace export and verifies healthy delivery plus the subscriber barrier still complete.
- No public API, configuration, or binding changes.

#### Where should the reviewer start?

Start with `OpenTelemetrySubscriber::force_flush` and `shutdown_provider` in `crates/core/src/observability/otel.rs`, then review the blocked-export regression in `otel_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-774


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented a blocked trace exporter flush from delaying event delivery to other subscribers.
  - Ensured the global subscriber lifecycle barrier remains responsive during exporter delays.

- **Tests**
  - Added regression coverage for concurrent event delivery, flushing, and cleanup while a trace exporter is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->