### PR TITLE
refactor: always include plugin component ordinals

### DIFF
--- a/crates/core/src/api/registry.rs
+++ b/crates/core/src/api/registry.rs
@@ -139,8 +139,9 @@ fn registration_identity(
     kind: RuntimeRegistrationKind,
     effective_name: &str,
 ) -> RuntimeRegistrationIdentity {
-    const PREFIX: &str = "__nemo_relay_plugin__";
-    let Some(rest) = effective_name.strip_prefix(PREFIX) else {
+    let Some((plugin_kind, component_ordinal, local_name)) =
+        crate::plugin::decode_plugin_component_effective_name(effective_name)
+    else {
         return RuntimeRegistrationIdentity {
             kind,
             local_name: effective_name.to_string(),
@@ -152,17 +153,6 @@ fn registration_identity(
             },
         };
     };
-    let mut pieces = rest.split("__");
-    let plugin_kind = pieces.next().unwrap_or_default().to_string();
-    let second = pieces.next().unwrap_or_default();
-    let (component_ordinal, local_name) = match second.parse::<u32>() {
-        Ok(ordinal) => (Some(ordinal), pieces.collect::<Vec<_>>().join("__")),
-        Err(_) => {
-            let mut local = vec![second];
-            local.extend(pieces);
-            (None, local.join("__"))
-        }
-    };
     RuntimeRegistrationIdentity {
         kind,
         local_name,
@@ -170,7 +160,7 @@ fn registration_identity(
         owner: RuntimeRegistrationOwner {
             kind: RuntimeRegistrationOwnerKind::Plugin,
             plugin_kind: Some(plugin_kind),
-            component_ordinal,
+            component_ordinal: Some(component_ordinal),
         },
     }
 }

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -407,7 +407,12 @@ impl PluginRegistration {
 #[derive(Default)]
 pub struct PluginRegistrationContext {
     registrations: Vec<PluginRegistration>,
-    namespace: Option<String>,
+    namespace: Option<PluginRegistrationNamespace>,
+}
+
+enum PluginRegistrationNamespace {
+    Plain(String),
+    PluginComponent(String),
 }
 
 impl PluginRegistrationContext {
@@ -420,7 +425,38 @@ impl PluginRegistrationContext {
     pub fn with_namespace(namespace: impl Into<String>) -> Self {
         Self {
             registrations: vec![],
-            namespace: Some(namespace.into()),
+            namespace: Some(PluginRegistrationNamespace::Plain(namespace.into())),
+        }
+    }
+
+    fn with_plugin_component_namespace(namespace: String) -> Self {
+        Self {
+            registrations: vec![],
+            namespace: Some(PluginRegistrationNamespace::PluginComponent(namespace)),
+        }
+    }
+
+    /// Creates a child context that extends this context's namespace.
+    ///
+    /// Child contexts preserve Relay-created plugin component qualification so
+    /// their local namespace segments and registration names remain encoded as
+    /// one effective component name.
+    pub fn with_child_namespace(&self, local_namespace: &str) -> Self {
+        let namespace = match &self.namespace {
+            Some(PluginRegistrationNamespace::Plain(namespace)) => {
+                PluginRegistrationNamespace::Plain(format!("{namespace}{local_namespace}"))
+            }
+            Some(PluginRegistrationNamespace::PluginComponent(namespace)) => {
+                PluginRegistrationNamespace::PluginComponent(format!(
+                    "{namespace}{}",
+                    encode_plugin_component_field(local_namespace)
+                ))
+            }
+            None => PluginRegistrationNamespace::Plain(local_namespace.to_string()),
+        };
+        Self {
+            registrations: vec![],
+            namespace: Some(namespace),
         }
     }
 
@@ -431,9 +467,19 @@ impl PluginRegistrationContext {
     /// not have to provide component instance ids.
     pub fn qualify_name(&self, name: &str) -> String {
         match &self.namespace {
-            Some(namespace) => format!("{namespace}{name}"),
+            Some(PluginRegistrationNamespace::Plain(namespace)) => format!("{namespace}{name}"),
+            Some(PluginRegistrationNamespace::PluginComponent(namespace)) => {
+                format!("{namespace}{}", encode_plugin_component_field(name))
+            }
             None => name.to_string(),
         }
+    }
+
+    pub(crate) fn uses_plugin_component_namespace(&self) -> bool {
+        matches!(
+            &self.namespace,
+            Some(PluginRegistrationNamespace::PluginComponent(_))
+        )
     }
 
     /// Registers an event subscriber and records its rollback closure.
@@ -2724,7 +2770,7 @@ struct PendingPluginRegistrationContext {
 impl PendingPluginRegistrationContext {
     fn new(namespace: String, rollback_failures: Option<Arc<Mutex<Vec<String>>>>) -> Self {
         Self {
-            context: PluginRegistrationContext::with_namespace(namespace),
+            context: PluginRegistrationContext::with_plugin_component_namespace(namespace),
             rollback_failures,
         }
     }
@@ -2800,7 +2846,85 @@ fn plugin_component_totals(config: &PluginConfig) -> HashMap<&str, usize> {
 }
 
 fn component_namespace(kind: &str, ordinal: usize) -> String {
-    format!("__nemo_relay_plugin__{kind}__{ordinal}__")
+    assert!(ordinal > 0, "plugin component ordinals are one-based");
+    format!(
+        "nemo-relay-plugin.v1.{}:{ordinal}:",
+        encode_plugin_component_field(kind)
+    )
+}
+
+pub(crate) fn encode_plugin_component_field(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX[(byte >> 4) as usize]));
+            encoded.push(char::from(HEX[(byte & 0x0f) as usize]));
+        }
+    }
+    encoded
+}
+
+pub(crate) fn decode_plugin_component_effective_name(
+    effective_name: &str,
+) -> Option<(String, u32, String)> {
+    const PREFIX: &str = "nemo-relay-plugin.v1.";
+
+    let rest = effective_name.strip_prefix(PREFIX)?;
+    let (encoded_kind, rest) = rest.split_once(':')?;
+    let (ordinal_text, encoded_local_name) = rest.split_once(':')?;
+    let ordinal = ordinal_text
+        .parse::<u32>()
+        .ok()
+        .filter(|ordinal| *ordinal > 0)?;
+    if ordinal.to_string() != ordinal_text {
+        return None;
+    }
+    let plugin_kind = decode_plugin_component_field(encoded_kind)?;
+    let local_name = decode_plugin_component_field(encoded_local_name)?;
+    (!plugin_kind.is_empty() && !local_name.is_empty()).then_some((
+        plugin_kind,
+        ordinal,
+        local_name,
+    ))
+}
+
+fn decode_plugin_component_field(encoded: &str) -> Option<String> {
+    let mut bytes = Vec::with_capacity(encoded.len());
+    let encoded = encoded.as_bytes();
+    let mut index = 0;
+
+    while index < encoded.len() {
+        let byte = encoded[index];
+        if byte == b'%' {
+            let high = *encoded.get(index + 1)?;
+            let low = *encoded.get(index + 2)?;
+            bytes.push((hex_value(high)? << 4) | hex_value(low)?);
+            index += 3;
+        } else if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            bytes.push(byte);
+            index += 1;
+        } else {
+            return None;
+        }
+    }
+
+    let decoded = String::from_utf8(bytes).ok()?;
+    (encode_plugin_component_field(&decoded) == std::str::from_utf8(encoded).ok()?)
+        .then_some(decoded)
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    }
 }
 
 fn validate_plugin_multiplicity(report: &mut ConfigReport, config: &PluginConfig) {

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -2653,7 +2653,6 @@ async fn initialize_plugin_components(
     rollback_failures: Option<Arc<Mutex<Vec<String>>>>,
 ) -> Result<Vec<PluginRegistration>> {
     ensure_builtin_plugins_registered()?;
-    let totals = plugin_component_totals(config);
     let mut ordinals: HashMap<&str, usize> = HashMap::new();
     let mut registrations = PendingPluginRegistrations::new(rollback_failures.clone());
 
@@ -2673,11 +2672,7 @@ async fn initialize_plugin_components(
             .entry(component.kind.as_str())
             .and_modify(|value| *value += 1)
             .or_insert(1);
-        let namespace = component_namespace(
-            &component.kind,
-            *ordinal,
-            totals.get(component.kind.as_str()).copied().unwrap_or(1),
-        );
+        let namespace = component_namespace(&component.kind, *ordinal);
 
         let mut pending =
             PendingPluginRegistrationContext::new(namespace, rollback_failures.clone());
@@ -2804,12 +2799,8 @@ fn plugin_component_totals(config: &PluginConfig) -> HashMap<&str, usize> {
     totals
 }
 
-fn component_namespace(kind: &str, ordinal: usize, total: usize) -> String {
-    if total > 1 {
-        format!("__nemo_relay_plugin__{kind}__{ordinal}__")
-    } else {
-        format!("__nemo_relay_plugin__{kind}__")
-    }
+fn component_namespace(kind: &str, ordinal: usize) -> String {
+    format!("__nemo_relay_plugin__{kind}__{ordinal}__")
 }
 
 fn validate_plugin_multiplicity(report: &mut ConfigReport, config: &PluginConfig) {

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -529,6 +529,7 @@ struct NativeHostPluginContext {
 
 struct NativeHostPluginRuntime {
     namespace: String,
+    encode_local_names: bool,
     active: AtomicBool,
     gates: Mutex<HashMap<String, NativeOwnedGate>>,
 }
@@ -3935,9 +3936,11 @@ unsafe extern "C" fn native_plugin_context_runtime(
         Ok(ctx) => ctx,
         Err(status) => return status,
     };
-    let namespace = unsafe { &*host_ctx.ctx }.qualify_name("");
+    let context = unsafe { &*host_ctx.ctx };
+    let namespace = context.qualify_name("");
     let runtime = Arc::new(NativeHostPluginRuntime {
         namespace,
+        encode_local_names: context.uses_plugin_component_namespace(),
         active: AtomicBool::new(true),
         gates: Mutex::new(HashMap::new()),
     });
@@ -4060,7 +4063,15 @@ unsafe extern "C" fn native_plugin_runtime_register_conditional_middleware_guard
         return NemoRelayStatus::AlreadyExists;
     }
     let handle = format!("gate-{}", Uuid::now_v7());
-    let qualified_name = format!("{}{}", runtime.namespace, local_name);
+    let qualified_name = if runtime.encode_local_names {
+        format!(
+            "{}{}",
+            runtime.namespace,
+            crate::plugin::encode_plugin_component_field(&local_name)
+        )
+    } else {
+        format!("{}{}", runtime.namespace, local_name)
+    };
     if let Err(error) = register_conditional_middleware_guardrail(
         &qualified_name,
         kinds,

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -6736,7 +6736,7 @@ async fn test_runtime_registration_discovery_and_cross_owner_subscriber_gate() {
     setup_isolated_thread();
 
     let mut context =
-        PluginRegistrationContext::with_namespace("__nemo_relay_plugin__observability__");
+        PluginRegistrationContext::with_namespace("__nemo_relay_plugin__observability__1__");
     let deliveries = Arc::new(AtomicU32::new(0));
     let captured_deliveries = Arc::clone(&deliveries);
     context
@@ -6757,7 +6757,7 @@ async fn test_runtime_registration_discovery_and_cross_owner_subscriber_gate() {
     assert_eq!(registration.kind, RuntimeRegistrationKind::Subscriber);
     assert_eq!(
         registration.effective_name,
-        "__nemo_relay_plugin__observability__opentelemetry"
+        "__nemo_relay_plugin__observability__1__opentelemetry"
     );
     assert_eq!(
         registration.owner.kind,
@@ -6767,6 +6767,7 @@ async fn test_runtime_registration_discovery_and_cross_owner_subscriber_gate() {
         registration.owner.plugin_kind.as_deref(),
         Some("observability")
     );
+    assert_eq!(registration.owner.component_ordinal, Some(1));
 
     register_conditional_middleware_guardrail(
         "external_observability_gate",

--- a/crates/core/tests/integration/middleware_tests.rs
+++ b/crates/core/tests/integration/middleware_tests.rs
@@ -6736,7 +6736,7 @@ async fn test_runtime_registration_discovery_and_cross_owner_subscriber_gate() {
     setup_isolated_thread();
 
     let mut context =
-        PluginRegistrationContext::with_namespace("__nemo_relay_plugin__observability__1__");
+        PluginRegistrationContext::with_namespace("nemo-relay-plugin.v1.observability:1:");
     let deliveries = Arc::new(AtomicU32::new(0));
     let captured_deliveries = Arc::clone(&deliveries);
     context
@@ -6757,7 +6757,7 @@ async fn test_runtime_registration_discovery_and_cross_owner_subscriber_gate() {
     assert_eq!(registration.kind, RuntimeRegistrationKind::Subscriber);
     assert_eq!(
         registration.effective_name,
-        "__nemo_relay_plugin__observability__1__opentelemetry"
+        "nemo-relay-plugin.v1.observability:1:opentelemetry"
     );
     assert_eq!(
         registration.owner.kind,

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -1511,7 +1511,7 @@ fn opentelemetry_endpoint_header_env_rejects_missing_and_duplicate_headers() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__opentelemetry")
+            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }
@@ -1547,7 +1547,7 @@ fn invalid_log_endpoint_keeps_valid_signal_subscriber() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__opentelemetry")
+            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }
@@ -1583,7 +1583,7 @@ fn invalid_metric_endpoint_keeps_valid_signal_subscriber() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__opentelemetry")
+            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }
@@ -1635,7 +1635,7 @@ fn malformed_derived_signal_endpoint_keeps_valid_peers() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__opentelemetry")
+            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }
@@ -2576,7 +2576,7 @@ fn atof_enabled_writes_jsonl_and_teardown_flushes() {
             .keys()
             .cloned()
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["__nemo_relay_plugin__observability__atof"]);
+        assert_eq!(names, vec!["__nemo_relay_plugin__observability__1__atof"]);
     }
 
     let agent = push_agent("atof-agent");
@@ -3703,11 +3703,11 @@ fn otlp_sections_register_inferred_subscribers_with_full_config() {
         .keys()
         .cloned()
         .collect::<Vec<_>>();
-    assert!(names.contains(&"__nemo_relay_plugin__observability__opentelemetry".to_string()));
+    assert!(names.contains(&"__nemo_relay_plugin__observability__1__opentelemetry".to_string()));
     assert_eq!(
         names
             .iter()
-            .filter(|name| *name == "__nemo_relay_plugin__observability__opentelemetry")
+            .filter(|name| *name == "__nemo_relay_plugin__observability__1__opentelemetry")
             .count(),
         1
     );
@@ -3918,7 +3918,7 @@ fn opentelemetry_rejects_canonical_collision_during_validation_and_activation() 
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__opentelemetry")
+            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
     );
 }
 
@@ -3994,7 +3994,7 @@ fn invalid_later_opentelemetry_endpoint_keeps_fanout_registration() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__opentelemetry")
+            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -1511,7 +1511,7 @@ fn opentelemetry_endpoint_header_env_rejects_missing_and_duplicate_headers() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
+            .contains_key("nemo-relay-plugin.v1.observability:1:opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }
@@ -1547,7 +1547,7 @@ fn invalid_log_endpoint_keeps_valid_signal_subscriber() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
+            .contains_key("nemo-relay-plugin.v1.observability:1:opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }
@@ -1583,7 +1583,7 @@ fn invalid_metric_endpoint_keeps_valid_signal_subscriber() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
+            .contains_key("nemo-relay-plugin.v1.observability:1:opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }
@@ -1635,7 +1635,7 @@ fn malformed_derived_signal_endpoint_keeps_valid_peers() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
+            .contains_key("nemo-relay-plugin.v1.observability:1:opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }
@@ -2576,7 +2576,7 @@ fn atof_enabled_writes_jsonl_and_teardown_flushes() {
             .keys()
             .cloned()
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["__nemo_relay_plugin__observability__1__atof"]);
+        assert_eq!(names, vec!["nemo-relay-plugin.v1.observability:1:atof"]);
     }
 
     let agent = push_agent("atof-agent");
@@ -3703,11 +3703,11 @@ fn otlp_sections_register_inferred_subscribers_with_full_config() {
         .keys()
         .cloned()
         .collect::<Vec<_>>();
-    assert!(names.contains(&"__nemo_relay_plugin__observability__1__opentelemetry".to_string()));
+    assert!(names.contains(&"nemo-relay-plugin.v1.observability:1:opentelemetry".to_string()));
     assert_eq!(
         names
             .iter()
-            .filter(|name| *name == "__nemo_relay_plugin__observability__1__opentelemetry")
+            .filter(|name| *name == "nemo-relay-plugin.v1.observability:1:opentelemetry")
             .count(),
         1
     );
@@ -3918,7 +3918,7 @@ fn opentelemetry_rejects_canonical_collision_during_validation_and_activation() 
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
+            .contains_key("nemo-relay-plugin.v1.observability:1:opentelemetry")
     );
 }
 
@@ -3994,7 +3994,7 @@ fn invalid_later_opentelemetry_endpoint_keeps_fanout_registration() {
             .read()
             .unwrap()
             .event_subscribers
-            .contains_key("__nemo_relay_plugin__observability__1__opentelemetry")
+            .contains_key("nemo-relay-plugin.v1.observability:1:opentelemetry")
     );
     clear_plugin_configuration().unwrap();
 }

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -15,7 +15,9 @@ use tokio::sync::Notify;
 use crate::api::event::{BaseEvent, Event, MarkEvent};
 use crate::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 use crate::api::llm::{llm_conditional_execution, llm_request_intercepts};
-use crate::api::registry::{RuntimeRegistrationKind, list_runtime_registrations};
+use crate::api::registry::{
+    RuntimeRegistrationKind, RuntimeRegistrationOwnerKind, list_runtime_registrations,
+};
 use crate::api::runtime::global_context;
 use crate::api::runtime::{LlmJsonStream, NemoRelayContextState};
 use crate::api::tool::tool_conditional_execution;
@@ -1312,11 +1314,15 @@ fn test_plugin_component_helpers_and_serialization_error_variant() {
     assert_eq!(totals.get("beta.plugin"), Some(&1));
     assert_eq!(
         component_namespace("alpha.plugin", 1),
-        "__nemo_relay_plugin__alpha.plugin__1__"
+        "nemo-relay-plugin.v1.alpha.plugin:1:"
     );
     assert_eq!(
         component_namespace("beta.plugin", 1),
-        "__nemo_relay_plugin__beta.plugin__1__"
+        "nemo-relay-plugin.v1.beta.plugin:1:"
+    );
+    assert_eq!(
+        component_namespace("alpha/plugin:π%", 2),
+        "nemo-relay-plugin.v1.alpha%2Fplugin%3A%CF%80%25:2:"
     );
 
     let parse_error = serde_json::from_str::<PluginConfig>("{").unwrap_err();
@@ -1328,6 +1334,103 @@ fn test_plugin_component_helpers_and_serialization_error_variant() {
         other => panic!("unexpected conversion result: {other}"),
     }
 
+    reset_global();
+}
+
+#[test]
+fn test_plugin_component_effective_names_escape_and_discover_fields() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+
+    let namespace = component_namespace("analytics/plugin:π%", 1);
+    let mut plugin_context = PluginRegistrationContext::with_plugin_component_namespace(namespace);
+    let mut global_registration_context = PluginRegistrationContext::new();
+    plugin_context
+        .register_subscriber("cache/value:π%", Arc::new(|_| {}))
+        .unwrap();
+    global_registration_context
+        .register_subscriber("global:subscriber", Arc::new(|_| {}))
+        .unwrap();
+    global_registration_context
+        .register_subscriber(
+            "__nemo_relay_plugin__analytics__1__subscriber",
+            Arc::new(|_| {}),
+        )
+        .unwrap();
+
+    let registrations =
+        list_runtime_registrations(Some(&BTreeSet::from([RuntimeRegistrationKind::Subscriber])))
+            .unwrap();
+    let plugin_registration = registrations
+        .iter()
+        .find(|registration| registration.local_name == "cache/value:π%")
+        .unwrap();
+    assert_eq!(
+        plugin_registration.effective_name,
+        "nemo-relay-plugin.v1.analytics%2Fplugin%3A%CF%80%25:1:cache%2Fvalue%3A%CF%80%25"
+    );
+    assert_eq!(
+        plugin_registration.owner.plugin_kind.as_deref(),
+        Some("analytics/plugin:π%")
+    );
+    assert_eq!(plugin_registration.owner.component_ordinal, Some(1));
+
+    let global_registration = registrations
+        .iter()
+        .find(|registration| registration.effective_name == "global:subscriber")
+        .unwrap();
+    assert_eq!(global_registration.local_name, "global:subscriber");
+    assert_eq!(
+        global_registration.owner.kind,
+        RuntimeRegistrationOwnerKind::GlobalApi
+    );
+    assert_eq!(global_registration.owner.component_ordinal, None);
+
+    let legacy_style_global_registration = registrations
+        .iter()
+        .find(|registration| {
+            registration.effective_name == "__nemo_relay_plugin__analytics__1__subscriber"
+        })
+        .unwrap();
+    assert_eq!(
+        legacy_style_global_registration.owner.kind,
+        RuntimeRegistrationOwnerKind::GlobalApi
+    );
+    assert_eq!(
+        legacy_style_global_registration.owner.component_ordinal,
+        None
+    );
+
+    let child_context = plugin_context.with_child_namespace("profile/π:");
+    assert_eq!(
+        child_context.qualify_name("subscriber%"),
+        "nemo-relay-plugin.v1.analytics%2Fplugin%3A%CF%80%25:1:profile%2F%CF%80%3Asubscriber%25"
+    );
+    assert!(
+        decode_plugin_component_effective_name(
+            "nemo-relay-plugin.v1.analytics%2Fplugin%3A%CF%80%25:1:cache%2Fvalue%3A%CF%80%25"
+        )
+        .is_some()
+    );
+    assert!(
+        decode_plugin_component_effective_name(
+            "nemo-relay-plugin.v1.analytics/plugin:1:subscriber"
+        )
+        .is_none()
+    );
+    assert!(
+        decode_plugin_component_effective_name("nemo-relay-plugin.v1.analytics:0:subscriber")
+            .is_none()
+    );
+    assert!(
+        decode_plugin_component_effective_name("__nemo_relay_plugin__analytics__1__subscriber")
+            .is_none()
+    );
+
+    let mut plugin_registrations = plugin_context.into_registrations();
+    rollback_registrations(&mut plugin_registrations);
+    let mut global_registrations = global_registration_context.into_registrations();
+    rollback_registrations(&mut global_registrations);
     reset_global();
 }
 
@@ -1539,8 +1642,8 @@ fn test_initialize_plugins_restores_previous_configuration_after_failed_replacem
     assert_eq!(
         names,
         vec![
-            "__nemo_relay_plugin__recording.plugin__1__subscriber",
-            "__nemo_relay_plugin__recording.plugin__1__subscriber",
+            "nemo-relay-plugin.v1.recording.plugin:1:subscriber",
+            "nemo-relay-plugin.v1.recording.plugin:1:subscriber",
         ]
     );
     reset_global();
@@ -1578,8 +1681,8 @@ fn test_initialize_plugins_restores_previous_configuration_after_replacement_pan
     assert_eq!(
         recorded_names().lock().unwrap().as_slice(),
         [
-            "__nemo_relay_plugin__recording.plugin__1__subscriber",
-            "__nemo_relay_plugin__recording.plugin__1__subscriber",
+            "nemo-relay-plugin.v1.recording.plugin:1:subscriber",
+            "nemo-relay-plugin.v1.recording.plugin:1:subscriber",
         ]
     );
 
@@ -2190,8 +2293,8 @@ fn test_initialize_plugins_skips_disabled_components_and_namespaces_multiple_ins
     assert_eq!(
         names,
         vec![
-            "__nemo_relay_plugin__recording.plugin__1__subscriber",
-            "__nemo_relay_plugin__recording.plugin__2__subscriber",
+            "nemo-relay-plugin.v1.recording.plugin:1:subscriber",
+            "nemo-relay-plugin.v1.recording.plugin:2:subscriber",
         ]
     );
     reset_global();
@@ -2222,7 +2325,7 @@ fn test_initialize_plugins_assigns_ordinal_to_lone_enabled_component() {
 
     assert_eq!(
         recorded_names().lock().unwrap().as_slice(),
-        ["__nemo_relay_plugin__recording.plugin__1__subscriber"]
+        ["nemo-relay-plugin.v1.recording.plugin:1:subscriber"]
     );
     reset_global();
 }
@@ -2253,7 +2356,7 @@ fn test_singleton_plugin_registration_discovers_ordinal() {
         .unwrap();
     assert_eq!(
         registration.effective_name,
-        "__nemo_relay_plugin__discoverable.plugin__1__subscriber"
+        "nemo-relay-plugin.v1.discoverable.plugin:1:subscriber"
     );
     assert_eq!(
         registration.owner.plugin_kind.as_deref(),

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -15,6 +15,7 @@ use tokio::sync::Notify;
 use crate::api::event::{BaseEvent, Event, MarkEvent};
 use crate::api::llm::{LlmRequest, LlmRequestInterceptOutcome};
 use crate::api::llm::{llm_conditional_execution, llm_request_intercepts};
+use crate::api::registry::{RuntimeRegistrationKind, list_runtime_registrations};
 use crate::api::runtime::global_context;
 use crate::api::runtime::{LlmJsonStream, NemoRelayContextState};
 use crate::api::tool::tool_conditional_execution;
@@ -25,6 +26,7 @@ struct PolicyAwarePlugin;
 
 struct SingletonPlugin;
 struct RecordingPlugin;
+struct DiscoverablePlugin;
 struct ReplacementPlugin;
 struct RestoreFailPlugin;
 struct RestoreBreakPlugin;
@@ -303,6 +305,24 @@ impl Plugin for RecordingPlugin {
             ));
             Ok(())
         })
+    }
+}
+
+impl Plugin for DiscoverablePlugin {
+    fn plugin_kind(&self) -> &str {
+        "discoverable.plugin"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Json>) -> Vec<ConfigDiagnostic> {
+        vec![]
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Json>,
+        ctx: &'a mut PluginRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move { ctx.register_subscriber("subscriber", Arc::new(|_| {})) })
     }
 }
 
@@ -1291,12 +1311,12 @@ fn test_plugin_component_helpers_and_serialization_error_variant() {
     assert_eq!(totals.get("alpha.plugin"), Some(&2));
     assert_eq!(totals.get("beta.plugin"), Some(&1));
     assert_eq!(
-        component_namespace("alpha.plugin", 1, totals["alpha.plugin"]),
+        component_namespace("alpha.plugin", 1),
         "__nemo_relay_plugin__alpha.plugin__1__"
     );
     assert_eq!(
-        component_namespace("beta.plugin", 1, totals["beta.plugin"]),
-        "__nemo_relay_plugin__beta.plugin__"
+        component_namespace("beta.plugin", 1),
+        "__nemo_relay_plugin__beta.plugin__1__"
     );
 
     let parse_error = serde_json::from_str::<PluginConfig>("{").unwrap_err();
@@ -1519,8 +1539,8 @@ fn test_initialize_plugins_restores_previous_configuration_after_failed_replacem
     assert_eq!(
         names,
         vec![
-            "__nemo_relay_plugin__recording.plugin__subscriber",
-            "__nemo_relay_plugin__recording.plugin__subscriber",
+            "__nemo_relay_plugin__recording.plugin__1__subscriber",
+            "__nemo_relay_plugin__recording.plugin__1__subscriber",
         ]
     );
     reset_global();
@@ -1558,8 +1578,8 @@ fn test_initialize_plugins_restores_previous_configuration_after_replacement_pan
     assert_eq!(
         recorded_names().lock().unwrap().as_slice(),
         [
-            "__nemo_relay_plugin__recording.plugin__subscriber",
-            "__nemo_relay_plugin__recording.plugin__subscriber",
+            "__nemo_relay_plugin__recording.plugin__1__subscriber",
+            "__nemo_relay_plugin__recording.plugin__1__subscriber",
         ]
     );
 
@@ -2174,6 +2194,74 @@ fn test_initialize_plugins_skips_disabled_components_and_namespaces_multiple_ins
             "__nemo_relay_plugin__recording.plugin__2__subscriber",
         ]
     );
+    reset_global();
+}
+
+#[test]
+fn test_initialize_plugins_assigns_ordinal_to_lone_enabled_component() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    register_plugin(Arc::new(RecordingPlugin)).unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime
+        .block_on(initialize_plugins_exact(PluginConfig {
+            components: vec![
+                PluginComponentSpec::new("recording.plugin"),
+                PluginComponentSpec {
+                    enabled: false,
+                    ..PluginComponentSpec::new("recording.plugin")
+                },
+            ],
+            ..PluginConfig::default()
+        }))
+        .unwrap();
+
+    assert_eq!(
+        recorded_names().lock().unwrap().as_slice(),
+        ["__nemo_relay_plugin__recording.plugin__1__subscriber"]
+    );
+    reset_global();
+}
+
+#[test]
+fn test_singleton_plugin_registration_discovers_ordinal() {
+    let _guard = lock_runtime_owner();
+    reset_global();
+    register_plugin(Arc::new(DiscoverablePlugin)).unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime
+        .block_on(initialize_plugins_exact(PluginConfig {
+            components: vec![PluginComponentSpec::new("discoverable.plugin")],
+            ..PluginConfig::default()
+        }))
+        .unwrap();
+
+    let registrations =
+        list_runtime_registrations(Some(&BTreeSet::from([RuntimeRegistrationKind::Subscriber])))
+            .unwrap();
+    let registration = registrations
+        .iter()
+        .find(|registration| registration.local_name == "subscriber")
+        .unwrap();
+    assert_eq!(
+        registration.effective_name,
+        "__nemo_relay_plugin__discoverable.plugin__1__subscriber"
+    );
+    assert_eq!(
+        registration.owner.plugin_kind.as_deref(),
+        Some("discoverable.plugin")
+    );
+    assert_eq!(registration.owner.component_ordinal, Some(1));
+
+    clear_plugin_configuration().unwrap();
     reset_global();
 }
 

--- a/crates/pii-redaction/src/local.rs
+++ b/crates/pii-redaction/src/local.rs
@@ -73,9 +73,7 @@ pub(super) fn register_local_backend(
         "Plugin resource access validation started"
     );
     let mut scoped_context = profile_name.map(|profile_name| {
-        PluginRegistrationContext::with_namespace(
-            ctx.qualify_name(&format!("{}/", profile_registration_prefix(profile_name))),
-        )
+        ctx.with_child_namespace(&format!("{}/", profile_registration_prefix(profile_name)))
     });
     let provider_context = scoped_context.as_mut().unwrap_or(ctx);
     match provider(config, provider_context) {

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -2281,7 +2281,7 @@ unsafe extern "C" fn capture_plugin_runtime_list_registrations(
                 "owner": {
                     "kind": "plugin",
                     "plugin_kind": "example",
-                    "component_ordinal": 0
+                    "component_ordinal": 1
                 }
             }]),
         )

--- a/crates/types/src/api/registry.rs
+++ b/crates/types/src/api/registry.rs
@@ -87,7 +87,7 @@ pub struct RuntimeRegistrationOwner {
     pub kind: RuntimeRegistrationOwnerKind,
     /// Plugin kind for plugin-owned registrations.
     pub plugin_kind: Option<String>,
-    /// Zero-based component ordinal when multiple components share a kind.
+    /// One-based ordinal for a Relay-created plugin component, when applicable.
     pub component_ordinal: Option<u32>,
 }
 

--- a/crates/types/tests/registry_tests.rs
+++ b/crates/types/tests/registry_tests.rs
@@ -106,7 +106,7 @@ fn runtime_registration_identity_round_trips_plugin_owner() {
     let identity = RuntimeRegistrationIdentity {
         kind: RuntimeRegistrationKind::Subscriber,
         local_name: "opentelemetry".into(),
-        effective_name: "__nemo_relay_plugin__observability__1__opentelemetry".into(),
+        effective_name: "nemo-relay-plugin.v1.observability:1:opentelemetry".into(),
         owner: RuntimeRegistrationOwner {
             kind: RuntimeRegistrationOwnerKind::Plugin,
             plugin_kind: Some("observability".into()),
@@ -120,7 +120,7 @@ fn runtime_registration_identity_round_trips_plugin_owner() {
         json!({
             "kind": "subscriber",
             "local_name": "opentelemetry",
-            "effective_name": "__nemo_relay_plugin__observability__1__opentelemetry",
+            "effective_name": "nemo-relay-plugin.v1.observability:1:opentelemetry",
             "owner": {
                 "kind": "plugin",
                 "plugin_kind": "observability",

--- a/docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx
+++ b/docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx
@@ -32,7 +32,12 @@ Plugin contexts qualify local names, and that qualification can change after a p
 restart or plugin configuration reload. A controller must not persist an effective name
 or construct one from a plugin kind, local name, or component position. In particular,
 singleton plugin component names include ordinal `1`; this normalizes their effective
-names with multi-component registrations.
+names with multi-component registrations. Relay currently emits plugin-component keys
+with the versioned internal grammar
+`nemo-relay-plugin.v1.{percent-encoded-kind}:{one-based-ordinal}:{percent-encoded-local-name}`.
+The kind and local name use UTF-8 percent encoding: unreserved RFC 3986 characters are
+literal, and delimiters, `%`, and non-ASCII bytes are escaped. This grammar is an
+implementation detail, not an application configuration or persistence format.
 
 Discovery reports global registrations even when a gate currently suppresses them. This
 behavior lets another controller inspect or manage an ineligible target. Discovery does

--- a/docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx
+++ b/docs/about-nemo-relay/concepts/conditional-middleware-guardrails.mdx
@@ -23,13 +23,16 @@ Relay describes each gateable global registration with four identity fields:
 - `kind` identifies the subscriber, metadata injector, guardrail, or intercept family.
 - `local_name` is the name that the registration owner supplied.
 - `effective_name` is the runtime name that a conditional middleware guardrail targets.
-- `owner` identifies core, global API, or plugin ownership. Plugin ownership also
-  includes the plugin kind and component ordinal when available.
+- `owner` identifies core, global API, or plugin ownership. Relay-created plugin
+  registrations include the plugin kind and a one-based component ordinal. The ordinal
+  is assigned among enabled components of the same kind in configuration order.
 
 Applications and plugins must discover the effective name from the active runtime.
 Plugin contexts qualify local names, and that qualification can change after a process
 restart or plugin configuration reload. A controller must not persist an effective name
-or construct one from a plugin kind, local name, or component position.
+or construct one from a plugin kind, local name, or component position. In particular,
+singleton plugin component names include ordinal `1`; this normalizes their effective
+names with multi-component registrations.
 
 Discovery reports global registrations even when a gate currently suppresses them. This
 behavior lets another controller inspect or manage an ineligible target. Discovery does

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -418,7 +418,7 @@ class RecordingHostStub:
                 pb.RuntimeRegistrationIdentity(
                     kind=pb.SUBSCRIBER,
                     local_name="opentelemetry",
-                    effective_name="__nemo_relay_plugin__observability__1__opentelemetry",
+                    effective_name="nemo-relay-plugin.v1.observability:1:opentelemetry",
                     owner=pb.RuntimeRegistrationOwner(
                         kind=pb.RUNTIME_REGISTRATION_OWNER_KIND_PLUGIN,
                         plugin_kind="observability",
@@ -2242,7 +2242,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         RuntimeRegistrationIdentity(
             kind=RuntimeRegistrationKind.SUBSCRIBER,
             local_name="opentelemetry",
-            effective_name="__nemo_relay_plugin__observability__1__opentelemetry",
+            effective_name="nemo-relay-plugin.v1.observability:1:opentelemetry",
             owner=plugin_api.RuntimeRegistrationOwner(
                 kind=RuntimeRegistrationOwnerKind.PLUGIN,
                 plugin_kind="observability",

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -418,10 +418,11 @@ class RecordingHostStub:
                 pb.RuntimeRegistrationIdentity(
                     kind=pb.SUBSCRIBER,
                     local_name="opentelemetry",
-                    effective_name="__nemo_relay_plugin__observability__opentelemetry",
+                    effective_name="__nemo_relay_plugin__observability__1__opentelemetry",
                     owner=pb.RuntimeRegistrationOwner(
                         kind=pb.RUNTIME_REGISTRATION_OWNER_KIND_PLUGIN,
                         plugin_kind="observability",
+                        component_ordinal=1,
                     ),
                 )
             ]
@@ -2241,10 +2242,11 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         RuntimeRegistrationIdentity(
             kind=RuntimeRegistrationKind.SUBSCRIBER,
             local_name="opentelemetry",
-            effective_name="__nemo_relay_plugin__observability__opentelemetry",
+            effective_name="__nemo_relay_plugin__observability__1__opentelemetry",
             owner=plugin_api.RuntimeRegistrationOwner(
                 kind=RuntimeRegistrationOwnerKind.PLUGIN,
                 plugin_kind="observability",
+                component_ordinal=1,
             ),
         )
     ]


### PR DESCRIPTION
#### Overview

Normalize Relay-created plugin component namespaces so every component, including a singleton, has a one-based ordinal.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Generate `__nemo_relay_plugin__{kind}__{ordinal}__` for every enabled plugin component.
- Preserve the existing registration transport and make singleton discovery report `component_ordinal: Some(1)`.
- Update core, observability, worker-SDK expectations, and conditional-middleware documentation.

Breaking behavior: singleton plugin `effective_name` values now include `__1__`; clients must continue to discover effective names at runtime rather than construct or persist them.

#### Where should the reviewer start?

Start with `crates/core/src/plugin.rs`, then the registration discovery tests in `crates/core/tests/unit/plugin_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin component namespaces and registration names now consistently include a one-based component ordinal, including singleton components.
  - Runtime registration metadata now reports the correct component ordinal (`1` for the first component).
  - Registration names now safely support encoded component and local names, improving identity accuracy across multiple plugin components.

- **Documentation**
  - Clarified component ordinal behavior and registration naming guidance, including singleton components and effective-name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->