### PR TITLE
fix: report OTLP queue drops after flush

### DIFF
--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -771,6 +771,8 @@ impl OpenTelemetrySubscriber {
     }
 
     /// Flushes finished spans through the underlying tracer provider.
+    ///
+    /// After a successful flush, runtime diagnostics include queue drops observed so far.
     pub fn force_flush(&self) -> Result<()> {
         flush_subscribers()?;
         self.inner
@@ -1066,7 +1068,7 @@ struct DiagnosticBatchSpanProcessor {
     completed_spans: AtomicU64,
     accepted_spans: Arc<AtomicU64>,
     diagnostics: Arc<TraceDeliveryDiagnostics>,
-    diagnostic_reported: AtomicBool,
+    reported_dropped_spans: AtomicU64,
 }
 
 impl DiagnosticBatchSpanProcessor {
@@ -1090,7 +1092,7 @@ impl DiagnosticBatchSpanProcessor {
             completed_spans: AtomicU64::new(0),
             accepted_spans,
             diagnostics,
-            diagnostic_reported: AtomicBool::new(false),
+            reported_dropped_spans: AtomicU64::new(0),
         }
     }
 
@@ -1099,17 +1101,28 @@ impl DiagnosticBatchSpanProcessor {
             .completed_spans
             .load(Ordering::Relaxed)
             .saturating_sub(self.accepted_spans.load(Ordering::Relaxed));
-        if dropped == 0 || self.diagnostic_reported.swap(true, Ordering::Relaxed) {
-            return dropped;
+        let mut reported = self.reported_dropped_spans.load(Ordering::Relaxed);
+        while dropped > reported {
+            match self.reported_dropped_spans.compare_exchange_weak(
+                reported,
+                dropped,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    self.diagnostics.runtime_diagnostics.record(
+                        "otel.spans_dropped",
+                        format!(
+                            "OpenTelemetry dropped spans before export to endpoint {} because the batch queue was full",
+                            self.diagnostics.endpoint
+                        ),
+                        dropped - reported,
+                    );
+                    break;
+                }
+                Err(current) => reported = current,
+            }
         }
-        self.diagnostics.runtime_diagnostics.record(
-            "otel.spans_dropped",
-            format!(
-                "OpenTelemetry dropped {dropped} spans before export to endpoint {} because the batch queue was full",
-                self.diagnostics.endpoint
-            ),
-            dropped,
-        );
         dropped
     }
 }
@@ -1126,6 +1139,9 @@ impl SpanProcessor for DiagnosticBatchSpanProcessor {
 
     fn force_flush(&self) -> OTelSdkResult {
         let result = self.inner.force_flush();
+        if result.is_ok() {
+            self.record_dropped_spans();
+        }
         if result.is_ok()
             && let Some(summary) = self.diagnostics.unresolved_failure_summary()
         {

--- a/crates/core/src/observability/otel_logs.rs
+++ b/crates/core/src/observability/otel_logs.rs
@@ -321,6 +321,8 @@ impl OpenTelemetryLogSubscriber {
     }
 
     /// Flush queued Relay events and the OTLP log processor.
+    ///
+    /// After a successful flush, runtime diagnostics include queue drops observed so far.
     pub fn force_flush(&self) -> Result<()> {
         flush_subscribers()?;
         self.inner
@@ -414,7 +416,7 @@ struct LogDeliveryDiagnostics {
     emitted: AtomicU64,
     accepted: AtomicU64,
     export_failures: AtomicU64,
-    queue_reported: AtomicBool,
+    reported_queue_drops: AtomicU64,
     endpoint: String,
     runtime_diagnostics: SignalRuntimeDiagnostics,
 }
@@ -425,7 +427,7 @@ impl LogDeliveryDiagnostics {
             emitted: AtomicU64::new(0),
             accepted: AtomicU64::new(0),
             export_failures: AtomicU64::new(0),
-            queue_reported: AtomicBool::new(false),
+            reported_queue_drops: AtomicU64::new(0),
             endpoint,
             runtime_diagnostics,
         }
@@ -448,15 +450,27 @@ impl LogDeliveryDiagnostics {
             .emitted
             .load(Ordering::Relaxed)
             .saturating_sub(self.accepted.load(Ordering::Relaxed));
-        if dropped > 0 && !self.queue_reported.swap(true, Ordering::Relaxed) {
-            self.runtime_diagnostics.record(
-                "otel.logs_dropped",
-                format!(
-                    "OpenTelemetry dropped {dropped} logs before export to endpoint {} because the batch queue was full",
-                    self.endpoint
-                ),
+        let mut reported = self.reported_queue_drops.load(Ordering::Relaxed);
+        while dropped > reported {
+            match self.reported_queue_drops.compare_exchange_weak(
+                reported,
                 dropped,
-            );
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    self.runtime_diagnostics.record(
+                        "otel.logs_dropped",
+                        format!(
+                            "OpenTelemetry dropped logs before export to endpoint {} because the batch queue was full",
+                            self.endpoint
+                        ),
+                        dropped - reported,
+                    );
+                    break;
+                }
+                Err(current) => reported = current,
+            }
         }
         dropped
     }
@@ -514,7 +528,11 @@ impl LogProcessor for DiagnosticBatchLogProcessor {
     }
 
     fn force_flush(&self) -> OTelSdkResult {
-        self.inner.force_flush()
+        let result = self.inner.force_flush();
+        if result.is_ok() {
+            self.diagnostics.record_queue_drops();
+        }
+        result
     }
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {

--- a/crates/core/tests/unit/observability/otel_logs_tests.rs
+++ b/crates/core/tests/unit/observability/otel_logs_tests.rs
@@ -322,7 +322,7 @@ fn log_delivery_state_reports_queue_and_export_failures_independently() {
 }
 
 #[test]
-fn direct_log_processor_records_queue_drops_on_shutdown() {
+fn direct_log_processor_records_cumulative_queue_drops_on_flush_and_shutdown() {
     let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);
     let delivery_diagnostics = Arc::new(LogDeliveryDiagnostics::new(
         "https://collector.example/v1/logs".to_string(),
@@ -332,9 +332,23 @@ fn direct_log_processor_records_queue_drops_on_shutdown() {
     delivery_diagnostics.accepted.store(1, Ordering::Relaxed);
     let processor = DiagnosticBatchLogProcessor {
         inner: BatchLogProcessor::builder(InMemoryLogExporter::default()).build(),
-        diagnostics: delivery_diagnostics,
+        diagnostics: Arc::clone(&delivery_diagnostics),
     };
 
+    processor.force_flush().unwrap();
+
+    let diagnostics = runtime_diagnostics.snapshot();
+    let diagnostic = diagnostics
+        .get("otel.logs_dropped")
+        .expect("direct subscriber flush drop diagnostic");
+    assert_eq!(diagnostic.count, 2);
+    assert!(
+        diagnostic
+            .message
+            .contains("https://collector.example/v1/logs")
+    );
+
+    delivery_diagnostics.emitted.store(5, Ordering::Relaxed);
     processor
         .shutdown_with_timeout(Duration::from_secs(1))
         .unwrap();
@@ -342,8 +356,8 @@ fn direct_log_processor_records_queue_drops_on_shutdown() {
     let diagnostics = runtime_diagnostics.snapshot();
     let diagnostic = diagnostics
         .get("otel.logs_dropped")
-        .expect("direct subscriber drop diagnostic");
-    assert_eq!(diagnostic.count, 2);
+        .expect("direct subscriber shutdown drop diagnostic");
+    assert_eq!(diagnostic.count, 4);
     assert!(
         diagnostic
             .message

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -4727,6 +4727,39 @@ fn dropped_spans_are_recorded_in_the_active_plugin_report() {
 }
 
 #[test]
+fn direct_trace_processor_records_cumulative_queue_drops_on_flush_and_shutdown() {
+    let runtime_diagnostics = SignalRuntimeDiagnostics::new(None);
+    let processor = DiagnosticBatchSpanProcessor::new_with_batch_config(
+        InMemorySpanExporterBuilder::new().build(),
+        "https://collector.example/v1/traces".to_string(),
+        runtime_diagnostics.clone(),
+        BatchConfigBuilder::default().build(),
+    );
+    processor.completed_spans.store(3, Ordering::Relaxed);
+    processor.accepted_spans.store(1, Ordering::Relaxed);
+
+    processor.force_flush().unwrap();
+    assert_eq!(
+        runtime_diagnostics
+            .snapshot()
+            .get("otel.spans_dropped")
+            .map(|diagnostic| diagnostic.count),
+        Some(2)
+    );
+
+    processor.completed_spans.store(5, Ordering::Relaxed);
+    processor
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+    let diagnostics = runtime_diagnostics.snapshot();
+    let diagnostic = diagnostics
+        .get("otel.spans_dropped")
+        .expect("direct trace drop diagnostic");
+    assert_eq!(diagnostic.count, 4);
+    assert!(diagnostic.message.contains("https://collector.example:443"));
+}
+
+#[test]
 fn plugin_trace_subscriber_runtime_diagnostics_use_trace_field() {
     let _guard = crate::observability::test_mutex().lock().unwrap();
     let _ = crate::plugin::clear_plugin_configuration();

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -5216,6 +5216,12 @@ impl OpenTelemetrySubscriber {
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
+    /// Return bounded runtime diagnostics recorded by this subscriber.
+    #[napi(ts_return_type = "Array<{ code: string; message: string; count: number }>")]
+    pub fn runtime_diagnostics(&self) -> Json {
+        otel_runtime_diagnostics_json(self.inner.runtime_diagnostics())
+    }
+
     /// Shut down the underlying tracer provider.
     #[napi]
     pub fn shutdown(&self) -> napi::Result<()> {

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -5207,6 +5207,8 @@ impl OpenTelemetrySubscriber {
     }
 
     /// Force a flush of finished spans through the exporter.
+    ///
+    /// A successful flush updates `runtimeDiagnostics()` with queue drops observed so far.
     #[napi]
     pub fn force_flush(&self) -> napi::Result<()> {
         self.inner
@@ -5295,6 +5297,8 @@ impl OpenTelemetryLogSubscriber {
     }
 
     /// Flush queued Relay events and the OTLP log processor.
+    ///
+    /// A successful flush updates `runtimeDiagnostics()` with queue drops observed so far.
     #[napi]
     pub fn force_flush(&self) -> napi::Result<()> {
         self.inner

--- a/crates/node/tests/otel_tests.mjs
+++ b/crates/node/tests/otel_tests.mjs
@@ -58,6 +58,7 @@ describe('OpenTelemetrySubscriber', () => {
     assert.equal(subscriber.deregister(name), true);
     assert.equal(subscriber.deregister(name), false);
     subscriber.forceFlush();
+    assert.deepEqual(subscriber.runtimeDiagnostics(), []);
     subscriber.shutdown();
   });
 

--- a/crates/node/tests/public_observability_api_fixture.ts
+++ b/crates/node/tests/public_observability_api_fixture.ts
@@ -49,6 +49,7 @@ metric(
 const logDiagnostics: Array<{ code: string; message: string; count: number }> = logSubscriber.runtimeDiagnostics();
 const metricDiagnostics: Array<{ code: string; message: string; count: number }> =
   metricSubscriber.runtimeDiagnostics();
+const traceDiagnostics: Array<{ code: string; message: string; count: number }> = traceSubscriber.runtimeDiagnostics();
 logSubscriber.register('fixture-log-subscriber');
 const logDeregistered: boolean = logSubscriber.deregister('fixture-log-subscriber');
 logSubscriber.forceFlush();

--- a/crates/python/src/py_types/observability.rs
+++ b/crates/python/src/py_types/observability.rs
@@ -701,6 +701,8 @@ impl PyOpenTelemetrySubscriber {
     }
 
     /// Force a flush of finished spans through the exporter.
+    ///
+    /// A successful flush updates ``runtime_diagnostics()`` with queue drops observed so far.
     pub(crate) fn force_flush(&self, py: Python<'_>) -> PyResult<()> {
         py.detach(|| {
             self.with_runtime_context(|| {
@@ -915,6 +917,9 @@ impl PyOpenTelemetryLogSubscriber {
             .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
     }
 
+    /// Flush queued Relay events and the OTLP log processor.
+    ///
+    /// A successful flush updates ``runtime_diagnostics()`` with queue drops observed so far.
     fn force_flush(&self, py: Python<'_>) -> PyResult<()> {
         py.detach(|| self.inner.force_flush())
             .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -726,7 +726,9 @@ call the binding's force-flush method (`force_flush()` or `forceFlush()`), and
 then call `shutdown()`. Force flush first crosses Relay's subscriber barrier
 and then flushes the provider. Log shutdown drains the batch queue. Metric
 shutdown performs the reader's final collection; it does not add a second
-metric flush.
+metric flush. For direct trace and log subscribers, a successful force flush
+updates `runtime_diagnostics()` with any batch queue drops observed so far; the
+diagnostic count remains cumulative through later flushes and shutdown.
 
 ### Log and Metric Subscriber Lifecycle
 

--- a/go/nemo_relay/nemo_relay.go
+++ b/go/nemo_relay/nemo_relay.go
@@ -2608,7 +2608,8 @@ func (s *OpenTelemetrySubscriber) Deregister(name string) error {
 	return checkStatus(status)
 }
 
-// ForceFlush flushes finished spans through the underlying exporter.
+// ForceFlush flushes finished spans through the underlying exporter. A successful flush updates
+// RuntimeDiagnostics with queue drops observed so far.
 func (s *OpenTelemetrySubscriber) ForceFlush() error {
 	status := C.nemo_relay_otel_subscriber_force_flush(s.ptr)
 	return checkStatus(status)
@@ -2893,7 +2894,8 @@ func (s *OpenTelemetryLogSubscriber) Deregister(name string) error {
 	return checkStatus(C.nemo_relay_otel_log_subscriber_deregister(cName))
 }
 
-// ForceFlush drains Relay delivery and queued log batches.
+// ForceFlush drains Relay delivery and queued log batches. A successful flush updates
+// RuntimeDiagnostics with queue drops observed so far.
 func (s *OpenTelemetryLogSubscriber) ForceFlush() error {
 	return checkStatus(C.nemo_relay_otel_log_subscriber_force_flush(s.ptr))
 }

--- a/python/nemo_relay/README.md
+++ b/python/nemo_relay/README.md
@@ -219,6 +219,10 @@ before emitting marks, then deregister, force-flush, and shut it down during
 graceful teardown. Their `runtime_diagnostics()` snapshots contain bounded
 `code`, `message`, and `count` entries:
 
+A successful direct log or trace `force_flush()` also updates this snapshot
+with any queue drops observed so far; the diagnostic count remains cumulative
+through later flushes and shutdown.
+
 ```python
 from nemo_relay import (
     OpenTelemetryLogConfig,

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -706,6 +706,36 @@ class TestOpenTelemetryTypes:
                 metric_subscriber.deregister(metric_name)
                 metric_subscriber.shutdown()
 
+    def test_direct_log_subscriber_reports_queue_drops_after_force_flush(self):
+        emitted = 200
+        with _OtelCollector() as collector:
+            config = OpenTelemetryLogConfig(collector.endpoint)
+            config.max_queue_size = 2
+            config.max_export_batch_size = 1
+            config.scheduled_delay_millis = 60_000
+            subscriber = OpenTelemetryLogSubscriber(config)
+            subscriber_name = f"py_otel_log_drops_{uuid4().hex}"
+            subscriber.register(subscriber_name)
+            try:
+                for index in range(emitted):
+                    scope.event(
+                        f"log-overflow-{index}",
+                        data={"index": index},
+                        severity=LogSeverity.Info,
+                    )
+                subscribers.flush()
+                subscriber.force_flush()
+
+                arrived = len(collector.server.requests)
+                assert arrived < emitted, "the fixture must overflow the log queue"
+                diagnostic = subscriber.runtime_diagnostics().get("otel.logs_dropped")
+                assert diagnostic is not None
+                assert diagnostic.count == emitted - arrived
+                assert collector.endpoint in diagnostic.message
+            finally:
+                subscriber.deregister(subscriber_name)
+                subscriber.shutdown()
+
     def test_config_defaults_mutation_and_repr(self):
         config = OpenTelemetryConfig("full", "http://localhost:4318/v1/traces")
 


### PR DESCRIPTION
#### Overview

Expose OTLP trace and log batch-queue drops through direct subscriber runtime diagnostics after a successful force flush, while retaining final shutdown accounting.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Record only newly observed queue-drop deltas after successful trace and log force flushes, keeping diagnostic counts cumulative through shutdown.
- Preserve direct flush behavior and plugin-only teardown errors.
- Add Rust and Python regressions and update Rust, Python, Node.js, Go, and OTLP documentation.

#### Where should the reviewer start?

Start with `DiagnosticBatchSpanProcessor` and `DiagnosticBatchLogProcessor`, which now advance the reported cumulative drop total after a successful flush.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API for retrieving runtime diagnostics as JSON.
  - Successful `force_flush()` calls now update diagnostics with observed dropped spans and log events.

- **Bug Fixes**
  - Drop counts are reported cumulatively across repeated flushes and shutdown.
  - Concurrent queue drops are tracked accurately without duplicate or missed reporting.
  - Diagnostics continue to include the affected collector endpoint.

- **Documentation**
  - Clarified runtime diagnostic behavior across supported language APIs.

- **Tests**
  - Added coverage for cumulative reporting, queue overflow, flushing, shutdown, and endpoint details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->