### PR TITLE
fix: clarify tool execution result return errors

### DIFF
--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -2871,11 +2871,7 @@ pub fn tool_call_execute_async(
         let pa_fn = pa_fn.clone();
         Box::pin(async move {
             let result = pa_fn.call(args).await?;
-            serde_json::from_value(result).map_err(|error| {
-                FlowError::Internal(format!(
-                    "tool execution callback must return ToolExecutionResult: {error}"
-                ))
-            })
+            callable::parse_tool_execution_result(result)
         })
     });
 

--- a/crates/node/src/callable.rs
+++ b/crates/node/src/callable.rs
@@ -806,10 +806,10 @@ pub fn wrap_js_tool_request_intercept_fn(
     })
 }
 
-fn parse_tool_execution_result(value: Json) -> Result<ToolExecutionResult> {
+pub(crate) fn parse_tool_execution_result(value: Json) -> Result<ToolExecutionResult> {
     serde_json::from_value(value).map_err(|error| {
-        FlowError::Internal(format!(
-            "tool execution callback must return ToolExecutionResult: {error}"
+        FlowError::InvalidArgument(format!(
+            "tool execution callback must return ToolExecutionResult; return {{ result: payload }}, not a raw object: {error}"
         ))
     })
 }
@@ -1604,8 +1604,8 @@ pub fn wrap_js_tool_exec_intercept_fn(
                 pending_marks: Vec<JsPendingMarkSpec>,
             }
             let outcome: JsOutcome = serde_json::from_value(result).map_err(|error| {
-                FlowError::Internal(format!(
-                    "invalid JS tool execution intercept outcome: {error}"
+                FlowError::InvalidArgument(format!(
+                    "tool execution intercept must return {{ result, annotation?, pendingMarks? }}; return {{ result: downstream.result, annotation: downstream.annotation }} after next(args): {error}"
                 ))
             })?;
             Ok(ToolExecutionInterceptOutcome {

--- a/crates/node/tests/tools_tests.mjs
+++ b/crates/node/tests/tools_tests.mjs
@@ -232,7 +232,12 @@ describe('Tool execute', () => {
       () => toolCallExecuteAsync('exec_async_tool_legacy_raw', {}, async () => ({ legacy: true })),
     ];
     for (const execute of cases) {
-      await assert.rejects(execute, /must return ToolExecutionResult/i);
+      await assert.rejects(execute, (error) => {
+        assert.match(error.message, /must return ToolExecutionResult/i);
+        assert.match(error.message, /return \{ result: payload \}, not a raw object/i);
+        assert.doesNotMatch(error.message, /internal error/i);
+        return true;
+      });
     }
   });
 
@@ -1427,15 +1432,30 @@ describe('Tool intercepts', () => {
     }
   });
 
-  it('execution intercept rejects legacy raw results', async () => {
+  it('execution intercept rejects legacy raw results with forwarding guidance', async () => {
     registerToolExecutionIntercept('node_tool_exec_legacy', 10, async () => ({ legacyResult: true }));
     try {
       await assert.rejects(
         () => toolCallExecute('legacy_tool', {}, (args) => args, null, null, null, null),
-        /invalid JS tool execution intercept outcome/i,
+        (error) => {
+          assert.match(error.message, /tool execution intercept must return/i);
+          assert.match(error.message, /result: downstream\.result, annotation: downstream\.annotation/i);
+          assert.doesNotMatch(error.message, /internal error/i);
+          return true;
+        },
       );
     } finally {
       deregisterToolExecutionIntercept('node_tool_exec_legacy');
+    }
+  });
+
+  it('execution intercept may directly forward the canonical Node result', async () => {
+    registerToolExecutionIntercept('node_tool_exec_forward_result', 10, async (args, next) => next(args));
+    try {
+      const result = await toolCallExecute('forward_result_tool', { ok: true }, (args) => toolResult(args));
+      assert.deepEqual(result, toolResult({ ok: true }));
+    } finally {
+      deregisterToolExecutionIntercept('node_tool_exec_forward_result');
     }
   });
 

--- a/crates/python/src/py_callable.rs
+++ b/crates/python/src/py_callable.rs
@@ -57,7 +57,7 @@ use crate::convert::{json_to_py, py_to_json};
 use crate::py_types::{
     PyAnnotatedLLMRequest, PyAnnotatedLLMResponse, PyLLMRequest, PyLLMRequestInterceptOutcome,
     PyLlmSanitizeRequestContext, PyLlmSanitizeResponseContext, PyScopeStack,
-    PyToolExecutionInterceptOutcome, PyToolExecutionResult,
+    PyToolExecutionInterceptOutcome, PyToolExecutionResult, TOOL_EXECUTION_INTERCEPT_RESULT_ERROR,
 };
 
 type PyValueFuture = Pin<Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send>>;
@@ -73,6 +73,29 @@ fn python_callback_error(error: PyErr) -> FlowError {
     FlowError::CallbackException {
         message: error.to_string(),
         exception_type,
+    }
+}
+
+fn tool_execution_callback_result_error(error: impl std::fmt::Display) -> FlowError {
+    FlowError::InvalidArgument(format!(
+        "tool execution callback must return ToolExecutionResult; return ToolExecutionResult(payload), not a raw dict: {error}"
+    ))
+}
+
+fn tool_execution_intercept_outcome_error(error: impl std::fmt::Display) -> FlowError {
+    FlowError::InvalidArgument(format!(
+        "tool execution intercept must return ToolExecutionInterceptOutcome; after await next(args), return ToolExecutionInterceptOutcome(result=downstream.result, annotation=downstream.annotation): {error}"
+    ))
+}
+
+fn tool_execution_intercept_callback_error(error: PyErr) -> FlowError {
+    if error
+        .to_string()
+        .contains(TOOL_EXECUTION_INTERCEPT_RESULT_ERROR)
+    {
+        tool_execution_intercept_outcome_error(error)
+    } else {
+        python_callback_error(error)
     }
 }
 
@@ -537,6 +560,17 @@ async fn resolve_py_object_or_future(
     }
 }
 
+async fn resolve_py_tool_execution_intercept_outcome(
+    outcome: FlowResult<Result<Py<PyAny>, PyValueFuture>>,
+) -> FlowResult<Py<PyAny>> {
+    match outcome? {
+        Ok(value) => Ok(value),
+        Err(future) => future
+            .await
+            .map_err(tool_execution_intercept_callback_error),
+    }
+}
+
 fn next_async_iter_coro(async_iter: &Arc<Py<PyAny>>) -> FlowResult<Option<Py<PyAny>>> {
     Python::attach(|py| {
         py.import("nemo_relay._event_sanitizer_context")
@@ -997,11 +1031,7 @@ pub fn wrap_py_tool_exec_fn(
             Python::attach(|py| {
                 result
                     .extract::<PyToolExecutionResult>(py)
-                    .map_err(|error| {
-                        FlowError::Internal(format!(
-                            "tool execution callback must return ToolExecutionResult: {error}"
-                        ))
-                    })?
+                    .map_err(tool_execution_callback_result_error)?
                     .to_inner(py)
                     .map_err(|error| FlowError::Internal(error.to_string()))
             })
@@ -1153,7 +1183,7 @@ pub fn wrap_py_tool_exec_intercept_fn(
         let name = name.to_string();
         let task_locals = task_locals_with_running_loop(task_locals.as_ref());
         Box::pin(async move {
-            let result = resolve_py_object_or_future(Python::attach(|py| {
+            let result = resolve_py_tool_execution_intercept_outcome(Python::attach(|py| {
                 let (invocation_context, task_locals) = copy_middleware_invocation(py, task_locals)
                     .map_err(|error| FlowError::Internal(error.to_string()))?;
                 let py_args =
@@ -1175,7 +1205,7 @@ pub fn wrap_py_tool_exec_intercept_fn(
                     }
                     None => callback.bind(py).call1((&name, py_args, py_next)),
                 }
-                .map_err(|e: PyErr| FlowError::Internal(e.to_string()))?;
+                .map_err(tool_execution_intercept_callback_error)?;
                 split_py_object_or_future_with_locals(
                     py,
                     result.unbind(),
@@ -1188,11 +1218,7 @@ pub fn wrap_py_tool_exec_intercept_fn(
                 result
                     .extract::<PyToolExecutionInterceptOutcome>(py)
                     .map(|value| value.inner)
-                    .map_err(|e| {
-                        FlowError::Internal(format!(
-                            "tool execution intercept must return ToolExecutionInterceptOutcome: {e}"
-                        ))
-                    })
+                    .map_err(tool_execution_intercept_outcome_error)
             })
         })
     })

--- a/crates/python/src/py_types/core.rs
+++ b/crates/python/src/py_types/core.rs
@@ -24,6 +24,9 @@ use nemo_relay::api::runtime::{
 };
 use nemo_relay::api::tool::{ToolExecutionInterceptOutcome, ToolExecutionResult};
 
+pub(crate) const TOOL_EXECUTION_INTERCEPT_RESULT_ERROR: &str =
+    "ToolExecutionInterceptOutcome result must be the downstream payload, not ToolExecutionResult";
+
 /// Structured identity of the codec active during LLM sanitization.
 #[pyclass(name = "LlmCodecIdentity", frozen)]
 pub struct PyLlmCodecIdentity {
@@ -1237,6 +1240,11 @@ impl PyToolExecutionInterceptOutcome {
         pending_marks: Vec<PyPendingMarkSpec>,
         annotation: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
+        if result.is_instance_of::<PyToolExecutionResult>() {
+            return Err(pyo3::exceptions::PyTypeError::new_err(
+                TOOL_EXECUTION_INTERCEPT_RESULT_ERROR,
+            ));
+        }
         Ok(Self {
             inner: ToolExecutionInterceptOutcome {
                 result: py_to_json(result)?,

--- a/docs/reference/tool-execution-intercept-outcomes.mdx
+++ b/docs/reference/tool-execution-intercept-outcomes.mdx
@@ -141,6 +141,31 @@ changes together:
 5. Wrap the result passed to a manual tool end helper in
    `ToolExecutionResult`.
 
+### Return-Shape Errors
+
+Python distinguishes `ToolExecutionResult` from
+`ToolExecutionInterceptOutcome`. A callback that returns a raw dictionary is
+rejected; return `ToolExecutionResult(payload)` instead. A forwarding intercept
+must unwrap the downstream result:
+
+```python
+downstream = await next(args)
+return ToolExecutionInterceptOutcome(
+    result=downstream.result,
+    annotation=downstream.annotation,
+)
+```
+
+Do not pass `downstream` itself as the outcome result or return it directly.
+The resulting `RuntimeError` names the required wrapper and this unwrapping
+form.
+
+Node.js represents both values as compatible object shapes. Therefore,
+`return await next(args)` is a valid forwarding intercept in Node.js. Raw tool
+callback returns and raw intercept outcomes are still rejected with guidance to
+return `{ result: payload }` or
+`{ result: downstream.result, annotation: downstream.annotation }`.
+
 Rebuild native plugins and workers against the same NeMo Relay release that
 hosts them. For binding-specific examples, refer to the
 [Migration Guides](/reference/migration-guides#return-canonical-tool-execution-results).

--- a/python/tests/test_tools.py
+++ b/python/tests/test_tools.py
@@ -118,12 +118,14 @@ class TestToolsAsync:
         assert result.result == {"result": 10}
 
     async def test_execute_rejects_legacy_raw_result(self):
-        with pytest.raises(RuntimeError, match="must return ToolExecutionResult"):
+        with pytest.raises(RuntimeError, match="must return ToolExecutionResult") as error:
             await tools.execute(
                 "legacy_raw_result",
                 {},
                 lambda _args: {"legacy": True},  # type: ignore[arg-type]
             )
+        assert "ToolExecutionResult(payload), not a raw dict" in str(error.value)
+        assert "internal error" not in str(error.value)
 
     async def test_execute_rejects_cyclic_results_and_remains_usable(self):
         def cyclic_result(_args):
@@ -935,10 +937,39 @@ class TestToolInterceptsAsync:
             lambda name, args, next: {"legacy_result": True},  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
         )
         try:
-            with pytest.raises(RuntimeError, match="must return ToolExecutionInterceptOutcome"):
+            with pytest.raises(RuntimeError, match="must return ToolExecutionInterceptOutcome") as error:
                 await tools.execute("legacy_tool", {}, lambda args: ToolExecutionResult(args))
+            assert "after await next(args)" in str(error.value)
+            assert "internal error" not in str(error.value)
         finally:
             intercepts.deregister_tool_execution("py_exec_legacy")
+
+    async def test_execution_intercept_rejects_downstream_result_without_unwrapping(self):
+        async def leftover(_name, args, next):
+            downstream = await next(args)
+            return ToolExecutionInterceptOutcome(downstream)  # type: ignore[arg-type]
+
+        intercepts.register_tool_execution("py_exec_leftover", 1, leftover)
+        try:
+            with pytest.raises(RuntimeError, match="must return ToolExecutionInterceptOutcome") as error:
+                await tools.execute("leftover_tool", {}, lambda args: ToolExecutionResult(args))
+            assert "result=downstream.result, annotation=downstream.annotation" in str(error.value)
+            assert "internal error" not in str(error.value)
+        finally:
+            intercepts.deregister_tool_execution("py_exec_leftover")
+
+    async def test_execution_intercept_rejects_downstream_result_as_its_outcome(self):
+        async def leftover_return(_name, args, next):
+            return await next(args)  # type: ignore[return-value]
+
+        intercepts.register_tool_execution("py_exec_leftover_return", 1, leftover_return)
+        try:
+            with pytest.raises(RuntimeError, match="must return ToolExecutionInterceptOutcome") as error:
+                await tools.execute("leftover_return_tool", {}, lambda args: ToolExecutionResult(args))
+            assert "result=downstream.result, annotation=downstream.annotation" in str(error.value)
+            assert "internal error" not in str(error.value)
+        finally:
+            intercepts.deregister_tool_execution("py_exec_leftover_return")
 
     async def test_request_intercept_break_chain(self):
         def first_fn(name, args):


### PR DESCRIPTION
#### Overview

Clarify Python and Node diagnostics for invalid canonical tool-execution result returns.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Classify Python callback and execution-intercept return-shape mistakes as caller errors and explain the canonical wrapper/unwrap form.
- Add equivalent actionable Node diagnostics for raw callback and interceptor outcome objects, while preserving Node's valid direct `next()` forwarding.
- Document the Python/Node difference and add regression coverage.

#### Where should the reviewer start?

Start in `crates/python/src/py_callable.rs` and `crates/node/src/callable.rs`; the adjacent `tools` tests capture each rejected return form.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for tool execution and interception callback results.
  * Error messages now clearly explain the required result wrappers and forwarding behavior.
  * Prevented invalid downstream result combinations and improved async callback error handling.

* **Documentation**
  * Added migration guidance for callback and interception return shapes across Python and Node.js.

* **Tests**
  * Expanded coverage for invalid raw results, wrapped results, direct forwarding, and detailed error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->