### PR TITLE
fix(observability): correlate Responses tool calls in ATIF

### DIFF
--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -1214,6 +1214,7 @@ fn extract_tool_calls(output: &Json) -> Option<Vec<AtifToolCall>> {
     if calls.is_empty() { None } else { Some(calls) }
 }
 
+/// Provider payload shape governing tool-call identifier semantics.
 #[derive(Clone, Copy)]
 enum ToolCallOrigin {
     Generic,
@@ -1221,6 +1222,7 @@ enum ToolCallOrigin {
     AnthropicMessages,
 }
 
+/// Select the first usable correlation identifier for the provider payload shape.
 fn tool_call_id_for_origin(
     tool_call: &serde_json::Map<String, Json>,
     origin: ToolCallOrigin,
@@ -1236,12 +1238,14 @@ fn tool_call_id_for_origin(
                     .filter(|value| !value.is_empty())
             })
         }
-        ToolCallOrigin::Generic | ToolCallOrigin::AnthropicMessages => tool_call
-            .get("id")
-            .or_else(|| tool_call.get("tool_call_id"))
-            .or_else(|| tool_call.get("call_id"))
-            .and_then(Json::as_str)
-            .filter(|value| !value.is_empty()),
+        ToolCallOrigin::Generic | ToolCallOrigin::AnthropicMessages => {
+            ["id", "tool_call_id", "call_id"].iter().find_map(|field| {
+                tool_call
+                    .get(*field)
+                    .and_then(Json::as_str)
+                    .filter(|value| !value.is_empty())
+            })
+        }
     }
 }
 

--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -1150,31 +1150,35 @@ fn openai_responses_input_content_message(content: &Json) -> Option<Json> {
     None
 }
 
-/// Try to promote `tool_calls` from the raw LLM response into `AtifToolCall` entries.
+/// Try to promote provider tool calls from a raw LLM response into `AtifToolCall` entries.
 ///
-/// Expected shape per OpenAI convention:
-/// ```json
-/// "tool_calls": [{ "id": "...", "type": "function", "function": { "name": "...", "arguments": "..." } }]
-/// ```
+/// Supports generic/OpenAI Chat `tool_calls`, OpenAI Responses `function_call`
+/// output items, and Anthropic `tool_use` content blocks. Provider-specific ID
+/// semantics are preserved so later observations can correlate to the call.
 ///
 /// String `arguments` are parsed into JSON for consistency with NeMo Relay tool events
 /// which always provide parsed arguments.
 ///
 /// Returns `None` if there are no tool calls or the structure is unrecognized.
 fn extract_tool_calls(output: &Json) -> Option<Vec<AtifToolCall>> {
-    let arr = tool_call_array(output)
-        .filter(|arr| !arr.is_empty())
-        .map(|arr| arr.iter().collect::<Vec<_>>())
-        .or_else(|| openai_responses_function_call_items(output))
-        .or_else(|| anthropic_messages_tool_use_items(output))?;
+    let (arr, origin) = if let Some(tool_calls) = tool_call_array(output).filter(|a| !a.is_empty())
+    {
+        (
+            tool_calls.iter().collect::<Vec<_>>(),
+            ToolCallOrigin::Generic,
+        )
+    } else if let Some(function_calls) = openai_responses_function_call_items(output) {
+        (function_calls, ToolCallOrigin::OpenAiResponses)
+    } else {
+        (
+            anthropic_messages_tool_use_items(output)?,
+            ToolCallOrigin::AnthropicMessages,
+        )
+    };
     let mut calls = Vec::with_capacity(arr.len());
     for (index, tc) in arr.iter().enumerate() {
         let tc_obj = tc.as_object()?;
-        let mut id = tc_obj
-            .get("id")
-            .or_else(|| tc_obj.get("tool_call_id"))
-            .or_else(|| tc_obj.get("call_id"))
-            .and_then(Json::as_str)
+        let mut id = tool_call_id_for_origin(tc_obj, origin)
             .unwrap_or("")
             .to_string();
         let func = tc_obj.get("function").and_then(Json::as_object);
@@ -1208,6 +1212,37 @@ fn extract_tool_calls(output: &Json) -> Option<Vec<AtifToolCall>> {
         });
     }
     if calls.is_empty() { None } else { Some(calls) }
+}
+
+#[derive(Clone, Copy)]
+enum ToolCallOrigin {
+    Generic,
+    OpenAiResponses,
+    AnthropicMessages,
+}
+
+fn tool_call_id_for_origin(
+    tool_call: &serde_json::Map<String, Json>,
+    origin: ToolCallOrigin,
+) -> Option<&str> {
+    match origin {
+        // Responses distinguishes the output item `id` (`fc_*`) from the
+        // invocation `call_id` used by function_call_output and tool events.
+        ToolCallOrigin::OpenAiResponses => {
+            ["call_id", "id", "tool_call_id"].iter().find_map(|field| {
+                tool_call
+                    .get(*field)
+                    .and_then(Json::as_str)
+                    .filter(|value| !value.is_empty())
+            })
+        }
+        ToolCallOrigin::Generic | ToolCallOrigin::AnthropicMessages => tool_call
+            .get("id")
+            .or_else(|| tool_call.get("tool_call_id"))
+            .or_else(|| tool_call.get("call_id"))
+            .and_then(Json::as_str)
+            .filter(|value| !value.is_empty()),
+    }
 }
 
 // Annotation adapters: read the normalized message from an annotation, returning

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -2343,6 +2343,7 @@ fn test_exporter_openai_responses_function_calls_promoted_and_correlated() {
                 },
                 {
                     "type": "function_call",
+                    "id": "fc_terminal_item_1",
                     "call_id": "call_terminal_1",
                     "name": "terminal",
                     "arguments": "{\"command\":\"pwd\"}",
@@ -2360,13 +2361,15 @@ fn test_exporter_openai_responses_function_calls_promoted_and_correlated() {
         .output(json!({"stdout": "/workspace"}))
         .build();
 
-    for (offset, event) in [&mut llm_end, &mut tool_end].into_iter().enumerate() {
+    // Streaming clients can execute and finish a tool before Relay receives the
+    // delayed LLM end event containing the complete Responses output.
+    for (offset, event) in [&mut tool_end, &mut llm_end].into_iter().enumerate() {
         set_event_timestamp(event, base + chrono::Duration::seconds(offset as i64));
     }
 
     {
         let mut state = exporter.state.lock().unwrap();
-        state.events.extend([llm_end, tool_end]);
+        state.events.extend([tool_end, llm_end]);
     }
 
     let trajectory = exporter.export().unwrap();
@@ -2385,6 +2388,128 @@ fn test_exporter_openai_responses_function_calls_promoted_and_correlated() {
     let result = &agent_step.observation.as_ref().unwrap().results[0];
     assert_eq!(result.source_call_id.as_deref(), Some("call_terminal_1"));
     assert_structured_observation_result_extra(result, json!({"stdout": "/workspace"}));
+}
+
+#[test]
+fn test_openai_responses_tool_call_ids_use_invocation_ids_with_fallbacks() {
+    let calls = extract_tool_calls(&json!({
+        "output": [
+            {
+                "type": "function_call",
+                "id": "fc_item_1",
+                "call_id": "call_1",
+                "name": "first",
+                "arguments": "{}"
+            },
+            {
+                "type": "function_call",
+                "id": "fc_item_2",
+                "call_id": null,
+                "name": "second",
+                "arguments": "{}"
+            },
+            {
+                "type": "function_call",
+                "id": "fc_item_3",
+                "call_id": "",
+                "name": "third",
+                "arguments": "{}"
+            },
+            {
+                "type": "function_call",
+                "tool_call_id": "legacy_call_4",
+                "name": "fourth",
+                "arguments": "{}"
+            },
+            {
+                "type": "function_call",
+                "name": "fifth",
+                "arguments": "{}"
+            },
+            {
+                "type": "function_call",
+                "id": "fc_item_6",
+                "call_id": 42,
+                "name": "sixth",
+                "arguments": "{}"
+            }
+        ]
+    }))
+    .expect("Responses function calls");
+
+    assert_eq!(calls.len(), 6);
+    assert_eq!(calls[0].tool_call_id, "call_1");
+    assert_eq!(calls[1].tool_call_id, "fc_item_2");
+    assert_eq!(calls[2].tool_call_id, "fc_item_3");
+    assert_eq!(calls[3].tool_call_id, "legacy_call_4");
+    assert_eq!(calls[4].tool_call_id, "fifth:5");
+    assert_eq!(calls[5].tool_call_id, "fc_item_6");
+}
+
+#[test]
+fn test_non_responses_tool_calls_preserve_provider_id_semantics() {
+    let chat_calls = extract_tool_calls(&json!({
+        "tool_calls": [
+            {
+                "type": "function",
+                "id": "chat_call_1",
+                "call_id": "responses_call_1",
+                "tool_call_id": "legacy_call_1",
+                "function": {"name": "chat_tool", "arguments": "{}"}
+            },
+            {
+                "type": "function",
+                "call_id": "responses_call_2",
+                "tool_call_id": "legacy_call_2",
+                "function": {"name": "chat_tool_2", "arguments": "{}"}
+            }
+        ]
+    }))
+    .expect("Chat Completions tool call");
+    assert_eq!(chat_calls[0].tool_call_id, "chat_call_1");
+    assert_eq!(chat_calls[1].tool_call_id, "legacy_call_2");
+
+    let anthropic_calls = extract_tool_calls(&json!({
+        "type": "message",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "call_id": "responses_call_1",
+                "name": "anthropic_tool",
+                "input": {}
+            }
+        ]
+    }))
+    .expect("Anthropic tool use");
+    assert_eq!(anthropic_calls[0].tool_call_id, "toolu_1");
+}
+
+#[test]
+fn test_generic_tool_calls_keep_precedence_over_responses_output() {
+    let calls = extract_tool_calls(&json!({
+        "tool_calls": [
+            {
+                "type": "function",
+                "id": "generic_call_1",
+                "function": {"name": "generic_tool", "arguments": "{}"}
+            }
+        ],
+        "output": [
+            {
+                "type": "function_call",
+                "id": "fc_item_1",
+                "call_id": "responses_call_1",
+                "name": "responses_tool",
+                "arguments": "{}"
+            }
+        ]
+    }))
+    .expect("generic tool calls");
+
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].tool_call_id, "generic_call_1");
+    assert_eq!(calls[0].function_name, "generic_tool");
 }
 
 #[test]

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -2462,12 +2462,41 @@ fn test_non_responses_tool_calls_preserve_provider_id_semantics() {
                 "call_id": "responses_call_2",
                 "tool_call_id": "legacy_call_2",
                 "function": {"name": "chat_tool_2", "arguments": "{}"}
+            },
+            {
+                "type": "function",
+                "id": null,
+                "tool_call_id": "legacy_call_3",
+                "function": {"name": "chat_tool_3", "arguments": "{}"}
+            },
+            {
+                "type": "function",
+                "id": "",
+                "call_id": "responses_call_4",
+                "function": {"name": "chat_tool_4", "arguments": "{}"}
+            },
+            {
+                "type": "function",
+                "id": 42,
+                "tool_call_id": "legacy_call_5",
+                "function": {"name": "chat_tool_5", "arguments": "{}"}
+            },
+            {
+                "type": "function",
+                "id": null,
+                "tool_call_id": "",
+                "call_id": false,
+                "function": {"name": "chat_tool_6", "arguments": "{}"}
             }
         ]
     }))
     .expect("Chat Completions tool call");
     assert_eq!(chat_calls[0].tool_call_id, "chat_call_1");
     assert_eq!(chat_calls[1].tool_call_id, "legacy_call_2");
+    assert_eq!(chat_calls[2].tool_call_id, "legacy_call_3");
+    assert_eq!(chat_calls[3].tool_call_id, "responses_call_4");
+    assert_eq!(chat_calls[4].tool_call_id, "legacy_call_5");
+    assert_eq!(chat_calls[5].tool_call_id, "chat_tool_6:6");
 
     let anthropic_calls = extract_tool_calls(&json!({
         "type": "message",
@@ -2478,11 +2507,19 @@ fn test_non_responses_tool_calls_preserve_provider_id_semantics() {
                 "call_id": "responses_call_1",
                 "name": "anthropic_tool",
                 "input": {}
+            },
+            {
+                "type": "tool_use",
+                "id": null,
+                "tool_call_id": "toolu_2",
+                "name": "anthropic_tool_2",
+                "input": {}
             }
         ]
     }))
     .expect("Anthropic tool use");
     assert_eq!(anthropic_calls[0].tool_call_id, "toolu_1");
+    assert_eq!(anthropic_calls[1].tool_call_id, "toolu_2");
 }
 
 #[test]


### PR DESCRIPTION
#### Overview

Fixes ATIF tool-result correlation for OpenAI Responses function calls.

OpenAI Responses uses two different identifiers on a function-call output item: `id` identifies the response item (`fc_*`), while `call_id` identifies the tool invocation and is reused by `function_call_output`. The exporter previously selected `id` first, so Relay could emit the agent tool call as `fc_*` while the corresponding tool observation used `call-*`. That left a valid result orphaned in the exported trajectory.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Tracks whether tool calls came from generic/OpenAI Chat, OpenAI Responses, or Anthropic Messages output.
- Selects `call_id`, then `id`, then `tool_call_id` only for Responses function-call items.
- Preserves `id`, then `tool_call_id`, then `call_id` precedence for Chat, Anthropic, and generic payloads while allowing null, empty, and non-string values to fall through to a valid fallback.
- Preserves compatible fallbacks for absent, null, empty, and non-string Responses `call_id` values.
- Adds a regression in the real ordering where a tool finishes before the delayed terminal LLM event.
- Adds multiple-call, fallback, mixed-shape precedence, and provider non-regression coverage.

This changes a conforming Responses ATIF `tool_call_id` from the response-item `fc_*` ID to the semantic `call-*` invocation ID. That is the intended corrective behavior and allows `Step.tool_calls[].tool_call_id` to match `Step.observation.results[].source_call_id`.

#### Validation

- `cargo test -p nemo-relay --lib observability::atif::tests` — 102 passed
- `cargo clippy -p nemo-relay --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `just test-rust` — full workspace, FFI serial pass, doctests, and Rust examples passed
- Live Codex CLI -> current Relay -> NVIDIA OpenAI-compatible Responses endpoint: the raw item retained `id=fc_*`, while both exported tool call and observation used the same `call-*` ID

#### Where should the reviewer start?

Start with `extract_tool_calls` and `tool_call_id_for_origin` in `crates/core/src/observability/atif.rs`, then the realistic Responses regression in `test_exporter_openai_responses_function_calls_promoted_and_correlated`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to NVIDIA-NeMo/Gym#2468


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool-call records now identify whether they originated from generic/OpenAI Chat, OpenAI Responses, or Anthropic Messages formats.
  * OpenAI Responses tool results now correlate using the call ID when available, improving support for delayed completions and invocation identifiers.

* **Bug Fixes**
  * Preserved provider-specific ID behavior and prioritized standard tool-call data when multiple response formats are present.

* **Documentation**
  * Clarified supported formats and tool-call correlation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->