### PR TITLE
enhancement: add stderr logging opt-out

### DIFF
--- a/crates/core/src/logging/config.rs
+++ b/crates/core/src/logging/config.rs
@@ -11,6 +11,7 @@ use crate::error::{FlowError, Result};
 use serde::Deserialize;
 
 const LOG_LEVEL_ENV: &str = "NEMO_RELAY_LOG";
+const LOG_STDERR_ENV: &str = "NEMO_RELAY_LOG_STDERR";
 const LOG_STDERR_FORMAT_ENV: &str = "NEMO_RELAY_LOG_STDERR_FORMAT";
 const LOG_CONFIG_PATH_ENV: &str = "NEMO_RELAY_LOG_CONFIG_PATH";
 
@@ -43,7 +44,9 @@ pub const MAX_FILE_SINK_RETAINED_FILES: usize = 9;
 pub struct LoggingConfig {
     /// Minimum severity for operational logs.
     pub level: LogLevel,
-    /// Encoding for the always-on stderr sink.
+    /// Whether the stderr sink is enabled.
+    pub stderr_enabled: bool,
+    /// Encoding for the stderr sink when it is enabled.
     pub stderr_format: LogFormat,
     /// Additional file sinks beyond stderr.
     pub sinks: Vec<LogSinkConfig>,
@@ -56,6 +59,7 @@ impl Default for LoggingConfig {
     fn default() -> Self {
         Self {
             level: LogLevel::Error,
+            stderr_enabled: true,
             stderr_format: LogFormat::Human,
             sinks: Vec::new(),
             flush_interval_millis: DEFAULT_FILE_FLUSH_INTERVAL_MILLIS,
@@ -66,30 +70,36 @@ impl Default for LoggingConfig {
 impl LoggingConfig {
     /// Resolves logging configuration from the supported process environment.
     ///
-    /// Returns `None` when no logging environment variables are present. Direct level and stderr
-    /// format settings may be combined. `NEMO_RELAY_LOG_CONFIG_PATH` selects an absolute TOML file
-    /// instead and is mutually exclusive with both direct settings.
+    /// Returns `None` when no logging environment variables are present. Direct level, stderr,
+    /// and stderr format settings may be combined. `NEMO_RELAY_LOG_CONFIG_PATH` selects an
+    /// absolute TOML file instead and is mutually exclusive with all direct settings.
     pub fn from_environment() -> Result<Option<Self>> {
         let level = environment_value(LOG_LEVEL_ENV)?;
+        let stderr_enabled = environment_value(LOG_STDERR_ENV)?;
         let stderr_format = environment_value(LOG_STDERR_FORMAT_ENV)?;
         let config_path = environment_value(LOG_CONFIG_PATH_ENV)?;
 
-        if config_path.is_some() && (level.is_some() || stderr_format.is_some()) {
+        if config_path.is_some()
+            && (level.is_some() || stderr_enabled.is_some() || stderr_format.is_some())
+        {
             return Err(FlowError::InvalidArgument(format!(
                 "{LOG_CONFIG_PATH_ENV} cannot be combined with {LOG_LEVEL_ENV} or \
-                 {LOG_STDERR_FORMAT_ENV}"
+                 {LOG_STDERR_ENV} or {LOG_STDERR_FORMAT_ENV}"
             )));
         }
         if let Some(path) = config_path {
             return Self::from_file_path(path).map(Some);
         }
-        if level.is_none() && stderr_format.is_none() {
+        if level.is_none() && stderr_enabled.is_none() && stderr_format.is_none() {
             return Ok(None);
         }
 
         let mut config = Self::default();
         if let Some(level) = level {
             config.level = LogLevel::parse(&level)?;
+        }
+        if let Some(stderr_enabled) = stderr_enabled {
+            config.stderr_enabled = parse_bool(LOG_STDERR_ENV, &stderr_enabled)?;
         }
         if let Some(stderr_format) = stderr_format {
             config.stderr_format = LogFormat::parse(&stderr_format)?;
@@ -200,6 +210,16 @@ impl LogFormat {
     }
 }
 
+fn parse_bool(name: &str, raw: &str) -> Result<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" => Ok(true),
+        "false" | "0" => Ok(false),
+        other => Err(FlowError::InvalidArgument(format!(
+            "invalid {name} value '{other}'; expected true or false"
+        ))),
+    }
+}
+
 /// Additional operational log sink beyond always-on stderr.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LogSinkConfig {
@@ -296,6 +316,7 @@ struct LoggingDocument {
 #[serde(deny_unknown_fields)]
 struct RawLoggingConfig {
     level: Option<String>,
+    stderr_enabled: Option<bool>,
     stderr_format: Option<String>,
     flush_interval_millis: Option<u64>,
     #[serde(default)]
@@ -307,6 +328,9 @@ impl RawLoggingConfig {
         let mut config = LoggingConfig::default();
         if let Some(level) = self.level {
             config.level = LogLevel::parse(&level)?;
+        }
+        if let Some(stderr_enabled) = self.stderr_enabled {
+            config.stderr_enabled = stderr_enabled;
         }
         if let Some(stderr_format) = self.stderr_format {
             config.stderr_format = LogFormat::parse(&stderr_format)?;

--- a/crates/core/src/logging/mod.rs
+++ b/crates/core/src/logging/mod.rs
@@ -108,7 +108,8 @@ pub struct LoggingRuntime {
 impl LoggingRuntime {
     /// Installs process-wide operational logging from resolved configuration.
     ///
-    /// Stderr is always enabled. Explicit file sinks fail initialization if they cannot be
+    /// Stderr is enabled by default and can be disabled with [`LoggingConfig::stderr_enabled`].
+    /// Explicit file sinks fail initialization if they cannot be
     /// opened. Dropping the returned runtime flushes sinks and detaches its logger from the
     /// process-global `log` proxy when it is still installed.
     pub fn configure(config: LoggingConfig) -> Result<Self> {
@@ -206,7 +207,8 @@ impl Drop for LoggingRuntime {
 
 /// Installs process-wide operational logging from resolved config.
 ///
-/// Stderr is always enabled. Explicit file sinks fail startup if they cannot be opened.
+/// Stderr is enabled by default and can be disabled with [`LoggingConfig::stderr_enabled`].
+/// Explicit file sinks fail startup if they cannot be opened.
 ///
 /// Verbosity comes from [`LoggingConfig::level`]: records below that minimum severity are discarded.
 /// Dropping the returned [`LoggingRuntime`] flushes sinks and detaches this logger from the

--- a/crates/core/src/logging/sink.rs
+++ b/crates/core/src/logging/sink.rs
@@ -28,20 +28,22 @@ pub(crate) fn build_logger(
     let mut active_paths: Vec<PathBuf> = Vec::new();
     let mut reserved_paths: Vec<PathBuf> = Vec::new();
 
-    let stderr_sink = StdStreamSink::builder()
-        .stderr()
-        .style_mode(StyleMode::Never)
-        .formatter(RelayFormatter {
-            format: config.stderr_format,
-            root_relay_id: root_relay_id.clone(),
-        })
-        .level_filter(spdlog_level_filter(config.level))
-        .error_handler(stderr_error_handler("stderr"))
-        .build_arc()
-        .map_err(|error| {
-            FlowError::InvalidArgument(format!("failed to create stderr logging sink: {error}"))
-        })?;
-    sinks.push(stderr_sink);
+    if config.stderr_enabled {
+        let stderr_sink = StdStreamSink::builder()
+            .stderr()
+            .style_mode(StyleMode::Never)
+            .formatter(RelayFormatter {
+                format: config.stderr_format,
+                root_relay_id: root_relay_id.clone(),
+            })
+            .level_filter(spdlog_level_filter(config.level))
+            .error_handler(stderr_error_handler("stderr"))
+            .build_arc()
+            .map_err(|error| {
+                FlowError::InvalidArgument(format!("failed to create stderr logging sink: {error}"))
+            })?;
+        sinks.push(stderr_sink);
+    }
 
     for sink in &config.sinks {
         let LogSinkConfig::File(file_sink) = sink;

--- a/crates/core/tests/coverage/logging_sink_tests.rs
+++ b/crates/core/tests/coverage/logging_sink_tests.rs
@@ -132,6 +132,16 @@ fn logger_builder_rejects_duplicate_reserved_and_invalid_queue_sinks() {
 }
 
 #[test]
+fn logger_builder_omits_stderr_when_disabled() {
+    let config = LoggingConfig {
+        stderr_enabled: false,
+        ..LoggingConfig::default()
+    };
+    let (logger, _) = build_logger(&config, "root".into()).unwrap();
+    assert!(logger.sinks().is_empty());
+}
+
+#[test]
 fn logger_builder_reports_file_and_rotating_file_open_errors() {
     let temp = tempfile::tempdir().unwrap();
     let blocked_parent = temp.path().join("not-a-directory");

--- a/crates/core/tests/coverage/logging_tests.rs
+++ b/crates/core/tests/coverage/logging_tests.rs
@@ -99,8 +99,15 @@ struct LoggingEnvScope {
 impl LoggingEnvScope {
     fn set(values: &[(&'static str, Option<&OsStr>)]) -> Self {
         let guard = lock_logging_tests();
+        let mut values = values.to_vec();
+        if !values
+            .iter()
+            .any(|(name, _)| *name == "NEMO_RELAY_LOG_STDERR")
+        {
+            values.push(("NEMO_RELAY_LOG_STDERR", None));
+        }
         let mut previous = Vec::with_capacity(values.len());
-        for &(name, value) in values {
+        for (name, value) in values {
             previous.push((name, std::env::var_os(name)));
             unsafe {
                 match value {
@@ -292,6 +299,7 @@ fn default_logging_runtime_rejects_invalid_environment() {
 fn logging_config_from_environment_resolves_direct_settings() {
     let _environment = LoggingEnvScope::set(&[
         ("NEMO_RELAY_LOG", Some(OsStr::new("debug"))),
+        ("NEMO_RELAY_LOG_STDERR", Some(OsStr::new("false"))),
         ("NEMO_RELAY_LOG_STDERR_FORMAT", Some(OsStr::new("jsonl"))),
         ("NEMO_RELAY_LOG_CONFIG_PATH", None),
     ]);
@@ -301,8 +309,22 @@ fn logging_config_from_environment_resolves_direct_settings() {
         .expect("direct environment settings should select a configuration");
 
     assert_eq!(config.level, LogLevel::Debug);
+    assert!(!config.stderr_enabled);
     assert_eq!(config.stderr_format, LogFormat::Jsonl);
     assert!(config.sinks.is_empty());
+}
+
+#[test]
+fn logging_config_rejects_invalid_stderr_environment_value() {
+    let _environment = LoggingEnvScope::set(&[
+        ("NEMO_RELAY_LOG", None),
+        ("NEMO_RELAY_LOG_STDERR", Some(OsStr::new("sometimes"))),
+        ("NEMO_RELAY_LOG_STDERR_FORMAT", None),
+        ("NEMO_RELAY_LOG_CONFIG_PATH", None),
+    ]);
+
+    let error = LoggingConfig::from_environment().unwrap_err().to_string();
+    assert!(error.contains("NEMO_RELAY_LOG_STDERR"), "{error}");
 }
 
 #[test]

--- a/crates/node/tests/logging_tests.mjs
+++ b/crates/node/tests/logging_tests.mjs
@@ -10,7 +10,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const packageDirectory = fileURLToPath(new URL('..', import.meta.url));
-const loggingEnvironmentNames = ['NEMO_RELAY_LOG', 'NEMO_RELAY_LOG_STDERR_FORMAT', 'NEMO_RELAY_LOG_CONFIG_PATH'];
+const loggingEnvironmentNames = ['NEMO_RELAY_LOG', 'NEMO_RELAY_LOG_STDERR', 'NEMO_RELAY_LOG_STDERR_FORMAT', 'NEMO_RELAY_LOG_CONFIG_PATH'];
 
 function requireBinding(loggingEnvironment, source = "require('./index.js')") {
   const environment = { ...process.env };
@@ -34,6 +34,16 @@ describe('operational logging', () => {
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stderr, /"event":"logging_initialized"/);
+  });
+
+  it('disables stderr logging from the environment', () => {
+    const result = requireBinding({
+      NEMO_RELAY_LOG: 'info',
+      NEMO_RELAY_LOG_STDERR: 'false',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, '');
   });
 
   it('rejects an invalid logging environment', () => {

--- a/docs/reference/operational-logging.mdx
+++ b/docs/reference/operational-logging.mdx
@@ -11,8 +11,9 @@ startup, configuration, plugins, gateway behavior, and runtime failures. It is
 separate from agent observability through ATOF, ATIF, OpenTelemetry, or
 OpenInference.
 
-Relay writes operational logs to stderr. Optional file sinks receive additional
-copies of those records. Each record includes a root Relay ID for correlation.
+Relay writes operational logs to stderr by default. Set `stderr_enabled` to
+`false` to disable that sink; optional file sinks continue receiving records.
+Each record includes a root Relay ID for correlation.
 
 ## Defaults
 
@@ -71,12 +72,14 @@ application that initializes logging with
 
 ```bash
 export NEMO_RELAY_LOG=debug
+export NEMO_RELAY_LOG_STDERR=false
 export NEMO_RELAY_LOG_STDERR_FORMAT=jsonl
 ```
 
 Supported values are:
 
 - `NEMO_RELAY_LOG`: `error`, `warn`, `info`, `debug`, or `trace`
+- `NEMO_RELAY_LOG_STDERR`: `true` (default) or `false`
 - `NEMO_RELAY_LOG_STDERR_FORMAT`: `human` or `jsonl`
 
 Alternatively, select an absolute TOML file:
@@ -111,6 +114,7 @@ Logging settings use a `[logging]` table:
 ```toml
 [logging]
 level = "info"
+stderr_enabled = false
 stderr_format = "human"
 flush_interval_millis = 1000
 

--- a/go/nemo_relay/logging_test.go
+++ b/go/nemo_relay/logging_test.go
@@ -16,6 +16,7 @@ const loggingHelperEnvironment = "NEMO_RELAY_TEST_LOGGING_HELPER"
 
 var loggingEnvironmentNames = map[string]struct{}{
 	"NEMO_RELAY_LOG":               {},
+	"NEMO_RELAY_LOG_STDERR":        {},
 	"NEMO_RELAY_LOG_STDERR_FORMAT": {},
 	"NEMO_RELAY_LOG_CONFIG_PATH":   {},
 }
@@ -44,8 +45,25 @@ func TestBindingLoggingEnvironment(t *testing.T) {
 	}
 
 	t.Run("initializes from environment", testLoggingInitialization)
+	t.Run("disables stderr from environment", testLoggingDisabledStderr)
 	t.Run("rejects invalid environment", testLoggingInvalidEnvironment)
 	t.Run("flushes file sink during shutdown", testLoggingFileSinkShutdown)
+}
+
+func testLoggingDisabledStderr(t *testing.T) {
+	command := exec.Command(os.Args[0], loggingEnvironmentTestRunArg)
+	command.Env = loggingTestEnvironment(
+		loggingHelperEnvironment+"=shutdown",
+		"NEMO_RELAY_LOG=info",
+		"NEMO_RELAY_LOG_STDERR=false",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("binding initialization failed: %v\n%s", err, output)
+	}
+	if strings.Contains(string(output), `"event":"logging_initialized"`) {
+		t.Fatalf("stderr logging was not disabled:\n%s", output)
+	}
 }
 
 func testLoggingInitialization(t *testing.T) {

--- a/python/tests/test_logging.py
+++ b/python/tests/test_logging.py
@@ -8,6 +8,7 @@ import sys
 
 _LOG_ENVIRONMENT = (
     "NEMO_RELAY_LOG",
+    "NEMO_RELAY_LOG_STDERR",
     "NEMO_RELAY_LOG_STDERR_FORMAT",
     "NEMO_RELAY_LOG_CONFIG_PATH",
 )
@@ -35,6 +36,16 @@ def test_binding_initializes_logging_from_environment():
 
     assert completed.returncode == 0, completed.stderr
     assert '"event":"logging_initialized"' in completed.stderr
+
+
+def test_binding_disables_stderr_logging_from_environment():
+    completed = _import_nemo_relay(
+        NEMO_RELAY_LOG="info",
+        NEMO_RELAY_LOG_STDERR="false",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not completed.stderr
 
 
 def test_binding_rejects_invalid_logging_environment():


### PR DESCRIPTION
#### Overview

Add an explicit, default-preserving opt-out for NeMo Relay operational stderr logging.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `NEMO_RELAY_LOG_STDERR=false` and `stderr_enabled = false` to disable the stderr sink.
- Keep optional file sinks active when stderr is disabled.
- Cover the behavior across Rust, Python, Node.js, and Go, and document the configuration.

#### Where should the reviewer start?

Start with `crates/core/src/logging/config.rs`, which resolves the new environment and TOML configuration, then `crates/core/src/logging/sink.rs`, which omits the stderr sink.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to enable or disable stderr logging through environment variables or TOML configuration.
  * Stderr logging remains enabled by default.
  * File-based logging continues operating when stderr logging is disabled.

* **Documentation**
  * Updated operational logging guidance with configuration examples and default behavior.

* **Bug Fixes**
  * Invalid stderr logging configuration values are now rejected clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->