### PR TITLE
ci: skip Fern docs for alpha tags

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -363,12 +363,31 @@ jobs:
         run: |
           "$GITHUB_WORKSPACE/source-checkout/node_modules/.bin/fern" generate --docs
 
+  skip-alpha-version-docs:
+    name: Skip nightly alpha docs
+    if: >-
+      ${{
+        (github.ref_type == 'tag' && contains(github.ref_name, '-alpha.'))
+        || (github.event_name == 'workflow_dispatch' && contains(inputs.tag, '-alpha.'))
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Report skipped docs publication
+        run: echo "Skipping Fern docs publication for nightly alpha tag."
+
   release-version-docs:
     name: Release docs version
     if: >-
       ${{
-        github.ref_type == 'tag'
-        || (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag != null)
+        (github.ref_type == 'tag' && !contains(github.ref_name, '-alpha.'))
+        || (
+          github.event_name == 'workflow_dispatch'
+          && inputs.tag != ''
+          && inputs.tag != null
+          && !contains(inputs.tag, '-alpha.')
+        )
       }}
     runs-on: ubuntu-latest
     environment: fern


### PR DESCRIPTION
#### Overview

- Treat nightly alpha Fern documentation publication as an intentional skip rather than a CI failure.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add a successful alpha-tag documentation skip job.
- Exclude alpha tags from the release documentation publication job while preserving stable, beta, and RC release behavior.

#### Where should the reviewer start?

- `.github/workflows/fern-docs.yml`, specifically the alpha-tag job conditions before `release-version-docs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Alpha release documentation is no longer published automatically.
  - Non-alpha release tags continue to publish documentation as usual.
  - Added clear reporting when documentation publication is skipped for alpha releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->