### PR TITLE
docs: clarify tool execution result payloads

### DIFF
--- a/docs/instrument-applications/instrument-tool-call.mdx
+++ b/docs/instrument-applications/instrument-tool-call.mdx
@@ -194,6 +194,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 </Tabs>
 
+## Python: Return Tool Results to the Model
+
+In a Python manual chat loop, send only the managed tool result's business
+payload to the model:
+
+```python
+import json
+
+tool_result = await nemo_relay.tools.execute(name, args, tool_callback)
+messages.append(
+    {
+        "role": "tool",
+        "content": json.dumps(tool_result.result),
+        "tool_call_id": tool_call["id"],
+    }
+)
+```
+
+Keep `tool_result.annotation` in the Python application for its own metadata
+and observability use. Do not use `str(tool_result)` for the tool message: it
+serializes the Python wrapper and can expose annotation data instead of the
+tool's business result.
+
 ## Validate the Integration
 
 Check both behavior and instrumentation:
@@ -237,6 +260,9 @@ Check these symptoms first when the workflow does not behave as expected.
 - **The tool appears outside the agent scope**: Pass the current scope handle into the managed execute helper.
 - **The call fails before execution**: A conditional-execution guardrail rejected the request.
 - **Subscribers see different data than the tool receives**: Sanitize guardrails change event payloads, while request intercepts change the real arguments.
+- **Python: The model receives the result wrapper or annotation metadata**:
+  Send `json.dumps(tool_result.result)` in the tool message, not
+  `str(tool_result)`.
 
 ## Next Steps
 

--- a/docs/reference/tool-execution-intercept-outcomes.mdx
+++ b/docs/reference/tool-execution-intercept-outcomes.mdx
@@ -10,14 +10,14 @@ canonical application-visible result:
 
 ```json
 {
-  "result": {},
-  "annotation": {}
+  "result": {}
 }
 ```
 
 `result` is required and contains the application-owned tool payload.
 `annotation` is optional opaque adjacent metadata. It can be any JSON value.
-An absent or JSON `null` annotation means that the result has no annotation.
+An absent or JSON `null` annotation means that the result has no annotation; an
+empty object (`{}`) is a present annotation.
 Relay transports the annotation without interpreting its schema.
 
 A tool execution intercept wraps or short-circuits that callback and returns a
@@ -26,7 +26,7 @@ canonical outcome:
 ```json
 {
   "result": {},
-  "annotation": {},
+  "annotation": {"source": "cache"},
   "pending_marks": []
 }
 ```


### PR DESCRIPTION
#### Overview

Clarify the payload that application chat loops send back to models and the semantics of empty tool-result annotations.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Document serializing `tool_result.result` with `json.dumps` instead of stringifying the `ToolExecutionResult` wrapper.
- Add a troubleshooting entry for models receiving wrapper or annotation metadata.
- Clarify that an empty annotation object is present metadata; omission or JSON `null` means no annotation.

#### Where should the reviewer start?

Start in `docs/instrument-applications/instrument-tool-call.mdx`; the adjacent reference update aligns the canonical JSON examples with the same result and annotation contract.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Python guidance for sending serialized managed tool results to models while keeping annotations separate.
  * Added troubleshooting advice for wrapper or annotation metadata appearing unexpectedly in model responses.
  * Clarified how absent, `null`, empty, and populated annotations are represented in tool execution results.
  * Updated examples to show annotated cached tool results accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->