### PR TITLE
docs: document OTLP partial-success limitation

### DIFF
--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -137,6 +137,11 @@ for destination paths and explicit-file alternatives.
 
 ## Known Issues in 0.8
 
+- OTLP collectors can return a successful response while rejecting individual
+  spans, log records, or metric data points. Relay 0.8 does not report these
+  partial successes in runtime diagnostics, and flush or shutdown can still
+  succeed. Monitor collector-side rejection metrics and logs; see
+  [OpenTelemetry](/configure-plugins/observability/opentelemetry#trace-batch-processor-configuration).
 - Go and the raw C FFI remain experimental and source-first. Generated API
   pages focus on Rust, Python, and Node.js.
 - Local coding-agent observability depends on host hooks and provider traffic

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -303,6 +303,15 @@ processor export timeout; use the endpoint's `timeout_millis` to bound each
 OTLP request.
 
 <Warning>
+**Known limitation: OTLP partial success is not reported.** A collector can
+return a successful OTLP response while rejecting individual spans, log
+records, or metric data points. With the vendored OpenTelemetry exporter,
+Relay treats that response as successful: it does not add a runtime diagnostic,
+and `force_flush()` and `shutdown()` can succeed. Monitor collector-side logs
+and rejection metrics when investigating missing telemetry.
+</Warning>
+
+<Warning>
 A full queue drops completed spans instead of applying backpressure to
 application work. Bursts can therefore drop spans that finish late, including
 an enclosing root span, and leave an incomplete trace in the backend.


### PR DESCRIPTION
#### Overview

Document the current OTLP collector partial-success observability gap in the 0.8 user documentation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add a known-limitation warning to the OTLP guide.
- Add the limitation to the 0.8 release notes' known issues and link to the guide.

#### Where should the reviewer start?

Start with the 0.8 known-issues entry, then follow its link to the OTLP guide for the detailed behavior and mitigation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance about a known issue where OTLP collectors may partially reject telemetry even when responses indicate success.
  * Clarified that Relay does not currently report these rejections or fail flush and shutdown operations.
  * Documented that collector logs and rejection metrics are needed to identify missing telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->