### PR TITLE
ci: update external action pins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,7 +266,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download CLI distribution artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -341,7 +341,7 @@ jobs:
           )
 
       - name: Upload CLI assets and checksums to draft GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
         with:
           draft: true
           prerelease: ${{ contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
@@ -364,13 +364,13 @@ jobs:
       UV_PYTHON_PREFERENCE: only-system
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -396,7 +396,7 @@ jobs:
 
       - name: Authenticate to crates.io with trusted publishing
         id: crates-io-auth
-        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
       - name: Publish to crates.io with trusted publishing
         working-directory: ${{ github.workspace }}
@@ -482,7 +482,7 @@ jobs:
           fi
 
       - name: Publish to PyPI with trusted publishing
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
         with:
           skip-existing: true
 
@@ -498,13 +498,13 @@ jobs:
     environment: npm
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,6 +267,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download CLI distribution artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -365,6 +367,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config
@@ -499,6 +503,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config
@@ -508,6 +514,7 @@ jobs:
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Download split Node package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci_changes.yml
+++ b/.github/workflows/ci_changes.yml
@@ -92,6 +92,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve comparison base
         id: comparison-base

--- a/.github/workflows/ci_changes.yml
+++ b/.github/workflows/ci_changes.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ ! inputs.full_ci }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -121,7 +121,7 @@ jobs:
       - name: Detect changed paths
         id: filter
         if: ${{ ! inputs.full_ci }}
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.01
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           base: ${{ steps.comparison-base.outputs.base }}
           filters: .github/ci-path-filters.yml

--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -130,6 +130,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config

--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -151,11 +151,11 @@ jobs:
         with:
           python-version: ${{ steps.ci-config.outputs.default_python_version }}
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -180,7 +180,7 @@ jobs:
           tool: cargo-about@${{ steps.ci-config.outputs.cargo_about_version }}
 
       - name: Cache pre-commit environments
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/.cache/pre-commit
           key: >-

--- a/.github/workflows/ci_go.yml
+++ b/.github/workflows/ci_go.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config

--- a/.github/workflows/ci_go.yml
+++ b/.github/workflows/ci_go.yml
@@ -52,13 +52,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -87,7 +87,7 @@ jobs:
           just --set ci true --set output_dir "${{ github.workspace }}" test-go
 
       - name: Upload Go coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true

--- a/.github/workflows/ci_license_diff.yml
+++ b/.github/workflows/ci_license_diff.yml
@@ -34,7 +34,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
         with:
           python-version: ${{ steps.ci-config.outputs.default_python_version }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upsert PR comment
         if: ${{ steps.comment.outputs.pr_number != '' }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: nemo-relay-license-diff
           number: ${{ steps.comment.outputs.pr_number }}

--- a/.github/workflows/ci_node.yml
+++ b/.github/workflows/ci_node.yml
@@ -86,13 +86,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -109,7 +109,7 @@ jobs:
         with:
           tool: cargo-llvm-cov@${{ steps.ci-config.outputs.cargo_llvm_cov_version }},just@${{ steps.ci-config.outputs.just_version }}
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
@@ -123,7 +123,7 @@ jobs:
         run: just --set ci true test-openclaw
 
       - name: Upload Node coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         if: ${{ !startsWith(matrix.platform, 'windows') }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -175,13 +175,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -205,7 +205,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: ${{ env.NEMO_RELAY_CI_WORKSPACE }}/uv.lock
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
@@ -264,13 +264,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -283,7 +283,7 @@ jobs:
           cache-bin: false
           save-if: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
@@ -350,7 +350,7 @@ jobs:
 
       - name: Checkout
         if: ${{ !contains(matrix.platform, 'musl') }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -359,7 +359,7 @@ jobs:
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: ${{ !contains(matrix.platform, 'musl') }}
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}

--- a/.github/workflows/ci_node.yml
+++ b/.github/workflows/ci_node.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config
@@ -176,6 +178,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config
@@ -265,6 +269,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config
@@ -179,6 +181,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -76,13 +76,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -127,7 +127,7 @@ jobs:
         run: just --set ci true --set output_dir "${{ github.workspace }}" test-python-langchain
 
       - name: Upload Python coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true
@@ -178,13 +178,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: ${{ !contains(matrix.platform, 'musl') }}
         with:
           cache: false
@@ -398,7 +398,7 @@ jobs:
 
       - name: Checkout
         if: ${{ !contains(matrix.platform, 'musl') }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -407,7 +407,7 @@ jobs:
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: ${{ matrix.platform == 'source-and-plugin' }}
         with:
           cache: false

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -99,13 +99,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload Rust coverage to Codecov
         if: ${{ matrix.platform != 'windows-arm64' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true
@@ -230,13 +230,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load CI tool versions
         id: ci-config
         uses: ./.github/actions/load-ci-tool-versions
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -396,7 +396,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -100,6 +100,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config
@@ -231,6 +233,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -36,14 +36,14 @@ jobs:
       docs: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.docs == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Detect changed paths
         id: filter
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.01
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: .github/ci-path-filters.yml
 
@@ -67,7 +67,7 @@ jobs:
       UV_PYTHON_PREFERENCE: only-system
     steps:
       - name: Checkout source branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: source-checkout
           fetch-depth: 1
@@ -84,12 +84,12 @@ jobs:
           cache-dependency-glob: ${{ github.workspace }}/source-checkout/uv.lock
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -129,7 +129,7 @@ jobs:
         run: just docs
 
       - name: Checkout docs website branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: docs-website
           path: docs-checkout
@@ -171,7 +171,7 @@ jobs:
 
       - name: Comment preview URL on PR
         if: ${{ steps.preview.outputs.url != '' }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: nemo-relay-fern-preview
           number: ${{ steps.preview.outputs.pr_number }}
@@ -195,7 +195,7 @@ jobs:
       UV_PYTHON_PREFERENCE: only-system
     steps:
       - name: Checkout source branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: source-checkout
@@ -207,7 +207,7 @@ jobs:
         uses: ./source-checkout/.github/actions/load-ci-tool-versions
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
           package-manager-cache: false
@@ -252,7 +252,7 @@ jobs:
       UV_PYTHON_PREFERENCE: only-system
     steps:
       - name: Checkout source branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: source-checkout
           fetch-depth: 1
@@ -269,12 +269,12 @@ jobs:
           cache-dependency-glob: ${{ github.workspace }}/source-checkout/uv.lock
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -314,7 +314,7 @@ jobs:
         run: just docs
 
       - name: Checkout docs website branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: docs-website
           path: docs-checkout
@@ -399,14 +399,14 @@ jobs:
           printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
 
       - name: Checkout workflow tools
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: workflow-checkout
           fetch-depth: 1
           persist-credentials: false
 
       - name: Checkout source branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.version.outputs.tag }}
           path: source-checkout
@@ -424,12 +424,12 @@ jobs:
           cache-dependency-glob: ${{ github.workspace }}/source-checkout/uv.lock
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.ci-config.outputs.node_version }}
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
           toolchain: ${{ steps.ci-config.outputs.rust_version }}
@@ -468,7 +468,7 @@ jobs:
         run: just docs-api-reference
 
       - name: Checkout docs website branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: docs-website
           path: docs-checkout

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect changed paths
         id: filter
@@ -71,6 +72,7 @@ jobs:
         with:
           path: source-checkout
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config
@@ -256,6 +258,7 @@ jobs:
         with:
           path: source-checkout
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config
@@ -411,6 +414,7 @@ jobs:
           ref: ${{ steps.version.outputs.tag }}
           path: source-checkout
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Load CI tool versions
         id: ci-config

--- a/.github/workflows/nightly-alpha-tag.yaml
+++ b/.github/workflows/nightly-alpha-tag.yaml
@@ -23,7 +23,7 @@ jobs:
       branches: ${{ steps.config.outputs.branches }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -46,7 +46,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
#### Overview

Refresh pinned third-party GitHub Actions used by CI, documentation, and nightly workflows to their approved current releases.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update checkout, setup-node, cache, Codecov, paths filtering, PR comments, release publishing, and package publishing action pins.
- Update the Rust toolchain and crates.io trusted-publishing action pins across CI and Fern documentation workflows.
- Preserve full commit-SHA pinning and readable release-version comments.

#### Where should the reviewer start?

Review the consolidated release and publishing changes in `.github/workflows/ci.yaml`, then the reusable CI workflow pins under `.github/workflows/ci_*.yml`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated build, testing, publishing, documentation, and nightly workflows to use newer pinned action versions.
  * Improved consistency across Rust, Python, Node.js, Go, release, and documentation automation.
* **Maintenance**
  * Refreshed tooling for source checkout, runtime setup, caching, code coverage, change detection, publishing, and pull request updates.
  * Improved workflow security by disabling credential persistence where applicable.
  * Disabled package-manager caching during npm setup for more predictable automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->