### PR TITLE
docs: note Codex image generation fix in 0.8

### DIFF
--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -167,6 +167,10 @@ for destination paths and explicit-file alternatives.
 
 ### Fixed Known Issues in 0.8
 
+- Codex image-generation requests now pass through the local Relay gateway to
+  the configured OpenAI upstream. Persistent Codex installations must refresh
+  the `nemo-relay-openai` provider configuration; see [Migration
+  Guides](/reference/migration-guides#refresh-the-installed-codex-provider-configuration).
 - Restored a trailing `/` on an OTLP/HTTP trace endpoint as an explicit
   root-path destination. A bare HTTP authority still defaults to
   `/v1/traces`; when version 4 implicitly derives log or metric destinations


### PR DESCRIPTION
#### Overview

Document the Codex image-generation routing fix in the NeMo Relay 0.8 release notes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add the merged OpenAI image-generation forwarding fix to the 0.8 fixed-known-issues list.
- Link persistent Codex users to the required provider-configuration refresh migration.

#### Where should the reviewer start?

Start with docs/about-nemo-relay/release-notes/index.mdx, under “Fixed Known Issues in 0.8.”

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-788](https://linear.app/nvidia/issue/RELAY-788/codex-pets-error-with-nemo-relay)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a known-issue note for Codex image-generation requests.
  * Documented Relay gateway routing, OpenAI upstream forwarding, and the need to refresh persistent provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->