### PR TITLE
fix(observability): make OTLP shutdown idempotent

### DIFF
--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -113,6 +113,13 @@ fn with_relay_ids<T>(uuid: Uuid, build: impl FnOnce() -> T) -> T {
 /// Result type for the OpenTelemetry subscriber crate.
 pub type Result<T> = std::result::Result<T, OpenTelemetryError>;
 
+pub(super) fn normalize_shutdown_result(result: OTelSdkResult) -> OTelSdkResult {
+    match result {
+        Err(OTelSdkError::AlreadyShutdown) => Ok(()),
+        result => result,
+    }
+}
+
 /// Errors produced while configuring or operating the OpenTelemetry subscriber.
 #[derive(Debug, thiserror::Error)]
 pub enum OpenTelemetryError {
@@ -717,12 +724,8 @@ impl OpenTelemetrySubscriber {
     }
 
     pub(crate) fn shutdown_provider(&self) -> Result<()> {
-        let result = self
-            .inner
-            .provider
-            .shutdown()
-            .map_err(|error| OpenTelemetryError::TraceProvider(error.to_string()));
-        if result.is_ok() {
+        let provider_result = self.inner.provider.shutdown();
+        if provider_result.is_ok() {
             log::info!(
                 target: "nemo_relay.observability",
                 event = "exporter_shutdown",
@@ -730,7 +733,8 @@ impl OpenTelemetrySubscriber {
                 "OpenTelemetry exporter shut down"
             );
         }
-        result
+        normalize_shutdown_result(provider_result)
+            .map_err(|error| OpenTelemetryError::TraceProvider(error.to_string()))
     }
 }
 

--- a/crates/core/src/observability/otel_logs.rs
+++ b/crates/core/src/observability/otel_logs.rs
@@ -30,7 +30,10 @@ use crate::observability::{relay_span_id, relay_trace_id};
 use crate::plugin::OTEL_RUNTIME_DELIVERY_FAILURE_MARKER;
 
 use super::OpenTelemetryRuntimeDiagnostics;
-use super::otel::{COMPLETED_SPAN_CONTEXT_LIMIT, OpenTelemetryError, OtlpTransport, Result};
+use super::otel::{
+    COMPLETED_SPAN_CONTEXT_LIMIT, OpenTelemetryError, OtlpTransport, Result,
+    normalize_shutdown_result,
+};
 use super::otel_signal::{
     MetricMarkClassification, SignalExporterRuntime, SignalRuntimeDiagnostics, build_grpc_metadata,
     build_in_owned_runtime, classify_metric_mark, reject_signal_header_environment,
@@ -312,18 +315,13 @@ impl OpenTelemetryLogSubscriber {
     /// Deregister this subscriber before calling shutdown.
     pub fn shutdown(&self) -> Result<()> {
         let barrier = flush_subscribers().map_err(OpenTelemetryError::Core);
-        let provider = self
-            .inner
-            .provider
-            .shutdown()
+        let provider = normalize_shutdown_result(self.inner.provider.shutdown())
             .map_err(|error| OpenTelemetryError::LogProvider(error.to_string()));
         barrier.and(provider)
     }
 
     pub(crate) fn shutdown_provider(&self) -> Result<()> {
-        self.inner
-            .provider
-            .shutdown()
+        normalize_shutdown_result(self.inner.provider.shutdown())
             .map_err(|error| OpenTelemetryError::LogProvider(error.to_string()))
     }
 

--- a/crates/core/src/observability/otel_metrics.rs
+++ b/crates/core/src/observability/otel_metrics.rs
@@ -33,7 +33,7 @@ use serde_json::Value as Json;
 use sha2::{Digest, Sha256};
 
 use super::OpenTelemetryRuntimeDiagnostics;
-use super::otel::{OpenTelemetryError, OtlpTransport, Result};
+use super::otel::{OpenTelemetryError, OtlpTransport, Result, normalize_shutdown_result};
 use super::otel_signal::{
     MetricMarkClassification, SignalExporterRuntime, SignalRuntimeDiagnostics, build_grpc_metadata,
     build_in_owned_runtime, classify_metric_mark, reject_signal_header_environment,
@@ -377,18 +377,13 @@ impl OpenTelemetryMetricSubscriber {
     /// Deregister this subscriber before calling shutdown.
     pub fn shutdown(&self) -> Result<()> {
         let barrier = flush_subscribers().map_err(OpenTelemetryError::Core);
-        let provider = self
-            .inner
-            .provider
-            .shutdown()
+        let provider = normalize_shutdown_result(self.inner.provider.shutdown())
             .map_err(|error| OpenTelemetryError::MetricProvider(error.to_string()));
         barrier.and(provider)
     }
 
     pub(crate) fn shutdown_provider(&self) -> Result<()> {
-        self.inner
-            .provider
-            .shutdown()
+        normalize_shutdown_result(self.inner.provider.shutdown())
             .map_err(|error| OpenTelemetryError::MetricProvider(error.to_string()))
     }
 

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -24,6 +24,10 @@ use crate::codec::response::{
 };
 use crate::json::Json;
 use crate::observability::atif::{AtifAgentInfo, AtifExporter, AtifStepExtra};
+use crate::observability::otel_logs::{OpenTelemetryLogConfig, OpenTelemetryLogSubscriber};
+use crate::observability::otel_metrics::{
+    OpenTelemetryMetricConfig, OpenTelemetryMetricSubscriber,
+};
 use crate::observability::{relay_span_id, relay_trace_id};
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry_sdk::trace::{BatchConfigBuilder, InMemorySpanExporterBuilder};
@@ -72,6 +76,77 @@ fn provider_errors_identify_their_telemetry_signal() {
     ] {
         assert_eq!(error.to_string(), expected);
     }
+}
+
+#[test]
+fn shutdown_is_idempotent_for_all_otlp_subscribers() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+
+    let trace = OpenTelemetrySubscriber::from_tracer_provider(
+        SdkTracerProvider::builder().build(),
+        "shutdown-idempotency-test",
+    );
+    trace.shutdown().unwrap();
+    trace.shutdown().unwrap();
+
+    let logs = OpenTelemetryLogSubscriber::new(OpenTelemetryLogConfig::new(
+        "http://127.0.0.1:4318/v1/logs",
+    ))
+    .unwrap();
+    logs.shutdown().unwrap();
+    logs.shutdown().unwrap();
+    assert!(logs.force_flush().is_err());
+
+    let metrics = OpenTelemetryMetricSubscriber::new(OpenTelemetryMetricConfig::new(
+        "http://127.0.0.1:4318/v1/metrics",
+    ))
+    .unwrap();
+    metrics.shutdown().unwrap();
+    metrics.shutdown().unwrap();
+    assert!(metrics.force_flush().is_err());
+}
+
+#[test]
+fn shutdown_normalization_preserves_provider_failures() {
+    let _guard = crate::observability::test_mutex().lock().unwrap();
+
+    assert!(normalize_shutdown_result(Err(OTelSdkError::AlreadyShutdown)).is_ok());
+
+    let error = normalize_shutdown_result(Err(OTelSdkError::InternalFailure(
+        "collector unavailable".to_string(),
+    )))
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        OTelSdkError::InternalFailure(message) if message == "collector unavailable"
+    ));
+
+    let processor = DiagnosticBatchSpanProcessor::new_with_batch_config(
+        AlwaysFailingSpanExporter,
+        "https://collector.example/v1/traces".to_string(),
+        SignalRuntimeDiagnostics::new(Some("opentelemetry.traces[0].endpoint".to_string())),
+        BatchConfigBuilder::default()
+            .with_max_export_batch_size(1)
+            .build(),
+    );
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+    provider
+        .tracer("first-shutdown-failure-test")
+        .start("export-fails")
+        .end();
+    provider.force_flush().unwrap_err();
+    let subscriber =
+        OpenTelemetrySubscriber::from_tracer_provider(provider, "first-shutdown-failure-test");
+
+    let error = subscriber.shutdown().unwrap_err();
+    assert!(matches!(
+        error,
+        OpenTelemetryError::TraceProvider(message)
+            if message.contains(OTEL_RUNTIME_DELIVERY_FAILURE_MARKER)
+    ));
+    subscriber.shutdown().unwrap();
 }
 
 struct RestoreThreadScopeStackGuard(ThreadScopeStackBinding);
@@ -229,6 +304,17 @@ impl SpanExporter for FailingThenRecoveringSpanExporter {
         } else {
             Ok(())
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct AlwaysFailingSpanExporter;
+
+impl SpanExporter for AlwaysFailingSpanExporter {
+    async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+        Err(OTelSdkError::InternalFailure(
+            "collector unavailable".to_string(),
+        ))
     }
 }
 

--- a/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/integration/api/coverage_sweeps_tests.rs
@@ -1771,7 +1771,7 @@ fn test_ffi_otel_projection_validation_from_integration_binary() {
         );
         assert_status!(
             nemo_relay_otel_subscriber_shutdown(subscriber),
-            NemoRelayStatus::Internal
+            NemoRelayStatus::Ok
         );
         nemo_relay_otel_subscriber_free(subscriber);
     }

--- a/crates/ffi/tests/support/ffi_coverage.rs
+++ b/crates/ffi/tests/support/ffi_coverage.rs
@@ -210,6 +210,6 @@ pub(crate) fn assert_otel_signal_lifecycle<H>(
     assert_eq!(deregister(name.as_ptr()), NemoRelayStatus::Ok);
     assert_eq!(shutdown(subscriber), NemoRelayStatus::Ok);
     assert_eq!(force_flush(subscriber), NemoRelayStatus::Internal);
-    assert_eq!(shutdown(subscriber), NemoRelayStatus::Internal);
+    assert_eq!(shutdown(subscriber), NemoRelayStatus::Ok);
     free(subscriber);
 }

--- a/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
@@ -3332,7 +3332,7 @@ fn test_ffi_observability_exporter_error_lifecycles() {
         );
         assert_status!(
             nemo_relay_otel_subscriber_shutdown(subscriber),
-            NemoRelayStatus::Internal
+            NemoRelayStatus::Ok
         );
         let missing_name = cstring(&unique_name("missing_otel_subscriber"));
         assert_status!(


### PR DESCRIPTION
#### Overview

Calling shutdown more than once on an OTLP trace, log, or metric subscriber currently surfaces the OpenTelemetry SDK's `AlreadyShutdown` error.

This change treats that expected lifecycle state as a successful no-op while preserving first-shutdown behavior and reporting real provider failures.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Normalize only `OTelSdkError::AlreadyShutdown` to success.
- Apply the behavior to trace, log, and metric shutdown paths.
- Preserve other SDK errors and their signal-specific error reporting.
- Add regression coverage proving:
  - the first shutdown succeeds
  - the second shutdown is harmless for every OTLP lane
  - a real first-shutdown failure remains visible

Validation:

- `cargo test -p nemo-relay --lib observability::otel::tests` — 68 passed.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- Changed-file pre-commit checks — passed.
- `just test-rust` — the core library passed all 1,600 tests; the broader command later encountered 8 unrelated CLI doctor localhost-listener timeouts. The unrelated full-suite failures were waived for this change.

#### Where should the reviewer start?

Start with the shutdown result normalizer and trace shutdown path in `crates/core/src/observability/otel.rs`, then review the all-lane regression tests in `crates/core/tests/unit/observability/otel_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [RELAY-781](https://linear.app/nvidia/issue/RELAY-781/nemo-relay080-rc2-a-second-shutdown-raises-on-every-otlp-lane-where)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observability provider shutdown handling so repeated shutdowns complete successfully.
  * Prevented expected “already shut down” results from being reported as errors.
  * Preserved meaningful provider and flush failure diagnostics when genuine shutdown issues occur.
  * Improved shutdown consistency across tracing, logging, and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->