### PR TITLE
fix: identify failed trace exporters safely

### DIFF
--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -212,7 +212,7 @@ fn trace_endpoint_log_identity(endpoint: &str) -> String {
     let Some(host) = endpoint.host_str() else {
         return "an invalid OTLP endpoint".to_string();
     };
-    let host = if host.contains(':') {
+    let host = if host.contains(':') && !host.starts_with('[') {
         format!("[{host}]")
     } else {
         host.to_string()

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -196,6 +196,33 @@ pub fn resolve_http_trace_endpoint(endpoint: &str) -> Cow<'_, str> {
     Cow::Owned(parsed.into())
 }
 
+/// Returns an endpoint identity that is safe to include in delivery failures.
+///
+/// Delivery errors can be written to stderr, so never include an endpoint's
+/// userinfo, path, query, or fragment. HTTP(S) origins remain sufficient to
+/// distinguish independently configured collectors without exposing a token
+/// embedded in a URL.
+fn trace_endpoint_log_identity(endpoint: &str) -> String {
+    let Ok(endpoint) = reqwest::Url::parse(endpoint) else {
+        return "an invalid OTLP endpoint".to_string();
+    };
+    if !matches!(endpoint.scheme(), "http" | "https") {
+        return "an invalid OTLP endpoint".to_string();
+    }
+    let Some(host) = endpoint.host_str() else {
+        return "an invalid OTLP endpoint".to_string();
+    };
+    let host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+    let port = endpoint
+        .port_or_known_default()
+        .expect("HTTP(S) URLs always have a known default port");
+    format!("{}://{host}:{port}", endpoint.scheme())
+}
+
 /// Configuration for the OpenTelemetry subscriber.
 #[derive(Debug, Clone)]
 pub struct OpenTelemetryConfig {
@@ -910,12 +937,19 @@ impl<E: SpanExporter> SpanExporter for CountingSpanExporter<E> {
         self.accepted_spans
             .fetch_add(batch.len() as u64, Ordering::Relaxed);
         let result = self.inner.export(batch).await;
-        if let Err(error) = &result {
-            self.diagnostics.record_export_failure(error);
-        } else {
-            self.diagnostics.record_export_success();
+        match result {
+            Ok(()) => {
+                self.diagnostics.record_export_success();
+                Ok(())
+            }
+            Err(_) => {
+                self.diagnostics.record_export_failure();
+                Err(OTelSdkError::InternalFailure(format!(
+                    "OpenTelemetry trace export to {} failed",
+                    self.diagnostics.endpoint
+                )))
+            }
         }
-        result
     }
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
@@ -942,21 +976,21 @@ struct TraceDeliveryDiagnostics {
 impl TraceDeliveryDiagnostics {
     fn new(endpoint: String, runtime_diagnostics: SignalRuntimeDiagnostics) -> Self {
         Self {
-            endpoint,
+            endpoint: trace_endpoint_log_identity(&endpoint),
             runtime_diagnostics,
             export_failures: AtomicU64::new(0),
             unresolved_export_failure: AtomicBool::new(false),
         }
     }
 
-    fn record_export_failure(&self, error: &impl std::fmt::Display) {
+    fn record_export_failure(&self) {
         self.export_failures.fetch_add(1, Ordering::Relaxed);
         self.unresolved_export_failure
             .store(true, Ordering::Relaxed);
         self.runtime_diagnostics.record(
             "otel.traces_export_failed",
             format!(
-                "OpenTelemetry trace export to endpoint {} failed: {error}",
+                "OpenTelemetry trace export to endpoint {} failed",
                 self.endpoint
             ),
             1,

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -232,6 +232,17 @@ impl SpanExporter for FailingThenRecoveringSpanExporter {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct SensitiveFailingSpanExporter;
+
+impl SpanExporter for SensitiveFailingSpanExporter {
+    async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+        Err(OTelSdkError::InternalFailure(
+            "Authorization: Bearer exporter-secret".to_string(),
+        ))
+    }
+}
+
 fn empty_annotated_response() -> AnnotatedLlmResponse {
     AnnotatedLlmResponse {
         id: None,
@@ -4503,11 +4514,7 @@ fn dropped_spans_are_recorded_in_the_active_plugin_report() {
         diagnostic.field.as_deref(),
         Some("opentelemetry.traces[2].endpoint")
     );
-    assert!(
-        diagnostic
-            .message
-            .contains("https://collector.example/v1/traces")
-    );
+    assert!(diagnostic.message.contains("https://collector.example:443"));
     assert_eq!(
         runtime_diagnostics
             .snapshot()
@@ -4585,12 +4592,8 @@ fn trace_export_failures_are_diagnosed_until_a_later_export_recovers() {
         .get("otel.traces_export_failed")
         .expect("trace export failure diagnostic");
     assert_eq!(diagnostic.count, 1);
-    assert!(
-        diagnostic
-            .message
-            .contains("https://collector.example/v1/traces")
-    );
-    assert!(diagnostic.message.contains("collector unavailable"));
+    assert!(diagnostic.message.contains("https://collector.example:443"));
+    assert!(!diagnostic.message.contains("collector unavailable"));
 
     let repeated_flush = provider.force_flush().unwrap_err();
     assert!(
@@ -4601,6 +4604,53 @@ fn trace_export_failures_are_diagnosed_until_a_later_export_recovers() {
 
     tracer.start("recovery-export").end();
     provider.force_flush().unwrap();
+    provider.shutdown().unwrap();
+}
+
+#[test]
+fn trace_export_failures_use_a_safe_endpoint_identity() {
+    let endpoint = "https://user:password@collector.example:4318/private-path?access_token=url-secret#fragment-secret";
+    let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);
+    let processor = DiagnosticBatchSpanProcessor::new_with_batch_config(
+        SensitiveFailingSpanExporter,
+        endpoint.to_string(),
+        runtime_diagnostics.clone(),
+        BatchConfigBuilder::default()
+            .with_max_export_batch_size(1)
+            .build(),
+    );
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+    let tracer = provider.tracer("safe-trace-export-failure-test");
+
+    tracer.start("export-fails").end();
+    let error = provider.force_flush().unwrap_err().to_string();
+    let diagnostic = runtime_diagnostics
+        .snapshot()
+        .get("otel.traces_export_failed")
+        .expect("trace export failure diagnostic")
+        .message
+        .clone();
+
+    for message in [&error, &diagnostic] {
+        assert!(message.contains("https://collector.example:4318"));
+        for secret in [
+            "user",
+            "password",
+            "private-path",
+            "url-secret",
+            "fragment-secret",
+            "exporter-secret",
+            "Authorization",
+        ] {
+            assert!(
+                !message.contains(secret),
+                "trace export failure leaked {secret:?}: {message}"
+            );
+        }
+    }
+
     provider.shutdown().unwrap();
 }
 
@@ -4655,12 +4705,8 @@ fn unrecovered_trace_export_failure_is_retained_in_the_active_plugin_report() {
         diagnostic.field.as_deref(),
         Some("opentelemetry.traces[2].endpoint")
     );
-    assert!(
-        diagnostic
-            .message
-            .contains("https://collector.example/v1/traces")
-    );
-    assert!(diagnostic.message.contains("collector unavailable"));
+    assert!(diagnostic.message.contains("https://collector.example:443"));
+    assert!(!diagnostic.message.contains("collector unavailable"));
 }
 
 #[test]

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -4608,6 +4608,20 @@ fn trace_export_failures_are_diagnosed_until_a_later_export_recovers() {
 }
 
 #[test]
+fn trace_endpoint_log_identity_redacts_and_validates_urls() {
+    for (endpoint, expected) in [
+        ("not a URL", "an invalid OTLP endpoint"),
+        ("ftp://collector.example/secret", "an invalid OTLP endpoint"),
+        (
+            "https://[::1]:4318/private?access_token=url-secret",
+            "https://[::1]:4318",
+        ),
+    ] {
+        assert_eq!(trace_endpoint_log_identity(endpoint), expected);
+    }
+}
+
+#[test]
 fn trace_export_failures_use_a_safe_endpoint_identity() {
     let endpoint = "https://user:password@collector.example:4318/private-path?access_token=url-secret#fragment-secret";
     let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -4702,6 +4702,10 @@ fn trace_endpoint_log_identity_redacts_and_validates_urls() {
             "https://[::1]:4318/private?access_token=url-secret",
             "https://[::1]:4318",
         ),
+        (
+            "https://user:password@collector.example:4318/private?access_token=url-secret#fragment-secret",
+            "https://collector.example:4318",
+        ),
     ] {
         assert_eq!(trace_endpoint_log_identity(endpoint), expected);
     }

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -295,7 +295,8 @@ For plugin-managed exporters, NeMo Relay also records `otel.spans_dropped` in th
 active plugin report's `runtime_diagnostics`. Its `count` is the exact number
 of dropped spans, `field` identifies the affected
 `opentelemetry.traces[N].endpoint`, and `message` includes the configured
-endpoint URL. If spans were dropped, clearing the plugin returns a delivery
+endpoint origin (scheme, host, and port), without URL credentials, paths, query
+parameters, or fragments. If spans were dropped, clearing the plugin returns a delivery
 failure error and retains the diagnostic for inspection. This error does not
 disable later plugin configuration.
 </Warning>

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -842,7 +842,9 @@ class TestOpenTelemetryTypes:
                 diagnostic = subscriber.runtime_diagnostics().get("otel.traces_export_failed")
                 assert diagnostic is not None
                 assert diagnostic.count == 1
-                assert collector.endpoint in diagnostic.message
+                endpoint_origin = f"http://127.0.0.1:{collector.server.server_port}"
+                assert endpoint_origin in diagnostic.message
+                assert collector.endpoint not in diagnostic.message
 
                 with pytest.raises(RuntimeError, match=r"otel\.traces_export_failed \(1\)"):
                     subscriber.force_flush()


### PR DESCRIPTION
#### Overview

Safely identify OpenTelemetry trace-export delivery failures without propagating sensitive endpoint or exporter-error contents.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Return a stable `scheme://host:port` identity for failed trace exports instead of the raw exporter error.
- Redact endpoint userinfo, paths, query parameters, and fragments from runtime diagnostics and stderr-facing errors.
- Add Rust and Python regression coverage for the redacted error contract, and document the safe endpoint identity.

#### Where should the reviewer start?

Review `crates/core/src/observability/otel.rs`, specifically `CountingSpanExporter::export` and `trace_endpoint_log_identity`. The regression test injects URL and exporter-error secrets to verify neither leaks.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-776](https://linear.app/nvidia/issue/RELAY-776/nemo-relay080-rc2-the-stderr-record-for-a-failed-export)

#### Validation

- Passed: `just test-rust`, `cargo clippy --workspace --all-targets -- -D warnings`, `just test-python`, `just test-node`, and `just docs`.
- `just test-go` has an independently reproducible timeout in `TestObservabilityPluginActivatesDerivedLogsAndExplicitMetrics` while waiting for `/v1/logs`; this change only alters the trace-export error path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenTelemetry export failure diagnostics to prevent sensitive endpoint details and exporter error information from being exposed.
  * Diagnostics now show only the endpoint’s scheme, host, and port.
  * Credentials, paths, queries, fragments, and authorization details are omitted.
  * Invalid endpoints are replaced with a generic label.
  * Export failures now return a consistent internal error message.

* **Documentation**
  * Clarified which endpoint information appears in dropped-span diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->