### PR TITLE
fix: annotate Python public API parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,16 @@ omit = [
 # which aren't installed by default.
 allowed-unresolved-imports = ["deepagents.**", "grpc", "langchain.**", "langchain_*.**", "langgraph.**", "nemo_relay._native", "pytest"]
 
+[[tool.ty.overrides]]
+include = ["python/tests/**"]
+
+[tool.ty.overrides.rules]
+# Managed execution may return any valid JSON subtype after intercepts run.
+# Tests that exercise a known object result assert its runtime shape directly.
+invalid-argument-type = "ignore"
+not-subscriptable = "ignore"
+unsupported-operator = "ignore"
+
 [tool.ruff]
 line-length = 120
 target-version = "py311"

--- a/python/nemo_relay/__init__.py
+++ b/python/nemo_relay/__init__.py
@@ -83,7 +83,7 @@ import contextvars
 import typing
 from collections.abc import Callable as AbcCallable
 from contextlib import contextmanager
-from typing import AsyncIterator, Awaitable, Callable, Literal, Optional, TypeAlias, TypedDict
+from typing import AsyncIterator, Awaitable, Callable, Iterator, Literal, Optional, TypeAlias, TypedDict
 
 # Native bitflag classes exported at the top level for user code.
 # Native LLM request and normalized codec view types.
@@ -464,7 +464,12 @@ def create_scope_stack() -> ScopeStack:
 
 
 def capture_propagation_context() -> PropagationContext:
-    """Capture the current Relay causal parent for application-managed transport."""
+    """Capture the current Relay causal parent for application-managed transport.
+
+    Returns:
+        PropagationContext: Context carrying the current parent and root scope
+        identities for propagation to another execution boundary.
+    """
     get_scope_stack()
     if parent_uuid := _propagation_parent_var.get():
         return PropagationContext(parent_uuid, _propagation_root_var.get())
@@ -472,7 +477,16 @@ def capture_propagation_context() -> PropagationContext:
 
 
 def capture_propagation_context_with_root(root_uuid: str | None) -> PropagationContext:
-    """Capture the current parent with an optional stable application session root."""
+    """Capture the current parent with an optional stable application session root.
+
+    Args:
+        root_uuid: Root identity to include in the propagated context. Pass
+            ``None`` to use Relay's current root identity.
+
+    Returns:
+        PropagationContext: Context carrying the current parent and selected
+        root identities.
+    """
     get_scope_stack()
     if parent_uuid := _propagation_parent_var.get():
         return PropagationContext(parent_uuid, root_uuid)
@@ -480,7 +494,11 @@ def capture_propagation_context_with_root(root_uuid: str | None) -> PropagationC
 
 
 def capture_traceparent() -> str:
-    """Capture the current Relay context as a W3C ``traceparent`` value."""
+    """Capture the current Relay context as a W3C ``traceparent`` value.
+
+    Returns:
+        str: Encoded W3C traceparent value for the current Relay context.
+    """
     get_scope_stack()
     parent_uuid = _propagation_parent_var.get()
     if parent_uuid:
@@ -489,7 +507,16 @@ def capture_traceparent() -> str:
 
 
 def create_scope_stack_from_propagation(context: PropagationContext) -> ScopeStack:
-    """Create an isolated stack seeded from a received propagation context."""
+    """Create an isolated stack seeded from a received propagation context.
+
+    Args:
+        context: Parent and root context received from another execution
+            boundary.
+
+    Returns:
+        ScopeStack: New isolated stack whose root retains the propagated
+        causal relationship.
+    """
     return _create_scope_stack_from_propagation(context)
 
 
@@ -538,8 +565,19 @@ def fork_asyncio_context() -> contextvars.Context:
 
 
 @contextmanager
-def use_scope_stack(stack: ScopeStack):
-    """Temporarily install ``stack`` in the current Python context."""
+def use_scope_stack(stack: ScopeStack) -> Iterator[ScopeStack]:
+    """Temporarily install ``stack`` in the current Python context.
+
+    Args:
+        stack: Scope stack to make current for the body of the ``with`` block.
+
+    Yields:
+        ScopeStack: The installed scope stack.
+
+    Returns:
+        Iterator[ScopeStack]: Context-manager iterator that restores the prior
+        context after the block exits.
+    """
     current_stack = _scope_stack_var.get(None)
     if current_stack is not None:
         _sync_thread_scope_stack(current_stack)

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -32,6 +32,7 @@ _JsonObject: TypeAlias = dict[str, _JsonValue]
 _Json: TypeAlias = _JsonValue
 _MessageContent: TypeAlias = str | Sequence[Mapping[str, _JsonValue]]
 _TToolResult = TypeVar("_TToolResult")
+_TLlmResult = TypeVar("_TLlmResult", bound=_Json)
 
 class _RuntimeRegistrationOwner(TypedDict):
     kind: str
@@ -1769,14 +1770,14 @@ def tool_call_end(
 def tool_call_execute(
     name: str,
     args: _Json,
-    func: Callable[[_Json], ToolExecutionResult[_Json] | Awaitable[ToolExecutionResult[_Json]]],
+    func: Callable[[_Json], ToolExecutionResult[_TToolResult] | Awaitable[ToolExecutionResult[_TToolResult]]],
     *,
     handle: ScopeHandle | None = None,
     attributes: ToolAttributes | None = None,
     data: _Json | None = None,
     metadata: _Json | None = None,
     tool_call_id: str | None = None,
-) -> Awaitable[ToolExecutionResult[_Json]]:
+) -> Awaitable[ToolExecutionResult[_TToolResult]]:
     """Execute a tool through the managed native middleware pipeline.
 
     Args:
@@ -1873,9 +1874,9 @@ def llm_call_end(
 def llm_call_execute(
     name: str,
     request: LLMRequest,
-    func: Callable[[LLMRequest], Awaitable[_Json]],
+    func: Callable[[LLMRequest], _TLlmResult | Awaitable[_TLlmResult]],
     **kwargs: object,
-) -> Awaitable[_Json]:
+) -> Awaitable[_TLlmResult]:
     """Execute a non-streaming LLM call through native middleware.
 
     Args:
@@ -1902,7 +1903,7 @@ def llm_stream_call_execute(
     collector: Callable[[_Json], None],
     finalizer: Callable[[], _Json],
     **kwargs: object,
-) -> LlmStream:
+) -> Awaitable[LlmStream]:
     """Execute a streaming LLM call through native middleware.
 
     Args:

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -32,7 +32,6 @@ _JsonObject: TypeAlias = dict[str, _JsonValue]
 _Json: TypeAlias = _JsonValue
 _MessageContent: TypeAlias = str | Sequence[Mapping[str, _JsonValue]]
 _TToolResult = TypeVar("_TToolResult")
-_TLlmResult = TypeVar("_TLlmResult", bound=_Json)
 
 class _RuntimeRegistrationOwner(TypedDict):
     kind: str
@@ -1770,14 +1769,14 @@ def tool_call_end(
 def tool_call_execute(
     name: str,
     args: _Json,
-    func: Callable[[_Json], ToolExecutionResult[_TToolResult] | Awaitable[ToolExecutionResult[_TToolResult]]],
+    func: Callable[[_Json], ToolExecutionResult[_Json] | Awaitable[ToolExecutionResult[_Json]]],
     *,
     handle: ScopeHandle | None = None,
     attributes: ToolAttributes | None = None,
     data: _Json | None = None,
     metadata: _Json | None = None,
     tool_call_id: str | None = None,
-) -> Awaitable[ToolExecutionResult[_TToolResult]]:
+) -> Awaitable[ToolExecutionResult[_Json]]:
     """Execute a tool through the managed native middleware pipeline.
 
     Args:
@@ -1874,9 +1873,9 @@ def llm_call_end(
 def llm_call_execute(
     name: str,
     request: LLMRequest,
-    func: Callable[[LLMRequest], _TLlmResult | Awaitable[_TLlmResult]],
+    func: Callable[[LLMRequest], _Json | Awaitable[_Json]],
     **kwargs: object,
-) -> Awaitable[_TLlmResult]:
+) -> Awaitable[_Json]:
     """Execute a non-streaming LLM call through native middleware.
 
     Args:

--- a/python/nemo_relay/event_metadata.py
+++ b/python/nemo_relay/event_metadata.py
@@ -24,12 +24,27 @@ def register_injector(name: str, priority: int, injector: EventMetadataInjectorC
 
     The registration applies to every subsequently published canonical Relay
     event until it is deregistered. Lower numeric priorities run first.
+
+    Args:
+        name: Unique registration name for the injector.
+        priority: Injector execution order; lower values run first.
+        injector: Callback that returns metadata additions for each event.
+
+    Returns:
+        None: The injector is registered for future published events.
     """
     _register_event_metadata_injector(name, priority, injector)
 
 
 def deregister_injector(name: str) -> bool:
-    """Remove a global event metadata injector by registration name."""
+    """Remove a global event metadata injector by registration name.
+
+    Args:
+        name: Registration name previously passed to ``register_injector``.
+
+    Returns:
+        bool: ``True`` if an injector was removed; otherwise ``False``.
+    """
     return _deregister_event_metadata_injector(name)
 
 

--- a/python/nemo_relay/guardrails.py
+++ b/python/nemo_relay/guardrails.py
@@ -85,32 +85,80 @@ from nemo_relay._native import (
 
 
 def register_mark_sanitize(name: str, priority: int, guardrail: EventSanitizeGuardrail) -> None:
-    """Register a sanitizer for mark event observability fields."""
+    """Register a global mark-event sanitizer.
+
+    Args:
+        name: Unique registration name.
+        priority: Execution order; lower values run first.
+        guardrail: Callback that sanitizes emitted mark-event fields.
+
+    Returns:
+        None: The registration is active until deregistered.
+    """
     return _native_register_mark_sanitize(name, priority, guardrail)
 
 
 def deregister_mark_sanitize(name: str) -> bool:
-    """Remove a global mark event sanitizer by name."""
+    """Remove a global mark-event sanitizer.
+
+    Args:
+        name: Registration name to remove.
+
+    Returns:
+        bool: Whether a registration was removed.
+    """
     return _native_deregister_mark_sanitize(name)
 
 
 def register_scope_sanitize_start(name: str, priority: int, guardrail: EventSanitizeGuardrail) -> None:
-    """Register a sanitizer for every scope start event category."""
+    """Register a global sanitizer for scope-start event fields.
+
+    Args:
+        name: Unique registration name.
+        priority: Execution order; lower values run first.
+        guardrail: Callback that sanitizes emitted scope-start event fields.
+
+    Returns:
+        None: The registration is active until deregistered.
+    """
     return _native_register_scope_sanitize_start(name, priority, guardrail)
 
 
 def deregister_scope_sanitize_start(name: str) -> bool:
-    """Remove a global scope-start event sanitizer by name."""
+    """Remove a global scope-start sanitizer.
+
+    Args:
+        name: Registration name to remove.
+
+    Returns:
+        bool: Whether a registration was removed.
+    """
     return _native_deregister_scope_sanitize_start(name)
 
 
 def register_scope_sanitize_end(name: str, priority: int, guardrail: EventSanitizeGuardrail) -> None:
-    """Register a sanitizer for every scope end event category."""
+    """Register a global sanitizer for scope-end event fields.
+
+    Args:
+        name: Unique registration name.
+        priority: Execution order; lower values run first.
+        guardrail: Callback that sanitizes emitted scope-end event fields.
+
+    Returns:
+        None: The registration is active until deregistered.
+    """
     return _native_register_scope_sanitize_end(name, priority, guardrail)
 
 
 def deregister_scope_sanitize_end(name: str) -> bool:
-    """Remove a global scope-end event sanitizer by name."""
+    """Remove a global scope-end sanitizer.
+
+    Args:
+        name: Registration name to remove.
+
+    Returns:
+        bool: Whether a registration was removed.
+    """
     return _native_deregister_scope_sanitize_end(name)
 
 

--- a/python/nemo_relay/integrations/deepagents/__init__.py
+++ b/python/nemo_relay/integrations/deepagents/__init__.py
@@ -18,13 +18,21 @@ def add_nemo_relay_integration(
     instrument_subagents: bool = True,
     **overrides: Any,
 ) -> dict[str, Any]:
-    """
-    Receives the keyword arguments for ``create_deep_agent`` and returns them with NeMo Relay observability attached.
+    """Attach NeMo Relay observability to ``create_deep_agent`` keyword arguments.
 
     Use this helper as ``create_deep_agent(**add_nemo_relay_integration(...))``.
     It injects Deep Agents-aware middleware at the top level, adds the same
     middleware to dictionary-style custom subagents that do not inherit parent
     middleware, and leaves any provided backend unchanged.
+
+    Args:
+        kwargs: Existing keyword arguments for ``create_deep_agent``.
+        instrument_subagents: Whether to add Relay middleware to dictionary
+            subagents that do not inherit parent middleware.
+        **overrides: Keyword arguments that override values from ``kwargs``.
+
+    Returns:
+        dict[str, Any]: Arguments ready to pass to ``create_deep_agent``.
     """
     observed = dict(kwargs or {})
     observed.update(overrides)

--- a/python/nemo_relay/llm.py
+++ b/python/nemo_relay/llm.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING
 
 from nemo_relay import Json
 from nemo_relay._context import ensure_scope_stack
@@ -61,8 +61,6 @@ from nemo_relay._native import (
 from nemo_relay._native import (
     llm_stream_call_execute as _native_llm_stream_call_execute,
 )
-
-TResponse = TypeVar("TResponse", bound=Json)
 
 if TYPE_CHECKING:
     from nemo_relay._native import (
@@ -199,7 +197,7 @@ def call_end(
 def execute(
     name: str,
     request: LLMRequest,
-    func: Callable[[LLMRequest], TResponse | Awaitable[TResponse]],
+    func: Callable[[LLMRequest], Json | Awaitable[Json]],
     *,
     handle: ScopeHandle | None = None,
     attributes: LLMAttributes | None = None,
@@ -208,7 +206,7 @@ def execute(
     model_name: str | None = None,
     codec: LlmCodec | None = None,
     response_codec: LlmResponseCodec | None = None,
-) -> Awaitable[Any]:
+) -> Awaitable[Json]:
     """Run an LLM call through the managed middleware pipeline.
 
     Pipeline order:
@@ -414,7 +412,7 @@ def request_intercepts(
     return _native_llm_request_intercepts(name, request)
 
 
-def conditional_execution(request: LLMRequest) -> None | Awaitable[None]:
+def conditional_execution(request: LLMRequest) -> Awaitable[None] | None:
     """Run LLM conditional-execution guardrails for ``request``.
 
     Args:
@@ -422,7 +420,7 @@ def conditional_execution(request: LLMRequest) -> None | Awaitable[None]:
             conditional-execution guardrails.
 
     Returns:
-        None | Awaitable[None]: ``None`` when execution is allowed, returned
+        Awaitable[None] | None: ``None`` when execution is allowed, returned
         directly outside an event loop or through an awaitable inside one.
 
     Notes:

--- a/python/nemo_relay/llm.py
+++ b/python/nemo_relay/llm.py
@@ -29,14 +29,19 @@ Example::
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar
 
+from nemo_relay import Json
 from nemo_relay._context import ensure_scope_stack
 from nemo_relay._native import (
+    LLMAttributes,
+    LLMHandle,
     LLMRequest,
+    LLMRequestInterceptOutcome,
     LlmStream,
+    ScopeHandle,
 )
 from nemo_relay._native import (
     llm_call as _native_llm_call,
@@ -57,9 +62,12 @@ from nemo_relay._native import (
     llm_stream_call_execute as _native_llm_stream_call_execute,
 )
 
+TResponse = TypeVar("TResponse", bound=Json)
+
 if TYPE_CHECKING:
-    from nemo_relay import Json
-    from nemo_relay._native import AnnotatedLLMResponse
+    from nemo_relay._native import (
+        AnnotatedLLMResponse,
+    )
     from nemo_relay.codecs import LlmCodec, LlmResponseCodec
 
 
@@ -67,13 +75,13 @@ def call(
     name: str,
     request: LLMRequest,
     *,
-    handle=None,
-    attributes=None,
-    data=None,
-    metadata=None,
+    handle: ScopeHandle | None = None,
+    attributes: LLMAttributes | None = None,
+    data: Json | None = None,
+    metadata: Json | None = None,
     model_name: str | None = None,
     timestamp: datetime | None = None,
-):
+) -> LLMHandle:
     """Start a manual LLM span and return its ``LLMHandle``.
 
     Args:
@@ -134,11 +142,11 @@ def call(
 
 
 def call_end(
-    handle,
-    response,
+    handle: LLMHandle,
+    response: Json,
     *,
-    data=None,
-    metadata=None,
+    data: Json | None = None,
+    metadata: Json | None = None,
     annotated_response: AnnotatedLLMResponse | Mapping[str, Json] | None = None,
     response_codec: LlmResponseCodec | None = None,
     timestamp: datetime | None = None,
@@ -191,16 +199,16 @@ def call_end(
 def execute(
     name: str,
     request: LLMRequest,
-    func,
+    func: Callable[[LLMRequest], TResponse | Awaitable[TResponse]],
     *,
-    handle=None,
-    attributes=None,
-    data=None,
-    metadata=None,
+    handle: ScopeHandle | None = None,
+    attributes: LLMAttributes | None = None,
+    data: Json | None = None,
+    metadata: Json | None = None,
     model_name: str | None = None,
     codec: LlmCodec | None = None,
     response_codec: LlmResponseCodec | None = None,
-):
+) -> Awaitable[Any]:
     """Run an LLM call through the managed middleware pipeline.
 
     Pipeline order:
@@ -282,18 +290,18 @@ def execute(
 def stream_execute(
     name: str,
     request: LLMRequest,
-    func,
-    collector,
-    finalizer,
+    func: Callable[[LLMRequest], AsyncIterator[Json]],
+    collector: Callable[[Json], None],
+    finalizer: Callable[[], Json],
     *,
-    handle=None,
-    attributes=None,
-    data=None,
-    metadata=None,
+    handle: ScopeHandle | None = None,
+    attributes: LLMAttributes | None = None,
+    data: Json | None = None,
+    metadata: Json | None = None,
     model_name: str | None = None,
     codec: LlmCodec | None = None,
     response_codec: LlmResponseCodec | None = None,
-) -> LlmStream:
+) -> Awaitable[LlmStream]:
     """Run a streaming LLM call through the managed middleware pipeline.
 
     Args:
@@ -382,7 +390,9 @@ def stream_execute(
     )
 
 
-def request_intercepts(name, request):
+def request_intercepts(
+    name: str, request: LLMRequest
+) -> LLMRequestInterceptOutcome | Awaitable[LLMRequestInterceptOutcome]:
     """Apply global LLM request intercepts to ``request``.
 
     Args:
@@ -404,7 +414,7 @@ def request_intercepts(name, request):
     return _native_llm_request_intercepts(name, request)
 
 
-def conditional_execution(request):
+def conditional_execution(request: LLMRequest) -> None | Awaitable[None]:
     """Run LLM conditional-execution guardrails for ``request``.
 
     Args:

--- a/python/nemo_relay/model_pricing.py
+++ b/python/nemo_relay/model_pricing.py
@@ -235,7 +235,15 @@ class ComponentSpec:
 
 
 def validate_config(config: PricingConfig | JsonObject) -> ConfigReport:
-    """Validate a model pricing config document without activating it."""
+    """Validate a model pricing config document without activating it.
+
+    Args:
+        config: Pricing configuration model or equivalent JSON object.
+
+    Returns:
+        ConfigReport: Diagnostics describing whether the configuration is
+        valid and can be activated.
+    """
     report = plugin_module.validate(
         plugin_module.PluginConfig(
             components=[ComponentSpec(config)],

--- a/python/nemo_relay/pii_redaction.py
+++ b/python/nemo_relay/pii_redaction.py
@@ -185,7 +185,15 @@ class ComponentSpec:
 
 
 def validate_config(config: PiiRedactionConfig | JsonObject) -> ConfigReport:
-    """Validate a PII redaction config document without activating it."""
+    """Validate a PII redaction config document without activating it.
+
+    Args:
+        config: PII-redaction configuration model or equivalent JSON object.
+
+    Returns:
+        ConfigReport: Diagnostics describing whether the configuration is
+        valid and can be activated.
+    """
     report = plugin_module.validate(
         plugin_module.PluginConfig(
             components=[ComponentSpec(config)],

--- a/python/nemo_relay/plugin.py
+++ b/python/nemo_relay/plugin.py
@@ -634,6 +634,10 @@ async def clear_async() -> None:
 
     Native teardown runs outside the Python event-loop thread so queued event
     sanitizers can finish before their plugin-owned registrations are removed.
+
+    Returns:
+        None: The active configuration has been cleared when the awaitable
+        resolves.
     """
     await _clear_plugin_configuration_async()
 

--- a/python/nemo_relay/runtime_registrations.py
+++ b/python/nemo_relay/runtime_registrations.py
@@ -75,7 +75,18 @@ def register_conditional_middleware_guardrail(
     registration_name: str,
     guardrail: ConditionalMiddlewareGuardrail,
 ) -> None:
-    """Register a global gate for registrations matching kind and effective name."""
+    """Register a global gate for registrations matching kind and effective name.
+
+    Args:
+        name: Unique name for this gate registration.
+        kinds: Registration kinds to which this gate applies.
+        registration_name: Effective registration name to match.
+        guardrail: Callback returning a rejection message or ``None`` to allow
+            the registration.
+
+    Returns:
+        None: The gate is registered for subsequent matching registrations.
+    """
 
     def wrapped(received_kinds: set[str], effective_name: str) -> str | None:
         return guardrail({RuntimeRegistrationKind(kind) for kind in received_kinds}, effective_name)
@@ -84,14 +95,30 @@ def register_conditional_middleware_guardrail(
 
 
 def deregister_conditional_middleware_guardrail(name: str) -> bool:
-    """Remove a named global registration gate."""
+    """Remove a named global registration gate.
+
+    Args:
+        name: Gate name previously passed to
+            ``register_conditional_middleware_guardrail``.
+
+    Returns:
+        bool: ``True`` if a gate was removed; otherwise ``False``.
+    """
     return _native_deregister(name)
 
 
 def list_runtime_registrations(
     kinds: Iterable[RuntimeRegistrationKind] | None = None,
 ) -> list[RuntimeRegistrationIdentity]:
-    """List a deterministic snapshot of global gateable registrations."""
+    """List a deterministic snapshot of global gateable registrations.
+
+    Args:
+        kinds: Optional registration kinds to include. When omitted, includes
+            every gateable global registration.
+
+    Returns:
+        list[RuntimeRegistrationIdentity]: Ordered registration identities.
+    """
     selected = None if kinds is None else {kind.value for kind in kinds}
     registrations = _native_list(selected)
     return [

--- a/python/nemo_relay/scope.py
+++ b/python/nemo_relay/scope.py
@@ -256,6 +256,10 @@ def scope(
         ScopeHandle: Handle for the scope that remains active inside the
         ``with`` block.
 
+    Returns:
+        Iterator[ScopeHandle]: Context-manager iterator that closes the scope
+        when the ``with`` block exits.
+
     Notes:
         The scope is always popped when the ``with`` block exits, even if the
         body raises an exception. Timestamp arguments must be timezone-aware

--- a/python/nemo_relay/scope_local.py
+++ b/python/nemo_relay/scope_local.py
@@ -21,10 +21,30 @@ Example::
 
 from __future__ import annotations
 
-from nemo_relay import EventMetadataInjectorCallback, ScopeHandle
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from nemo_relay import (
+    EventMetadataInjectorCallback,
+    EventSanitizeGuardrail,
+    LlmConditionalExecutionGuardrail,
+    LlmExecutionIntercept,
+    LlmRequestIntercept,
+    LlmSanitizeRequestGuardrail,
+    LlmSanitizeResponseGuardrail,
+    LlmStreamExecutionIntercept,
+    ScopeHandle,
+    ToolConditionalExecutionGuardrail,
+    ToolExecutionIntercept,
+    ToolRequestIntercept,
+    ToolSanitizeGuardrail,
+)
 from nemo_relay._native import (
     scope_deregister_event_metadata_injector as _deregister_event_metadata_injector,
 )
+
+if TYPE_CHECKING:
+    from nemo_relay import Event
 from nemo_relay._native import (
     scope_deregister_llm_conditional_execution_guardrail as _deregister_llm_conditional_execution,
 )
@@ -130,42 +150,120 @@ def register_event_metadata_injector(
     priority: int,
     injector: EventMetadataInjectorCallback,
 ) -> None:
-    """Register an event metadata injector owned by an active scope."""
+    """Register an event metadata injector owned by a scope.
+
+    Args:
+        scope_handle: Scope that owns the registration.
+        name: Unique registration name within the scope.
+        priority: Execution order; lower values run first.
+        injector: Callback that returns metadata additions for emitted events.
+
+    Returns:
+        None: The injector remains active until removal or scope closure.
+    """
     _register_event_metadata_injector(scope_handle.uuid, name, priority, injector)
 
 
 def deregister_event_metadata_injector(scope_handle: ScopeHandle, name: str) -> bool:
-    """Remove a scope-local event metadata injector by registration name."""
+    """Remove a scope-local event metadata injector.
+
+    Args:
+        scope_handle: Scope that owns the registration.
+        name: Registration name to remove.
+
+    Returns:
+        bool: Whether an injector was removed.
+    """
     return _deregister_event_metadata_injector(scope_handle.uuid, name)
 
 
-def register_mark_sanitize(scope_handle, name, priority, guardrail):
-    """Register a scope-local mark event sanitizer."""
+def register_mark_sanitize(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: EventSanitizeGuardrail
+) -> None:
+    """Register a mark-event sanitizer owned by a scope.
+
+    Args:
+        scope_handle: Scope that owns the registration.
+        name: Unique registration name within the scope.
+        priority: Execution order; lower values run first.
+        guardrail: Callback that sanitizes emitted mark-event fields.
+
+    Returns:
+        None: The sanitizer remains active until removal or scope closure.
+    """
     return _register_mark_sanitize(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_mark_sanitize(scope_handle, name):
-    """Remove a scope-local mark event sanitizer."""
+def deregister_mark_sanitize(scope_handle: ScopeHandle, name: str) -> bool:
+    """Remove a scope-local mark-event sanitizer.
+
+    Args:
+        scope_handle: Scope that owns the registration.
+        name: Registration name to remove.
+
+    Returns:
+        bool: Whether a sanitizer was removed.
+    """
     return _deregister_mark_sanitize(scope_handle.uuid, name)
 
 
-def register_scope_sanitize_start(scope_handle, name, priority, guardrail):
-    """Register a scope-local sanitizer for scope start events."""
+def register_scope_sanitize_start(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: EventSanitizeGuardrail
+) -> None:
+    """Register a scope-start event sanitizer owned by a scope.
+
+    Args:
+        scope_handle: Scope that owns the registration.
+        name: Unique registration name within the scope.
+        priority: Execution order; lower values run first.
+        guardrail: Callback that sanitizes emitted scope-start event fields.
+
+    Returns:
+        None: The sanitizer remains active until removal or scope closure.
+    """
     return _register_scope_sanitize_start(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_scope_sanitize_start(scope_handle, name):
-    """Remove a scope-local scope-start event sanitizer."""
+def deregister_scope_sanitize_start(scope_handle: ScopeHandle, name: str) -> bool:
+    """Remove a scope-local scope-start sanitizer.
+
+    Args:
+        scope_handle: Scope that owns the registration.
+        name: Registration name to remove.
+
+    Returns:
+        bool: Whether a sanitizer was removed.
+    """
     return _deregister_scope_sanitize_start(scope_handle.uuid, name)
 
 
-def register_scope_sanitize_end(scope_handle, name, priority, guardrail):
-    """Register a scope-local sanitizer for scope end events."""
+def register_scope_sanitize_end(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: EventSanitizeGuardrail
+) -> None:
+    """Register a scope-end event sanitizer owned by a scope.
+
+    Args:
+        scope_handle: Scope that owns the registration.
+        name: Unique registration name within the scope.
+        priority: Execution order; lower values run first.
+        guardrail: Callback that sanitizes emitted scope-end event fields.
+
+    Returns:
+        None: The sanitizer remains active until removal or scope closure.
+    """
     return _register_scope_sanitize_end(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_scope_sanitize_end(scope_handle, name):
-    """Remove a scope-local scope-end event sanitizer."""
+def deregister_scope_sanitize_end(scope_handle: ScopeHandle, name: str) -> bool:
+    """Remove a scope-local scope-end sanitizer.
+
+    Args:
+        scope_handle: Scope that owns the registration.
+        name: Registration name to remove.
+
+    Returns:
+        bool: Whether a sanitizer was removed.
+    """
     return _deregister_scope_sanitize_end(scope_handle.uuid, name)
 
 
@@ -174,7 +272,9 @@ def deregister_scope_sanitize_end(scope_handle, name):
 # ---------------------------------------------------------------------------
 
 
-def register_tool_sanitize_request(scope_handle, name, priority, guardrail):
+def register_tool_sanitize_request(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: ToolSanitizeGuardrail
+) -> None:
     """Register a scope-local tool sanitize-request guardrail.
 
     Args:
@@ -195,7 +295,7 @@ def register_tool_sanitize_request(scope_handle, name, priority, guardrail):
     return _register_tool_sanitize_request(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_tool_sanitize_request(scope_handle, name):
+def deregister_tool_sanitize_request(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local tool sanitize-request guardrail.
 
     Args:
@@ -213,7 +313,9 @@ def deregister_tool_sanitize_request(scope_handle, name):
     return _deregister_tool_sanitize_request(scope_handle.uuid, name)
 
 
-def register_tool_sanitize_response(scope_handle, name, priority, guardrail):
+def register_tool_sanitize_response(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: ToolSanitizeGuardrail
+) -> None:
     """Register a scope-local tool sanitize-response guardrail.
 
     Args:
@@ -234,7 +336,7 @@ def register_tool_sanitize_response(scope_handle, name, priority, guardrail):
     return _register_tool_sanitize_response(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_tool_sanitize_response(scope_handle, name):
+def deregister_tool_sanitize_response(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local tool sanitize-response guardrail.
 
     Args:
@@ -252,7 +354,9 @@ def deregister_tool_sanitize_response(scope_handle, name):
     return _deregister_tool_sanitize_response(scope_handle.uuid, name)
 
 
-def register_tool_conditional_execution(scope_handle, name, priority, guardrail):
+def register_tool_conditional_execution(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: ToolConditionalExecutionGuardrail
+) -> None:
     """Register a scope-local tool conditional-execution guardrail.
 
     Args:
@@ -274,7 +378,7 @@ def register_tool_conditional_execution(scope_handle, name, priority, guardrail)
     return _register_tool_conditional_execution(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_tool_conditional_execution(scope_handle, name):
+def deregister_tool_conditional_execution(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local tool conditional-execution guardrail.
 
     Args:
@@ -297,7 +401,9 @@ def deregister_tool_conditional_execution(scope_handle, name):
 # ---------------------------------------------------------------------------
 
 
-def register_tool_request(scope_handle, name, priority, break_chain, fn):
+def register_tool_request(
+    scope_handle: ScopeHandle, name: str, priority: int, break_chain: bool, fn: ToolRequestIntercept
+) -> None:
     """Register a scope-local tool request intercept.
 
     Args:
@@ -321,7 +427,7 @@ def register_tool_request(scope_handle, name, priority, break_chain, fn):
     return _register_tool_request(scope_handle.uuid, name, priority, break_chain, fn)
 
 
-def deregister_tool_request(scope_handle, name):
+def deregister_tool_request(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local tool request intercept.
 
     Args:
@@ -338,7 +444,7 @@ def deregister_tool_request(scope_handle, name):
     return _deregister_tool_request(scope_handle.uuid, name)
 
 
-def register_tool_execution(scope_handle, name, priority, fn):
+def register_tool_execution(scope_handle: ScopeHandle, name: str, priority: int, fn: ToolExecutionIntercept) -> None:
     """Register scope-local middleware around tool execution.
 
     Args:
@@ -365,7 +471,7 @@ def register_tool_execution(scope_handle, name, priority, fn):
     return _register_tool_execution(scope_handle.uuid, name, priority, fn)
 
 
-def deregister_tool_execution(scope_handle, name):
+def deregister_tool_execution(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local tool execution intercept.
 
     Args:
@@ -388,7 +494,9 @@ def deregister_tool_execution(scope_handle, name):
 # ---------------------------------------------------------------------------
 
 
-def register_llm_sanitize_request(scope_handle, name, priority, guardrail):
+def register_llm_sanitize_request(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: LlmSanitizeRequestGuardrail
+) -> None:
     """Register a scope-local LLM sanitize-request guardrail.
 
     Args:
@@ -409,7 +517,7 @@ def register_llm_sanitize_request(scope_handle, name, priority, guardrail):
     return _register_llm_sanitize_request(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_llm_sanitize_request(scope_handle, name):
+def deregister_llm_sanitize_request(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local LLM sanitize-request guardrail.
 
     Args:
@@ -427,7 +535,9 @@ def deregister_llm_sanitize_request(scope_handle, name):
     return _deregister_llm_sanitize_request(scope_handle.uuid, name)
 
 
-def register_llm_sanitize_response(scope_handle, name, priority, guardrail):
+def register_llm_sanitize_response(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: LlmSanitizeResponseGuardrail
+) -> None:
     """Register a scope-local LLM sanitize-response guardrail.
 
     Args:
@@ -448,7 +558,7 @@ def register_llm_sanitize_response(scope_handle, name, priority, guardrail):
     return _register_llm_sanitize_response(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_llm_sanitize_response(scope_handle, name):
+def deregister_llm_sanitize_response(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local LLM sanitize-response guardrail.
 
     Args:
@@ -466,7 +576,9 @@ def deregister_llm_sanitize_response(scope_handle, name):
     return _deregister_llm_sanitize_response(scope_handle.uuid, name)
 
 
-def register_llm_conditional_execution(scope_handle, name, priority, guardrail):
+def register_llm_conditional_execution(
+    scope_handle: ScopeHandle, name: str, priority: int, guardrail: LlmConditionalExecutionGuardrail
+) -> None:
     """Register a scope-local LLM conditional-execution guardrail.
 
     Args:
@@ -488,7 +600,7 @@ def register_llm_conditional_execution(scope_handle, name, priority, guardrail):
     return _register_llm_conditional_execution(scope_handle.uuid, name, priority, guardrail)
 
 
-def deregister_llm_conditional_execution(scope_handle, name):
+def deregister_llm_conditional_execution(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local LLM conditional-execution guardrail.
 
     Args:
@@ -511,7 +623,9 @@ def deregister_llm_conditional_execution(scope_handle, name):
 # ---------------------------------------------------------------------------
 
 
-def register_llm_request(scope_handle, name, priority, break_chain, fn):
+def register_llm_request(
+    scope_handle: ScopeHandle, name: str, priority: int, break_chain: bool, fn: LlmRequestIntercept
+) -> None:
     """Register a scope-local LLM request intercept.
 
     Args:
@@ -521,8 +635,9 @@ def register_llm_request(scope_handle, name, priority, break_chain, fn):
         priority: Execution order for the intercept. Lower values run first.
         break_chain: Whether to stop applying lower-priority request intercepts
             after this intercept runs.
-        fn: Callable invoked as ``fn(name, request, annotated)`` that returns a
-            tuple of ``(request, annotated)`` for the next stage.
+        fn: Callable invoked as ``fn(name, request, annotated)`` that returns
+            an ``LLMRequestInterceptOutcome`` or an awaitable of that outcome
+            for the next stage.
 
     Returns:
         None: This function returns after the scope-local intercept is
@@ -535,7 +650,7 @@ def register_llm_request(scope_handle, name, priority, break_chain, fn):
     return _register_llm_request(scope_handle.uuid, name, priority, break_chain, fn)
 
 
-def deregister_llm_request(scope_handle, name):
+def deregister_llm_request(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local LLM request intercept.
 
     Args:
@@ -552,7 +667,7 @@ def deregister_llm_request(scope_handle, name):
     return _deregister_llm_request(scope_handle.uuid, name)
 
 
-def register_llm_execution(scope_handle, name, priority, fn):
+def register_llm_execution(scope_handle: ScopeHandle, name: str, priority: int, fn: LlmExecutionIntercept) -> None:
     """Register scope-local middleware around non-streaming LLM execution.
 
     Args:
@@ -577,7 +692,7 @@ def register_llm_execution(scope_handle, name, priority, fn):
     return _register_llm_execution(scope_handle.uuid, name, priority, fn)
 
 
-def deregister_llm_execution(scope_handle, name):
+def deregister_llm_execution(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local LLM execution intercept.
 
     Args:
@@ -595,7 +710,9 @@ def deregister_llm_execution(scope_handle, name):
     return _deregister_llm_execution(scope_handle.uuid, name)
 
 
-def register_llm_stream_execution(scope_handle, name, priority, fn):
+def register_llm_stream_execution(
+    scope_handle: ScopeHandle, name: str, priority: int, fn: LlmStreamExecutionIntercept
+) -> None:
     """Register scope-local middleware around streaming LLM execution.
 
     Args:
@@ -623,7 +740,7 @@ def register_llm_stream_execution(scope_handle, name, priority, fn):
     return _register_llm_stream_execution(scope_handle.uuid, name, priority, fn)
 
 
-def deregister_llm_stream_execution(scope_handle, name):
+def deregister_llm_stream_execution(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local streaming LLM execution intercept.
 
     Args:
@@ -646,7 +763,7 @@ def deregister_llm_stream_execution(scope_handle, name):
 # ---------------------------------------------------------------------------
 
 
-def register_subscriber(scope_handle, name, callback):
+def register_subscriber(scope_handle: ScopeHandle, name: str, callback: "Callable[[Event], None]") -> None:
     """Register an event subscriber that is active only for ``scope_handle``.
 
     Args:
@@ -677,7 +794,7 @@ def register_subscriber(scope_handle, name, callback):
     return _register_subscriber(scope_handle.uuid, name, callback)
 
 
-def deregister_subscriber(scope_handle, name):
+def deregister_subscriber(scope_handle: ScopeHandle, name: str) -> bool:
     """Remove a scope-local event subscriber.
 
     Args:

--- a/python/nemo_relay/subscribers.py
+++ b/python/nemo_relay/subscribers.py
@@ -204,6 +204,9 @@ def flush() -> None:
     Raises:
         RuntimeError: If called while an ``asyncio`` event loop is running on
             the current thread.
+
+    Returns:
+        None: All eligible queued work has completed before this returns.
     """
     if _publication_callback_active():
         return None
@@ -225,6 +228,10 @@ async def flush_async() -> None:
     thread coalesces concurrent barriers and waits for the native dispatcher
     without blocking the Python event loop. Managed tool, LLM, and guardrail
     work registered before the flush is included through its terminal event.
+
+    Returns:
+        None: All eligible queued work has completed when the awaitable
+        resolves.
     """
     if _publication_callback_active():
         return None

--- a/python/nemo_relay/tools.py
+++ b/python/nemo_relay/tools.py
@@ -20,9 +20,20 @@ Example::
     assert result.result == {"result": "HELLO"}
 """
 
-from datetime import datetime
+from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import TypeVar
+
+from nemo_relay import Json
 from nemo_relay._context import ensure_scope_stack
+from nemo_relay._native import (
+    ScopeHandle,
+    ToolAttributes,
+    ToolExecutionResult,
+    ToolHandle,
+)
 from nemo_relay._native import (
     tool_call as _native_tool_call,
 )
@@ -39,18 +50,20 @@ from nemo_relay._native import (
     tool_request_intercepts as _native_tool_request_intercepts,
 )
 
+TToolResult = TypeVar("TToolResult")
+
 
 def call(
-    name,
-    args,
+    name: str,
+    args: Json,
     *,
-    handle=None,
-    attributes=None,
-    data=None,
-    metadata=None,
-    tool_call_id=None,
+    handle: ScopeHandle | None = None,
+    attributes: ToolAttributes | None = None,
+    data: Json | None = None,
+    metadata: Json | None = None,
+    tool_call_id: str | None = None,
     timestamp: datetime | None = None,
-):
+) -> ToolHandle:
     """Start a manual tool span and return its ``ToolHandle``.
 
     Args:
@@ -109,7 +122,14 @@ def call(
     )
 
 
-def call_end(handle, result, *, data=None, metadata=None, timestamp: datetime | None = None):
+def call_end(
+    handle: ToolHandle,
+    result: ToolExecutionResult[Json],
+    *,
+    data: Json | None = None,
+    metadata: Json | None = None,
+    timestamp: datetime | None = None,
+) -> None:
     """Finish a manual tool span started by ``call()``.
 
     Args:
@@ -137,7 +157,17 @@ def call_end(handle, result, *, data=None, metadata=None, timestamp: datetime | 
     return _native_tool_call_end(handle, result, data=data, metadata=metadata, timestamp=timestamp)
 
 
-def execute(name, args, func, *, handle=None, attributes=None, data=None, metadata=None, tool_call_id=None):
+def execute(
+    name: str,
+    args: Json,
+    func: Callable[[Json], ToolExecutionResult[TToolResult] | Awaitable[ToolExecutionResult[TToolResult]]],
+    *,
+    handle: ScopeHandle | None = None,
+    attributes: ToolAttributes | None = None,
+    data: Json | None = None,
+    metadata: Json | None = None,
+    tool_call_id: str | None = None,
+) -> Awaitable[ToolExecutionResult[TToolResult]]:
     """Run a tool through the managed middleware pipeline.
 
     Pipeline order:
@@ -202,7 +232,7 @@ def execute(name, args, func, *, handle=None, attributes=None, data=None, metada
     )
 
 
-def request_intercepts(name, args):
+def request_intercepts(name: str, args: Json) -> Json | Awaitable[Json]:
     """Apply global tool request intercepts to ``args``.
 
     Args:
@@ -222,7 +252,7 @@ def request_intercepts(name, args):
     return _native_tool_request_intercepts(name, args)
 
 
-def conditional_execution(name, args):
+def conditional_execution(name: str, args: Json) -> None | Awaitable[None]:
     """Run tool conditional-execution guardrails for ``args``.
 
     Args:

--- a/python/nemo_relay/tools.py
+++ b/python/nemo_relay/tools.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from datetime import datetime
-from typing import TypeVar
 
 from nemo_relay import Json
 from nemo_relay._context import ensure_scope_stack
@@ -49,8 +48,6 @@ from nemo_relay._native import (
 from nemo_relay._native import (
     tool_request_intercepts as _native_tool_request_intercepts,
 )
-
-TToolResult = TypeVar("TToolResult")
 
 
 def call(
@@ -160,14 +157,14 @@ def call_end(
 def execute(
     name: str,
     args: Json,
-    func: Callable[[Json], ToolExecutionResult[TToolResult] | Awaitable[ToolExecutionResult[TToolResult]]],
+    func: Callable[[Json], ToolExecutionResult[Json] | Awaitable[ToolExecutionResult[Json]]],
     *,
     handle: ScopeHandle | None = None,
     attributes: ToolAttributes | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
     tool_call_id: str | None = None,
-) -> Awaitable[ToolExecutionResult[TToolResult]]:
+) -> Awaitable[ToolExecutionResult[Json]]:
     """Run a tool through the managed middleware pipeline.
 
     Pipeline order:
@@ -252,7 +249,7 @@ def request_intercepts(name: str, args: Json) -> Json | Awaitable[Json]:
     return _native_tool_request_intercepts(name, args)
 
 
-def conditional_execution(name: str, args: Json) -> None | Awaitable[None]:
+def conditional_execution(name: str, args: Json) -> Awaitable[None] | None:
     """Run tool conditional-execution guardrails for ``args``.
 
     Args:
@@ -260,7 +257,7 @@ def conditional_execution(name: str, args: Json) -> None | Awaitable[None]:
         args: JSON-compatible tool arguments to validate.
 
     Returns:
-        None | Awaitable[None]: ``None`` when execution is allowed, returned
+        Awaitable[None] | None: ``None`` when execution is allowed, returned
         directly outside an event loop or through an awaitable inside one.
 
     Notes:

--- a/python/nemo_relay/typed.py
+++ b/python/nemo_relay/typed.py
@@ -48,7 +48,7 @@ import weakref
 from typing import AsyncIterator, Awaitable, Callable, Generic, Protocol, TypeVar, cast, overload
 
 from nemo_relay import Json, llm, tools
-from nemo_relay._native import LLMRequest, LlmStream, ScopeHandle, ToolExecutionResult
+from nemo_relay._native import LLMAttributes, LLMRequest, LlmStream, ScopeHandle, ToolAttributes, ToolExecutionResult
 from nemo_relay.codecs import LlmCodec, LlmResponseCodec
 
 T = TypeVar("T")
@@ -472,7 +472,7 @@ async def tool_execute(
     result_codec: Codec[TResult],
     *,
     handle: ScopeHandle | None = None,
-    attributes: int | None = None,
+    attributes: ToolAttributes | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
     tool_call_id: str | None = None,
@@ -488,7 +488,7 @@ async def tool_execute(
     result_codec: Codec[TResult],
     *,
     handle: ScopeHandle | None = None,
-    attributes: int | None = None,
+    attributes: ToolAttributes | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
     tool_call_id: str | None = None,
@@ -503,7 +503,7 @@ async def tool_execute(
     result_codec: Codec[TResult],
     *,
     handle: ScopeHandle | None = None,
-    attributes: int | None = None,
+    attributes: ToolAttributes | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
     tool_call_id: str | None = None,
@@ -592,7 +592,7 @@ async def llm_execute(
     response_json_codec: Codec[TResponse],
     *,
     handle: ScopeHandle | None = None,
-    attributes: int | None = None,
+    attributes: LLMAttributes | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
     model_name: str | None = None,
@@ -609,7 +609,7 @@ async def llm_execute(
     response_json_codec: Codec[TResponse],
     *,
     handle: ScopeHandle | None = None,
-    attributes: int | None = None,
+    attributes: LLMAttributes | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
     model_name: str | None = None,
@@ -625,7 +625,7 @@ async def llm_execute(
     response_json_codec: Codec[TResponse],
     *,
     handle: ScopeHandle | None = None,
-    attributes: int | None = None,
+    attributes: LLMAttributes | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
     model_name: str | None = None,
@@ -716,7 +716,7 @@ async def llm_stream_execute(
     response_json_codec: Codec[TResponse],
     *,
     handle: ScopeHandle | None = None,
-    attributes: int | None = None,
+    attributes: LLMAttributes | None = None,
     data: Json | None = None,
     metadata: Json | None = None,
     model_name: str | None = None,

--- a/python/tests/async_helpers.py
+++ b/python/tests/async_helpers.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Async helpers shared by Python tests."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import TypeVar, cast
+
+from typing_extensions import TypeIs
+
+T = TypeVar("T")
+
+
+async def resolve_async_result(value: T | Awaitable[T]) -> T:
+    """Resolve a value that Relay may return directly or through an awaitable."""
+    if _is_awaitable(value):
+        return cast(T, await value)
+    return cast(T, value)
+
+
+def _is_awaitable(value: T | Awaitable[T]) -> TypeIs[Awaitable[T]]:
+    """Narrow a Relay helper's direct-or-awaitable return contract."""
+    return isinstance(value, Awaitable)

--- a/python/tests/test_adaptive.py
+++ b/python/tests/test_adaptive.py
@@ -9,6 +9,7 @@ from typing import cast
 from uuid import uuid4
 
 import pytest
+from async_helpers import resolve_async_result
 
 from nemo_relay import (
     AnnotatedLLMRequest,
@@ -226,7 +227,7 @@ class TestAdaptivePluginConfiguration:
             )
             with scope.scope("adaptive-runtime-translate", ScopeType.Agent) as handle:
                 runtime.bind_scope(handle)
-                translated = await llm.request_intercepts("anthropic", request)
+                translated = await resolve_async_result(llm.request_intercepts("anthropic", request))
                 assert translated.request.content == {
                     "messages": [{"role": "user", "content": "Hello"}],
                     "system": "You are helpful.",

--- a/python/tests/test_context_isolation.py
+++ b/python/tests/test_context_isolation.py
@@ -8,6 +8,7 @@ import contextvars
 import uuid
 
 import pytest
+from async_helpers import resolve_async_result
 
 import nemo_relay
 from nemo_relay._native import capture_thread_scope_stack, restore_thread_scope_stack
@@ -242,8 +243,8 @@ def test_concurrent_tool_lifecycle_uses_owning_task_stack(subscribed_events):
                 )
 
                 await asyncio.sleep(0)
-                args = await nemo_relay.tools.request_intercepts("task-tool", {"owner": owner})
-                await nemo_relay.tools.conditional_execution("task-tool", args)
+                args = await resolve_async_result(nemo_relay.tools.request_intercepts("task-tool", {"owner": owner}))
+                await resolve_async_result(nemo_relay.tools.conditional_execution("task-tool", args))
 
                 manual_handle = nemo_relay.tools.call(f"manual-tool-{owner}", args)
                 await asyncio.sleep(0)
@@ -301,9 +302,9 @@ def test_concurrent_llm_lifecycle_uses_owning_task_stack(subscribed_events):
 
                 request = nemo_relay.LLMRequest({}, {"messages": [], "owner": owner})
                 await asyncio.sleep(0)
-                intercepted = await nemo_relay.llm.request_intercepts("task-llm", request)
+                intercepted = await resolve_async_result(nemo_relay.llm.request_intercepts("task-llm", request))
                 assert intercepted.request.content["intercepted_by"] == owner
-                await nemo_relay.llm.conditional_execution(request)
+                await resolve_async_result(nemo_relay.llm.conditional_execution(request))
 
                 manual_handle = nemo_relay.llm.call(f"manual-llm-{owner}", request)
                 await asyncio.sleep(0)

--- a/python/tests/test_dynamic_plugin_host.py
+++ b/python/tests/test_dynamic_plugin_host.py
@@ -718,7 +718,7 @@ async def test_worker_activation_executes_and_releases_callbacks(worker_dynamic_
     loop = asyncio.get_running_loop()
     loop_thread = threading.get_ident()
 
-    async def tool_provider(args: Json) -> ToolExecutionResult[Json]:
+    async def tool_provider(args: Json) -> ToolExecutionResult[dict[str, Json]]:
         assert asyncio.get_running_loop() is loop
         assert threading.get_ident() == loop_thread
         await asyncio.sleep(0)
@@ -739,6 +739,7 @@ async def test_worker_activation_executes_and_releases_callbacks(worker_dynamic_
     try:
         result = await tools.execute("python-worker-fixture", {"input": True}, tool_provider)
         assert result.result["worker_plugin_tool_execution"] is True
+        assert isinstance(result.result["args"], dict)
         assert result.result["args"]["worker_plugin_tool_execution_request"] is True
 
         llm_result = await llm.execute(

--- a/python/tests/test_llm.py
+++ b/python/tests/test_llm.py
@@ -6,10 +6,11 @@
 import asyncio
 import contextvars
 import threading
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable
 from typing import NoReturn, cast
 
 import pytest
+from async_helpers import resolve_async_result
 
 from nemo_relay import (
     Event,
@@ -559,6 +560,7 @@ class TestLLMIntercepts:
         transformed = llm.request_intercepts("direct_llm", make_request())
         intercepts.deregister_llm_request("py_llm_req_direct")
 
+        assert not isinstance(transformed, Awaitable)
         assert transformed.request.content["direct"] is True
         assert len(transformed.pending_marks) == 1
         assert transformed.pending_marks[0].name == pending_mark.name
@@ -789,8 +791,8 @@ class TestLLMInterceptsAsync:
         token = request_id.set("emitter")
         try:
             assert await llm.execute("context_llm", make_request(), lambda _request: {}) == {"ok": True}
-            await llm.conditional_execution(make_request())
-            standalone = await llm.request_intercepts("context_llm_standalone", make_request())
+            await resolve_async_result(llm.conditional_execution(make_request()))
+            standalone = await resolve_async_result(llm.request_intercepts("context_llm_standalone", make_request()))
             assert standalone.request.content == make_request().content
         finally:
             request_id.reset(token)
@@ -889,7 +891,7 @@ class TestLLMInterceptsAsync:
             stream = await llm.stream_execute(
                 "custom_iterator_context_llm",
                 make_request(),
-                lambda _request: None,
+                lambda _request: None,  # ty: ignore[invalid-argument-type]
                 lambda _chunk: None,
                 lambda: {},
             )
@@ -1315,7 +1317,11 @@ class TestLLMStreaming:
 
     async def test_stream_execute_rejects_invalid_iterator(self):
         stream = await llm.stream_execute(
-            "stream_invalid_iter_llm", make_request(), lambda request: object(), lambda chunk: None, lambda: {}
+            "stream_invalid_iter_llm",
+            make_request(),
+            lambda request: object(),  # ty: ignore[invalid-argument-type]
+            lambda chunk: None,
+            lambda: {},
         )
         with pytest.raises(RuntimeError, match="__anext__"):
             await anext(stream)
@@ -1484,7 +1490,7 @@ class TestLLMStreaming:
                 await llm.stream_execute(
                     "async_stream_callback_fail_llm",
                     make_request(),
-                    async_stream_func,
+                    async_stream_func,  # ty: ignore[invalid-argument-type]
                     lambda chunk: None,
                     lambda: {},
                 )
@@ -1515,7 +1521,7 @@ class TestLLMStreaming:
                 make_request(),
                 stream_func,
                 lambda chunk: None,
-                lambda: object(),
+                lambda: object(),  # ty: ignore[invalid-argument-type]
             )
             chunks = []
             async for chunk in stream:

--- a/python/tests/test_public_api_annotations.py
+++ b/python/tests/test_public_api_annotations.py
@@ -4,6 +4,7 @@
 """Regression tests for public Python API annotations and documentation."""
 
 import inspect
+from importlib import import_module
 from importlib.util import find_spec
 from types import ModuleType
 
@@ -18,10 +19,14 @@ def _public_modules() -> list[ModuleType]:
         for value in vars(nemo_relay).values()
         if isinstance(value, ModuleType) and value.__name__.startswith("nemo_relay")
     )
-    if find_spec("langchain_core") is not None:
-        from nemo_relay.integrations import deepagents, langchain, langgraph
-
-        modules.extend([deepagents, langchain, langgraph])
+    integration_dependencies = {
+        "nemo_relay.integrations.langchain": ("langchain_core",),
+        "nemo_relay.integrations.langgraph": ("langchain_core", "langgraph"),
+        "nemo_relay.integrations.deepagents": ("langchain_core", "langgraph", "deepagents"),
+    }
+    for module_name, dependencies in integration_dependencies.items():
+        if all(find_spec(dependency) is not None for dependency in dependencies):
+            modules.append(import_module(module_name))
     return modules
 
 

--- a/python/tests/test_public_api_annotations.py
+++ b/python/tests/test_public_api_annotations.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for public Python API annotations and documentation."""
+
+import inspect
+from importlib.util import find_spec
+from types import ModuleType
+
+import nemo_relay
+
+
+def _public_modules() -> list[ModuleType]:
+    """Return core modules plus installed optional integration modules."""
+    modules: list[ModuleType] = [nemo_relay]
+    modules.extend(
+        value
+        for value in vars(nemo_relay).values()
+        if isinstance(value, ModuleType) and value.__name__.startswith("nemo_relay")
+    )
+    if find_spec("langchain_core") is not None:
+        from nemo_relay.integrations import deepagents, langchain, langgraph
+
+        modules.extend([deepagents, langchain, langgraph])
+    return modules
+
+
+def test_exported_functions_have_complete_type_annotations():
+    modules = _public_modules()
+
+    missing = []
+    for module in modules:
+        for name in getattr(module, "__all__", ()):
+            function = getattr(module, name, None)
+            if not inspect.isfunction(function):
+                continue
+            signature = inspect.signature(function)
+            parameters = [
+                parameter.name
+                for parameter in signature.parameters.values()
+                if parameter.annotation is inspect.Parameter.empty
+            ]
+            if parameters or signature.return_annotation is inspect.Signature.empty:
+                missing.append(f"{module.__name__}.{name}: {', '.join(parameters) or 'return'}")
+
+    assert not missing, "public API functions missing annotations:\n" + "\n".join(missing)
+
+
+def test_exported_functions_have_comprehensive_docstrings():
+    """Require public functions to document parameters and return behavior."""
+    modules = _public_modules()
+
+    missing = []
+    for module in modules:
+        for name in getattr(module, "__all__", ()):
+            function = getattr(module, name, None)
+            if not inspect.isfunction(function):
+                continue
+            docstring = inspect.getdoc(function) or ""
+            signature = inspect.signature(function)
+            requirements = ["Returns:"]
+            if signature.parameters:
+                requirements.append("Args:")
+            absent = ["docstring"] if not docstring else []
+            absent.extend(requirement for requirement in requirements if requirement not in docstring)
+            if absent:
+                missing.append(f"{module.__name__}.{name}: {', '.join(absent)}")
+
+    assert not missing, "public API functions missing comprehensive docstrings:\n" + "\n".join(missing)

--- a/python/tests/test_scope_local.py
+++ b/python/tests/test_scope_local.py
@@ -641,7 +641,11 @@ class TestScopeLocalLlmWrappers:
             assert scope_local.deregister_llm_conditional_execution(handle, "sl_llm_cond_cov") is True
 
             scope_local.register_llm_request(
-                handle, "sl_llm_int_cov", 1, False, lambda name, req, annotated: (req, annotated)
+                handle,
+                "sl_llm_int_cov",
+                1,
+                False,
+                lambda name, req, annotated: LLMRequestInterceptOutcome(req, annotated),
             )
             assert scope_local.deregister_llm_request(handle, "sl_llm_int_cov") is True
 

--- a/python/tests/test_tools.py
+++ b/python/tests/test_tools.py
@@ -8,10 +8,12 @@ import contextvars
 import gc
 import warnings
 from collections import UserDict, UserList
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import cast
 
 import pytest
+from async_helpers import resolve_async_result
 
 from nemo_relay import (
     Event,
@@ -122,7 +124,7 @@ class TestToolsAsync:
             await tools.execute(
                 "legacy_raw_result",
                 {},
-                lambda _args: {"legacy": True},  # type: ignore[arg-type]
+                lambda _args: {"legacy": True},  # ty: ignore[invalid-argument-type]
             )
 
     async def test_execute_rejects_cyclic_results_and_remains_usable(self):
@@ -464,7 +466,8 @@ class TestToolIntercepts:
         transformed = tools.request_intercepts("direct_tool", {"input": True})
         intercepts.deregister_tool_request("py_req_int_direct")
 
-        assert transformed["direct"] is True
+        assert not isinstance(transformed, Awaitable)
+        assert transformed == {"input": True, "direct": True}
 
     def test_execution_intercept_register_deregister(self):
         intercepts.register_tool_execution(
@@ -673,8 +676,10 @@ class TestToolInterceptsAsync:
         try:
             result = await tools.execute("context_tool", {"ok": True}, lambda args: ToolExecutionResult(args))
             assert result.result == {"ok": True}
-            await tools.conditional_execution("context_tool_standalone", {})
-            assert await tools.request_intercepts("context_tool_standalone", {"ok": True}) == {"ok": True}
+            await resolve_async_result(tools.conditional_execution("context_tool_standalone", {}))
+            assert await resolve_async_result(tools.request_intercepts("context_tool_standalone", {"ok": True})) == {
+                "ok": True
+            }
         finally:
             request_id.reset(token)
             intercepts.deregister_tool_execution("py_tool_context_execution")


### PR DESCRIPTION
#### Overview

Add complete parameter and return type annotations to the Python SDK's exported lifecycle and scope-local APIs.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Annotate public tool, LLM, scope-local, and scope-stack helper functions.
- Add a regression test that verifies every exported Python function has parameter and return annotations.

#### Where should the reviewer start?

Start with `python/tests/test_public_api_annotations.py`, then review the matching public wrappers in `python/nemo_relay/tools.py`, `python/nemo_relay/llm.py`, and `python/nemo_relay/scope_local.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved type information across public LLM, tool, scope, and lifecycle APIs.
  * Added clearer annotations for callbacks, payloads, handles, attributes, asynchronous results, and return values.
  * Improved support for typed tool results, LLM results, and streaming operations.
  * Expanded guidance for scope management, guardrails, registration APIs, validation, and subscriber flushing.

* **Tests**
  * Added checks to ensure exported APIs maintain complete annotations and documentation.
  * Updated coverage for synchronous and asynchronous lifecycle callbacks and execution results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->