### PR TITLE
fix: preserve typed metrics through PII sanitization

### DIFF
--- a/crates/pii-redaction/README.md
+++ b/crates/pii-redaction/README.md
@@ -145,7 +145,10 @@ detector = "email"
 `custom_mark_payload_policy = "preserve"` is the default and leaves unknown
 plugin mark payloads intact for analysis. Use `redact_all_leaves` when opaque
 plugins may emit content: scalar leaves in data, metadata, and opaque category
-profile fields are replaced while typed category identity remains valid.
+profile fields are replaced while typed category identity remains valid. Relay
+metric-schema marks use schema-aware sanitization instead: required measurement
+fields and numeric analytics remain valid for metric export, while descriptions
+and string attribute values are redacted.
 Strings become `[REDACTED]`, numbers become `0`, booleans become `false`, and
 nulls, keys, arrays, and object shape are retained.
 Known Relay marks are sanitized semantically so their structural and analytical

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -9,7 +9,10 @@ use serde::de::DeserializeOwned;
 use serde_json::{Map, Value as Json};
 use sha2::{Digest, Sha256};
 
-use nemo_relay::api::event::{CategoryProfile, Event, ScopeCategory};
+use nemo_relay::api::event::{
+    CategoryProfile, Event, METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION, MetricEnvelope,
+    ScopeCategory,
+};
 use nemo_relay::api::llm::LlmRequest;
 use nemo_relay::api::runtime::{
     BuiltinLlmCodec, EventSanitizeFn, LlmCodecIdentity, LlmSanitizeRequestFn,
@@ -184,6 +187,92 @@ impl CompiledBuiltinBackend {
     fn sanitize_json_preorder_dfs(&self, value: Json) -> Json {
         self.sanitize_json_preorder_dfs_at_path(value, &mut Vec::new())
             .unwrap_or(Json::Null)
+    }
+
+    fn sanitize_metric_envelope(&self, data: Json) -> Option<Json> {
+        let mut envelope = serde_json::from_value::<MetricEnvelope>(data).ok()?;
+        envelope.validate().ok()?;
+        for (index, measurement) in envelope.measurements.iter_mut().enumerate() {
+            measurement.description = measurement.description.take().and_then(|description| {
+                self.sanitize_metric_string_at_path(
+                    description,
+                    &[
+                        "measurements".to_string(),
+                        index.to_string(),
+                        "description".to_string(),
+                    ],
+                )
+            });
+            measurement.attributes = measurement
+                .attributes
+                .take()
+                .map(|attributes| self.sanitize_metric_attributes(attributes, index));
+        }
+        envelope.validate().ok()?;
+        serde_json::to_value(envelope).ok()
+    }
+
+    fn sanitize_metric_string_at_path(
+        &self,
+        value: String,
+        path_segments: &[String],
+    ) -> Option<String> {
+        let mut path_segments = path_segments.to_vec();
+        self.sanitize_json_preorder_dfs_at_path(Json::String(value), &mut path_segments)
+            .and_then(|value| value.as_str().map(str::to_string))
+    }
+
+    fn sanitize_metric_attributes(&self, attributes: Json, measurement_index: usize) -> Json {
+        let Json::Object(attributes) = attributes else {
+            return attributes;
+        };
+        Json::Object(
+            attributes
+                .into_iter()
+                .filter_map(|(key, value)| {
+                    self.sanitize_metric_attribute(value, measurement_index, &key)
+                        .map(|value| (key, value))
+                })
+                .collect(),
+        )
+    }
+
+    fn sanitize_metric_attribute(
+        &self,
+        value: Json,
+        measurement_index: usize,
+        attribute_key: &str,
+    ) -> Option<Json> {
+        let base_path = [
+            "measurements".to_string(),
+            measurement_index.to_string(),
+            "attributes".to_string(),
+            escape_json_pointer_segment(attribute_key),
+        ];
+        match value {
+            Json::String(value) => self
+                .sanitize_metric_string_at_path(value, &base_path)
+                .map(Json::String),
+            Json::Array(values) if values.iter().all(Json::is_string) => values
+                .into_iter()
+                .enumerate()
+                .map(|(index, value)| match value {
+                    Json::String(value) => self.sanitize_metric_string_at_path(
+                        value,
+                        &[
+                            base_path[0].clone(),
+                            base_path[1].clone(),
+                            base_path[2].clone(),
+                            base_path[3].clone(),
+                            index.to_string(),
+                        ],
+                    ),
+                    _ => unreachable!("checked all metric attribute values are strings"),
+                })
+                .collect::<Option<Vec<_>>>()
+                .map(|values| Json::Array(values.into_iter().map(Json::String).collect())),
+            value => Some(value),
+        }
     }
 
     fn sanitize_tool_result_annotation(&self, profile: &mut CategoryProfile) {
@@ -535,6 +624,15 @@ fn event_sanitize_callback_with_scope_categories(
             if let Some(trajectory) = backend.trajectory.as_ref() {
                 return Ok(trajectory.sanitize_event_fields(&event, fields));
             }
+            if is_relay_metric_mark(&event) {
+                fields.data = fields
+                    .data
+                    .and_then(|data| backend.sanitize_metric_envelope(data));
+                fields.metadata = fields
+                    .metadata
+                    .map(|metadata| backend.sanitize_json_preorder_dfs(metadata));
+                return Ok(fields);
+            }
             let specialized_scope = matches!(event.as_ref(), Event::Scope(_))
                 && event
                     .category()
@@ -568,6 +666,13 @@ fn event_sanitize_callback_with_scope_categories(
             Ok(fields)
         })
     })
+}
+
+fn is_relay_metric_mark(event: &Event) -> bool {
+    matches!(event, Event::Mark(_))
+        && event.data_schema().is_some_and(|schema| {
+            schema.name == METRIC_DATA_SCHEMA_NAME && schema.version == METRIC_DATA_SCHEMA_VERSION
+        })
 }
 
 pub(super) fn llm_sanitize_request_callback(

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -254,24 +254,27 @@ impl CompiledBuiltinBackend {
             Json::String(value) => self
                 .sanitize_metric_string_at_path(value, &base_path)
                 .map(Json::String),
-            Json::Array(values) if values.iter().all(Json::is_string) => values
-                .into_iter()
-                .enumerate()
-                .map(|(index, value)| match value {
-                    Json::String(value) => self.sanitize_metric_string_at_path(
-                        value,
-                        &[
-                            base_path[0].clone(),
-                            base_path[1].clone(),
-                            base_path[2].clone(),
-                            base_path[3].clone(),
-                            index.to_string(),
-                        ],
-                    ),
-                    _ => unreachable!("checked all metric attribute values are strings"),
-                })
-                .collect::<Option<Vec<_>>>()
-                .map(|values| Json::Array(values.into_iter().map(Json::String).collect())),
+            Json::Array(values) if values.iter().all(Json::is_string) => Some(Json::Array(
+                values
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(|(index, value)| match value {
+                        Json::String(value) => self
+                            .sanitize_metric_string_at_path(
+                                value,
+                                &[
+                                    base_path[0].clone(),
+                                    base_path[1].clone(),
+                                    base_path[2].clone(),
+                                    base_path[3].clone(),
+                                    index.to_string(),
+                                ],
+                            )
+                            .map(Json::String),
+                        _ => unreachable!("checked all metric attribute values are strings"),
+                    })
+                    .collect(),
+            )),
             value => Some(value),
         }
     }

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -9,10 +9,7 @@ use serde::de::DeserializeOwned;
 use serde_json::{Map, Value as Json};
 use sha2::{Digest, Sha256};
 
-use nemo_relay::api::event::{
-    CategoryProfile, Event, METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION, MetricEnvelope,
-    ScopeCategory,
-};
+use nemo_relay::api::event::{CategoryProfile, Event, MetricEnvelope, ScopeCategory};
 use nemo_relay::api::llm::LlmRequest;
 use nemo_relay::api::runtime::{
     BuiltinLlmCodec, EventSanitizeFn, LlmCodecIdentity, LlmSanitizeRequestFn,
@@ -29,7 +26,7 @@ use nemo_relay::plugin::{PluginError, Result as PluginResult};
 use super::component::BuiltinBackendConfig;
 use super::detectors::BuiltinDetector;
 use super::overlay::BuiltinCodecName;
-use super::trajectory::{CustomMarkPayloadPolicy, TrajectorySanitizer};
+use super::trajectory::{CustomMarkPayloadPolicy, TrajectorySanitizer, is_relay_metric_mark};
 
 #[derive(Clone)]
 pub(super) struct CompiledBuiltinBackend {
@@ -673,14 +670,6 @@ fn event_sanitize_callback_with_scope_categories(
             Ok(fields)
         })
     })
-}
-
-/// Return whether an event carries Relay's typed metric schema.
-fn is_relay_metric_mark(event: &Event) -> bool {
-    matches!(event, Event::Mark(_))
-        && event.data_schema().is_some_and(|schema| {
-            schema.name == METRIC_DATA_SCHEMA_NAME && schema.version == METRIC_DATA_SCHEMA_VERSION
-        })
 }
 
 pub(super) fn llm_sanitize_request_callback(

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -189,6 +189,7 @@ impl CompiledBuiltinBackend {
             .unwrap_or(Json::Null)
     }
 
+    /// Sanitize optional metric text without modifying required export fields.
     fn sanitize_metric_envelope(&self, data: Json) -> Option<Json> {
         let mut envelope = serde_json::from_value::<MetricEnvelope>(data).ok()?;
         envelope.validate().ok()?;
@@ -212,6 +213,7 @@ impl CompiledBuiltinBackend {
         serde_json::to_value(envelope).ok()
     }
 
+    /// Sanitize metric text using its payload-relative JSON Pointer.
     fn sanitize_metric_string_at_path(
         &self,
         value: String,
@@ -222,6 +224,7 @@ impl CompiledBuiltinBackend {
             .and_then(|value| value.as_str().map(str::to_string))
     }
 
+    /// Sanitize string-valued attributes while retaining analytical values.
     fn sanitize_metric_attributes(&self, attributes: Json, measurement_index: usize) -> Json {
         let Json::Object(attributes) = attributes else {
             return attributes;
@@ -237,6 +240,7 @@ impl CompiledBuiltinBackend {
         )
     }
 
+    /// Sanitize one metric attribute without changing its scalar type.
     fn sanitize_metric_attribute(
         &self,
         value: Json,
@@ -631,6 +635,9 @@ fn event_sanitize_callback_with_scope_categories(
                 fields.metadata = fields
                     .metadata
                     .map(|metadata| backend.sanitize_json_preorder_dfs(metadata));
+                fields.category_profile = fields.category_profile.and_then(|profile| {
+                    sanitize_serializable_with_backend::<CategoryProfile>(&backend, profile).ok()
+                });
                 return Ok(fields);
             }
             let specialized_scope = matches!(event.as_ref(), Event::Scope(_))
@@ -668,6 +675,7 @@ fn event_sanitize_callback_with_scope_categories(
     })
 }
 
+/// Return whether an event carries Relay's typed metric schema.
 fn is_relay_metric_mark(event: &Event) -> bool {
     matches!(event, Event::Mark(_))
         && event.data_schema().is_some_and(|schema| {

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -254,27 +254,34 @@ impl CompiledBuiltinBackend {
             Json::String(value) => self
                 .sanitize_metric_string_at_path(value, &base_path)
                 .map(Json::String),
-            Json::Array(values) if values.iter().all(Json::is_string) => Some(Json::Array(
-                values
-                    .into_iter()
-                    .enumerate()
-                    .filter_map(|(index, value)| match value {
-                        Json::String(value) => self
-                            .sanitize_metric_string_at_path(
-                                value,
-                                &[
-                                    base_path[0].clone(),
-                                    base_path[1].clone(),
-                                    base_path[2].clone(),
-                                    base_path[3].clone(),
-                                    index.to_string(),
-                                ],
-                            )
-                            .map(Json::String),
-                        _ => unreachable!("checked all metric attribute values are strings"),
-                    })
-                    .collect(),
-            )),
+            Json::Array(values) if values.iter().all(Json::is_string) => {
+                if matches!(self.action, BuiltinAction::Remove)
+                    && self.matches_current_preorder_path(&base_path)
+                {
+                    return None;
+                }
+                Some(Json::Array(
+                    values
+                        .into_iter()
+                        .enumerate()
+                        .filter_map(|(index, value)| match value {
+                            Json::String(value) => self
+                                .sanitize_metric_string_at_path(
+                                    value,
+                                    &[
+                                        base_path[0].clone(),
+                                        base_path[1].clone(),
+                                        base_path[2].clone(),
+                                        base_path[3].clone(),
+                                        index.to_string(),
+                                    ],
+                                )
+                                .map(Json::String),
+                            _ => unreachable!("checked all metric attribute values are strings"),
+                        })
+                        .collect(),
+                ))
+            }
             value => Some(value),
         }
     }

--- a/crates/pii-redaction/src/trajectory.rs
+++ b/crates/pii-redaction/src/trajectory.rs
@@ -137,6 +137,9 @@ impl TrajectorySanitizer {
             fields.metadata = fields
                 .metadata
                 .map(|value| redact_semantic_content(value, &self.replacement, None));
+            fields.category_profile = fields
+                .category_profile
+                .and_then(|profile| sanitize_category_profile(profile, &self.replacement));
             return fields;
         }
 
@@ -180,6 +183,7 @@ impl TrajectorySanitizer {
         fields
     }
 
+    /// Redact optional metric text without modifying required export fields.
     fn sanitize_metric_envelope(&self, data: Json) -> Option<Json> {
         let mut envelope = serde_json::from_value::<MetricEnvelope>(data).ok()?;
         envelope.validate().ok()?;
@@ -198,6 +202,7 @@ impl TrajectorySanitizer {
     }
 }
 
+/// Return whether an event carries Relay's typed metric schema.
 fn is_relay_metric_mark(event: &Event) -> bool {
     matches!(event, Event::Mark(_))
         && event.data_schema().is_some_and(|schema| {
@@ -205,6 +210,7 @@ fn is_relay_metric_mark(event: &Event) -> bool {
         })
 }
 
+/// Redact strings in a typed metric attribute object.
 fn redact_metric_string_attributes(value: Json, replacement: &str) -> Json {
     match value {
         Json::Object(values) => Json::Object(
@@ -217,6 +223,7 @@ fn redact_metric_string_attributes(value: Json, replacement: &str) -> Json {
     }
 }
 
+/// Redact an individual typed metric attribute when it contains text.
 fn redact_metric_string_attribute(value: Json, replacement: &str) -> Json {
     match value {
         Json::String(_) => Json::String(replacement.to_string()),

--- a/crates/pii-redaction/src/trajectory.rs
+++ b/crates/pii-redaction/src/trajectory.rs
@@ -203,7 +203,7 @@ impl TrajectorySanitizer {
 }
 
 /// Return whether an event carries Relay's typed metric schema.
-fn is_relay_metric_mark(event: &Event) -> bool {
+pub(crate) fn is_relay_metric_mark(event: &Event) -> bool {
     matches!(event, Event::Mark(_))
         && event.data_schema().is_some_and(|schema| {
             schema.name == METRIC_DATA_SCHEMA_NAME && schema.version == METRIC_DATA_SCHEMA_VERSION

--- a/crates/pii-redaction/src/trajectory.rs
+++ b/crates/pii-redaction/src/trajectory.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use serde_json::Value as Json;
 
-use nemo_relay::api::event::{CategoryProfile, Event};
+use nemo_relay::api::event::{
+    CategoryProfile, Event, METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION, MetricEnvelope,
+};
 use nemo_relay::codec::request::AnnotatedLlmRequest;
 use nemo_relay::codec::response::AnnotatedLlmResponse;
 
@@ -128,6 +130,16 @@ impl TrajectorySanitizer {
         event: &Event,
         mut fields: nemo_relay::api::event::EventSanitizeFields,
     ) -> nemo_relay::api::event::EventSanitizeFields {
+        if is_relay_metric_mark(event) {
+            fields.data = fields
+                .data
+                .and_then(|data| self.sanitize_metric_envelope(data));
+            fields.metadata = fields
+                .metadata
+                .map(|value| redact_semantic_content(value, &self.replacement, None));
+            return fields;
+        }
+
         let category = event.category().map(|category| category.as_str());
         let specialized_scope =
             matches!(event, Event::Scope(_)) && matches!(category, Some("llm" | "tool"));
@@ -166,6 +178,55 @@ impl TrajectorySanitizer {
             .category_profile
             .and_then(|profile| sanitize_category_profile(profile, &self.replacement));
         fields
+    }
+
+    fn sanitize_metric_envelope(&self, data: Json) -> Option<Json> {
+        let mut envelope = serde_json::from_value::<MetricEnvelope>(data).ok()?;
+        envelope.validate().ok()?;
+        for measurement in &mut envelope.measurements {
+            measurement.description = measurement
+                .description
+                .take()
+                .map(|_| (*self.replacement).clone());
+            measurement.attributes = measurement
+                .attributes
+                .take()
+                .map(|attributes| redact_metric_string_attributes(attributes, &self.replacement));
+        }
+        envelope.validate().ok()?;
+        serde_json::to_value(envelope).ok()
+    }
+}
+
+fn is_relay_metric_mark(event: &Event) -> bool {
+    matches!(event, Event::Mark(_))
+        && event.data_schema().is_some_and(|schema| {
+            schema.name == METRIC_DATA_SCHEMA_NAME && schema.version == METRIC_DATA_SCHEMA_VERSION
+        })
+}
+
+fn redact_metric_string_attributes(value: Json, replacement: &str) -> Json {
+    match value {
+        Json::Object(values) => Json::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, redact_metric_string_attribute(value, replacement)))
+                .collect(),
+        ),
+        value => value,
+    }
+}
+
+fn redact_metric_string_attribute(value: Json, replacement: &str) -> Json {
+    match value {
+        Json::String(_) => Json::String(replacement.to_string()),
+        Json::Array(values) if values.iter().all(Json::is_string) => Json::Array(
+            values
+                .into_iter()
+                .map(|_| Json::String(replacement.to_string()))
+                .collect(),
+        ),
+        value => value,
     }
 }
 

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -1186,7 +1186,10 @@ async fn trajectory_metric_marks_preserve_typed_measurements_and_redact_text() {
         Arc::new(event),
         EventSanitizeFields {
             data: Some(data),
-            category_profile: None,
+            category_profile: Some(CategoryProfile {
+                extra: BTreeMap::from([("owner".into(), json!("person@example.com"))]),
+                ..CategoryProfile::default()
+            }),
             metadata: Some(json!({"owner": "person@example.com"})),
         },
     )
@@ -1212,6 +1215,10 @@ async fn trajectory_metric_marks_preserve_typed_measurements_and_redact_text() {
     assert_eq!(data["measurements"][0]["attributes"]["attempt"], 2);
     assert_eq!(data["measurements"][0]["attributes"]["sampled"], true);
     assert_eq!(sanitized.metadata.unwrap()["owner"], "[REDACTED]");
+    assert_eq!(
+        sanitized.category_profile.unwrap().extra["owner"],
+        "[REDACTED]"
+    );
 }
 
 #[tokio::test]
@@ -1247,7 +1254,10 @@ async fn builtin_metric_marks_preserve_typed_measurements() {
         Arc::new(event),
         EventSanitizeFields {
             data: Some(data),
-            category_profile: None,
+            category_profile: Some(CategoryProfile {
+                extra: BTreeMap::from([("owner".into(), json!("person@example.com"))]),
+                ..CategoryProfile::default()
+            }),
             metadata: None,
         },
     )
@@ -1263,6 +1273,93 @@ async fn builtin_metric_marks_preserve_typed_measurements() {
     assert_eq!(data["measurements"][0]["value"], 1);
     assert!(data["measurements"][0]["description"].is_null());
     assert_eq!(data["measurements"][0]["attributes"], json!({}));
+    assert!(
+        !sanitized
+            .category_profile
+            .unwrap()
+            .extra
+            .contains_key("owner")
+    );
+}
+
+#[tokio::test]
+async fn trajectory_metric_marks_drop_invalid_envelopes() {
+    let data = json!({
+        "measurements": [{
+            "name": "example.invalid",
+            "kind": "counter",
+            "value_type": "invalid",
+            "value": 1
+        }]
+    });
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .name("example.metrics")
+            .data(data.clone())
+            .data_schema(
+                DataSchema::builder()
+                    .name(METRIC_DATA_SCHEMA_NAME)
+                    .version(METRIC_DATA_SCHEMA_VERSION)
+                    .build(),
+            )
+            .build(),
+        None,
+        None,
+    ));
+    let callback = crate::builtin::event_sanitize_callback(trajectory_backend(None, "preserve"));
+    let sanitized = callback(
+        Arc::new(event),
+        EventSanitizeFields {
+            data: Some(data),
+            category_profile: None,
+            metadata: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(sanitized.data.is_none());
+}
+
+#[tokio::test]
+async fn builtin_metric_marks_drop_invalid_envelopes() {
+    let data = json!({
+        "measurements": [{
+            "name": "example.invalid",
+            "kind": "counter",
+            "value_type": "invalid",
+            "value": 1
+        }]
+    });
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .name("example.metrics")
+            .data(data.clone())
+            .data_schema(
+                DataSchema::builder()
+                    .name(METRIC_DATA_SCHEMA_NAME)
+                    .version(METRIC_DATA_SCHEMA_VERSION)
+                    .build(),
+            )
+            .build(),
+        None,
+        None,
+    ));
+    let callback = crate::builtin::event_sanitize_callback(
+        crate::builtin::CompiledBuiltinBackend::new(BuiltinBackendConfig::default(), None).unwrap(),
+    );
+    let sanitized = callback(
+        Arc::new(event),
+        EventSanitizeFields {
+            data: Some(data),
+            category_profile: None,
+            metadata: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(sanitized.data.is_none());
 }
 
 #[tokio::test]

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -1283,6 +1283,63 @@ async fn builtin_metric_marks_preserve_typed_measurements() {
 }
 
 #[tokio::test]
+async fn builtin_metric_marks_remove_only_targeted_string_array_elements() {
+    let data = json!({
+        "measurements": [{
+            "name": "example.request_count",
+            "kind": "counter",
+            "value_type": "u64",
+            "value": 1,
+            "attributes": {"regions": ["us-east", "us-west"]}
+        }]
+    });
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .name("example.metrics")
+            .data(data.clone())
+            .data_schema(
+                DataSchema::builder()
+                    .name(METRIC_DATA_SCHEMA_NAME)
+                    .version(METRIC_DATA_SCHEMA_VERSION)
+                    .build(),
+            )
+            .build(),
+        None,
+        None,
+    ));
+    let callback = crate::builtin::event_sanitize_callback(
+        crate::builtin::CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                target_paths: vec!["/measurements/0/attributes/regions/0".to_string()],
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap(),
+    );
+    let sanitized = callback(
+        Arc::new(event),
+        EventSanitizeFields {
+            data: Some(data),
+            category_profile: None,
+            metadata: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let data = sanitized.data.unwrap();
+    serde_json::from_value::<MetricEnvelope>(data.clone())
+        .unwrap()
+        .validate()
+        .unwrap();
+    assert_eq!(
+        data["measurements"][0]["attributes"]["regions"],
+        json!(["us-west"])
+    );
+}
+
+#[tokio::test]
 async fn trajectory_metric_marks_drop_invalid_envelopes() {
     let data = json!({
         "measurements": [{

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -6,8 +6,9 @@
 
 use super::*;
 use crate::api::event::{
-    BaseEvent, CategoryProfile, Event, EventCategory, EventSanitizeFields, MarkEvent,
-    ScopeCategory, ScopeEvent,
+    BaseEvent, CategoryProfile, DataSchema, Event, EventCategory, EventSanitizeFields,
+    METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION, MarkEvent, MetricEnvelope, ScopeCategory,
+    ScopeEvent,
 };
 use crate::api::llm::{
     LlmCallExecuteParams, LlmCallParams, LlmRequest, LlmStreamCallExecuteParams, llm_call,
@@ -1132,6 +1133,136 @@ async fn trajectory_custom_mark_policy_is_explicit_and_shape_preserving() {
     let profile = sanitized.category_profile.unwrap();
     assert_eq!(profile.subtype.as_deref(), Some("neutral.plugin"));
     assert_eq!(profile.extra["opaque"]["label"], "[REDACTED]");
+}
+
+#[tokio::test]
+async fn trajectory_metric_marks_preserve_typed_measurements_and_redact_text() {
+    let data = json!({
+        "measurements": [
+            {
+                "name": "example.request_count",
+                "kind": "counter",
+                "value_type": "u64",
+                "value": 1,
+                "description": "private request count",
+                "attributes": {
+                    "owner": "person@example.com",
+                    "regions": ["us-east", "us-west"],
+                    "attempt": 2,
+                    "sampled": true
+                }
+            },
+            {
+                "name": "example.queue_delta",
+                "kind": "up_down_counter",
+                "value_type": "i64",
+                "value": -2
+            },
+            {
+                "name": "example.latency",
+                "kind": "histogram",
+                "value_type": "f64",
+                "value": 3.5,
+                "boundaries": [1.0, 5.0]
+            }
+        ]
+    });
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .name("example.metrics")
+            .data(data.clone())
+            .data_schema(
+                DataSchema::builder()
+                    .name(METRIC_DATA_SCHEMA_NAME)
+                    .version(METRIC_DATA_SCHEMA_VERSION)
+                    .build(),
+            )
+            .build(),
+        None,
+        None,
+    ));
+    let callback = crate::builtin::event_sanitize_callback(trajectory_backend(None, "preserve"));
+    let sanitized = callback(
+        Arc::new(event),
+        EventSanitizeFields {
+            data: Some(data),
+            category_profile: None,
+            metadata: Some(json!({"owner": "person@example.com"})),
+        },
+    )
+    .await
+    .unwrap();
+
+    let data = sanitized.data.unwrap();
+    let envelope = serde_json::from_value::<MetricEnvelope>(data.clone()).unwrap();
+    envelope.validate().unwrap();
+    assert_eq!(data["measurements"][0]["value_type"], "u64");
+    assert_eq!(data["measurements"][0]["value"], 1);
+    assert_eq!(data["measurements"][1]["value_type"], "i64");
+    assert_eq!(data["measurements"][1]["value"], -2);
+    assert_eq!(data["measurements"][2]["value_type"], "f64");
+    assert_eq!(data["measurements"][2]["value"], 3.5);
+    assert_eq!(data["measurements"][2]["boundaries"], json!([1.0, 5.0]));
+    assert_eq!(data["measurements"][0]["description"], "[REDACTED]");
+    assert_eq!(data["measurements"][0]["attributes"]["owner"], "[REDACTED]");
+    assert_eq!(
+        data["measurements"][0]["attributes"]["regions"],
+        json!(["[REDACTED]", "[REDACTED]"])
+    );
+    assert_eq!(data["measurements"][0]["attributes"]["attempt"], 2);
+    assert_eq!(data["measurements"][0]["attributes"]["sampled"], true);
+    assert_eq!(sanitized.metadata.unwrap()["owner"], "[REDACTED]");
+}
+
+#[tokio::test]
+async fn builtin_metric_marks_preserve_typed_measurements() {
+    let data = json!({
+        "measurements": [{
+            "name": "example.request_count",
+            "kind": "counter",
+            "value_type": "u64",
+            "value": 1,
+            "description": "private request count",
+            "attributes": {"owner": "person@example.com"}
+        }]
+    });
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .name("example.metrics")
+            .data(data.clone())
+            .data_schema(
+                DataSchema::builder()
+                    .name(METRIC_DATA_SCHEMA_NAME)
+                    .version(METRIC_DATA_SCHEMA_VERSION)
+                    .build(),
+            )
+            .build(),
+        None,
+        None,
+    ));
+    let callback = crate::builtin::event_sanitize_callback(
+        crate::builtin::CompiledBuiltinBackend::new(BuiltinBackendConfig::default(), None).unwrap(),
+    );
+    let sanitized = callback(
+        Arc::new(event),
+        EventSanitizeFields {
+            data: Some(data),
+            category_profile: None,
+            metadata: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let data = sanitized.data.unwrap();
+    serde_json::from_value::<MetricEnvelope>(data.clone())
+        .unwrap()
+        .validate()
+        .unwrap();
+    assert_eq!(data["measurements"][0]["value_type"], "u64");
+    assert_eq!(data["measurements"][0]["value"], 1);
+    assert!(data["measurements"][0]["description"].is_null());
+    assert_eq!(data["measurements"][0]["attributes"], json!({}));
 }
 
 #[tokio::test]

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -1283,7 +1283,7 @@ async fn builtin_metric_marks_preserve_typed_measurements() {
 }
 
 #[tokio::test]
-async fn builtin_metric_marks_remove_only_targeted_string_array_elements() {
+async fn builtin_metric_marks_remove_string_array_attributes_at_target_paths() {
     let data = json!({
         "measurements": [{
             "name": "example.request_count",
@@ -1318,7 +1318,7 @@ async fn builtin_metric_marks_remove_only_targeted_string_array_elements() {
         .unwrap(),
     );
     let sanitized = callback(
-        Arc::new(event),
+        Arc::new(event.clone()),
         EventSanitizeFields {
             data: Some(data),
             category_profile: None,
@@ -1337,6 +1337,42 @@ async fn builtin_metric_marks_remove_only_targeted_string_array_elements() {
         data["measurements"][0]["attributes"]["regions"],
         json!(["us-west"])
     );
+
+    let callback = crate::builtin::event_sanitize_callback(
+        crate::builtin::CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                target_paths: vec!["/measurements/0/attributes/regions".to_string()],
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap(),
+    );
+    let sanitized = callback(
+        Arc::new(event),
+        EventSanitizeFields {
+            data: Some(json!({
+                "measurements": [{
+                    "name": "example.request_count",
+                    "kind": "counter",
+                    "value_type": "u64",
+                    "value": 1,
+                    "attributes": {"regions": ["us-east", "us-west"]}
+                }]
+            })),
+            category_profile: None,
+            metadata: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let data = sanitized.data.unwrap();
+    serde_json::from_value::<MetricEnvelope>(data.clone())
+        .unwrap()
+        .validate()
+        .unwrap();
+    assert_eq!(data["measurements"][0]["attributes"], json!({}));
 }
 
 #[tokio::test]

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -255,6 +255,10 @@ The plugin sanitizes optional text without invalidating the envelope:
 - With `target_paths`, those fields are sanitized only when their
   payload-relative JSON Pointer matches, such as
   `/measurements/0/description` or `/measurements/0/attributes/owner`.
+- With `action = "remove"`, targeting a whole string-array attribute removes
+  that attribute. Targeting an individual element removes that element and
+  compacts the remaining array; Relay cannot use a `null` placeholder because
+  typed OpenTelemetry metric attributes must remain valid homogeneous arrays.
 - Numeric and boolean metric attributes remain analytical telemetry.
 
 The `trajectory_context` preset replaces descriptions and string-valued

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -250,14 +250,18 @@ exporter can validate and export the mark.
 
 The plugin sanitizes optional text without invalidating the envelope:
 
-- Measurement descriptions follow the configured built-in action.
-- String-valued metric attributes follow the configured built-in action.
+- With no `target_paths`, measurement descriptions and string-valued metric
+  attributes follow the configured built-in action.
+- With `target_paths`, those fields are sanitized only when their
+  payload-relative JSON Pointer matches, such as
+  `/measurements/0/description` or `/measurements/0/attributes/owner`.
 - Numeric and boolean metric attributes remain analytical telemetry.
 
 The `trajectory_context` preset replaces descriptions and string-valued
 attributes with its configured replacement while retaining the required metric
-fields. Its `custom_mark_payload_policy` applies only to opaque marks in the
-`custom` category; it does not control Relay typed metric envelopes.
+fields. That preset does not accept `target_paths`. Its
+`custom_mark_payload_policy` applies only to opaque marks in the `custom`
+category; it does not control Relay typed metric envelopes.
 
 ## Action Semantics
 

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -241,6 +241,24 @@ The `builtin` section contains:
 | `unmasked_prefix` | Leading character count to keep when `action = "mask"`. Defaults to `0`, unless a detector-specific masking preset is active. |
 | `unmasked_suffix` | Trailing character count to keep when `action = "mask"`. Defaults to `0`, unless a detector-specific masking preset is active. |
 
+## Typed Metric Marks
+
+Relay recognizes marks that use its `nemo.relay.metric_measurements` schema as
+typed metric envelopes. PII sanitization preserves the measurement name, kind,
+value type, numeric value, and histogram boundaries so the OpenTelemetry metric
+exporter can validate and export the mark.
+
+The plugin sanitizes optional text without invalidating the envelope:
+
+- Measurement descriptions follow the configured built-in action.
+- String-valued metric attributes follow the configured built-in action.
+- Numeric and boolean metric attributes remain analytical telemetry.
+
+The `trajectory_context` preset replaces descriptions and string-valued
+attributes with its configured replacement while retaining the required metric
+fields. Its `custom_mark_payload_policy` applies only to opaque marks in the
+`custom` category; it does not control Relay typed metric envelopes.
+
 ## Action Semantics
 
 ### `remove`


### PR DESCRIPTION
#### Overview

Preserve Relay typed metric envelopes through PII sanitization so OpenTelemetry can validate and export them.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Detect Relay metric marks from their data schema before generic payload redaction.
- Preserve required metric fields and analytical numeric values while sanitizing descriptions and string attributes.
- Add metric-envelope regression tests and document the behavior in the PII plugin reference.

#### Where should the reviewer start?

Start with `crates/pii-redaction/src/trajectory.rs`, then review the matching built-in sanitizer path and metric regression tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes #888
- Closes RELAY-787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema-aware sanitization for metric events.
  * Preserves required measurements, numeric and boolean values, and valid metric boundaries.
  * Redacts descriptions, string attributes, string arrays, and sensitive metadata.
  * Removes malformed metric events that cannot be validated safely.

* **Documentation**
  * Expanded guidance for typed metric events, trajectory context, and custom payload policies.

* **Tests**
  * Added coverage for metric validity and redaction across sanitization modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->