### PR TITLE
fix: reject ambiguous Gemini function call IDs

### DIFF
--- a/crates/core/src/codec/gemini_generate_content.rs
+++ b/crates/core/src/codec/gemini_generate_content.rs
@@ -5,8 +5,13 @@
 //!
 //! Implements [`LlmCodec`] (request decode/encode) and [`LlmResponseCodec`]
 //! (response decode) for the Gemini generateContent API format.
+//!
+//! Gemini function-call IDs are normalized as tool-call IDs and echoed in
+//! `functionResponse.id`. For legacy responses that omit an ID, the codec uses
+//! the function name only when it is unambiguous; duplicate effective IDs are
+//! rejected because their function responses cannot be correlated safely.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::Deserialize;
 
@@ -231,6 +236,20 @@ fn parse_optional_id(obj: &serde_json::Map<String, Json>, context: &str) -> Resu
     }
 }
 
+/// Reject an ID that would make function-call correlation ambiguous in one Gemini content item.
+fn ensure_unique_gemini_function_id(
+    seen_ids: &mut HashSet<String>,
+    id: &str,
+    part_kind: &str,
+) -> Result<()> {
+    if seen_ids.insert(id.to_string()) {
+        return Ok(());
+    }
+    Err(FlowError::InvalidArgument(format!(
+        "Gemini {part_kind} parts have duplicate effective id '{id}'; distinct ids are required to correlate function responses"
+    )))
+}
+
 fn is_gemini_part_data_key(key: &str) -> bool {
     matches!(
         key,
@@ -417,6 +436,7 @@ fn extract_parts_message_content(parts: &[Json]) -> Result<Option<MessageContent
 /// parts are skipped; callers must validate text+functionCall conflicts separately.
 fn extract_parts_tool_calls(parts: &[Json]) -> Result<Option<Vec<ResponseToolCall>>> {
     let mut calls: Vec<ResponseToolCall> = Vec::new();
+    let mut seen_ids = HashSet::new();
     for p in parts {
         let Some(fc) = p.get("functionCall") else {
             continue;
@@ -446,6 +466,7 @@ fn extract_parts_tool_calls(parts: &[Json]) -> Result<Option<Vec<ResponseToolCal
 
         let id =
             parse_optional_id(fc_obj, "response functionCall")?.unwrap_or_else(|| name.clone());
+        ensure_unique_gemini_function_id(&mut seen_ids, &id, "functionCall")?;
 
         let arguments = match fc_obj.get("args") {
             None => Json::Object(Default::default()),
@@ -728,6 +749,7 @@ fn gemini_function_response_messages(parts: &[Json], responses: &[&Json]) -> Res
             "Gemini contents item must not mix functionResponse with visible/native parts".into(),
         ));
     }
+    let mut seen_ids = HashSet::new();
     responses
         .iter()
         .map(|part| {
@@ -741,6 +763,7 @@ fn gemini_function_response_messages(parts: &[Json], responses: &[&Json]) -> Res
                 .unwrap()
                 .to_string();
             let id = parse_optional_id(response, "functionResponse")?.unwrap_or(name);
+            ensure_unique_gemini_function_id(&mut seen_ids, &id, "functionResponse")?;
             Ok(Message::Tool {
                 content: gemini_function_response_to_message_content(
                     part.get("functionResponse").unwrap(),
@@ -755,12 +778,14 @@ fn gemini_function_call_messages(
     content: Option<MessageContent>,
     calls: &[&Json],
 ) -> Result<Vec<Message>> {
+    let mut seen_ids = HashSet::new();
     let tool_calls = calls
         .iter()
         .map(|part| {
             let call = part.get("functionCall").and_then(Json::as_object).unwrap();
             let name = call.get("name").and_then(Json::as_str).unwrap().to_string();
             let id = parse_optional_id(call, "functionCall")?.unwrap_or_else(|| name.clone());
+            ensure_unique_gemini_function_id(&mut seen_ids, &id, "functionCall")?;
             let args = call
                 .get("args")
                 .cloned()

--- a/crates/core/tests/unit/codec/gemini_generate_content_tests.rs
+++ b/crates/core/tests/unit/codec/gemini_generate_content_tests.rs
@@ -487,6 +487,43 @@ fn test_gemini_response_function_call_extraction_validates_shape_and_id_fallback
 }
 
 #[test]
+fn test_gemini_function_call_decoders_reject_duplicate_effective_ids() {
+    let duplicate_idless_calls = [
+        json!({"functionCall": {"name": "search", "args": {"q": "dogs"}}}),
+        json!({"functionCall": {"name": "search", "args": {"q": "cats"}}}),
+    ];
+    assert!(extract_parts_tool_calls(&duplicate_idless_calls).is_err());
+    assert!(
+        gemini_function_call_messages(
+            None,
+            &[&duplicate_idless_calls[0], &duplicate_idless_calls[1]]
+        )
+        .is_err()
+    );
+
+    let duplicate_explicit_calls = [
+        json!({"functionCall": {"id": "call_1", "name": "search", "args": {"q": "dogs"}}}),
+        json!({"functionCall": {"id": "call_1", "name": "search", "args": {"q": "cats"}}}),
+    ];
+    assert!(extract_parts_tool_calls(&duplicate_explicit_calls).is_err());
+
+    let duplicate_idless_responses = [
+        json!({"functionResponse": {"name": "search", "response": {"result": "dogs"}}}),
+        json!({"functionResponse": {"name": "search", "response": {"result": "cats"}}}),
+    ];
+    assert!(
+        gemini_function_response_messages(
+            &duplicate_idless_responses,
+            &[
+                &duplicate_idless_responses[0],
+                &duplicate_idless_responses[1]
+            ],
+        )
+        .is_err()
+    );
+}
+
+#[test]
 fn test_gemini_provider_native_part_validation_and_tool_payload_conversion() {
     let valid = json!({
         "type": "provider_native",

--- a/docs/about-nemo-relay/concepts/codecs.mdx
+++ b/docs/about-nemo-relay/concepts/codecs.mdx
@@ -115,6 +115,20 @@ A provider-native component can only be encoded by the provider API named
 in its `provider` field. Provider mismatches and portable edits that the target
 API cannot represent fail before the provider callback.
 
+### Gemini Function-Call Correlation
+
+For Gemini `generateContent`, the codec maps a provider `functionCall.id` to
+the normalized tool-call ID and echoes that same value in the matching
+`functionResponse.id`. This preserves Gemini's call-to-result correlation for
+parallel function calls.
+
+Older Gemini payloads can omit `functionCall.id`. In that case, the codec uses
+the function name as a compatibility fallback only when it is unique within the
+content item. Payloads with duplicate effective IDs, including two id-less
+calls to the same function, fail decoding because their function responses
+cannot be correlated safely. Use the exact Gemini function-call ID whenever the
+provider supplies one.
+
 ### Preservation Is Not Semantic Support
 
 Provider APIs can add fields or change semantics before Relay's built-in codecs


### PR DESCRIPTION
#### Overview

Reject Gemini function-call batches that cannot be correlated safely because their effective IDs collide.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Preserve the legacy function-name fallback for a single id-less call.
- Reject duplicate effective IDs for decoded function calls and function responses.
- Document the correlation rule and add regression coverage for id-less and explicit-ID collisions.

#### Where should the reviewer start?

Start with `crates/core/src/codec/gemini_generate_content.rs`, where all Gemini function-call decode paths share the duplicate-ID validation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Gemini function-call handling by detecting and rejecting duplicate identifiers.
  - Added validation for duplicate explicit IDs and IDs derived from function names.
  - Prevented ambiguous function responses from being incorrectly correlated.

- **Documentation**
  - Documented how Gemini function-call and function-response IDs are preserved, matched, and derived when unavailable.

- **Tests**
  - Added coverage for duplicate identifier scenarios during request and response decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->