### PR TITLE
feat: add categories to grpc-v1 worker marks

### DIFF
--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -70,7 +70,7 @@ use tokio_stream::wrappers::UnixListenerStream;
 #[cfg(unix)]
 use tower::service_fn;
 
-use crate::api::event::{DataSchema, Event, EventSanitizeFields, LogSeverity};
+use crate::api::event::{DataSchema, Event, EventCategory, EventSanitizeFields, LogSeverity};
 use crate::api::llm::{LLM_REQUEST_INTERCEPT_OUTCOME_SCHEMA, LlmRequest};
 use crate::api::registry::{
     RuntimeRegistrationKind, RuntimeRegistrationOwnerKind,
@@ -2876,6 +2876,7 @@ impl RelayHostRuntime for WorkerHostRuntimeService {
             metadata,
             data_schema,
             severity,
+            category,
         } = request.into_inner();
         self.state.authorize(&activation_id, &auth_token)?;
         let data_schema = optional_typed_envelope::<DataSchema>(
@@ -2884,6 +2885,7 @@ impl RelayHostRuntime for WorkerHostRuntimeService {
             DATA_SCHEMA_SCHEMA,
         );
         let severity = optional_log_severity(&severity);
+        let category = (!category.is_empty()).then(|| EventCategory::new(category));
         let result = self.with_stack(scope.as_ref(), || {
             emit_scope_mark(
                 EmitMarkEventParams::builder()
@@ -2892,6 +2894,7 @@ impl RelayHostRuntime for WorkerHostRuntimeService {
                     .metadata_opt(optional_envelope_to_json(metadata)?)
                     .data_schema_opt(data_schema?)
                     .severity_opt(severity?)
+                    .category_opt(category)
                     .build(),
             )
         });

--- a/crates/core/tests/fixtures/worker_plugin/src/main.rs
+++ b/crates/core/tests/fixtures/worker_plugin/src/main.rs
@@ -4,8 +4,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use nemo_relay_worker::{
-    ConfigDiagnostic, DiagnosticLevel, EventSanitizeFields, Json, LlmRequest,
-    METRIC_DATA_SCHEMA_NAME, MetricKind, MetricMeasurement, MetricValueType, PendingMarkSpec,
+    ConfigDiagnostic, DiagnosticLevel, EmitMarkOptions, EventCategory, EventSanitizeFields, Json,
+    LlmRequest, METRIC_DATA_SCHEMA_NAME, MetricKind, MetricMeasurement, MetricValueType,
+    PendingMarkSpec,
 };
 use nemo_relay_worker::{
     JsonStream, LlmNext, LlmStreamNext, PluginContext, RuntimeRegistrationKind, ScopeType,
@@ -384,7 +385,13 @@ async fn emit_runtime_events(
     runtime: nemo_relay_worker::PluginRuntime,
 ) -> nemo_relay_worker::Result<()> {
     runtime
-        .emit_mark("fixture.worker.mark", Some(json!("current")), None)
+        .emit_mark_with_options_and_category(
+            "fixture.worker.mark",
+            Some(json!("current")),
+            None,
+            EmitMarkOptions::default(),
+            EventCategory::custom(),
+        )
         .await?;
     let scope = runtime
         .push_scope(

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -446,6 +446,12 @@ async fn rust_worker_registers_and_invokes_all_current_surfaces() {
             .unwrap()["worker_plugin_mark"],
         true
     );
+    assert_eq!(
+        find_event(&captured_events, "fixture.worker.mark", None)
+            .category()
+            .map(|category| category.as_str()),
+        Some("custom")
+    );
     assert_parent(
         &captured_events,
         "fixture.worker.scope",

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -2005,6 +2005,7 @@ async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
             metadata: None,
             data_schema: None,
             severity: String::new(),
+            category: String::new(),
         }))
         .await
         .expect_err("bad activation id should fail auth");
@@ -2023,6 +2024,7 @@ async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
             metadata: None,
             data_schema: None,
             severity: String::new(),
+            category: String::new(),
         }))
         .await
         .expect("missing stack should return host ack")
@@ -2045,6 +2047,7 @@ async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
             metadata: None,
             data_schema: None,
             severity: String::new(),
+            category: String::new(),
         }))
         .await
         .expect("no-scope mark should succeed")
@@ -2070,6 +2073,7 @@ async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
                 .unwrap(),
             ),
             severity: "warning".into(),
+            category: "custom".into(),
         }))
         .await
         .expect("typed mark options should return host ack")

--- a/crates/worker-proto/README.md
+++ b/crates/worker-proto/README.md
@@ -39,7 +39,7 @@ and tool execution intercepts use structural `ToolExecutionInterceptOutcome` mes
 | JSON envelope helpers | Serialize Relay DTOs through `json_envelope` and `decode_json_envelope`, keeping protobuf responsible for transport flow rather than runtime data modeling. |
 | JSON value helpers | Serialize application-owned fields inside structural tool-result messages through `json_value` and `decode_json_value`. |
 | Tool results | `ToolNext` returns `ToolExecutionResultResponse`, and `ToolExecutionInterceptResult` returns `ToolExecutionInterceptOutcome`. Both preserve the application result and optional annotation. Intercept outcomes also include ordered pending marks. These fields use lossless protobuf `JsonValue` wrappers rather than `google.protobuf.Value`. |
-| Mark options | `EmitMarkRequest.data_schema` carries a `nemo.relay.DataSchema@1` envelope and `severity` carries the log severity. Omitting both preserves legacy behavior. |
+| Mark options | `EmitMarkRequest.data_schema` carries a `nemo.relay.DataSchema@1` envelope, `severity` carries the log severity, and `category` carries an optional semantic mark category. Omitting these fields preserves legacy behavior. |
 | Runtime diagnostics | Authenticated `GetRuntimeDiagnostics` returns a bounded active-host `{ code, message, count }` snapshot. Older hosts return gRPC `UNIMPLEMENTED`. |
 
 ## Installation

--- a/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
+++ b/crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto
@@ -389,6 +389,7 @@ message EmitMarkRequest {
   JsonEnvelope metadata = 6;
   JsonEnvelope data_schema = 7;
   string severity = 8;
+  string category = 9;
 }
 
 message PushScopeRequest {

--- a/crates/worker-proto/tests/proto_tests.rs
+++ b/crates/worker-proto/tests/proto_tests.rs
@@ -217,6 +217,7 @@ fn emit_mark_additive_fields_preserve_legacy_wire_compatibility() {
     assert_eq!(legacy.name, "mark");
     assert!(legacy.data_schema.is_none());
     assert!(legacy.severity.is_empty());
+    assert!(legacy.category.is_empty());
 
     let request = EmitMarkRequest {
         name: "mark".into(),
@@ -228,12 +229,13 @@ fn emit_mark_additive_fields_preserve_legacy_wire_compatibility() {
             .unwrap(),
         ),
         severity: "warn".into(),
+        category: "custom".into(),
         ..EmitMarkRequest::default()
     };
     let encoded = request.encode_to_vec();
     assert_eq!(
         encoded,
-        b"\x22\x04mark\x3a\x52\x0a\x17nemo.relay.DataSchema@1\x12\x37{\"name\":\"nemo.relay.metric_measurements\",\"version\":\"1\"}\x42\x04warn"
+        b"\x22\x04mark\x3a\x52\x0a\x17nemo.relay.DataSchema@1\x12\x37{\"name\":\"nemo.relay.metric_measurements\",\"version\":\"1\"}\x42\x04warn\x4a\x06custom"
             .to_vec()
     );
     let round_trip = EmitMarkRequest::decode(encoded.as_slice()).unwrap();

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1000,7 +1000,7 @@ impl PluginRuntime {
         metadata: Option<Json>,
         options: EmitMarkOptions,
     ) -> Result<()> {
-        self.emit_mark_with_optional_category(name, data, metadata, options, None)
+        self.emit_mark_impl(name, data, metadata, options, None)
             .await
     }
 
@@ -1013,11 +1013,11 @@ impl PluginRuntime {
         options: EmitMarkOptions,
         category: EventCategory,
     ) -> Result<()> {
-        self.emit_mark_with_optional_category(name, data, metadata, options, Some(category))
+        self.emit_mark_impl(name, data, metadata, options, Some(category))
             .await
     }
 
-    async fn emit_mark_with_optional_category(
+    async fn emit_mark_impl(
         &self,
         name: &str,
         data: Option<Json>,
@@ -1097,11 +1097,34 @@ impl PluginRuntime {
         measurements: Vec<MetricMeasurement>,
         metadata: Option<Json>,
     ) -> Result<()> {
+        self.emit_metric_impl(name, measurements, metadata, None)
+            .await
+    }
+
+    /// Emits a validated Relay metric-measurement mark with an event category.
+    pub async fn emit_metric_with_category(
+        &self,
+        name: &str,
+        measurements: Vec<MetricMeasurement>,
+        metadata: Option<Json>,
+        category: EventCategory,
+    ) -> Result<()> {
+        self.emit_metric_impl(name, measurements, metadata, Some(category))
+            .await
+    }
+
+    async fn emit_metric_impl(
+        &self,
+        name: &str,
+        measurements: Vec<MetricMeasurement>,
+        metadata: Option<Json>,
+        category: Option<EventCategory>,
+    ) -> Result<()> {
         let envelope = MetricEnvelope { measurements };
         envelope
             .validate()
             .map_err(|err| WorkerSdkError::InvalidInput(err.to_string()))?;
-        self.emit_mark_with_optional_category(
+        self.emit_mark_impl(
             name,
             Some(serde_json::to_value(envelope)?),
             metadata,
@@ -1114,7 +1137,7 @@ impl PluginRuntime {
                 ),
                 severity: None,
             },
-            None,
+            category,
         )
         .await
     }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -35,7 +35,7 @@ use futures_util::{Stream, StreamExt};
 use hyper_util::rt::TokioIo;
 pub use nemo_relay_types::Json;
 pub use nemo_relay_types::api::event::{
-    DataSchema, Event, EventSanitizeFields, LogSeverity, METRIC_DATA_SCHEMA_NAME,
+    DataSchema, Event, EventCategory, EventSanitizeFields, LogSeverity, METRIC_DATA_SCHEMA_NAME,
     METRIC_DATA_SCHEMA_VERSION, MetricEnvelope, MetricKind, MetricMeasurement, MetricValueType,
     PendingMarkSpec,
 };
@@ -1000,6 +1000,31 @@ impl PluginRuntime {
         metadata: Option<Json>,
         options: EmitMarkOptions,
     ) -> Result<()> {
+        self.emit_mark_with_optional_category(name, data, metadata, options, None)
+            .await
+    }
+
+    /// Emits a mark event through the host runtime with optional schema, severity, and category.
+    pub async fn emit_mark_with_options_and_category(
+        &self,
+        name: &str,
+        data: Option<Json>,
+        metadata: Option<Json>,
+        options: EmitMarkOptions,
+        category: EventCategory,
+    ) -> Result<()> {
+        self.emit_mark_with_optional_category(name, data, metadata, options, Some(category))
+            .await
+    }
+
+    async fn emit_mark_with_optional_category(
+        &self,
+        name: &str,
+        data: Option<Json>,
+        metadata: Option<Json>,
+        options: EmitMarkOptions,
+        category: Option<EventCategory>,
+    ) -> Result<()> {
         let scope = self.current_scope_context();
         let mut client = self.host_client().await?;
         let response = client
@@ -1020,6 +1045,11 @@ impl PluginRuntime {
                     .map(severity_wire_value)
                     .transpose()?
                     .unwrap_or_default(),
+                category: category
+                    .as_ref()
+                    .map(EventCategory::as_str)
+                    .unwrap_or_default()
+                    .into(),
             }))
             .await
             .map_err(|err| WorkerSdkError::Transport(err.to_string()))?
@@ -1071,7 +1101,7 @@ impl PluginRuntime {
         envelope
             .validate()
             .map_err(|err| WorkerSdkError::InvalidInput(err.to_string()))?;
-        self.emit_mark_with_options(
+        self.emit_mark_with_optional_category(
             name,
             Some(serde_json::to_value(envelope)?),
             metadata,
@@ -1084,6 +1114,7 @@ impl PluginRuntime {
                 ),
                 severity: None,
             },
+            None,
         )
         .await
     }

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -20,9 +20,9 @@ use futures_util::{Stream, StreamExt};
 use hyper_util::rt::TokioIo;
 use nemo_relay_types::api::event::{BaseEvent, Event, MarkEvent, PendingMarkSpec};
 use nemo_relay_worker::{
-    ANNOTATED_LLM_REQUEST_SCHEMA, DataSchema, EmitMarkOptions, Json, JsonStream, LlmNext,
-    LlmRequest, LlmStreamNext, LogSeverity, MetricKind, MetricMeasurement, MetricValueType,
-    PluginContext, PluginRuntime, Result, RuntimeRegistrationKind, ScopeType,
+    ANNOTATED_LLM_REQUEST_SCHEMA, DataSchema, EmitMarkOptions, EventCategory, Json, JsonStream,
+    LlmNext, LlmRequest, LlmStreamNext, LogSeverity, MetricKind, MetricMeasurement,
+    MetricValueType, PluginContext, PluginRuntime, Result, RuntimeRegistrationKind, ScopeType,
     ToolExecutionInterceptOutcome, ToolNext, WorkerPlugin, WorkerSdkError, WorkerServerConfig,
     serve_plugin, serve_plugin_arc, serve_plugin_arc_with_config,
 };
@@ -924,6 +924,7 @@ async fn worker_service_invokes_every_registration_surface() {
         .find(|request| request.name == "tool-exec-telemetry")
         .expect("extended mark request");
     assert_eq!(telemetry_mark.severity, "warn");
+    assert_eq!(telemetry_mark.category, "custom");
     let data_schema = telemetry_mark.data_schema.expect("mark data schema");
     assert_eq!(data_schema.schema, "nemo.relay.DataSchema@1");
     assert_eq!(
@@ -2075,7 +2076,7 @@ impl WorkerPlugin for SurfacePlugin {
                 }
                 runtime.emit_mark("tool-exec", None, None).await?;
                 runtime
-                    .emit_mark_with_options(
+                    .emit_mark_with_options_and_category(
                         "tool-exec-telemetry",
                         Some(json!({"measurements": []})),
                         None,
@@ -2088,6 +2089,7 @@ impl WorkerPlugin for SurfacePlugin {
                             ),
                             severity: Some(LogSeverity::Warn),
                         },
+                        EventCategory::custom(),
                     )
                     .await?;
                 runtime

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -939,6 +939,7 @@ async fn worker_service_invokes_every_registration_surface() {
         .into_iter()
         .find(|request| request.name == "tool-exec-metric")
         .expect("metric mark request");
+    assert_eq!(metric_mark.category, "custom");
     let metric_schema = metric_mark.data_schema.expect("metric data schema");
     assert_eq!(
         decode_json_envelope::<DataSchema>(&metric_schema).unwrap(),
@@ -2093,7 +2094,7 @@ impl WorkerPlugin for SurfacePlugin {
                     )
                     .await?;
                 runtime
-                    .emit_metric(
+                    .emit_metric_with_category(
                         "tool-exec-metric",
                         vec![MetricMeasurement {
                             name: "worker.requests".into(),
@@ -2106,6 +2107,7 @@ impl WorkerPlugin for SurfacePlugin {
                             boundaries: None,
                         }],
                         None,
+                        EventCategory::custom(),
                     )
                     .await?;
                 let stack_id = runtime.create_scope_stack().await?;

--- a/docs/build-plugins/workers/about.mdx
+++ b/docs/build-plugins/workers/about.mdx
@@ -18,7 +18,7 @@ SDK worker, regenerate custom protobuf bindings, and declare `compat.relay` begi
 `0.8.0`. The protocol remains named `grpc-v1`; this is a changed tool-result contract,
 not a new protocol family.
 
-Workers can add a data schema and log severity to a mark, emit validated metric
+Workers can add a data schema, log severity, and semantic category to a mark, emit validated metric
 measurements, and read the current host-level runtime diagnostics. These diagnostics are
 ordered by code and are not attributed to a particular plugin.
 

--- a/docs/build-plugins/workers/grpc-v1-protocol.mdx
+++ b/docs/build-plugins/workers/grpc-v1-protocol.mdx
@@ -253,7 +253,7 @@ The host-runtime request and response fields are complete in the following table
 
 | RPC | Request Fields | Response Fields |
 |---|---|---|
-| `EmitMark` | `activation_id`, `auth_token`, captured `scope`, `name`, optional `data`, `metadata`, `data_schema`, and `severity` | `HostAck.ok` or `HostAck.error` |
+| `EmitMark` | `activation_id`, `auth_token`, captured `scope`, `name`, optional `data`, `metadata`, `data_schema`, `severity`, and `category` | `HostAck.ok` or `HostAck.error` |
 | `GetRuntimeDiagnostics` | `activation_id` and `auth_token` | Ordered `RuntimeDiagnostic` entries with `code`, `message`, and `count` |
 | `PushScope` | `activation_id`, `auth_token`, captured `scope`, `name`, `scope_type`, and optional `data`, `metadata`, and `input` | `scope_handle_id` or `error` |
 | `PopScope` | `activation_id`, `auth_token`, owned `scope_handle_id`, and optional `output` and `metadata` | `HostAck.ok` or `HostAck.error` |
@@ -270,9 +270,10 @@ The host-runtime request and response fields are complete in the following table
 agent, function, tool, LLM, retriever, embedder, reranker, guardrail, evaluator, custom,
 and unknown scopes. The unspecified wire value is invalid for a pushed scope.
 
-`EmitMarkRequest.data_schema` uses the `nemo.relay.DataSchema@1` envelope, and
-`severity` accepts `trace`, `debug`, `info`, `warn`, or `error`. Omitting both preserves
-the original mark behavior. `GetRuntimeDiagnostics` aggregates repeated codes, retains
+`EmitMarkRequest.data_schema` uses the `nemo.relay.DataSchema@1` envelope,
+`severity` accepts `trace`, `debug`, `info`, `warn`, or `error`, and `category` is an
+optional semantic category for the emitted mark. Omitting these fields preserves the
+original mark behavior. `GetRuntimeDiagnostics` aggregates repeated codes, retains
 the latest message, sorts entries by code, and returns at most 32 entries. It is a
 host-level view, so it does not identify the plugin that recorded a diagnostic.
 

--- a/docs/build-plugins/workers/runtime-events-and-scopes.mdx
+++ b/docs/build-plugins/workers/runtime-events-and-scopes.mdx
@@ -152,14 +152,14 @@ the worker registrations. Failed registration returns no initial gates. Ordinary
 teardown removes every gate that remains owned by the worker activation.
 
 Use typed [mark](/about-nemo-relay/concepts/events) options when an exported mark needs
-a data schema or log severity. Use
+a data schema, log severity, or semantic category. Use
 `emit_metric` for Relay metric measurements. `runtime_diagnostics` returns the bounded,
 ordered host-level `{ code, message, count }` snapshot. It does not identify the plugin
 that recorded a diagnostic.
 
 ## Emit Typed Telemetry and Read Diagnostics
 
-Choose your worker language to add schema and severity metadata to a mark and inspect
+Choose your worker language to add schema, severity, and category metadata to a mark and inspect
 runtime diagnostics:
 
 <Tabs>
@@ -172,6 +172,7 @@ await ctx.runtime.emit_mark(
     {"allowed": True},
     data_schema=DataSchema("example.policy.decision", "1"),
     severity=LogSeverity.INFO,
+    category="custom",
 )
 await ctx.runtime.emit_metric(
     "example.python_worker.requests",
@@ -185,10 +186,10 @@ if diagnostic is not None:
 </Tab>
 <Tab title="Rust" language="rust">
 ```rust
-use nemo_relay_worker::{DataSchema, EmitMarkOptions, LogSeverity};
+use nemo_relay_worker::{DataSchema, EmitMarkOptions, EventCategory, LogSeverity};
 
 runtime
-    .emit_mark_with_options(
+    .emit_mark_with_options_and_category(
         "example.rust_worker.policy_decision",
         Some(json!({ "allowed": true })),
         None,
@@ -201,6 +202,7 @@ runtime
             ),
             severity: Some(LogSeverity::Info),
         },
+        EventCategory::custom(),
     )
     .await?;
 

--- a/docs/build-plugins/workers/runtime-events-and-scopes.mdx
+++ b/docs/build-plugins/workers/runtime-events-and-scopes.mdx
@@ -165,14 +165,14 @@ runtime diagnostics:
 <Tabs>
 <Tab title="Python" language="python">
 ```python
-from nemo_relay_plugin import DataSchema, LogSeverity
+from nemo_relay_plugin import DataSchema, EventCategory, LogSeverity
 
 await ctx.runtime.emit_mark(
     "example.python_worker.policy_decision",
     {"allowed": True},
     data_schema=DataSchema("example.policy.decision", "1"),
     severity=LogSeverity.INFO,
-    category="custom",
+    category=EventCategory.CUSTOM,
 )
 await ctx.runtime.emit_metric(
     "example.python_worker.requests",

--- a/justfile
+++ b/justfile
@@ -1077,6 +1077,7 @@ check-python-worker-proto:
     emit_mark = pb.EmitMarkRequest.DESCRIPTOR.fields_by_name
     assert emit_mark["data_schema"].number == 7
     assert emit_mark["severity"].number == 8
+    assert emit_mark["category"].number == 9
     tool_result = pb.ToolExecutionResult.DESCRIPTOR.fields_by_name
     assert tool_result["result"].message_type.full_name == "nemo.relay.worker.v1.JsonValue"
     assert tool_result["annotation"].message_type.full_name == "nemo.relay.worker.v1.JsonValue"

--- a/python/plugin/README.md
+++ b/python/plugin/README.md
@@ -99,14 +99,14 @@ Marks can also declare a typed data schema, exported-log severity, and semantic 
 changing the stable `grpc-v1` protocol identifier:
 
 ```python
-from nemo_relay_plugin import DataSchema, LogSeverity
+from nemo_relay_plugin import DataSchema, EventCategory, LogSeverity
 
 await ctx.runtime.emit_mark(
     "acme.policy.decision",
     {"allowed": True},
     data_schema=DataSchema("acme.policy.decision", "1"),
     severity=LogSeverity.INFO,
-    category="custom",
+    category=EventCategory.CUSTOM,
 )
 ```
 

--- a/python/plugin/README.md
+++ b/python/plugin/README.md
@@ -95,7 +95,7 @@ async def main() -> None:
     await serve_plugin(PolicyPlugin())
 ```
 
-Marks can also declare a typed data schema and exported-log severity without
+Marks can also declare a typed data schema, exported-log severity, and semantic category without
 changing the stable `grpc-v1` protocol identifier:
 
 ```python
@@ -106,6 +106,7 @@ await ctx.runtime.emit_mark(
     {"allowed": True},
     data_schema=DataSchema("acme.policy.decision", "1"),
     severity=LogSeverity.INFO,
+    category="custom",
 )
 ```
 

--- a/python/plugin/src/nemo_relay_plugin/__init__.py
+++ b/python/plugin/src/nemo_relay_plugin/__init__.py
@@ -18,6 +18,7 @@ appropriate executor.
 Public data types:
     Json: Any JSON-serializable Python value.
     DataSchema: Schema identity for a mark's opaque data payload.
+    EventCategory: Well-known semantic category for a Relay event.
     LogSeverity: Telemetry severity assigned to an exported mark log.
     MetricKind: OpenTelemetry instrument kind for a metric measurement.
     MetricValueType: Explicit numeric representation for a metric measurement.
@@ -89,6 +90,7 @@ from ._api import (
     DataSchema,
     DiagnosticLevel,
     Event,
+    EventCategory,
     EventMetadataInjectorCallback,
     EventSanitizeCallback,
     EventSanitizeFields,
@@ -149,6 +151,7 @@ __all__ = [
     "DataSchema",
     "DiagnosticLevel",
     "Event",
+    "EventCategory",
     "EventMetadataInjectorCallback",
     "EventSanitizeCallback",
     "EventSanitizeFields",

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -25,6 +25,7 @@ Public data types:
     LlmOptimizationTokens: Explicit token evidence by category.
     LlmOptimizationTokenImpact: Baseline, effective, and saved token evidence.
     LlmRequestInterceptOutcome: Canonical LLM request-intercept result.
+    EventCategory: Well-known semantic categories for Relay events.
     DiagnosticLevel: Severity of a configuration diagnostic.
     ConfigDiagnostic: Structured configuration warning or error.
     ScopeType: Semantic category for a Relay execution scope.
@@ -334,6 +335,26 @@ class LogSeverity(str, Enum):
     ERROR = "error"
 
 
+class EventCategory(str, Enum):
+    """Well-known semantic categories for Relay events.
+
+    Pass a string instead to preserve a producer-defined category that is not
+    represented here.
+    """
+
+    AGENT = "agent"
+    FUNCTION = "function"
+    LLM = "llm"
+    TOOL = "tool"
+    RETRIEVER = "retriever"
+    EMBEDDER = "embedder"
+    RERANKER = "reranker"
+    GUARDRAIL = "guardrail"
+    EVALUATOR = "evaluator"
+    CUSTOM = "custom"
+    UNKNOWN = "unknown"
+
+
 class MetricKind(str, Enum):
     """OpenTelemetry instrument kind recorded by a metric mark."""
 
@@ -469,7 +490,7 @@ class PendingMarkSpec:
     """Describe a mark Relay emits under a managed lifecycle scope."""
 
     name: str
-    category: str | None = None
+    category: EventCategory | str | None = None
     category_profile: Json | None = None
     data: Json | None = None
     metadata: Json | None = None
@@ -1639,7 +1660,7 @@ class PluginRuntime:
         *,
         data_schema: DataSchema | Mapping[str, Json] | None = None,
         severity: LogSeverity | str | None = None,
-        category: str | None = None,
+        category: EventCategory | str | None = None,
         scope_stack_id: str | None = None,
         parent_scope_id: str | None = None,
     ) -> None:
@@ -1652,7 +1673,8 @@ class PluginRuntime:
             data_schema: Optional typed schema identity for ``data``.
             severity: Optional telemetry log severity. ``warning`` is accepted
                 as an alias for ``warn``.
-            category: Optional semantic category for the mark.
+            category: Optional semantic category for the mark. Accepts an
+                :class:`EventCategory` value or a producer-defined string.
             scope_stack_id: Optional host-issued stack to correlate the event
                 with. When omitted, the current local binding is used.
             parent_scope_id: Optional parent scope for the event. When omitted,
@@ -1717,7 +1739,7 @@ class PluginRuntime:
         measurements: Iterable[MetricMeasurement | Mapping[str, Json]],
         metadata: Json | None = None,
         *,
-        category: str | None = None,
+        category: EventCategory | str | None = None,
         scope_stack_id: str | None = None,
         parent_scope_id: str | None = None,
     ) -> None:

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -1639,6 +1639,7 @@ class PluginRuntime:
         *,
         data_schema: DataSchema | Mapping[str, Json] | None = None,
         severity: LogSeverity | str | None = None,
+        category: str | None = None,
         scope_stack_id: str | None = None,
         parent_scope_id: str | None = None,
     ) -> None:
@@ -1651,6 +1652,7 @@ class PluginRuntime:
             data_schema: Optional typed schema identity for ``data``.
             severity: Optional telemetry log severity. ``warning`` is accepted
                 as an alias for ``warn``.
+            category: Optional semantic category for the mark.
             scope_stack_id: Optional host-issued stack to correlate the event
                 with. When omitted, the current local binding is used.
             parent_scope_id: Optional parent scope for the event. When omitted,
@@ -1661,6 +1663,8 @@ class PluginRuntime:
                 the request.
             TypeError: A payload is not JSON-serializable.
         """
+        if category is not None and not isinstance(category, str):
+            raise TypeError("category must be a string or None")
         response = await self._host_stub.EmitMark(
             pb.EmitMarkRequest(
                 activation_id=self._activation_id,
@@ -1674,6 +1678,7 @@ class PluginRuntime:
                     DATA_SCHEMA_SCHEMA,
                 ),
                 severity=_log_severity_value(severity),
+                category=category or "",
             )
         )
         _ack_to_result(response)
@@ -1711,6 +1716,7 @@ class PluginRuntime:
         measurements: Iterable[MetricMeasurement | Mapping[str, Json]],
         metadata: Json | None = None,
         *,
+        category: str | None = None,
         scope_stack_id: str | None = None,
         parent_scope_id: str | None = None,
     ) -> None:
@@ -1719,6 +1725,7 @@ class PluginRuntime:
         Relay performs authoritative metric-schema validation after the mark is
         sanitized. This helper supplies the reserved schema and preserves each
         measurement mapping without maintaining a second validator in the SDK.
+        The optional category is forwarded to the emitted mark.
         """
         encoded: list[dict[str, Json]] = []
         for measurement in measurements:
@@ -1730,6 +1737,7 @@ class PluginRuntime:
             {"measurements": encoded},
             metadata,
             data_schema=DataSchema(METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION),
+            category=category,
             scope_stack_id=scope_stack_id,
             parent_scope_id=parent_scope_id,
         )

--- a/python/plugin/src/nemo_relay_plugin/_api.py
+++ b/python/plugin/src/nemo_relay_plugin/_api.py
@@ -1661,7 +1661,8 @@ class PluginRuntime:
         Raises:
             WorkerSdkError: The scope selection is invalid or the host rejects
                 the request.
-            TypeError: A payload is not JSON-serializable.
+            TypeError: A payload is not JSON-serializable, or ``category`` is
+                neither a string nor ``None``.
         """
         if category is not None and not isinstance(category, str):
             raise TypeError("category must be a string or None")

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -28,6 +28,7 @@ from nemo_relay_plugin import (  # noqa: E402
     ConfigDiagnostic,
     DataSchema,
     DiagnosticLevel,
+    EventCategory,
     Json,
     LlmOptimizationContribution,
     LlmRequestInterceptOutcome,
@@ -2302,7 +2303,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         {"measurements": []},
         data_schema=DataSchema("nemo.relay.metric_measurements", "1"),
         severity=LogSeverity.WARNING,
-        category="custom",
+        category=EventCategory.CUSTOM,
     )
     await runtime.emit_metric(
         "telemetry-metric",
@@ -2314,7 +2315,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
                 "value": 42,
             }
         ],
-        category="custom",
+        category="vendor.metric",
     )
     await runtime.emit_mark("explicit", scope_stack_id="explicit-stack", parent_scope_id="explicit-parent")
     await runtime.drop_scope_stack(stack_id)
@@ -2347,7 +2348,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         "name": "nemo.relay.metric_measurements",
         "version": "1",
     }
-    assert metric_mark.category == "custom"
+    assert metric_mark.category == "vendor.metric"
 
     override_mark = next(
         request

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -2302,6 +2302,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         {"measurements": []},
         data_schema=DataSchema("nemo.relay.metric_measurements", "1"),
         severity=LogSeverity.WARNING,
+        category="custom",
     )
     await runtime.emit_metric(
         "telemetry-metric",
@@ -2313,6 +2314,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
                 "value": 42,
             }
         ],
+        category="custom",
     )
     await runtime.emit_mark("explicit", scope_stack_id="explicit-stack", parent_scope_id="explicit-parent")
     await runtime.drop_scope_stack(stack_id)
@@ -2334,6 +2336,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         "version": "1",
     }
     assert telemetry_mark.severity == "warn"
+    assert telemetry_mark.category == "custom"
     metric_mark = next(
         request
         for request in host_stub.requests
@@ -2344,6 +2347,7 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         "name": "nemo.relay.metric_measurements",
         "version": "1",
     }
+    assert metric_mark.category == "custom"
 
     override_mark = next(
         request
@@ -2370,6 +2374,8 @@ async def test_runtime_host_calls_and_scope_context(host_stub: RecordingHostStub
         await runtime.emit_mark("empty-parent", scope_stack_id="stack", parent_scope_id="")
     with pytest.raises(ValueError, match="invalid log severity"):
         await runtime.emit_mark("invalid-severity", severity="fatal")
+    with pytest.raises(TypeError, match="category must be a string or None"):
+        await runtime.emit_mark("invalid-category", category=cast(Any, 1))
     with pytest.raises(ValueError, match="exactly name and version"):
         await runtime.emit_mark("invalid-schema", data_schema={"name": "schema"})
     with pytest.raises(TypeError, match="measurements must contain mappings"):


### PR DESCRIPTION
#### Overview

Add an optional semantic category to marks emitted by `grpc-v1` dynamic workers. This restores worker access to Relay’s existing mark-category semantics without changing the protocol identifier or legacy omitted-field behavior.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add additive `EmitMarkRequest.category` field 9 and map a non-empty value to Relay’s `EventCategory` in the host bridge.
- Expose category on Python `emit_mark` and `emit_metric`; add a category-aware Rust mark-emission method while keeping existing `EmitMarkOptions` struct literals source-compatible.
- Cover protobuf wire compatibility, Rust and Python SDK serialization, host behavior, and live worker-plugin round-tripping.
- Update grpc-v1 protocol and worker SDK documentation.

#### Where should the reviewer start?

Start with `crates/worker-proto/proto/nemo/relay/worker/v1/plugin_worker.proto` and `crates/core/src/plugin/dynamic/worker.rs`; together they define the additive wire field and host conversion.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #888

#### Validation

Passed:

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just test-rust`
- `just test-python`
- `just test-go`
- `just test-node`
- `just docs`
- focused protocol, worker SDK, host-runtime, and live worker-plugin tests

`uv run pre-commit run --all-files` was attempted. Its repository-wide `ty` hook also traverses the separate untracked `tokenomics-meter/` checkout and reports pre-existing diagnostics there (plus existing unused-ignore diagnostics outside this change). The changed Python worker API passes a focused `ty` check, and the relevant pre-commit hooks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional semantic categories to worker-generated marks and metrics.
  * Category metadata is supported across Python and Rust plugin APIs, including standard event categories and custom values.
  * Existing events remain compatible when no category is provided.
  * Python APIs validate category values before sending events.

* **Documentation**
  * Updated worker event and protocol documentation with category usage and examples.

* **Tests**
  * Added coverage for category serialization, runtime emission, validation, and legacy compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->