### PR TITLE
fix(adaptive): emit bypass marks for uncacheable tools

### DIFF
--- a/crates/adaptive/src/response_cache/mark.rs
+++ b/crates/adaptive/src/response_cache/mark.rs
@@ -63,6 +63,8 @@ pub(crate) enum CacheReason {
     StreamNoCodec,
     /// The request body cannot be parsed.
     UnparseableBody,
+    /// The tool's resolved policy does not permit caching.
+    Uncacheable,
     /// Canonical JSON cannot safely represent an integer in the key.
     UnrepresentableNumber,
 }
@@ -81,6 +83,7 @@ impl CacheReason {
             Self::StoreError => "store_error",
             Self::StreamNoCodec => "stream_no_codec",
             Self::UnparseableBody => "unparseable_body",
+            Self::Uncacheable => "uncacheable",
             Self::UnrepresentableNumber => "unrepresentable_number",
         }
     }

--- a/crates/adaptive/src/response_cache/tool.rs
+++ b/crates/adaptive/src/response_cache/tool.rs
@@ -235,6 +235,11 @@ async fn run_tool_cache(
     let policy = resolve_policy(&name, &response_cache, &tools);
 
     if !policy.cacheable {
+        emit_cache_mark(
+            CacheMark::new(CacheMarkStatus::Bypass, store.backend_kind())
+                .surface(CacheSurface::Tool)
+                .reason(CacheReason::Uncacheable),
+        );
         return next(args).await.map(Into::into);
     }
 

--- a/crates/adaptive/tests/integration/response_cache_tests.rs
+++ b/crates/adaptive/tests/integration/response_cache_tests.rs
@@ -1994,14 +1994,55 @@ async fn unclassified_tool_calls_emit_uncacheable_bypasses_and_run_live() {
 
     let captured = Arc::new(StdMutex::new(Vec::<Event>::new()));
     let sink = Arc::clone(&captured);
+    let (bypass_tx, bypass_rx) = tokio::sync::mpsc::unbounded_channel();
+    let bypass_rx = Arc::new(Mutex::new(bypass_rx));
     register_subscriber(
         "response_cache_unclassified_tool_capture",
-        Arc::new(move |event: &Event| sink.lock().unwrap().push(event.clone())),
+        Arc::new(move |event: &Event| {
+            if event.name() == "response_cache"
+                && event
+                    .data()
+                    .and_then(|data| data.get("status"))
+                    .and_then(Json::as_str)
+                    == Some("bypass")
+                && event
+                    .metadata()
+                    .and_then(|metadata| metadata.get("nemo_relay.response_cache.reason"))
+                    .and_then(Json::as_str)
+                    == Some("uncacheable")
+                && event
+                    .metadata()
+                    .and_then(|metadata| metadata.get("nemo_relay.response_cache.surface"))
+                    .and_then(Json::as_str)
+                    == Some("tool")
+            {
+                let _ = bypass_tx.send(());
+            }
+            sink.lock().unwrap().push(event.clone());
+        }),
     )
     .unwrap();
 
     let calls = Arc::new(AtomicUsize::new(0));
-    let tool = counting_tool(Arc::clone(&calls), json!({"written": "pizza"}));
+    let tool: ToolExecutionNextFn = {
+        let calls = Arc::clone(&calls);
+        let bypass_rx = Arc::clone(&bypass_rx);
+        Arc::new(move |_args: Json| {
+            let calls = Arc::clone(&calls);
+            let bypass_rx = Arc::clone(&bypass_rx);
+            Box::pin(async move {
+                let mut bypass_rx = bypass_rx.lock().await;
+                let bypass_seen =
+                    tokio::time::timeout(Duration::from_secs(1), bypass_rx.recv()).await;
+                assert!(
+                    matches!(bypass_seen, Ok(Some(()))),
+                    "the matching bypass mark must be queued before the live callback starts"
+                );
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(json!({"written": "pizza"}).into())
+            })
+        })
+    };
 
     tool_call("write_order", &tool, json!({"item": "pizza"})).await;
     tool_call("write_order", &tool, json!({"item": "pizza"})).await;

--- a/crates/adaptive/tests/integration/response_cache_tests.rs
+++ b/crates/adaptive/tests/integration/response_cache_tests.rs
@@ -1987,6 +1987,66 @@ async fn classified_tool_repeat_is_a_hit_that_skips_the_tool() {
 }
 
 #[tokio::test]
+async fn unclassified_tool_calls_emit_uncacheable_bypasses_and_run_live() {
+    let _guard = TEST_MUTEX.lock().await;
+    reset_global();
+    activate_cache(cache_with_tools(one_cacheable_class(&["docs_lookup"]))).await;
+
+    let captured = Arc::new(StdMutex::new(Vec::<Event>::new()));
+    let sink = Arc::clone(&captured);
+    register_subscriber(
+        "response_cache_unclassified_tool_capture",
+        Arc::new(move |event: &Event| sink.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let tool = counting_tool(Arc::clone(&calls), json!({"written": "pizza"}));
+
+    tool_call("write_order", &tool, json!({"item": "pizza"})).await;
+    tool_call("write_order", &tool, json!({"item": "pizza"})).await;
+    flush_subscribers().unwrap();
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "an unclassified tool must run live on every call"
+    );
+    let events = captured.lock().unwrap();
+    let cache_marks: Vec<_> = events
+        .iter()
+        .filter(|event| event.name() == "response_cache")
+        .map(|event| {
+            (
+                event
+                    .data()
+                    .and_then(|data| data.get("status"))
+                    .and_then(Json::as_str),
+                event
+                    .metadata()
+                    .and_then(|metadata| metadata.get("nemo_relay.response_cache.reason"))
+                    .and_then(Json::as_str),
+                event
+                    .metadata()
+                    .and_then(|metadata| metadata.get("nemo_relay.response_cache.surface"))
+                    .and_then(Json::as_str),
+            )
+        })
+        .collect();
+    assert_eq!(
+        cache_marks,
+        vec![
+            (Some("bypass"), Some("uncacheable"), Some("tool")),
+            (Some("bypass"), Some("uncacheable"), Some("tool")),
+        ],
+        "each unclassified call must emit exactly one ordered bypass decision"
+    );
+
+    drop(events);
+    deregister_subscriber("response_cache_unclassified_tool_capture").unwrap();
+}
+
+#[tokio::test]
 async fn an_effectful_class_is_never_cached() {
     let _guard = TEST_MUTEX.lock().await;
     reset_global();
@@ -2208,6 +2268,21 @@ async fn tool_hit_emits_a_surface_tool_mark_with_saved_invocations() {
     flush_subscribers().unwrap();
 
     let events = captured.lock().unwrap();
+    let cache_statuses: Vec<_> = events
+        .iter()
+        .filter(|event| event.name() == "response_cache")
+        .filter_map(|event| {
+            event
+                .data()
+                .and_then(|data| data.get("status"))
+                .and_then(Json::as_str)
+        })
+        .collect();
+    assert_eq!(
+        cache_statuses,
+        vec!["miss", "hit"],
+        "a cacheable repeat must emit one miss followed by one hit"
+    );
     let hit_mark = events
         .iter()
         .find(|event| {

--- a/crates/adaptive/tests/unit/response_cache/mark_tests.rs
+++ b/crates/adaptive/tests/unit/response_cache/mark_tests.rs
@@ -62,6 +62,7 @@ fn cache_mark_labels_have_stable_telemetry_values() {
         black_box(CacheReason::UnparseableBody).as_str(),
         "unparseable_body"
     );
+    assert_eq!(black_box(CacheReason::Uncacheable).as_str(), "uncacheable");
     assert_eq!(
         black_box(CacheReason::UnrepresentableNumber).as_str(),
         "unrepresentable_number"

--- a/docs/configure-plugins/adaptive/response-cache.mdx
+++ b/docs/configure-plugins/adaptive/response-cache.mdx
@@ -450,17 +450,22 @@ Every cache decision emits a `response_cache` mark with
 | `miss` | No entry was served; the call ran live. After an ordinary lookup miss, Relay attempts to store a cacheable result. |
 | `bypass` | The request is not cacheable, or the `bypass_rate` sampler chose to run live. |
 
-Mark attributes use `nemo_relay.response_cache.*`: `backend`, `surface`,
-`key_hash` (the `sha256:…` fingerprint), `ttl_ms`, and `age_ms` as applicable;
-`saved_tokens` and `saved_cost_usd` appear on LLM hits when they can be
-derived, while `saved_invocations` appears on tool hits. Tool marks use
-`surface = "tool"`; unclassified, uncacheable tools emit a `bypass` mark with
-`reason = "uncacheable"` before the callback runs live. A `reason` appears on
-bypasses and store-error misses (for example `uncacheable`, `sampled`,
-`stateful_store`, `store_error`, or `stream_no_codec`). Cache marks
-never include prompts, answers, or credentials, but treat `key_hash` as
-sensitive telemetry: a hash can still reveal information when an observer can
-guess the keyed input.
+Cache mark attributes use `nemo_relay.response_cache.*`. They can include
+`backend`, `surface`, `key_hash`, `ttl_ms`, and `age_ms`. LLM hit marks can also
+include `saved_tokens` and `saved_cost_usd`. Tool hit marks can include
+`saved_invocations`.
+
+Tool marks use `surface = "tool"`. Unclassified tools that use the default
+policy and explicitly uncacheable tools emit a `bypass` mark with
+`reason = "uncacheable"` before Relay runs the tool.
+
+Other bypass reasons include `sampled`, `stateful_store`, and
+`stream_no_codec`. A failed cache-store operation produces a `miss` with
+`reason = "store_error"`.
+
+Cache marks do not contain prompts, answers, or credentials. Treat `key_hash`
+as sensitive because an observer might identify an input by guessing and
+hashing it.
 
 `nemo-relay doctor` reports the cache state: `not configured` when the section
 is absent, `configured but disabled (adaptive plugin disabled)` when the

--- a/docs/configure-plugins/adaptive/response-cache.mdx
+++ b/docs/configure-plugins/adaptive/response-cache.mdx
@@ -454,9 +454,10 @@ Mark attributes use `nemo_relay.response_cache.*`: `backend`, `surface`,
 `key_hash` (the `sha256:…` fingerprint), `ttl_ms`, and `age_ms` as applicable;
 `saved_tokens` and `saved_cost_usd` appear on LLM hits when they can be
 derived, while `saved_invocations` appears on tool hits. Tool marks use
-`surface = "tool"`; unclassified, uncacheable tools pass through without a
-cache mark. A `reason` appears on bypasses and store-error misses (for example
-`sampled`, `stateful_store`, `store_error`, or `stream_no_codec`). Cache marks
+`surface = "tool"`; unclassified, uncacheable tools emit a `bypass` mark with
+`reason = "uncacheable"` before the callback runs live. A `reason` appears on
+bypasses and store-error misses (for example `uncacheable`, `sampled`,
+`stateful_store`, `store_error`, or `stream_no_codec`). Cache marks
 never include prompts, answers, or credentials, but treat `key_hash` as
 sensitive telemetry: a hash can still reveal information when an observer can
 guess the keyed input.


### PR DESCRIPTION
#### Overview

Unclassified tools already bypass the response cache and execute live, but that decision did not emit an ATOF `response_cache` mark. This change emits one `bypass` mark with `surface = "tool"` and `reason = "uncacheable"` before the live tool callback runs.

Existing response-cache behavior is preserved: uncacheable tools still run live on every call, while cacheable tools continue to emit their existing miss and hit marks.

- [ ] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [ ] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Adds the stable `uncacheable` response-cache reason.
- Emits the mark on the resolved non-cacheable tool path without changing callback execution or error propagation.
- Adds regression coverage proving each unclassified tool call emits exactly one ordered bypass mark and still runs live.
- Strengthens existing cacheable-tool coverage to verify the normal `miss` followed by `hit` ordering.
- Updates the response-cache documentation to describe the emitted mark.

Validation:

- `cargo test -p nemo-relay-adaptive response_cache::mark::tests::cache_mark_labels_have_stable_telemetry_values -- --exact` — passed.
- `cargo test -p nemo-relay-adaptive --test response_cache_integration unclassified_tool_calls_emit_uncacheable_bypasses_and_run_live -- --exact` — passed.
- `cargo test -p nemo-relay-adaptive --test response_cache_integration tool_hit_emits_a_surface_tool_mark_with_saved_invocations -- --exact` — passed.
- `cargo test -p nemo-relay-adaptive --test response_cache_integration` — passed all 49 tests.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- File-scoped pre-commit checks — passed.
- `just docs` — passed; the optional external redirects comparison was skipped after its source returned HTTP 403.
- `just test-rust` — adaptive targets completed, but the broader suite later failed in an unrelated `nemo-relay-cli --lib` test.
- Repository-wide pre-commit — all hooks passed except the attribution generator, which reported an unrelated `ATTRIBUTIONS-Rust.md` metadata difference without a `Cargo.lock` change.

#### Where should the reviewer start?

Start with [`crates/adaptive/src/response_cache/tool.rs`](crates/adaptive/src/response_cache/tool.rs), where the non-cacheable policy branch emits the mark before running the live callback. The regression behavior is covered in [`crates/adaptive/tests/integration/response_cache_tests.rs`](crates/adaptive/tests/integration/response_cache_tests.rs).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [RELAY-780](https://linear.app/nvidia/issue/RELAY-780/nemo-relay080-rc2response-cache-atof-mark-not-emitted-on-bypass-for)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `uncacheable` cache-bypass reason to response metadata.
  - Uncacheable tools now report bypass events with tool-surface details.

- **Bug Fixes**
  - Unclassified tools now execute live on every invocation instead of using cached responses.
  - Cacheable tool requests now accurately report miss and hit events.

- **Documentation**
  - Clarified cache-mark attributes, bypass reasons, uncacheable tool behavior, and input-identifying metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->