### PR TITLE
fix: report metric export failures to stderr

### DIFF
--- a/crates/core/src/logging/mod.rs
+++ b/crates/core/src/logging/mod.rs
@@ -35,9 +35,18 @@ pub(crate) use format::format_event_for_test;
 static LOGGER_LIFECYCLE_LOCK: Mutex<()> = Mutex::new(());
 static DEFAULT_LOGGING_RUNTIME: Mutex<Option<LoggingRuntime>> = Mutex::new(None);
 static ACTIVE_RELAY_LOGGER: Mutex<Option<Weak<Logger>>> = Mutex::new(None);
+#[cfg(test)]
+static TEST_LOGGING_LOCK: Mutex<()> = Mutex::new(());
 
 fn lock_logger_lifecycle() -> MutexGuard<'static, ()> {
     LOGGER_LIFECYCLE_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+}
+
+#[cfg(test)]
+pub(crate) fn lock_test_logging() -> MutexGuard<'static, ()> {
+    TEST_LOGGING_LOCK
         .lock()
         .unwrap_or_else(|error| error.into_inner())
 }

--- a/crates/core/src/observability/otel_metrics.rs
+++ b/crates/core/src/observability/otel_metrics.rs
@@ -485,23 +485,34 @@ impl MetricDeliveryDiagnostics {
         let failures = self.export_failures.load(Ordering::Relaxed);
         (failures > 0).then(|| format!("otel.metrics_export_failed ({failures})"))
     }
+
+    fn record_export_failure(&self, error: &impl std::fmt::Display) -> u64 {
+        let failure_count = self.export_failures.fetch_add(1, Ordering::Relaxed) + 1;
+        self.runtime_diagnostics.record(
+            "otel.metrics_export_failed",
+            format!(
+                "OpenTelemetry metric export to endpoint {} failed: {error}",
+                self.endpoint
+            ),
+            1,
+        );
+        failure_count
+    }
 }
 
 impl<E: PushMetricExporter> PushMetricExporter for DiagnosticMetricExporter<E> {
     async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
         let result = self.inner.export(metrics).await;
         if let Err(error) = &result {
-            self.diagnostics
-                .export_failures
-                .fetch_add(1, Ordering::Relaxed);
-            self.diagnostics.runtime_diagnostics.record(
-                "otel.metrics_export_failed",
-                format!(
-                    "OpenTelemetry metric export to endpoint {} failed: {error}",
-                    self.diagnostics.endpoint
-                ),
-                1,
-            );
+            let failure_count = self.diagnostics.record_export_failure(error);
+            if should_relog_runtime_diagnostic(failure_count) {
+                log::error!(
+                    target: "nemo_relay.observability",
+                    event = "otel_metrics_export_failed",
+                    endpoint = self.diagnostics.endpoint.as_str();
+                    "OpenTelemetry metric export failed: {error}"
+                );
+            }
         }
         result
     }

--- a/crates/core/tests/coverage/logging_tests.rs
+++ b/crates/core/tests/coverage/logging_tests.rs
@@ -18,7 +18,6 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier, Condvar, Mutex, MutexGuard};
 use std::time::Duration;
 
-static LOGGING_TEST_LOCK: Mutex<()> = Mutex::new(());
 const FOREIGN_LOGGER_CHILD_ENV: &str = "NEMO_RELAY_TEST_FOREIGN_LOGGER_CHILD";
 
 struct ForeignLogger;
@@ -89,9 +88,7 @@ impl SpanExporter for BlockingSpanExporter {
 }
 
 fn lock_logging_tests() -> MutexGuard<'static, ()> {
-    LOGGING_TEST_LOCK
-        .lock()
-        .unwrap_or_else(|error| error.into_inner())
+    super::lock_test_logging()
 }
 
 struct LoggingEnvScope {

--- a/crates/core/tests/unit/observability/otel_metrics_tests.rs
+++ b/crates/core/tests/unit/observability/otel_metrics_tests.rs
@@ -331,6 +331,34 @@ fn metric_delivery_state_survives_exporter_error_wrapping() {
 }
 
 #[test]
+fn metric_export_failure_logging_is_independent_of_diagnostic_capacity() {
+    let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);
+    for index in 0..32 {
+        runtime_diagnostics.record(
+            format!("test.diagnostic.{index}"),
+            "diagnostic capacity filler".to_string(),
+            1,
+        );
+    }
+    let diagnostics = MetricDeliveryDiagnostics::new(
+        "https://collector.example/v1/metrics".to_string(),
+        runtime_diagnostics.clone(),
+    );
+
+    assert_eq!(
+        diagnostics.record_export_failure(&"collector unavailable"),
+        1
+    );
+    assert!(should_relog_runtime_diagnostic(1));
+    assert!(
+        runtime_diagnostics
+            .snapshot()
+            .get("otel.metrics_export_failed")
+            .is_none()
+    );
+}
+
+#[test]
 fn valid_envelope_records_counter_gauge_and_negative_histogram() {
     let (mut processor, exporter, provider) = processor();
     let mut counter = measurement(

--- a/crates/core/tests/unit/observability/otel_metrics_tests.rs
+++ b/crates/core/tests/unit/observability/otel_metrics_tests.rs
@@ -7,6 +7,9 @@ use super::*;
 use crate::api::event::{
     BaseEvent, DataSchema, METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION, MarkEvent,
 };
+use crate::logging::{
+    FileLogSinkConfig, LogFormat, LogLevel, LogSinkConfig, LoggingConfig, init_logging,
+};
 use crate::observability::otel_logs::{OpenTelemetryLogConfig, OpenTelemetryLogSubscriber};
 use opentelemetry_proto::tonic::collector::logs::v1::logs_service_server::{
     LogsService, LogsServiceServer,
@@ -20,7 +23,7 @@ use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     ExportMetricsServiceRequest, ExportMetricsServiceResponse,
 };
-use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader};
 use prost::Message;
 use serde_json::json;
@@ -86,6 +89,29 @@ fn processor() -> (
         exporter,
         provider,
     )
+}
+
+#[derive(Debug)]
+struct FailingMetricExporter;
+
+impl PushMetricExporter for FailingMetricExporter {
+    async fn export(&self, _metrics: &ResourceMetrics) -> OTelSdkResult {
+        Err(opentelemetry_sdk::error::OTelSdkError::InternalFailure(
+            "collector unavailable".to_string(),
+        ))
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn temporality(&self) -> Temporality {
+        Temporality::Cumulative
+    }
 }
 
 #[test]
@@ -332,6 +358,20 @@ fn metric_delivery_state_survives_exporter_error_wrapping() {
 
 #[test]
 fn metric_export_failure_logging_is_independent_of_diagnostic_capacity() {
+    let _logging_lock = crate::logging::lock_test_logging();
+    let temporary_directory = tempfile::tempdir().unwrap();
+    let log_path = temporary_directory.path().join("metric-export.log.jsonl");
+    let runtime = init_logging(&LoggingConfig {
+        level: LogLevel::Error,
+        sinks: vec![LogSinkConfig::File(FileLogSinkConfig {
+            path: log_path.clone(),
+            level: LogLevel::Error,
+            format: LogFormat::Jsonl,
+            ..FileLogSinkConfig::default()
+        })],
+        ..LoggingConfig::default()
+    })
+    .unwrap();
     let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);
     for index in 0..32 {
         runtime_diagnostics.record(
@@ -340,16 +380,34 @@ fn metric_export_failure_logging_is_independent_of_diagnostic_capacity() {
             1,
         );
     }
-    let diagnostics = MetricDeliveryDiagnostics::new(
-        "https://collector.example/v1/metrics".to_string(),
-        runtime_diagnostics.clone(),
-    );
+    let exporter = DiagnosticMetricExporter {
+        inner: FailingMetricExporter,
+        diagnostics: Arc::new(MetricDeliveryDiagnostics::new(
+            "https://collector.example/v1/metrics".to_string(),
+            runtime_diagnostics.clone(),
+        )),
+    };
 
-    assert_eq!(
-        diagnostics.record_export_failure(&"collector unavailable"),
-        1
-    );
-    assert!(should_relog_runtime_diagnostic(1));
+    let result = futures::executor::block_on(exporter.export(&ResourceMetrics::default()));
+    assert!(result.is_err());
+    runtime.logger.flush();
+    let mut contents = String::new();
+    for _ in 0..50 {
+        contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+        if contents.contains("otel_metrics_export_failed") {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    runtime.shutdown();
+
+    let record: serde_json::Value = contents
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .find(|record: &serde_json::Value| record["event"] == "otel_metrics_export_failed")
+        .expect("metric export failure error record");
+    assert_eq!(record["level"], "error");
+    assert_eq!(record["target"], "nemo_relay.observability");
     assert!(
         runtime_diagnostics
             .snapshot()


### PR DESCRIPTION
#### Overview

Report failed OTLP metric exports to the operational error log so operators see collector failures on stderr without enabling debug logging.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Record an `otel_metrics_export_failed` error for the first failed metric export and subsequent power-of-two failure counts.
- Keep logging independent of the bounded runtime-diagnostics store, so a saturated store cannot suppress the first operator-visible error.
- Add regression coverage for the diagnostics-capacity case.

#### Where should the reviewer start?

Start with `DiagnosticMetricExporter::export` in `crates/core/src/observability/otel_metrics.rs`; it records the diagnostic and emits the rate-limited operational error.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metric export failure logging to report errors at configured diagnostic intervals instead of on every failure.
  - Ensured export failure tracking continues reliably even when runtime diagnostic storage is full.
- **Tests**
  - Added regression coverage for export failure handling when diagnostic capacity is exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->