### PR TITLE
test: extend worker cancellation timeout

### DIFF
--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -64,7 +64,7 @@ use tower::service_fn;
 const ACTIVATION_ID: &str = "activation-1";
 const AUTH_TOKEN: &str = "secret-token";
 const PLUGIN_ID: &str = "acme.worker";
-const WORKER_TEST_TIMEOUT: Duration = Duration::from_secs(5);
+const WORKER_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 const REQUIRED_WORKER_ENVS: &[&str] = &[
     "NEMO_RELAY_WORKER_SOCKET",
     "NEMO_RELAY_HOST_SOCKET",


### PR DESCRIPTION
#### Overview

Increase the worker cancellation test deadline from 5 seconds to 10 seconds to tolerate delayed gRPC cancellation responses on busy Windows CI runners.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Extend the shared `WORKER_TEST_TIMEOUT` used by the unary and streaming cancellation tests.
- Preserve bounded completion checks while providing CI scheduling and transport headroom.

#### Where should the reviewer start?

Review `crates/worker/tests/worker_sdk_tests.rs`, specifically the shared timeout used by the cancellation tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

#### Validation

- `cargo fmt --all --check`
- Focused worker cancellation tests
- `just test-rust`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --files crates/worker/tests/worker_sdk_tests.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the worker test timeout to improve reliability during slower test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->