### PR TITLE
docs: repair stable plugin-guide redirects

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -119,20 +119,22 @@ redirects:
 # Build plugin guides
 - source: /nemo/relay/build-plugins/basic-guide
   destination: /nemo/relay/build-plugins/language-binding/about
+# The replacement plugin-authoring guides are not yet published to stable.
+# Keep legacy public routes on the last stable guide set until that release.
 - source: /nemo/relay/build-plugins/dynamic-plugins/about
-  destination: /nemo/relay/build-plugins/package-discoverable-plugins
+  destination: /nemo/relay/v0.7.3/build-plugins/dynamic-plugins/about
 - source: /nemo/relay/build-plugins/dynamic-plugins/native-dynamic/about
-  destination: /nemo/relay/build-plugins/native/about
+  destination: /nemo/relay/v0.7.3/build-plugins/dynamic-plugins/native-dynamic/about
 - source: /nemo/relay/build-plugins/dynamic-plugins/native-dynamic/rust-native-plugin-example
-  destination: /nemo/relay/build-plugins/native/build-and-package
+  destination: /nemo/relay/v0.7.3/build-plugins/dynamic-plugins/native-dynamic/rust-native-plugin-example
 - source: /nemo/relay/build-plugins/dynamic-plugins/grpc-worker/about
-  destination: /nemo/relay/build-plugins/workers/about
+  destination: /nemo/relay/v0.7.3/build-plugins/dynamic-plugins/grpc-worker/about
 - source: /nemo/relay/build-plugins/dynamic-plugins/grpc-worker/python/about
-  destination: /nemo/relay/build-plugins/workers/python
+  destination: /nemo/relay/v0.7.3/build-plugins/dynamic-plugins/grpc-worker/python/about
 - source: /nemo/relay/build-plugins/dynamic-plugins/grpc-worker/rust/about
-  destination: /nemo/relay/build-plugins/workers/rust
+  destination: /nemo/relay/v0.7.3/build-plugins/dynamic-plugins/grpc-worker/rust/about
 - source: /nemo/relay/build-plugins/dynamic-plugins/grpc-worker/grpc-worker-protocol
-  destination: /nemo/relay/build-plugins/workers/grpc-v1-protocol
+  destination: /nemo/relay/v0.7.3/build-plugins/dynamic-plugins/grpc-worker/grpc-worker-protocol
 
 # CLI guides
 - source: /nemo/relay/nemo-relay-cli/cursor


### PR DESCRIPTION
#### Overview

Restore the seven shared legacy plugin-guide redirects to the current stable documentation set, preventing production links from reaching unpublished replacement pages.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Retarget all seven dynamic-plugin legacy routes to their verified `v0.7.3` equivalents.
- Document that the redirects are temporary until the replacement guide tree is published as stable.

#### Where should the reviewer start?

Review the build-plugin redirect block in `fern/docs.yml`; all seven targets resolve in the currently published stable documentation set.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated legacy build-plugin documentation links to point to the NeMo Relay v0.7.3 guides.
  * Added guidance indicating that replacement plugin-authoring documentation is still being finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->