### PR TITLE
feat(codec): add Amazon Bedrock Converse codec

### DIFF
--- a/crates/adaptive/src/acg/request_surfaces/mod.rs
+++ b/crates/adaptive/src/acg/request_surfaces/mod.rs
@@ -52,6 +52,8 @@ impl RequestSurface {
             ProviderSurface::OCIGenAI => None,
             // Gemini generateContent ACG request editing is intentionally unsupported.
             ProviderSurface::GeminiGenerateContent => None,
+            // Bedrock Converse ACG request editing is intentionally unsupported.
+            ProviderSurface::BedrockConverse => None,
         }
     }
 

--- a/crates/adaptive/src/response_cache/intercept.rs
+++ b/crates/adaptive/src/response_cache/intercept.rs
@@ -17,7 +17,9 @@ use nemo_relay::api::runtime::{
     LlmExecutionFn, LlmExecutionNextFn, LlmJsonStream, LlmStreamExecutionFn,
     LlmStreamExecutionNextFn, LlmStreamInner,
 };
-use nemo_relay::codec::resolve::{detect_request_surface_with_hint, streaming_codec};
+use nemo_relay::codec::resolve::{
+    ProviderSurface, detect_request_surface_with_hint, streaming_codec,
+};
 use nemo_relay::codec::streaming::StreamingCodec;
 use nemo_relay::error::Result as FlowResult;
 use serde_json::Value as Json;
@@ -222,8 +224,8 @@ async fn run_cache(
 /// single aggregate response (via the configured codec) and stores **that** — the
 /// same shape a buffered call stores — so buffered and streaming entries share
 /// one key. Replays the stored aggregate on a hit. Aggregation needs a codec,
-/// inferred from the request surface; only an unrecognized surface runs live
-/// (uncached). Fails open.
+/// inferred from the request surface. Unrecognized surfaces and surfaces with
+/// no faithful native replay run live (uncached). Fails open.
 async fn run_cache_stream(
     provider: String,
     request: LlmRequest,
@@ -249,6 +251,10 @@ async fn run_cache_stream(
             return next(request).await;
         }
     };
+    if let Some(reason) = stream_cache_bypass_reason(surface) {
+        emit_cache_mark(CacheMark::new(CacheMarkStatus::Bypass, backend).reason(reason));
+        return next(request).await;
+    }
     let codec = streaming_codec(surface);
 
     // As in `run_cache`, the decision mark is emitted before `next()`.
@@ -320,6 +326,13 @@ async fn run_cache_stream(
             next(request).await
         }
     }
+}
+
+fn stream_cache_bypass_reason(surface: ProviderSurface) -> Option<CacheReason> {
+    // A buffered Converse response is not a valid ConverseStream event. Until
+    // Relay can synthesize that event sequence, do not create an entry that a
+    // later streaming caller cannot consume faithfully.
+    matches!(surface, ProviderSurface::BedrockConverse).then_some(CacheReason::StreamNoReplay)
 }
 
 /// Tees a live stream: forwards each chunk to the consumer while feeding it to the
@@ -637,6 +650,7 @@ fn request_model(request: &LlmRequest) -> Option<String> {
         .content
         .get("model")
         .and_then(Json::as_str)
+        .or_else(|| request.content.get("modelId").and_then(Json::as_str))
         .map(str::to_string)
 }
 

--- a/crates/adaptive/src/response_cache/key.rs
+++ b/crates/adaptive/src/response_cache/key.rs
@@ -60,7 +60,7 @@ pub fn build_cache_key(
     request: &LlmRequest,
     config: &ResponseCacheConfig,
 ) -> KeyOutcome {
-    if let Some(reason) = cache_bypass_reason(request, config) {
+    if let Some(reason) = cache_bypass_reason(provider, request, config) {
         return KeyOutcome::Bypass(reason);
     }
 
@@ -78,11 +78,11 @@ pub fn build_cache_key(
         normalize_tool_call_ids(object);
     }
 
-    if config.key_strategy == ResponseCacheKeyStrategy::Logical
-        && let Some(object) = body.as_object_mut()
-        && let Some(tools) = object.get("tools").cloned()
-    {
-        object.insert("tools".to_string(), structural_tool_schema(&tools));
+    if config.key_strategy == ResponseCacheKeyStrategy::Logical {
+        canonicalize_logical_tools(
+            &mut body,
+            detected_bedrock_converse(provider, &request.content),
+        );
     }
 
     let header_allowlist = normalized_header_allowlist(&config.header_allowlist);
@@ -117,7 +117,11 @@ pub fn build_cache_key(
     }
 }
 
-fn cache_bypass_reason(request: &LlmRequest, config: &ResponseCacheConfig) -> Option<CacheReason> {
+fn cache_bypass_reason(
+    provider: &str,
+    request: &LlmRequest,
+    config: &ResponseCacheConfig,
+) -> Option<CacheReason> {
     if request.content.is_null() {
         return Some(CacheReason::UnparseableBody);
     }
@@ -129,7 +133,8 @@ fn cache_bypass_reason(request: &LlmRequest, config: &ResponseCacheConfig) -> Op
         return Some(reason);
     }
     (!config.cache_nondeterministic
-        && request_temperature(&request.content).is_none_or(|temperature| temperature > 0.0))
+        && request_temperature(provider, &request.content)
+            .is_none_or(|temperature| temperature > 0.0))
     .then_some(CacheReason::NondeterministicTemperature)
 }
 
@@ -428,6 +433,9 @@ fn lossy_request_shape(surface: ProviderSurface, content: &Json) -> bool {
                     .and_then(Json::as_array)
                     .is_some_and(|items| items.iter().any(lossy_gemini_content_item))
         }
+        // Bedrock-only request fields are preserved through the codec rather
+        // than fully normalized, so keep cache keys on the raw request.
+        ProviderSurface::BedrockConverse => true,
     }
 }
 
@@ -598,7 +606,7 @@ fn raw_has_messages(request: &LlmRequest) -> bool {
     non_empty_array("messages") || non_empty_array("input")
 }
 
-fn request_temperature(content: &Json) -> Option<f64> {
+fn request_temperature(provider: &str, content: &Json) -> Option<f64> {
     content
         .get("temperature")
         .and_then(Json::as_f64)
@@ -607,6 +615,20 @@ fn request_temperature(content: &Json) -> Option<f64> {
                 .pointer("/params/temperature")
                 .and_then(Json::as_f64)
         })
+        .or_else(|| {
+            detected_bedrock_converse(provider, content)
+                .then(|| {
+                    content
+                        .pointer("/inferenceConfig/temperature")
+                        .and_then(Json::as_f64)
+                })
+                .flatten()
+        })
+}
+
+fn detected_bedrock_converse(provider: &str, content: &Json) -> bool {
+    detect_request_surface_with_hint(content, Some(provider))
+        == Some(ProviderSurface::BedrockConverse)
 }
 
 /// Keeps only allowlisted headers, matched case-insensitively and emitted with
@@ -719,6 +741,31 @@ fn structural_tool_schema(tools: &Json) -> Json {
     entries
         .sort_by_cached_key(|entry| serde_json_canonicalizer::to_string(entry).unwrap_or_default());
     Json::Array(entries)
+}
+
+/// Applies the `logical` tool projection to provider-native tool locations.
+///
+/// Most supported providers put their tool array at the request root. Bedrock
+/// Converse nests it under `toolConfig`; only that array is projected so
+/// sibling controls such as `toolChoice` remain part of the cache key.
+fn canonicalize_logical_tools(body: &mut Json, bedrock_converse: bool) {
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+
+    if let Some(tools) = object.get("tools").cloned() {
+        object.insert("tools".to_string(), structural_tool_schema(&tools));
+    }
+
+    if !bedrock_converse {
+        return;
+    }
+
+    if let Some(tool_config) = object.get_mut("toolConfig").and_then(Json::as_object_mut)
+        && let Some(tools) = tool_config.get("tools").cloned()
+    {
+        tool_config.insert("tools".to_string(), structural_tool_schema(&tools));
+    }
 }
 
 /// Removes every string-valued `description` key, at any depth. A non-string

--- a/crates/adaptive/src/response_cache/mark.rs
+++ b/crates/adaptive/src/response_cache/mark.rs
@@ -61,6 +61,8 @@ pub(crate) enum CacheReason {
     StoreError,
     /// The streaming response has no supported codec.
     StreamNoCodec,
+    /// The provider has no faithful native streaming replay.
+    StreamNoReplay,
     /// The request body cannot be parsed.
     UnparseableBody,
     /// The tool's resolved policy does not permit caching.
@@ -82,6 +84,7 @@ impl CacheReason {
             Self::StatefulStore => "stateful_store",
             Self::StoreError => "store_error",
             Self::StreamNoCodec => "stream_no_codec",
+            Self::StreamNoReplay => "stream_no_replay",
             Self::UnparseableBody => "unparseable_body",
             Self::Uncacheable => "uncacheable",
             Self::UnrepresentableNumber => "unrepresentable_number",

--- a/crates/adaptive/src/response_cache/replay.rs
+++ b/crates/adaptive/src/response_cache/replay.rs
@@ -90,6 +90,9 @@ fn synthesize_replay_chunks(aggregate: &Json) -> Option<Vec<Json>> {
         // re-aggregates it and rejects shapes the streaming collector cannot
         // preserve exactly.
         ProviderSurface::GeminiGenerateContent => vec![aggregate.clone()],
+        // A Converse aggregate is not a valid ConverseStream event. Native
+        // replay requires event synthesis and is deliberately deferred.
+        ProviderSurface::BedrockConverse => return None,
     })
 }
 

--- a/crates/adaptive/tests/unit/acg/request_surface_tests.rs
+++ b/crates/adaptive/tests/unit/acg/request_surface_tests.rs
@@ -286,6 +286,14 @@ fn test_request_surface_resolution_and_passthrough_support_cover_matrix() {
         headers: serde_json::Map::new(),
         content: json!({"model": "unknown"}),
     };
+    let bedrock_request = LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({
+            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "system": [{"text": "helpful"}],
+            "messages": []
+        }),
+    };
 
     assert!(RequestSurface::OpenAIChat.supports_provider("passthrough"));
     assert!(!RequestSurface::OpenAIChat.supports_provider("unknown"));
@@ -310,6 +318,11 @@ fn test_request_surface_resolution_and_passthrough_support_cover_matrix() {
     };
     assert!(matches!(
         super::resolve_request_surface_from_request(&gemini_request),
+        Err(crate::acg::AcgError::Internal(message))
+            if message.contains("does not have an ACG applier")
+    ));
+    assert!(matches!(
+        super::resolve_request_surface_from_request(&bedrock_request),
         Err(crate::acg::AcgError::Internal(message))
             if message.contains("does not have an ACG applier")
     ));

--- a/crates/adaptive/tests/unit/response_cache/intercept_tests.rs
+++ b/crates/adaptive/tests/unit/response_cache/intercept_tests.rs
@@ -114,6 +114,43 @@ fn sampled_bypass_uses_a_unit_interval_rng() {
     assert_eq!(should_bypass(0.5), expected);
 }
 
+#[test]
+fn request_model_falls_back_to_bedrock_model_id() {
+    let bedrock = LlmRequest {
+        headers: Default::default(),
+        content: json!({
+            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": []
+        }),
+    };
+    assert_eq!(
+        request_model(&bedrock).as_deref(),
+        Some("anthropic.claude-3-5-sonnet-20241022-v2:0")
+    );
+
+    let explicit_model = LlmRequest {
+        headers: Default::default(),
+        content: json!({"model": "normalized-model", "modelId": "bedrock-model"}),
+    };
+    assert_eq!(
+        request_model(&explicit_model).as_deref(),
+        Some("normalized-model"),
+        "the existing model field remains authoritative when both spellings are present"
+    );
+}
+
+#[test]
+fn bedrock_streaming_cache_is_explicitly_bypassed_until_native_replay_exists() {
+    assert_eq!(
+        stream_cache_bypass_reason(ProviderSurface::BedrockConverse),
+        Some(CacheReason::StreamNoReplay)
+    );
+    assert_eq!(
+        stream_cache_bypass_reason(ProviderSurface::OpenAIChat),
+        None
+    );
+}
+
 #[tokio::test]
 async fn write_behind_returns_eof_before_cache_commit_completes() {
     let (tx, rx) = tokio::sync::mpsc::channel(1);

--- a/crates/adaptive/tests/unit/response_cache/key_tests.rs
+++ b/crates/adaptive/tests/unit/response_cache/key_tests.rs
@@ -245,6 +245,33 @@ fn legacy_skip_keys_cannot_collapse_raw_fallback_fields() {
 }
 
 #[test]
+fn bedrock_converse_keys_use_the_raw_envelope() {
+    let config = cache_all_config();
+    let make = |tenant: &str| {
+        request(json!({
+            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+            "requestMetadata": {"tenant": tenant}
+        }))
+    };
+    let first = make("alpha");
+    let second = make("beta");
+
+    for request in [&first, &second] {
+        assert_eq!(
+            resolved_body("aws.bedrock.converse", request).1,
+            None,
+            "Bedrock Converse cache keys must retain the complete raw request envelope"
+        );
+    }
+    assert_ne!(
+        key_of("aws.bedrock.converse", &first, &config),
+        key_of("aws.bedrock.converse", &second, &config),
+        "an unmodeled Bedrock request field can affect the answer and must partition cache entries"
+    );
+}
+
+#[test]
 fn namespace_and_provider_separate_keys() {
     let request = request(json!({"model": "m", "messages": [{"role": "user", "content": "hi"}]}));
     let ns_a = ResponseCacheConfig {
@@ -576,6 +603,41 @@ fn nondeterministic_calls_bypass_only_when_disabled() {
         build_cache_key("openai", &sampled, &opt_in),
         KeyOutcome::Key(_)
     ));
+}
+
+#[test]
+fn bedrock_converse_uses_nested_temperature_for_cache_eligibility() {
+    let with_temperature = |temperature: f64| {
+        request(json!({
+            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+            "inferenceConfig": {"temperature": temperature}
+        }))
+    };
+    let config = ResponseCacheConfig::default();
+
+    assert!(matches!(
+        build_cache_key("aws.bedrock.converse", &with_temperature(0.0), &config),
+        KeyOutcome::Key(_)
+    ));
+    assert_eq!(
+        build_cache_key("aws.bedrock.converse", &with_temperature(0.7), &config),
+        KeyOutcome::Bypass(CacheReason::NondeterministicTemperature)
+    );
+}
+
+#[test]
+fn opaque_nested_temperature_does_not_change_cache_eligibility() {
+    let request = request(json!({
+        "prompt_text": "hi",
+        "inferenceConfig": {"temperature": 0.0}
+    }));
+
+    assert_eq!(
+        build_cache_key("custom-provider", &request, &ResponseCacheConfig::default()),
+        KeyOutcome::Bypass(CacheReason::NondeterministicTemperature),
+        "Bedrock's nested temperature must not change an opaque provider's cache policy"
+    );
 }
 
 #[test]
@@ -1323,6 +1385,22 @@ fn tool(name: &str, description: &str, param: &str, param_type: &str) -> Json {
     })
 }
 
+fn bedrock_tool(name: &str, description: &str, param: &str, param_type: &str) -> Json {
+    json!({
+        "toolSpec": {
+            "name": name,
+            "description": description,
+            "inputSchema": {"json": {
+                "type": "object",
+                "properties": {param: {
+                    "type": param_type,
+                    "description": "a param"
+                }}
+            }}
+        }
+    })
+}
+
 #[test]
 fn logical_ignores_tool_description_and_order() {
     let a = request(json!({
@@ -1346,6 +1424,119 @@ fn logical_ignores_tool_description_and_order() {
         key_of("openai", &a, &cache_all_config()),
         key_of("openai", &b, &cache_all_config()),
         "exact_request must not collapse reworded/reordered tools"
+    );
+}
+
+#[test]
+fn bedrock_logical_ignores_tool_description_and_order() {
+    let with_tools = |tools: Vec<Json>| {
+        request(json!({
+            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+            "inferenceConfig": {"temperature": 0.0},
+            "toolConfig": {
+                "tools": tools,
+                "toolChoice": {"auto": {}}
+            }
+        }))
+    };
+    let first = with_tools(vec![
+        bedrock_tool("get_weather", "Get the weather.", "city", "string"),
+        bedrock_tool("get_time", "Get the time.", "tz", "string"),
+    ]);
+    let second = with_tools(vec![
+        bedrock_tool("get_time", "Return the current time.", "tz", "string"),
+        bedrock_tool(
+            "get_weather",
+            "Look up weather, reworded.",
+            "city",
+            "string",
+        ),
+    ]);
+
+    assert_eq!(
+        key_of("aws.bedrock.converse", &first, &logical_config()),
+        key_of("aws.bedrock.converse", &second, &logical_config()),
+        "Bedrock logical keying must ignore tool description text and tool order"
+    );
+    assert_ne!(
+        key_of("aws.bedrock.converse", &first, &cache_all_config()),
+        key_of("aws.bedrock.converse", &second, &cache_all_config()),
+        "exact_request must preserve Bedrock tool descriptions and order"
+    );
+}
+
+#[test]
+fn bedrock_logical_keeps_tool_interface_and_tool_config_controls() {
+    let with_tool = |tool: Json, tool_choice: Json| {
+        request(json!({
+            "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+            "inferenceConfig": {"temperature": 0.0},
+            "toolConfig": {
+                "tools": [tool],
+                "toolChoice": tool_choice
+            }
+        }))
+    };
+    let base = with_tool(
+        bedrock_tool("get_weather", "description", "city", "string"),
+        json!({"auto": {}}),
+    );
+    let renamed_parameter = with_tool(
+        bedrock_tool("get_weather", "description", "location", "string"),
+        json!({"auto": {}}),
+    );
+    let retyped_parameter = with_tool(
+        bedrock_tool("get_weather", "description", "city", "number"),
+        json!({"auto": {}}),
+    );
+    let forced_tool = with_tool(
+        bedrock_tool("get_weather", "description", "city", "string"),
+        json!({"tool": {"name": "get_weather"}}),
+    );
+    let config = logical_config();
+
+    assert_ne!(
+        key_of("aws.bedrock.converse", &base, &config),
+        key_of("aws.bedrock.converse", &renamed_parameter, &config),
+        "a renamed Bedrock tool parameter must change the key"
+    );
+    assert_ne!(
+        key_of("aws.bedrock.converse", &base, &config),
+        key_of("aws.bedrock.converse", &retyped_parameter, &config),
+        "a retyped Bedrock tool parameter must change the key"
+    );
+    assert_ne!(
+        key_of("aws.bedrock.converse", &base, &config),
+        key_of("aws.bedrock.converse", &forced_tool, &config),
+        "Bedrock toolConfig controls outside tools must remain in the key"
+    );
+}
+
+#[test]
+fn opaque_logical_keys_preserve_nested_tool_config() {
+    let with_description = |description: &str| {
+        request(json!({
+            "prompt_text": "hi",
+            "temperature": 0.0,
+            "toolConfig": {
+                "tools": [{
+                    "name": "get_weather",
+                    "description": description,
+                    "inputSchema": {"type": "object"}
+                }]
+            }
+        }))
+    };
+    let first = with_description("Get the weather.");
+    let second = with_description("Look up current conditions.");
+
+    assert_eq!(resolved_body("custom-provider", &first).1, None);
+    assert_ne!(
+        key_of("custom-provider", &first, &logical_config()),
+        key_of("custom-provider", &second, &logical_config()),
+        "Bedrock's nested tool projection must not change an opaque provider's cache keys"
     );
 }
 

--- a/crates/adaptive/tests/unit/response_cache/mark_tests.rs
+++ b/crates/adaptive/tests/unit/response_cache/mark_tests.rs
@@ -59,6 +59,10 @@ fn cache_mark_labels_have_stable_telemetry_values() {
         "stream_no_codec"
     );
     assert_eq!(
+        black_box(CacheReason::StreamNoReplay).as_str(),
+        "stream_no_replay"
+    );
+    assert_eq!(
         black_box(CacheReason::UnparseableBody).as_str(),
         "unparseable_body"
     );

--- a/crates/adaptive/tests/unit/response_cache/replay_tests.rs
+++ b/crates/adaptive/tests/unit/response_cache/replay_tests.rs
@@ -146,6 +146,34 @@ fn gemini_replay_rejects_multi_candidate_aggregates_as_lossy() {
 }
 
 #[test]
+fn bedrock_converse_aggregate_has_no_streaming_replay() {
+    let aggregate = json!({
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "hello"}]
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 9, "outputTokens": 3, "totalTokens": 12}
+    });
+
+    assert_eq!(
+        detect_response_surface(&aggregate),
+        Some(ProviderSurface::BedrockConverse),
+        "the fixture must exercise the Bedrock response surface"
+    );
+    assert!(
+        synthesize_replay_chunks(&aggregate).is_none(),
+        "a buffered Converse response is not itself a native ConverseStream event"
+    );
+    assert!(
+        replay_is_lossy(&aggregate),
+        "the streaming cache must run live until native ConverseStream replay is implemented"
+    );
+}
+
+#[test]
 fn responses_replay_sequence_numbers_are_contiguous() {
     let aggregate = json!({
         "id": "r1",

--- a/crates/core/src/api/llm.rs
+++ b/crates/core/src/api/llm.rs
@@ -36,8 +36,8 @@ use crate::api::scope::event;
 use crate::api::scope::{EmitMarkEventParams, ScopeHandle, metadata_with_log_severity};
 use crate::api::shared::{
     ensure_runtime_owner, inject_dynamo_session_ids, inject_traceparent, inject_traceparent_value,
-    metadata_with_otel_error, metadata_with_otel_status, resolve_parent_uuid,
-    run_request_intercepts_with_codec_and_recorder, snapshot_event_sanitizers,
+    message_starts_new_user_turn, metadata_with_otel_error, metadata_with_otel_status,
+    resolve_parent_uuid, run_request_intercepts_with_codec_and_recorder, snapshot_event_sanitizers,
     snapshot_event_subscribers,
 };
 use crate::codec::request::{AnnotatedLlmRequest, Message};
@@ -385,7 +385,7 @@ fn project_llm_request_to_current_user_turn(
     };
     if !request_turn_projection_needed(
         &annotation.messages,
-        &|message| matches!(message, Message::User { .. }),
+        &message_starts_new_user_turn,
         &|message| matches!(message, Message::System { .. }),
     ) {
         return;
@@ -416,7 +416,7 @@ fn limit_annotated_request_history_to_current_user_turn(
 ) -> bool {
     retain_current_request_turn(
         &mut annotated_request.messages,
-        |message| matches!(message, Message::User { .. }),
+        message_starts_new_user_turn,
         |message| matches!(message, Message::System { .. }),
     )
 }

--- a/crates/core/src/api/shared.rs
+++ b/crates/core/src/api/shared.rs
@@ -16,7 +16,7 @@ use crate::api::runtime::{
 use crate::api::runtime::{current_scope_stack, task_scope_top};
 use crate::api::scope::ScopeHandle;
 use crate::api::scope::ScopeType;
-use crate::codec::request::AnnotatedLlmRequest;
+use crate::codec::request::{AnnotatedLlmRequest, ContentPart, Message, MessageContent};
 use crate::codec::traits::LlmCodec;
 use crate::error::{FlowError, Result};
 use crate::json::{Json, merge_json};
@@ -289,6 +289,36 @@ pub(crate) fn metadata_with_otel_error(metadata: Option<Json>, error: &FlowError
         }
     }
     metadata
+}
+
+/// Whether a normalized message starts a fresh human turn rather than a
+/// provider-shaped tool continuation.
+pub(crate) fn message_starts_new_user_turn(message: &Message) -> bool {
+    let Message::User { content, .. } = message else {
+        return false;
+    };
+    match content {
+        MessageContent::Text(_) => true,
+        MessageContent::Parts(parts) => {
+            let has_user_input = parts.iter().any(|part| {
+                matches!(
+                    part,
+                    ContentPart::Text { .. }
+                        | ContentPart::ImageUrl { .. }
+                        | ContentPart::Image { .. }
+                        | ContentPart::Audio { .. }
+                        | ContentPart::File { .. }
+                )
+            });
+            has_user_input
+                || !parts.iter().any(|part| {
+                    matches!(
+                        part,
+                        ContentPart::ToolUse { .. } | ContentPart::ToolResult { .. }
+                    )
+                })
+        }
+    }
 }
 
 pub(crate) type InterceptedLlmRequest = (

--- a/crates/core/src/codec/bedrock_converse.rs
+++ b/crates/core/src/codec/bedrock_converse.rs
@@ -1,0 +1,1469 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Built-in codec for Amazon Bedrock Converse and ConverseStream payloads.
+//!
+//! This codec operates on the JSON-compatible request and response dictionaries used by AWS SDK
+//! calls. It does not implement SigV4 signing, HTTP transport, or conversion of SDK-native binary
+//! values into JSON.
+
+use crate::api::llm::LlmRequest;
+use crate::api::runtime::{BuiltinLlmCodec, LlmCodecIdentity};
+use crate::error::{FlowError, Result, UpstreamFailure, UpstreamFailureClass};
+use crate::json::Json;
+
+use super::request::{
+    AnnotatedLlmRequest, ContentPart, FunctionDefinition, GenerationParams, Message,
+    MessageContent, ProviderNativeComponent, ToolCall, ToolChoice, ToolChoiceFunction,
+    ToolChoiceFunctionName, ToolDefinition,
+};
+use super::resolve::{ProviderSurface, ProviderSurfaceDescriptor};
+use super::response::{
+    AnnotatedLlmResponse, ApiSpecificResponse, FinishReason, ResponseToolCall, Usage,
+};
+use super::traits::{LlmCodec, LlmResponseCodec};
+
+const BEDROCK_PROVIDER: &str = "bedrock_converse";
+const MAX_UPSTREAM_ERROR_BODY_BYTES: usize = 64 * 1024;
+const MODELED_REQUEST_KEYS: &[&str] = &[
+    "modelId",
+    "messages",
+    "system",
+    "inferenceConfig",
+    "toolConfig",
+];
+
+/// Built-in codec for Amazon Bedrock's model-independent Converse API.
+pub struct BedrockConverseCodec;
+
+pub(crate) const PROVIDER_SURFACE: ProviderSurfaceDescriptor = ProviderSurfaceDescriptor {
+    surface: ProviderSurface::BedrockConverse,
+    detect_request: |obj, hint| {
+        let hinted = matches!(hint, Some("aws.bedrock.converse" | "bedrock.converse"));
+        let converse_shape = [
+            "messages",
+            "system",
+            "promptVariables",
+            "inferenceConfig",
+            "toolConfig",
+            "additionalModelRequestFields",
+        ]
+        .into_iter()
+        .any(|key| obj.contains_key(key));
+        obj.contains_key("modelId") && (hinted || converse_shape)
+    },
+    detect_response: |obj| {
+        obj.get("output")
+            .and_then(|output| output.get("message"))
+            .is_some_and(Json::is_object)
+            && (obj.contains_key("stopReason")
+                || obj.contains_key("usage")
+                || obj.contains_key("metrics"))
+    },
+    decode_request: |request| BedrockConverseCodec.decode(request),
+    decode_response: |raw| BedrockConverseCodec.decode_response(raw),
+    codec_name: BEDROCK_PROVIDER,
+    request_codec: || std::sync::Arc::new(BedrockConverseCodec),
+    response_codec: || std::sync::Arc::new(BedrockConverseCodec),
+    streaming_codec: || Box::new(BedrockConverseStreamingCodec::new()),
+};
+
+fn native_component(value: &Json) -> ProviderNativeComponent {
+    ProviderNativeComponent {
+        provider: BEDROCK_PROVIDER.into(),
+        kind: value
+            .as_object()
+            .and_then(|obj| obj.keys().next())
+            .cloned()
+            .unwrap_or_else(|| "unknown".into()),
+        value: value.clone(),
+    }
+}
+
+fn required_object<'a>(
+    value: &'a Json,
+    context: &str,
+) -> Result<&'a serde_json::Map<String, Json>> {
+    value.as_object().ok_or_else(|| {
+        FlowError::InvalidArgument(format!("Bedrock Converse {context} must be an object"))
+    })
+}
+
+fn required_array<'a>(value: &'a Json, context: &str) -> Result<&'a [Json]> {
+    value.as_array().map(Vec::as_slice).ok_or_else(|| {
+        FlowError::InvalidArgument(format!("Bedrock Converse {context} must be an array"))
+    })
+}
+
+fn required_string<'a>(
+    obj: &'a serde_json::Map<String, Json>,
+    key: &str,
+    context: &str,
+) -> Result<&'a str> {
+    obj.get(key).and_then(Json::as_str).ok_or_else(|| {
+        FlowError::InvalidArgument(format!(
+            "Bedrock Converse {context} is missing string field {key}"
+        ))
+    })
+}
+
+fn provider_native_content(value: &Json) -> ContentPart {
+    let native = native_component(value);
+    ContentPart::ProviderNative {
+        provider: native.provider,
+        kind: native.kind,
+        value: native.value,
+    }
+}
+
+fn decode_content_block(value: &Json) -> Result<ContentPart> {
+    let obj = required_object(value, "content block")?;
+    let data_keys = [
+        "text",
+        "image",
+        "audio",
+        "document",
+        "toolUse",
+        "toolResult",
+        "video",
+        "guardContent",
+        "cachePoint",
+        "reasoningContent",
+        "citationsContent",
+        "searchResult",
+        "toolAddition",
+        "toolRemoval",
+    ]
+    .into_iter()
+    .filter(|key| obj.contains_key(*key))
+    .collect::<Vec<_>>();
+    if data_keys.len() != 1 {
+        return Ok(provider_native_content(value));
+    }
+
+    match data_keys[0] {
+        "text" => {
+            let text = required_string(obj, "text", "text content block")?;
+            Ok(ContentPart::Text {
+                text: text.into(),
+                extra: obj
+                    .iter()
+                    .filter(|(key, _)| key.as_str() != "text")
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect(),
+            })
+        }
+        "image" => Ok(ContentPart::Image {
+            image: obj["image"].clone(),
+            extra: obj
+                .iter()
+                .filter(|(key, _)| key.as_str() != "image")
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        }),
+        "document" => Ok(ContentPart::File {
+            file: obj["document"].clone(),
+            extra: obj
+                .iter()
+                .filter(|(key, _)| key.as_str() != "document")
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        }),
+        "toolUse" => {
+            let tool = required_object(&obj["toolUse"], "toolUse block")?;
+            Ok(ContentPart::ToolUse {
+                id: required_string(tool, "toolUseId", "toolUse block")?.into(),
+                name: required_string(tool, "name", "toolUse block")?.into(),
+                input: tool.get("input").cloned().ok_or_else(|| {
+                    FlowError::InvalidArgument(
+                        "Bedrock Converse toolUse block is missing input".into(),
+                    )
+                })?,
+                extra: tool
+                    .iter()
+                    .filter(|(key, _)| !matches!(key.as_str(), "toolUseId" | "name" | "input"))
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect(),
+            })
+        }
+        "toolResult" => {
+            let result = required_object(&obj["toolResult"], "toolResult block")?;
+            let status = match result.get("status") {
+                None | Some(Json::Null) => None,
+                Some(Json::String(status)) if status == "success" => Some(false),
+                Some(Json::String(status)) if status == "error" => Some(true),
+                Some(_) => return Ok(provider_native_content(value)),
+            };
+            Ok(ContentPart::ToolResult {
+                tool_use_id: required_string(result, "toolUseId", "toolResult block")?.into(),
+                content: result.get("content").cloned().ok_or_else(|| {
+                    FlowError::InvalidArgument(
+                        "Bedrock Converse toolResult block is missing content".into(),
+                    )
+                })?,
+                is_error: status,
+                extra: result
+                    .iter()
+                    .filter(|(key, _)| !matches!(key.as_str(), "toolUseId" | "content" | "status"))
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect(),
+            })
+        }
+        _ => Ok(provider_native_content(value)),
+    }
+}
+
+fn decode_content(value: &Json, context: &str) -> Result<MessageContent> {
+    let parts = required_array(value, context)?
+        .iter()
+        .map(decode_content_block)
+        .collect::<Result<Vec<_>>>()?;
+    Ok(MessageContent::Parts(parts))
+}
+
+fn encode_content_part(part: &ContentPart) -> Result<Json> {
+    match part {
+        ContentPart::Text { text, extra } => {
+            let mut obj = extra.clone();
+            obj.insert("text".into(), Json::String(text.clone()));
+            Ok(Json::Object(obj))
+        }
+        ContentPart::Image { image, extra } => {
+            let mut obj = extra.clone();
+            obj.insert("image".into(), image.clone());
+            Ok(Json::Object(obj))
+        }
+        ContentPart::File { file, extra } => {
+            let mut obj = extra.clone();
+            obj.insert("document".into(), file.clone());
+            Ok(Json::Object(obj))
+        }
+        ContentPart::ToolUse {
+            id,
+            name,
+            input,
+            extra,
+        } => {
+            let mut tool = extra.clone();
+            tool.insert("toolUseId".into(), Json::String(id.clone()));
+            tool.insert("name".into(), Json::String(name.clone()));
+            tool.insert("input".into(), input.clone());
+            Ok(serde_json::json!({"toolUse": tool}))
+        }
+        ContentPart::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+            extra,
+        } => {
+            let mut result = extra.clone();
+            result.insert("toolUseId".into(), Json::String(tool_use_id.clone()));
+            result.insert("content".into(), content.clone());
+            if let Some(is_error) = is_error {
+                result.insert(
+                    "status".into(),
+                    Json::String(if *is_error { "error" } else { "success" }.into()),
+                );
+            }
+            Ok(serde_json::json!({"toolResult": result}))
+        }
+        ContentPart::ProviderNative {
+            provider, value, ..
+        } if provider == BEDROCK_PROVIDER => Ok(value.clone()),
+        other => Err(FlowError::InvalidArgument(format!(
+            "content part {other:?} cannot be encoded for Bedrock Converse"
+        ))),
+    }
+}
+
+fn encode_content(content: &MessageContent) -> Result<Json> {
+    let parts = match content {
+        MessageContent::Text(text) => vec![serde_json::json!({"text": text})],
+        MessageContent::Parts(parts) => parts
+            .iter()
+            .map(encode_content_part)
+            .collect::<Result<Vec<_>>>()?,
+    };
+    Ok(Json::Array(parts))
+}
+
+fn decode_message(value: &Json) -> Result<Message> {
+    let obj = required_object(value, "message")?;
+    let role = required_string(obj, "role", "message")?;
+    let content = obj
+        .get("content")
+        .ok_or_else(|| {
+            FlowError::InvalidArgument("Bedrock Converse message is missing content".into())
+        })
+        .and_then(|value| decode_content(value, "message content"))?;
+
+    if obj
+        .keys()
+        .any(|key| !matches!(key.as_str(), "role" | "content"))
+    {
+        return Ok(Message::ProviderNative {
+            provider: BEDROCK_PROVIDER.into(),
+            kind: role.into(),
+            value: value.clone(),
+        });
+    }
+    match role {
+        "user" => Ok(Message::User {
+            content,
+            name: None,
+        }),
+        "assistant" => Ok(Message::Assistant {
+            content: Some(content),
+            tool_calls: None,
+            name: None,
+        }),
+        _ => Ok(Message::ProviderNative {
+            provider: BEDROCK_PROVIDER.into(),
+            kind: role.into(),
+            value: value.clone(),
+        }),
+    }
+}
+
+fn encode_tool_call(call: &ToolCall) -> Result<Json> {
+    if call.call_type != "function" {
+        return Err(FlowError::InvalidArgument(format!(
+            "Bedrock Converse cannot encode tool call type {}",
+            call.call_type
+        )));
+    }
+    let input = serde_json::from_str::<Json>(&call.function.arguments).map_err(|error| {
+        FlowError::InvalidArgument(format!(
+            "Bedrock Converse tool call {} has invalid JSON arguments: {error}",
+            call.id
+        ))
+    })?;
+    Ok(serde_json::json!({
+        "toolUse": {
+            "toolUseId": call.id,
+            "name": call.function.name,
+            "input": input,
+        }
+    }))
+}
+
+fn encode_message(message: &Message) -> Result<Json> {
+    match message {
+        Message::User {
+            content,
+            name: None,
+        } => Ok(serde_json::json!({
+            "role": "user",
+            "content": encode_content(content)?,
+        })),
+        Message::Assistant {
+            content,
+            tool_calls,
+            name: None,
+        } => {
+            let mut blocks = match content {
+                Some(content) => match encode_content(content)? {
+                    Json::Array(blocks) => blocks,
+                    _ => unreachable!("Bedrock content encoder always returns an array"),
+                },
+                None => Vec::new(),
+            };
+            if let Some(calls) = tool_calls {
+                blocks.extend(
+                    calls
+                        .iter()
+                        .map(encode_tool_call)
+                        .collect::<Result<Vec<_>>>()?,
+                );
+            }
+            Ok(serde_json::json!({"role": "assistant", "content": blocks}))
+        }
+        Message::Tool {
+            content,
+            tool_call_id,
+        } => Ok(serde_json::json!({
+            "role": "user",
+            "content": [{
+                "toolResult": {
+                    "toolUseId": tool_call_id,
+                    "content": encode_content(content)?,
+                }
+            }],
+        })),
+        Message::ProviderNative {
+            provider, value, ..
+        } if provider == BEDROCK_PROVIDER => Ok(value.clone()),
+        other => Err(FlowError::InvalidArgument(format!(
+            "message {other:?} cannot be encoded for Bedrock Converse"
+        ))),
+    }
+}
+
+fn decode_tool(value: &Json) -> Result<ToolDefinition> {
+    let obj = required_object(value, "tool definition")?;
+    let Some(spec_value) = obj.get("toolSpec") else {
+        let native = native_component(value);
+        return Ok(ToolDefinition::ProviderNative {
+            provider: native.provider,
+            kind: native.kind,
+            value: native.value,
+        });
+    };
+    let spec = required_object(spec_value, "toolSpec")?;
+    let parameters = spec
+        .get("inputSchema")
+        .and_then(Json::as_object)
+        .and_then(|schema| schema.get("json"))
+        .cloned();
+    Ok(ToolDefinition::Function {
+        function: FunctionDefinition {
+            name: required_string(spec, "name", "toolSpec")?.into(),
+            description: super::optional_string(spec, "description", "Bedrock Converse toolSpec")?,
+            parameters,
+            strict: super::optional_bool(spec, "strict", "Bedrock Converse toolSpec")?,
+            extra: spec
+                .iter()
+                .filter(|(key, _)| {
+                    !matches!(
+                        key.as_str(),
+                        "name" | "description" | "inputSchema" | "strict"
+                    )
+                })
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        },
+        extra: obj
+            .iter()
+            .filter(|(key, _)| key.as_str() != "toolSpec")
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    })
+}
+
+fn encode_tool(tool: &ToolDefinition) -> Result<Json> {
+    match tool {
+        ToolDefinition::Function { function, extra } => {
+            let mut spec = function.extra.clone();
+            spec.insert("name".into(), Json::String(function.name.clone()));
+            if let Some(description) = &function.description {
+                spec.insert("description".into(), Json::String(description.clone()));
+            }
+            if let Some(parameters) = &function.parameters {
+                spec.insert(
+                    "inputSchema".into(),
+                    serde_json::json!({"json": parameters}),
+                );
+            }
+            if let Some(strict) = function.strict {
+                spec.insert("strict".into(), Json::Bool(strict));
+            }
+            let mut obj = extra.clone();
+            obj.insert("toolSpec".into(), Json::Object(spec));
+            Ok(Json::Object(obj))
+        }
+        ToolDefinition::ProviderNative {
+            provider, value, ..
+        } if provider == BEDROCK_PROVIDER => Ok(value.clone()),
+        other => Err(FlowError::InvalidArgument(format!(
+            "tool {other:?} cannot be encoded for Bedrock Converse"
+        ))),
+    }
+}
+
+fn decode_tool_choice(value: &Json) -> ToolChoice {
+    let Some(obj) = value.as_object() else {
+        return ToolChoice::ProviderNative(native_component(value));
+    };
+    if obj.len() == 1 && obj.get("auto").is_some_and(Json::is_object) {
+        ToolChoice::Auto
+    } else if obj.len() == 1 && obj.get("any").is_some_and(Json::is_object) {
+        ToolChoice::Required
+    } else if obj.len() == 1 {
+        if let Some(name) = obj
+            .get("tool")
+            .and_then(Json::as_object)
+            .and_then(|tool| tool.get("name"))
+            .and_then(Json::as_str)
+        {
+            return ToolChoice::Specific(ToolChoiceFunction {
+                choice_type: "function".into(),
+                function: ToolChoiceFunctionName { name: name.into() },
+            });
+        }
+        ToolChoice::ProviderNative(native_component(value))
+    } else {
+        ToolChoice::ProviderNative(native_component(value))
+    }
+}
+
+fn encode_tool_choice(choice: &ToolChoice) -> Result<Json> {
+    match choice {
+        ToolChoice::Auto => Ok(serde_json::json!({"auto": {}})),
+        ToolChoice::Required => Ok(serde_json::json!({"any": {}})),
+        ToolChoice::Specific(choice) if choice.choice_type == "function" => {
+            Ok(serde_json::json!({"tool": {"name": choice.function.name}}))
+        }
+        ToolChoice::ProviderNative(native) if native.provider == BEDROCK_PROVIDER => {
+            Ok(native.value.clone())
+        }
+        ToolChoice::None => Err(FlowError::InvalidArgument(
+            "Bedrock Converse has no tool choice equivalent for none".into(),
+        )),
+        other => Err(FlowError::InvalidArgument(format!(
+            "tool choice {other:?} cannot be encoded for Bedrock Converse"
+        ))),
+    }
+}
+
+fn decode_generation_params(
+    obj: &serde_json::Map<String, Json>,
+) -> Result<Option<GenerationParams>> {
+    let Some(config) = obj.get("inferenceConfig") else {
+        return Ok(None);
+    };
+    if config.is_null() {
+        return Ok(None);
+    }
+    let config = required_object(config, "inferenceConfig")?;
+    let temperature =
+        super::optional_f64(config, "temperature", "Bedrock Converse inferenceConfig")?;
+    let max_tokens = super::optional_u64(config, "maxTokens", "Bedrock Converse inferenceConfig")?;
+    let top_p = super::optional_f64(config, "topP", "Bedrock Converse inferenceConfig")?;
+    let stop = config
+        .get("stopSequences")
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            serde_json::from_value::<Vec<String>>(value.clone()).map_err(|error| {
+                FlowError::InvalidArgument(format!(
+                    "invalid Bedrock Converse inferenceConfig.stopSequences: {error}"
+                ))
+            })
+        })
+        .transpose()?;
+    let params = GenerationParams {
+        temperature,
+        max_tokens,
+        top_p,
+        stop,
+    };
+    Ok((params != GenerationParams::default()).then_some(params))
+}
+
+fn json_number(value: f64, field: &str) -> Result<Json> {
+    serde_json::Number::from_f64(value)
+        .map(Json::Number)
+        .ok_or_else(|| {
+            FlowError::InvalidArgument(format!(
+                "Bedrock Converse inferenceConfig.{field} must be finite"
+            ))
+        })
+}
+
+fn set_or_remove(obj: &mut serde_json::Map<String, Json>, key: &str, value: Option<Json>) {
+    if let Some(value) = value {
+        obj.insert(key.into(), value);
+    } else {
+        obj.remove(key);
+    }
+}
+
+fn patch_extra_fields(
+    obj: &mut serde_json::Map<String, Json>,
+    baseline: &serde_json::Map<String, Json>,
+    edited: &serde_json::Map<String, Json>,
+) {
+    for key in baseline.keys().filter(|key| !edited.contains_key(*key)) {
+        obj.remove(key);
+    }
+    for (key, value) in edited {
+        if baseline.get(key) != Some(value) {
+            obj.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn validate_supported_fields(
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    let unsupported_changed = annotated.store != baseline.store
+        || annotated.previous_response_id != baseline.previous_response_id
+        || annotated.truncation != baseline.truncation
+        || annotated.reasoning != baseline.reasoning
+        || annotated.include != baseline.include
+        || annotated.user != baseline.user
+        || annotated.metadata != baseline.metadata
+        || annotated.service_tier != baseline.service_tier
+        || annotated.parallel_tool_calls != baseline.parallel_tool_calls
+        || annotated.max_output_tokens != baseline.max_output_tokens
+        || annotated.max_tool_calls != baseline.max_tool_calls
+        || annotated.top_logprobs != baseline.top_logprobs
+        || annotated.stream != baseline.stream
+        || annotated.api_specific != baseline.api_specific;
+    if unsupported_changed {
+        return Err(FlowError::InvalidArgument(
+            "request contains fields that cannot be encoded for Bedrock Converse".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_prompt_resource_request(obj: &serde_json::Map<String, Json>) -> Result<()> {
+    let is_prompt_resource = obj
+        .get("modelId")
+        .and_then(Json::as_str)
+        .is_some_and(|model| model.starts_with("arn:") && model.contains(":prompt/"));
+    if !is_prompt_resource {
+        return Ok(());
+    }
+    let has_forbidden_fields = [
+        "additionalModelRequestFields",
+        "inferenceConfig",
+        "system",
+        "toolConfig",
+    ]
+    .into_iter()
+    .any(|key| obj.contains_key(key));
+    if has_forbidden_fields {
+        return Err(FlowError::InvalidArgument(
+            "Bedrock Converse prompt resource ARNs cannot be combined with system, inferenceConfig, toolConfig, or additionalModelRequestFields"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+impl LlmCodec for BedrockConverseCodec {
+    fn codec_identity(&self) -> LlmCodecIdentity {
+        LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::BedrockConverse)
+    }
+
+    fn decode(&self, request: &LlmRequest) -> Result<AnnotatedLlmRequest> {
+        let obj = request.content.as_object().ok_or_else(|| {
+            FlowError::InvalidArgument("Bedrock Converse request content must be an object".into())
+        })?;
+        let model =
+            super::optional_string(obj, "modelId", "Bedrock Converse")?.ok_or_else(|| {
+                FlowError::InvalidArgument("Bedrock Converse request is missing modelId".into())
+            })?;
+        let messages = obj
+            .get("messages")
+            .map(|value| {
+                required_array(value, "messages")?
+                    .iter()
+                    .map(decode_message)
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+        let instructions = obj
+            .get("system")
+            .filter(|value| !value.is_null())
+            .map(|value| decode_content(value, "system"))
+            .transpose()?;
+        let params = decode_generation_params(obj)?;
+
+        let (tools, tool_choice) = match obj.get("toolConfig") {
+            None | Some(Json::Null) => (None, None),
+            Some(value) => {
+                let config = required_object(value, "toolConfig")?;
+                let tools = config
+                    .get("tools")
+                    .map(|value| {
+                        required_array(value, "toolConfig.tools")?
+                            .iter()
+                            .map(decode_tool)
+                            .collect::<Result<Vec<_>>>()
+                    })
+                    .transpose()?;
+                let choice = config.get("toolChoice").map(decode_tool_choice);
+                (tools, choice)
+            }
+        };
+
+        let extra = obj
+            .iter()
+            .filter(|(key, _)| !MODELED_REQUEST_KEYS.contains(&key.as_str()))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        Ok(AnnotatedLlmRequest {
+            messages,
+            instructions,
+            model: Some(model),
+            params,
+            tools,
+            tool_choice,
+            store: None,
+            previous_response_id: None,
+            truncation: None,
+            reasoning: None,
+            include: None,
+            user: None,
+            metadata: None,
+            service_tier: None,
+            parallel_tool_calls: None,
+            max_output_tokens: None,
+            max_tool_calls: None,
+            top_logprobs: None,
+            stream: None,
+            api_specific: None,
+            extra,
+        })
+    }
+
+    fn encode(&self, annotated: &AnnotatedLlmRequest, original: &LlmRequest) -> Result<LlmRequest> {
+        let baseline = self.decode(original)?;
+        validate_supported_fields(annotated, &baseline)?;
+        let mut content = original.content.clone();
+        let obj = content.as_object_mut().ok_or_else(|| {
+            FlowError::InvalidArgument("Bedrock Converse request content must be an object".into())
+        })?;
+
+        if annotated.model != baseline.model {
+            set_or_remove(obj, "modelId", annotated.model.clone().map(Json::String));
+        }
+        if annotated.messages != baseline.messages {
+            let messages = super::encode_changed_items(
+                &annotated.messages,
+                &baseline.messages,
+                obj.get("messages")
+                    .and_then(Json::as_array)
+                    .map(Vec::as_slice),
+                encode_message,
+            )?;
+            obj.insert("messages".into(), Json::Array(messages));
+        }
+        if annotated.instructions != baseline.instructions {
+            let encoded = annotated
+                .instructions
+                .as_ref()
+                .map(encode_content)
+                .transpose()?;
+            let encoded = match (
+                obj.get("system"),
+                baseline
+                    .instructions
+                    .as_ref()
+                    .map(encode_content)
+                    .transpose()?,
+                encoded,
+            ) {
+                (Some(original), Some(before), Some(edited)) => {
+                    Some(super::patch_changed_json(original, &before, &edited)?)
+                }
+                (_, _, edited) => edited,
+            };
+            set_or_remove(obj, "system", encoded);
+        }
+        if annotated.params != baseline.params {
+            patch_inference_config(obj, annotated.params.as_ref(), baseline.params.as_ref())?;
+        }
+        if annotated.tools != baseline.tools || annotated.tool_choice != baseline.tool_choice {
+            patch_tool_config(obj, annotated, &baseline)?;
+        }
+        patch_extra_fields(obj, &baseline.extra, &annotated.extra);
+        // Validate the final provider envelope, not only normalized fields:
+        // unknown members inside an otherwise-unmodeled inferenceConfig or
+        // toolConfig are still forbidden by Bedrock prompt resources.
+        validate_prompt_resource_request(obj)?;
+
+        Ok(LlmRequest {
+            headers: original.headers.clone(),
+            content,
+        })
+    }
+}
+
+fn patch_inference_config(
+    obj: &mut serde_json::Map<String, Json>,
+    edited: Option<&GenerationParams>,
+    baseline: Option<&GenerationParams>,
+) -> Result<()> {
+    let mut config = match obj.get("inferenceConfig") {
+        Some(Json::Object(config)) => config.clone(),
+        Some(Json::Null) | None => serde_json::Map::new(),
+        Some(_) => {
+            return Err(FlowError::InvalidArgument(
+                "Bedrock Converse inferenceConfig must be an object".into(),
+            ));
+        }
+    };
+    let fields = [
+        (
+            "temperature",
+            edited.and_then(|params| params.temperature),
+            baseline.and_then(|params| params.temperature),
+        ),
+        (
+            "topP",
+            edited.and_then(|params| params.top_p),
+            baseline.and_then(|params| params.top_p),
+        ),
+    ];
+    for (key, value, before) in fields {
+        if value != before {
+            set_or_remove(
+                &mut config,
+                key,
+                value.map(|value| json_number(value, key)).transpose()?,
+            );
+        }
+    }
+    let max_tokens = edited.and_then(|params| params.max_tokens);
+    if max_tokens != baseline.and_then(|params| params.max_tokens) {
+        set_or_remove(&mut config, "maxTokens", max_tokens.map(Json::from));
+    }
+    let stop = edited.and_then(|params| params.stop.as_ref());
+    if stop != baseline.and_then(|params| params.stop.as_ref()) {
+        set_or_remove(
+            &mut config,
+            "stopSequences",
+            stop.map(|values| serde_json::json!(values)),
+        );
+    }
+    if config.is_empty() {
+        obj.remove("inferenceConfig");
+    } else {
+        obj.insert("inferenceConfig".into(), Json::Object(config));
+    }
+    Ok(())
+}
+
+fn patch_tool_config(
+    obj: &mut serde_json::Map<String, Json>,
+    annotated: &AnnotatedLlmRequest,
+    baseline: &AnnotatedLlmRequest,
+) -> Result<()> {
+    let mut config = match obj.get("toolConfig") {
+        Some(Json::Object(config)) => config.clone(),
+        Some(Json::Null) | None => serde_json::Map::new(),
+        Some(_) => {
+            return Err(FlowError::InvalidArgument(
+                "Bedrock Converse toolConfig must be an object".into(),
+            ));
+        }
+    };
+    if annotated.tools != baseline.tools {
+        let tools = annotated
+            .tools
+            .as_deref()
+            .map(|tools| {
+                super::encode_changed_items(
+                    tools,
+                    baseline.tools.as_deref().unwrap_or(&[]),
+                    config
+                        .get("tools")
+                        .and_then(Json::as_array)
+                        .map(Vec::as_slice),
+                    encode_tool,
+                )
+            })
+            .transpose()?
+            .map(Json::Array);
+        set_or_remove(&mut config, "tools", tools);
+    }
+    if annotated.tool_choice != baseline.tool_choice {
+        let edited = annotated
+            .tool_choice
+            .as_ref()
+            .map(encode_tool_choice)
+            .transpose()?;
+        let before = baseline
+            .tool_choice
+            .as_ref()
+            .map(encode_tool_choice)
+            .transpose()?;
+        let edited = match (config.get("toolChoice"), before, edited) {
+            (Some(original), Some(before), Some(edited)) => {
+                Some(super::patch_changed_json(original, &before, &edited)?)
+            }
+            (_, _, edited) => edited,
+        };
+        set_or_remove(&mut config, "toolChoice", edited);
+    }
+    if config.is_empty() {
+        obj.remove("toolConfig");
+    } else {
+        obj.insert("toolConfig".into(), Json::Object(config));
+    }
+    Ok(())
+}
+
+fn map_stop_reason(reason: &str) -> FinishReason {
+    match reason {
+        "end_turn" | "stop_sequence" => FinishReason::Complete,
+        "max_tokens" => FinishReason::Length,
+        "tool_use" => FinishReason::ToolUse,
+        "guardrail_intervened" | "content_filtered" => FinishReason::ContentFilter,
+        other => FinishReason::Unknown(other.into()),
+    }
+}
+
+fn response_tool_calls(content: &[Json]) -> Result<Option<Vec<ResponseToolCall>>> {
+    let calls = content
+        .iter()
+        .filter_map(|block| block.get("toolUse"))
+        .map(|value| {
+            let tool = required_object(value, "response toolUse block")?;
+            Ok(ResponseToolCall {
+                id: required_string(tool, "toolUseId", "response toolUse block")?.into(),
+                name: required_string(tool, "name", "response toolUse block")?.into(),
+                arguments: tool.get("input").cloned().ok_or_else(|| {
+                    FlowError::InvalidArgument(
+                        "Bedrock Converse response toolUse block is missing input".into(),
+                    )
+                })?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok((!calls.is_empty()).then_some(calls))
+}
+
+fn decode_usage(value: Option<&Json>) -> Result<Option<Usage>> {
+    let Some(value) = value else { return Ok(None) };
+    let obj = required_object(value, "response usage")?;
+    let usage = Usage {
+        prompt_tokens: super::optional_u64(obj, "inputTokens", "Bedrock Converse usage")?,
+        completion_tokens: super::optional_u64(obj, "outputTokens", "Bedrock Converse usage")?,
+        total_tokens: super::optional_u64(obj, "totalTokens", "Bedrock Converse usage")?,
+        cache_read_tokens: super::optional_u64(
+            obj,
+            "cacheReadInputTokens",
+            "Bedrock Converse usage",
+        )?,
+        cache_write_tokens: super::optional_u64(
+            obj,
+            "cacheWriteInputTokens",
+            "Bedrock Converse usage",
+        )?,
+        cost: None,
+    };
+    Ok(Some(usage))
+}
+
+impl LlmResponseCodec for BedrockConverseCodec {
+    fn codec_identity(&self) -> LlmCodecIdentity {
+        LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::BedrockConverse)
+    }
+
+    fn decode_response(&self, response: &Json) -> Result<AnnotatedLlmResponse> {
+        let obj = required_object(response, "response")?;
+        let output = obj.get("output").ok_or_else(|| {
+            FlowError::InvalidArgument("Bedrock Converse response is missing output".into())
+        })?;
+        let message = required_object(output, "response output")?
+            .get("message")
+            .ok_or_else(|| {
+                FlowError::InvalidArgument(
+                    "Bedrock Converse response output is missing message".into(),
+                )
+            })?;
+        let message = required_object(message, "response message")?;
+        let content = message
+            .get("content")
+            .map(|value| required_array(value, "response message content"))
+            .transpose()?
+            .unwrap_or_default();
+        let normalized_message = (!content.is_empty())
+            .then(|| {
+                content
+                    .iter()
+                    .map(decode_content_block)
+                    .collect::<Result<Vec<_>>>()
+                    .map(MessageContent::Parts)
+            })
+            .transpose()?;
+        let tool_calls = response_tool_calls(content)?;
+        let finish_reason = obj
+            .get("stopReason")
+            .filter(|value| !value.is_null())
+            .map(|value| {
+                value.as_str().map(map_stop_reason).ok_or_else(|| {
+                    FlowError::InvalidArgument(
+                        "Bedrock Converse response stopReason must be a string".into(),
+                    )
+                })
+            })
+            .transpose()?;
+        let usage = decode_usage(obj.get("usage"))?;
+        let extra = obj
+            .iter()
+            .filter(|(key, _)| !matches!(key.as_str(), "output" | "stopReason" | "usage"))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let mut api_specific_data = serde_json::Map::new();
+        if let Some(stop_reason) = obj.get("stopReason") {
+            api_specific_data.insert("stopReason".into(), stop_reason.clone());
+        }
+        // Keep the complete usage object so newly added Bedrock counters
+        // (for example cacheDetails) are not lost when the common Usage shape
+        // extracts only the counters Relay understands.
+        if let Some(usage) = obj.get("usage") {
+            api_specific_data.insert("usage".into(), usage.clone());
+        }
+        let api_specific = (!api_specific_data.is_empty()).then(|| ApiSpecificResponse::Custom {
+            api_name: BEDROCK_PROVIDER.into(),
+            data: Json::Object(api_specific_data),
+        });
+
+        Ok(AnnotatedLlmResponse {
+            id: None,
+            // Converse responses do not identify the invoked model. Integrations
+            // must provide the request model through the managed LLM call.
+            model: None,
+            message: normalized_message,
+            tool_calls,
+            finish_reason,
+            usage,
+            optimization_summary: None,
+            api_specific,
+            extra,
+        })
+    }
+}
+
+/// Stateful accumulator for decoded `ConverseStream` event dictionaries.
+pub struct BedrockConverseStreamingCodec {
+    state: std::sync::Arc<std::sync::Mutex<BedrockConverseStreamingState>>,
+}
+
+impl BedrockConverseStreamingCodec {
+    /// Creates an empty, single-use ConverseStream accumulator.
+    pub fn new() -> Self {
+        Self {
+            state: std::sync::Arc::new(std::sync::Mutex::new(
+                BedrockConverseStreamingState::default(),
+            )),
+        }
+    }
+}
+
+impl Default for BedrockConverseStreamingCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl super::streaming::StreamingCodec for BedrockConverseStreamingCodec {
+    fn collector(&self) -> crate::api::runtime::LlmCollectorFn {
+        let state = std::sync::Arc::clone(&self.state);
+        Box::new(move |event: Json| -> Result<()> {
+            state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .observe(&event)
+        })
+    }
+
+    fn finalizer(&self) -> crate::api::runtime::LlmFinalizerFn {
+        let state = std::sync::Arc::clone(&self.state);
+        Box::new(move || -> Json {
+            let mut guard = state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut *guard).finalize()
+        })
+    }
+}
+
+#[derive(Debug)]
+struct BedrockConverseStreamingState {
+    aggregate: Option<Json>,
+    aggregation_supported: bool,
+    role: Option<String>,
+    blocks: std::collections::BTreeMap<u64, StreamingBlock>,
+    stop_reason: Option<String>,
+    usage: Option<Json>,
+    metrics: Option<Json>,
+    extra: serde_json::Map<String, Json>,
+}
+
+impl Default for BedrockConverseStreamingState {
+    fn default() -> Self {
+        Self {
+            aggregate: None,
+            aggregation_supported: true,
+            role: None,
+            blocks: std::collections::BTreeMap::new(),
+            stop_reason: None,
+            usage: None,
+            metrics: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct StreamingBlock {
+    value: serde_json::Map<String, Json>,
+    text: String,
+    has_text: bool,
+    tool_input: String,
+    has_tool_input: bool,
+}
+
+fn bedrock_stream_failure(kind: &str, payload: &Json) -> FlowError {
+    let payload = payload.as_object();
+    let default_message = "provider stream exception";
+    let message = payload
+        .and_then(|payload| payload.get("message"))
+        .and_then(Json::as_str)
+        .unwrap_or(default_message);
+    let original_message = payload
+        .and_then(|payload| payload.get("originalMessage"))
+        .and_then(Json::as_str);
+    let body = match original_message.filter(|original| *original != message) {
+        Some(original) => {
+            format!("Bedrock ConverseStream {kind}: {message}; original: {original}")
+        }
+        None => format!("Bedrock ConverseStream {kind}: {message}"),
+    };
+    let body = bounded_upstream_error_body(body);
+    let (default_status, class) = match kind {
+        "throttlingException" => (Some(429), UpstreamFailureClass::RetryableStatus),
+        "serviceUnavailableException" => (Some(503), UpstreamFailureClass::ModelUnavailable),
+        "internalServerException" => (Some(500), UpstreamFailureClass::RetryableStatus),
+        "modelStreamErrorException" => (Some(424), UpstreamFailureClass::RetryableStatus),
+        "modelTimeoutException" => (Some(408), UpstreamFailureClass::Timeout),
+        "validationException" => (Some(400), UpstreamFailureClass::InvalidRequest),
+        "accessDeniedException" => (Some(403), UpstreamFailureClass::Authentication),
+        _ => (None, UpstreamFailureClass::Other),
+    };
+    let status = payload
+        .and_then(|payload| {
+            payload
+                .get("originalStatusCode")
+                .or_else(|| payload.get("statusCode"))
+        })
+        .and_then(Json::as_u64)
+        .and_then(|status| u16::try_from(status).ok())
+        .or(default_status);
+    FlowError::Upstream(UpstreamFailure {
+        status,
+        body,
+        headers: std::collections::BTreeMap::new(),
+        class,
+    })
+}
+
+fn bounded_upstream_error_body(mut body: String) -> String {
+    if body.len() <= MAX_UPSTREAM_ERROR_BODY_BYTES {
+        return body;
+    }
+    let mut end = MAX_UPSTREAM_ERROR_BODY_BYTES;
+    while !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    body.truncate(end);
+    body
+}
+
+impl BedrockConverseStreamingState {
+    fn observe(&mut self, event: &Json) -> Result<()> {
+        let obj = required_object(event, "stream event")?;
+        let member_count = obj
+            .keys()
+            .filter(|key| {
+                matches!(
+                    key.as_str(),
+                    "output"
+                        | "messageStart"
+                        | "contentBlockStart"
+                        | "contentBlockDelta"
+                        | "contentBlockStop"
+                        | "messageStop"
+                        | "metadata"
+                ) || key.ends_with("Exception")
+            })
+            .count();
+        if member_count > 1 {
+            return Err(FlowError::InvalidArgument(
+                "Bedrock ConverseStream event contains multiple recognized union members".into(),
+            ));
+        }
+        if member_count == 0 {
+            // AWS SDKs intentionally surface future union members rather than
+            // discarding them. Forward the raw stream item unchanged, but do
+            // not synthesize a misleading partial final response.
+            self.mark_aggregation_unsupported("unknown top-level stream union member");
+            return Ok(());
+        }
+        if let Some((kind, payload)) = obj.iter().find(|(key, _)| key.ends_with("Exception")) {
+            return Err(bedrock_stream_failure(kind, payload));
+        }
+        if !self.aggregation_supported {
+            return Ok(());
+        }
+        if obj.contains_key("output") {
+            self.aggregate = Some(event.clone());
+            return Ok(());
+        }
+        if let Some(start) = obj.get("messageStart") {
+            let start = required_object(start, "messageStart event")?;
+            if let Some(role) = start.get("role") {
+                self.role = Some(
+                    role.as_str()
+                        .ok_or_else(|| {
+                            FlowError::InvalidArgument(
+                                "Bedrock ConverseStream messageStart.role must be a string".into(),
+                            )
+                        })?
+                        .into(),
+                );
+            }
+        }
+        if let Some(start) = obj.get("contentBlockStart") {
+            self.observe_block_start(start)?;
+        }
+        if let Some(delta) = obj.get("contentBlockDelta") {
+            self.observe_block_delta(delta)?;
+        }
+        if let Some(stop) = obj.get("contentBlockStop") {
+            self.observe_block_stop(stop)?;
+        }
+        if let Some(stop) = obj.get("messageStop") {
+            if self.aggregation_supported && !self.tool_inputs_are_valid() {
+                self.mark_aggregation_unsupported("toolUse.input is not complete JSON");
+            }
+            let stop = required_object(stop, "messageStop event")?;
+            if let Some(reason) = stop.get("stopReason") {
+                self.stop_reason = Some(
+                    reason
+                        .as_str()
+                        .ok_or_else(|| {
+                            FlowError::InvalidArgument(
+                                "Bedrock ConverseStream messageStop.stopReason must be a string"
+                                    .into(),
+                            )
+                        })?
+                        .into(),
+                );
+            }
+            for (key, value) in stop.iter().filter(|(key, _)| key.as_str() != "stopReason") {
+                self.extra.insert(key.clone(), value.clone());
+            }
+        }
+        if let Some(metadata) = obj.get("metadata") {
+            let metadata = required_object(metadata, "metadata event")?;
+            if let Some(usage) = metadata.get("usage") {
+                self.usage = Some(usage.clone());
+            }
+            if let Some(metrics) = metadata.get("metrics") {
+                self.metrics = Some(metrics.clone());
+            }
+            for (key, value) in metadata
+                .iter()
+                .filter(|(key, _)| !matches!(key.as_str(), "usage" | "metrics"))
+            {
+                self.extra.insert(key.clone(), value.clone());
+            }
+        }
+        Ok(())
+    }
+
+    fn mark_aggregation_unsupported(&mut self, reason: &str) {
+        if self.aggregation_supported {
+            log::warn!(
+                target: "nemo_relay.codec",
+                event = "bedrock_stream_aggregation_unsupported",
+                provider = BEDROCK_PROVIDER,
+                reason = reason;
+                "omitting normalized ConverseStream response for unsupported content"
+            );
+        }
+        self.aggregation_supported = false;
+        self.aggregate = None;
+        self.role = None;
+        self.blocks.clear();
+        self.stop_reason = None;
+        self.usage = None;
+        self.metrics = None;
+        self.extra.clear();
+    }
+
+    fn tool_inputs_are_valid(&self) -> bool {
+        for block in self.blocks.values() {
+            if block.has_tool_input && serde_json::from_str::<Json>(&block.tool_input).is_err() {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn block_mut(&mut self, index: u64) -> &mut StreamingBlock {
+        self.blocks.entry(index).or_default()
+    }
+
+    fn observe_block_start(&mut self, event: &Json) -> Result<()> {
+        let event = required_object(event, "contentBlockStart event")?;
+        let index = super::optional_u64(
+            event,
+            "contentBlockIndex",
+            "Bedrock ConverseStream contentBlockStart",
+        )?
+        .ok_or_else(|| {
+            FlowError::InvalidArgument(
+                "Bedrock ConverseStream contentBlockStart is missing contentBlockIndex".into(),
+            )
+        })?;
+        let start = event
+            .get("start")
+            .map(|value| required_object(value, "contentBlockStart.start"))
+            .transpose()?
+            .cloned()
+            .unwrap_or_default();
+        if start.keys().any(|key| !matches!(key.as_str(), "toolUse")) {
+            self.mark_aggregation_unsupported("unsupported contentBlockStart union member");
+            return Ok(());
+        }
+        self.block_mut(index).value = start;
+        Ok(())
+    }
+
+    fn observe_block_delta(&mut self, event: &Json) -> Result<()> {
+        let event = required_object(event, "contentBlockDelta event")?;
+        let index = super::optional_u64(
+            event,
+            "contentBlockIndex",
+            "Bedrock ConverseStream contentBlockDelta",
+        )?
+        .ok_or_else(|| {
+            FlowError::InvalidArgument(
+                "Bedrock ConverseStream contentBlockDelta is missing contentBlockIndex".into(),
+            )
+        })?;
+        let delta = event
+            .get("delta")
+            .ok_or_else(|| {
+                FlowError::InvalidArgument(
+                    "Bedrock ConverseStream contentBlockDelta is missing delta".into(),
+                )
+            })
+            .and_then(|value| required_object(value, "contentBlockDelta.delta"))?;
+        let delta_members = delta
+            .keys()
+            .filter(|key| {
+                matches!(
+                    key.as_str(),
+                    "text" | "toolUse" | "toolResult" | "reasoningContent" | "citation" | "image"
+                )
+            })
+            .count();
+        if delta_members != 1 {
+            self.mark_aggregation_unsupported("unknown or malformed contentBlockDelta union");
+            return Ok(());
+        }
+        if delta
+            .keys()
+            .any(|key| !matches!(key.as_str(), "text" | "toolUse"))
+        {
+            self.mark_aggregation_unsupported("unsupported contentBlockDelta union member");
+            return Ok(());
+        }
+        let block = self.block_mut(index);
+        if let Some(text) = delta.get("text") {
+            block.text.push_str(text.as_str().ok_or_else(|| {
+                FlowError::InvalidArgument(
+                    "Bedrock ConverseStream text delta must be a string".into(),
+                )
+            })?);
+            block.has_text = true;
+        }
+        if let Some(tool_delta) = delta.get("toolUse") {
+            let tool_delta = required_object(tool_delta, "toolUse delta")?;
+            if let Some(input) = tool_delta.get("input") {
+                block.tool_input.push_str(input.as_str().ok_or_else(|| {
+                    FlowError::InvalidArgument(
+                        "Bedrock ConverseStream toolUse.input delta must be a string".into(),
+                    )
+                })?);
+                block.has_tool_input = true;
+            }
+        }
+        Ok(())
+    }
+
+    fn observe_block_stop(&mut self, event: &Json) -> Result<()> {
+        let event = required_object(event, "contentBlockStop event")?;
+        let index = super::optional_u64(
+            event,
+            "contentBlockIndex",
+            "Bedrock ConverseStream contentBlockStop",
+        )?
+        .ok_or_else(|| {
+            FlowError::InvalidArgument(
+                "Bedrock ConverseStream contentBlockStop is missing contentBlockIndex".into(),
+            )
+        })?;
+        if !self.aggregation_supported {
+            return Ok(());
+        }
+        let block = self.blocks.get(&index).ok_or_else(|| {
+            FlowError::InvalidArgument(format!(
+                "Bedrock ConverseStream contentBlockStop references unknown block {index}"
+            ))
+        })?;
+        if block.has_tool_input && serde_json::from_str::<Json>(&block.tool_input).is_err() {
+            self.mark_aggregation_unsupported("toolUse.input is not complete JSON");
+        }
+        Ok(())
+    }
+
+    fn finalize(self) -> Json {
+        if !self.aggregation_supported {
+            return Json::Null;
+        }
+        if let Some(aggregate) = self.aggregate {
+            return aggregate;
+        }
+        let content = self
+            .blocks
+            .into_values()
+            .map(StreamingBlock::finalize)
+            .collect::<Vec<_>>();
+        let mut output = self.extra;
+        output.insert(
+            "output".into(),
+            serde_json::json!({
+                "message": {
+                    "role": self.role.unwrap_or_else(|| "assistant".into()),
+                    "content": content,
+                }
+            }),
+        );
+        if let Some(stop_reason) = self.stop_reason {
+            output.insert("stopReason".into(), Json::String(stop_reason));
+        }
+        if let Some(usage) = self.usage {
+            output.insert("usage".into(), usage);
+        }
+        if let Some(metrics) = self.metrics {
+            output.insert("metrics".into(), metrics);
+        }
+        Json::Object(output)
+    }
+}
+
+impl StreamingBlock {
+    fn finalize(mut self) -> Json {
+        if self.has_text {
+            self.value.insert("text".into(), Json::String(self.text));
+        }
+        if self.has_tool_input {
+            let input = serde_json::from_str::<Json>(&self.tool_input)
+                .unwrap_or(Json::String(self.tool_input));
+            let tool = self
+                .value
+                .entry("toolUse")
+                .or_insert_with(|| Json::Object(serde_json::Map::new()));
+            if let Some(tool) = tool.as_object_mut() {
+                tool.insert("input".into(), input);
+            }
+        }
+        Json::Object(self.value)
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/unit/codec/bedrock_converse_tests.rs"]
+mod tests;

--- a/crates/core/src/codec/mod.rs
+++ b/crates/core/src/codec/mod.rs
@@ -15,6 +15,7 @@
 //! provider codec from a raw payload when no codec annotation is present.
 
 pub mod anthropic;
+pub mod bedrock_converse;
 pub mod gemini_generate_content;
 pub mod model_pricing;
 pub mod oci_genai;

--- a/crates/core/src/codec/resolve.rs
+++ b/crates/core/src/codec/resolve.rs
@@ -14,7 +14,9 @@ use super::request::AnnotatedLlmRequest;
 use super::response::AnnotatedLlmResponse;
 use super::streaming::StreamingCodec;
 use super::traits::{LlmCodec, LlmResponseCodec};
-use super::{anthropic, gemini_generate_content, oci_genai, openai_chat, openai_responses};
+use super::{
+    anthropic, bedrock_converse, gemini_generate_content, oci_genai, openai_chat, openai_responses,
+};
 
 /// A built-in provider request/response surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,6 +31,8 @@ pub enum ProviderSurface {
     OCIGenAI,
     /// Gemini generateContent.
     GeminiGenerateContent,
+    /// Amazon Bedrock Converse.
+    BedrockConverse,
 }
 
 /// Request shape detector; the optional `&str` is a provider hint a codec may use
@@ -68,6 +72,9 @@ pub(crate) struct ProviderSurfaceDescriptor {
 /// surface it could shadow. Response detection requires exactly one match
 /// before decoding.
 pub(crate) static BUILTIN_PROVIDER_SURFACES: &[ProviderSurfaceDescriptor] = &[
+    // Converse precedes the overlapping messages/system surfaces because modelId
+    // is a provider-specific discriminator.
+    bedrock_converse::PROVIDER_SURFACE,
     openai_responses::PROVIDER_SURFACE,
     anthropic::PROVIDER_SURFACE,
     // OCI GenAI must precede OpenAI Chat: a bare OCI GENERIC chatRequest body
@@ -80,21 +87,25 @@ pub(crate) static BUILTIN_PROVIDER_SURFACES: &[ProviderSurfaceDescriptor] = &[
 
 /// Detect the request surface from a raw request body by top-level key.
 ///
-/// Priority: OpenAI Responses (`input`/`instructions`) > Anthropic Messages
-/// (`system`) > OpenAI Chat (`messages`) > Gemini generateContent (`contents`).
-/// `None` when no key matches or `body` is not an object. This is a best-effort heuristic: an
-/// Anthropic request that omits the optional top-level `system` is
-/// indistinguishable from OpenAI Chat and classifies as `OpenAIChat`.
+/// Priority: Bedrock Converse (`modelId` plus a Converse field) > OpenAI
+/// Responses (`input`/`instructions`) > Anthropic Messages (`system`) > OCI
+/// Generative AI (`chatRequest`) > OpenAI Chat (`messages`) > Gemini
+/// generateContent (`contents`). `None` when no shape matches or `body` is not
+/// an object. This is a best-effort heuristic: an Anthropic request that omits
+/// the optional top-level `system` is indistinguishable from OpenAI Chat and
+/// classifies as `OpenAIChat` without a provider hint.
 #[must_use]
 pub fn detect_request_surface(body: &Json) -> Option<ProviderSurface> {
     detect_request_surface_with_hint(body, None)
 }
 
-/// Like [`detect_request_surface`], but a recognized `provider_hint` resolves the
-/// one ambiguous shape (an Anthropic request without a top-level `system`,
-/// otherwise read as OpenAI Chat). Today, only the exact hints `"anthropic"`
-/// and `"anthropic.messages"` change detection; `None` or any other value is
-/// ignored and detection stays shape-only.
+/// Like [`detect_request_surface`], but a recognized `provider_hint` resolves
+/// otherwise ambiguous request shapes. The exact hints `"anthropic"` and
+/// `"anthropic.messages"` disambiguate system-less Anthropic Messages.
+/// `"aws.bedrock.converse"` and `"bedrock.converse"` can select a Converse
+/// envelope containing `modelId` even before another Converse-specific field is
+/// present; ordinary Converse requests are already identified by `modelId` plus
+/// their request fields. Unknown hints do not override stronger shape signals.
 #[must_use]
 pub fn detect_request_surface_with_hint(
     body: &Json,
@@ -163,6 +174,7 @@ fn descriptor_for(surface: ProviderSurface) -> &'static ProviderSurfaceDescripto
         ProviderSurface::AnthropicMessages => &anthropic::PROVIDER_SURFACE,
         ProviderSurface::OCIGenAI => &oci_genai::PROVIDER_SURFACE,
         ProviderSurface::GeminiGenerateContent => &gemini_generate_content::PROVIDER_SURFACE,
+        ProviderSurface::BedrockConverse => &bedrock_converse::PROVIDER_SURFACE,
     }
 }
 

--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -37,8 +37,9 @@ use uuid::Uuid;
 
 use crate::api::event::{Event, EventNormalizationExt};
 use crate::api::runtime::EventSubscriberFn;
+use crate::api::shared::message_starts_new_user_turn;
 use crate::api::subscriber::flush_subscribers;
-use crate::codec::request::{AnnotatedLlmRequest, ContentPart, Message, MessageContent};
+use crate::codec::request::{AnnotatedLlmRequest, Message, MessageContent};
 use crate::codec::response::AnnotatedLlmResponse;
 use crate::error::Result;
 use crate::json::Json;
@@ -1270,7 +1271,7 @@ fn atif_message_from_annotated_request(request: &AnnotatedLlmRequest) -> Option<
 fn annotated_message_turn_state(message: &Message) -> Option<RequestTurnState> {
     match message {
         Message::System { .. } | Message::Developer { .. } => None,
-        Message::User { content, .. } => Some(if annotated_content_starts_new_turn(content) {
+        Message::User { .. } => Some(if message_starts_new_user_turn(message) {
             RequestTurnState::FreshUser
         } else {
             RequestTurnState::Continuation
@@ -1281,34 +1282,6 @@ fn annotated_message_turn_state(message: &Message) -> Option<RequestTurnState> {
         | Message::ToolCallItem { .. }
         | Message::ToolResultItem { .. } => Some(RequestTurnState::Continuation),
         Message::ProviderNative { value, .. } => provider_native_turn_state(value),
-    }
-}
-
-fn annotated_content_starts_new_turn(content: &MessageContent) -> bool {
-    match content {
-        MessageContent::Text(_) => true,
-        MessageContent::Parts(parts) => {
-            let has_user_input = parts.iter().any(|part| {
-                matches!(
-                    part,
-                    ContentPart::Text { .. }
-                        | ContentPart::ImageUrl { .. }
-                        | ContentPart::Image { .. }
-                        | ContentPart::Audio { .. }
-                        | ContentPart::File { .. }
-                )
-            });
-            if has_user_input {
-                return true;
-            }
-            let has_tool_continuation = parts.iter().any(|part| {
-                matches!(
-                    part,
-                    ContentPart::ToolUse { .. } | ContentPart::ToolResult { .. }
-                )
-            });
-            !has_tool_continuation
-        }
     }
 }
 

--- a/crates/core/src/plugin/dynamic/native.rs
+++ b/crates/core/src/plugin/dynamic/native.rs
@@ -28,9 +28,9 @@ use crate::api::registry::{
     list_runtime_registrations, register_conditional_middleware_guardrail,
 };
 use crate::api::runtime::{
-    ConditionalMiddlewareGuardrailFn, EventMetadataInjectorFn, EventSanitizeFn, EventSubscriberFn,
-    LlmCodecIdentity, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn, LlmJsonStream,
-    LlmRequestInterceptFn, LlmSanitizeRequestContext, LlmSanitizeRequestFn,
+    BuiltinLlmCodec, ConditionalMiddlewareGuardrailFn, EventMetadataInjectorFn, EventSanitizeFn,
+    EventSubscriberFn, LlmCodecIdentity, LlmConditionalFn, LlmExecutionFn, LlmExecutionNextFn,
+    LlmJsonStream, LlmRequestInterceptFn, LlmSanitizeRequestContext, LlmSanitizeRequestFn,
     LlmSanitizeResponseContext, LlmSanitizeResponseFn, LlmStreamExecutionFn,
     LlmStreamExecutionNextFn, MiddlewareContinuationContext, ToolConditionalFn, ToolExecutionFn,
     ToolExecutionNextFn, ToolInterceptFn, ToolSanitizeFn,
@@ -3471,9 +3471,10 @@ fn native_async_codec_identity(identity: &LlmCodecIdentity) -> Json {
         LlmCodecIdentity::None => {
             serde_json::json!({"codec_kind": "none", "codec_id": Json::Null})
         }
-        LlmCodecIdentity::BuiltIn(codec) => {
-            serde_json::json!({"codec_kind": "builtin", "codec_id": codec.id()})
-        }
+        LlmCodecIdentity::BuiltIn(codec) => match native_v4_builtin_id(*codec) {
+            Some(id) => serde_json::json!({"codec_kind": "builtin", "codec_id": id}),
+            None => serde_json::json!({"codec_kind": "opaque", "codec_id": Json::Null}),
+        },
         LlmCodecIdentity::Runtime(id) => {
             serde_json::json!({"codec_kind": "runtime", "codec_id": id})
         }
@@ -5179,9 +5180,10 @@ fn native_llm_codec_identity(
 )> {
     let (codec_kind, codec_id) = match context {
         LlmCodecIdentity::None => (NemoRelayNativeLlmCodecKind::None, None),
-        LlmCodecIdentity::BuiltIn(codec) => {
-            (NemoRelayNativeLlmCodecKind::BuiltIn, Some(codec.id()))
-        }
+        LlmCodecIdentity::BuiltIn(codec) => match native_v4_builtin_id(*codec) {
+            Some(id) => (NemoRelayNativeLlmCodecKind::BuiltIn, Some(id)),
+            None => (NemoRelayNativeLlmCodecKind::Opaque, None),
+        },
         LlmCodecIdentity::Runtime(id) => (NemoRelayNativeLlmCodecKind::Runtime, Some(id.as_str())),
         LlmCodecIdentity::Opaque => (NemoRelayNativeLlmCodecKind::Opaque, None),
     };
@@ -5193,6 +5195,22 @@ fn native_llm_codec_identity(
             None => None,
         };
     Ok((codec_kind, codec_id))
+}
+
+/// Built-in IDs already exposed through the existing native codec-context ABI.
+/// Preserve those identities for compatibility. New identities travel as opaque
+/// until a versioned capability negotiation can prove that the loaded plugin
+/// understands them; the callback-scoped decode/encode capability remains
+/// available either way.
+fn native_v4_builtin_id(codec: BuiltinLlmCodec) -> Option<&'static str> {
+    match codec {
+        BuiltinLlmCodec::OpenAiChat
+        | BuiltinLlmCodec::OpenAiResponses
+        | BuiltinLlmCodec::AnthropicMessages
+        | BuiltinLlmCodec::OCIGenAI
+        | BuiltinLlmCodec::GeminiGenerateContent => Some(codec.id()),
+        BuiltinLlmCodec::BedrockConverse => None,
+    }
 }
 
 fn wrap_llm_conditional_fn(

--- a/crates/core/src/plugins/nemo_guardrails/component.rs
+++ b/crates/core/src/plugins/nemo_guardrails/component.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as Json};
 
-use crate::codec::resolve::supported_codec_names;
 use crate::plugin::{
     ConfigDiagnostic, ConfigPolicy, DiagnosticLevel, Plugin, PluginComponentSpec, PluginError,
     PluginRegistrationContext, Result as PluginResult, UnsupportedBehavior,
@@ -37,6 +36,16 @@ use remote::register_remote_backend;
     note = "the built-in NeMo Guardrails plugin is scheduled for removal in 0.9; no replacement is available in 0.8"
 )]
 pub const NEMO_GUARDRAILS_PLUGIN_KIND: &str = "nemo_guardrails";
+
+// Keep this list local to the deprecated integration. New core codecs must not
+// become Guardrails-supported merely because Relay can normalize them.
+const NEMO_GUARDRAILS_CODECS: &[&str] = &[
+    "openai_chat",
+    "openai_responses",
+    "anthropic_messages",
+    "oci_genai",
+    "gemini_generate_content",
+];
 
 /// Stable diagnostic code for the built-in plugin's deprecation warning.
 const NEMO_GUARDRAILS_DEPRECATION_CODE: &str = "nemo_guardrails.deprecated";
@@ -998,7 +1007,7 @@ fn validate_codec_requirements(
         return;
     };
 
-    if !supported_codec_names().contains(&codec) {
+    if !NEMO_GUARDRAILS_CODECS.contains(&codec) {
         push_policy_diag(
             diagnostics,
             policy.unsupported_value,
@@ -1007,7 +1016,7 @@ fn validate_codec_requirements(
             Some("codec".to_string()),
             format!(
                 "codec must be one of: {}",
-                supported_codec_names().join(", ")
+                NEMO_GUARDRAILS_CODECS.join(", ")
             ),
         );
     }

--- a/crates/core/src/plugins/nemo_guardrails/python.rs
+++ b/crates/core/src/plugins/nemo_guardrails/python.rs
@@ -904,14 +904,15 @@ impl LocalGuardrailsCodec {
         }
     }
 
-    fn from_provider_surface(surface: ProviderSurface) -> Self {
-        match surface {
+    fn from_provider_surface(surface: ProviderSurface) -> Option<Self> {
+        Some(match surface {
             ProviderSurface::OpenAIChat => Self::OpenAIChat,
             ProviderSurface::OpenAIResponses => Self::OpenAIResponses,
             ProviderSurface::AnthropicMessages => Self::AnthropicMessages,
             ProviderSurface::OCIGenAI => Self::OCIGenAI,
             ProviderSurface::GeminiGenerateContent => Self::GeminiGenerateContent,
-        }
+            ProviderSurface::BedrockConverse => return None,
+        })
     }
 
     fn decode(&self, request: &LlmRequest) -> FlowResult<AnnotatedLlmRequest> {
@@ -941,7 +942,13 @@ fn resolve_codec(config: &NeMoGuardrailsConfig) -> PluginResult<Option<LocalGuar
 
     match config.codec.as_deref() {
         Some(name) => match ProviderSurface::from_codec_name(name) {
-            Some(surface) => Ok(Some(LocalGuardrailsCodec::from_provider_surface(surface))),
+            Some(surface) => LocalGuardrailsCodec::from_provider_surface(surface)
+                .map(Some)
+                .ok_or_else(|| {
+                    PluginError::InvalidConfig(format!(
+                        "the deprecated local NeMo Guardrails plugin does not support codec '{name}'"
+                    ))
+                }),
             None => Err(PluginError::InvalidConfig(format!(
                 "unsupported local NeMo Guardrails codec '{name}'"
             ))),

--- a/crates/core/tests/integration/pipeline_tests.rs
+++ b/crates/core/tests/integration/pipeline_tests.rs
@@ -35,6 +35,7 @@ use nemo_relay::api::runtime::{create_scope_stack, set_thread_scope_stack};
 use nemo_relay::api::scope::{EmitMarkEventParams, ScopeType, event};
 use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
 use nemo_relay::codec::anthropic::AnthropicMessagesCodec;
+use nemo_relay::codec::bedrock_converse::{BedrockConverseCodec, BedrockConverseStreamingCodec};
 use nemo_relay::codec::oci_genai::OCIGenAIChatCodec;
 use nemo_relay::codec::openai_chat::OpenAIChatCodec;
 use nemo_relay::codec::optimization::{
@@ -47,6 +48,7 @@ use nemo_relay::codec::response::{
     AnnotatedLlmResponse, CostEstimate, CostSource, PricingCatalog, PricingResolver, Usage,
     reset_active_pricing_resolver, set_active_pricing_resolver,
 };
+use nemo_relay::codec::streaming::StreamingCodec;
 use nemo_relay::codec::traits::{LlmCodec, LlmResponseCodec};
 use nemo_relay::error::{FlowError, Result};
 use nemo_relay::json::Json;
@@ -325,6 +327,25 @@ fn first_message_text(request: &AnnotatedLlmRequest) -> Option<&str> {
             content: Some(MessageContent::Text(text)),
             ..
         } => Some(text.as_str()),
+        Message::System {
+            content: MessageContent::Parts(parts),
+            ..
+        }
+        | Message::User {
+            content: MessageContent::Parts(parts),
+            ..
+        }
+        | Message::Tool {
+            content: MessageContent::Parts(parts),
+            ..
+        }
+        | Message::Assistant {
+            content: Some(MessageContent::Parts(parts)),
+            ..
+        } => parts.iter().find_map(|part| match part {
+            ContentPart::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        }),
         _ => None,
     }
 }
@@ -1601,6 +1622,247 @@ async fn test_oci_genai_response_codec_populates_annotated_response() {
     assert_eq!(usage.total_tokens, Some(640));
 
     deregister_subscriber("oci_resp_codec_sub").unwrap();
+}
+
+#[tokio::test]
+async fn test_bedrock_converse_codecs_populate_managed_pipeline_annotations() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let event_capture = Arc::clone(&events);
+    register_subscriber(
+        "bedrock_converse_pipeline_sub",
+        Arc::new(move |event: &Event| {
+            event_capture.lock().unwrap().push(event.clone());
+        }),
+    )
+    .unwrap();
+
+    let provider_request = Arc::new(Mutex::new(None));
+    let provider_request_capture = Arc::clone(&provider_request);
+    let provider: LlmExecutionNextFn = Arc::new(move |request| {
+        *provider_request_capture.lock().unwrap() = Some(request);
+        Box::pin(async move {
+            Ok(json!({
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"text": "The weather is clear."},
+                            {"toolUse": {
+                                "toolUseId": "tool-1",
+                                "name": "get_weather",
+                                "input": {"city": "Paris"}
+                            }}
+                        ]
+                    }
+                },
+                "stopReason": "tool_use",
+                "usage": {
+                    "inputTokens": 12,
+                    "outputTokens": 8,
+                    "totalTokens": 20,
+                    "cacheReadInputTokens": 2
+                },
+                "metrics": {"latencyMs": 42}
+            }))
+        })
+    });
+    let model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+    let request = make_llm_request(json!({
+        "modelId": model_id,
+        "messages": [{
+            "role": "user",
+            "content": [{"text": "What is the weather in Paris?"}]
+        }],
+        "inferenceConfig": {"temperature": 0.0, "maxTokens": 128},
+        "toolConfig": {"tools": [{"toolSpec": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "inputSchema": {"json": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            }}
+        }}]},
+        "requestMetadata": {"tenant": "pipeline-test"}
+    }));
+
+    llm_call_execute(
+        LlmCallExecuteParams::builder()
+            .name("aws.bedrock.converse")
+            .request(request.clone())
+            .func(provider)
+            .model_name(model_id)
+            .codec(Arc::new(BedrockConverseCodec))
+            .response_codec(Arc::new(BedrockConverseCodec))
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    let captured_provider_request = provider_request
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("provider callback should receive the Converse request");
+    assert_eq!(captured_provider_request.content, request.content);
+
+    let captured = captured_events_snapshot(&events);
+    let start_event = captured
+        .iter()
+        .find(|event| is_scope_event(event, ScopeType::Llm, ScopeCategory::Start))
+        .expect("expected LlmStart event");
+    assert_eq!(start_event.model_name(), Some(model_id));
+    let annotated_request = start_event
+        .annotated_request()
+        .expect("Bedrock request codec should populate the start annotation");
+    assert_eq!(annotated_request.model.as_deref(), Some(model_id));
+    assert_eq!(
+        first_message_text(annotated_request),
+        Some("What is the weather in Paris?")
+    );
+    assert_eq!(
+        annotated_request
+            .params
+            .as_ref()
+            .and_then(|params| params.temperature),
+        Some(0.0)
+    );
+
+    let end_event = captured
+        .iter()
+        .find(|event| is_scope_event(event, ScopeType::Llm, ScopeCategory::End))
+        .expect("expected LlmEnd event");
+    assert_eq!(end_event.model_name(), Some(model_id));
+    let annotated_response = end_event
+        .annotated_response()
+        .expect("Bedrock response codec should populate the end annotation");
+    assert_eq!(
+        annotated_response.response_text(),
+        Some("The weather is clear.")
+    );
+    assert_eq!(
+        annotated_response.finish_reason,
+        Some(FinishReason::ToolUse)
+    );
+    let tool_calls = annotated_response
+        .tool_calls
+        .as_ref()
+        .expect("Bedrock tool call should be normalized");
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].id, "tool-1");
+    assert_eq!(tool_calls[0].name, "get_weather");
+    assert_eq!(tool_calls[0].arguments, json!({"city": "Paris"}));
+    let usage = annotated_response
+        .usage
+        .as_ref()
+        .expect("Bedrock token usage should be normalized");
+    assert_eq!(usage.prompt_tokens, Some(12));
+    assert_eq!(usage.completion_tokens, Some(8));
+    assert_eq!(usage.total_tokens, Some(20));
+    assert_eq!(usage.cache_read_tokens, Some(2));
+
+    deregister_subscriber("bedrock_converse_pipeline_sub").unwrap();
+}
+
+#[tokio::test]
+async fn test_bedrock_converse_stream_preserves_chunks_and_populates_annotation() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    reset_global();
+    setup_isolated_thread();
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let event_capture = Arc::clone(&events);
+    register_subscriber(
+        "bedrock_converse_stream_pipeline_sub",
+        Arc::new(move |event: &Event| {
+            event_capture.lock().unwrap().push(event.clone());
+        }),
+    )
+    .unwrap();
+
+    let chunks = vec![
+        json!({"messageStart": {"role": "assistant"}}),
+        json!({"contentBlockDelta": {
+            "contentBlockIndex": 0,
+            "delta": {"text": "The weather is clear."}
+        }}),
+        json!({"contentBlockStop": {"contentBlockIndex": 0}}),
+        json!({"contentBlockStart": {
+            "contentBlockIndex": 1,
+            "start": {"toolUse": {"toolUseId": "tool-1", "name": "get_weather"}}
+        }}),
+        json!({"contentBlockDelta": {
+            "contentBlockIndex": 1,
+            "delta": {"toolUse": {"input": "{\"city\":\"Paris\"}"}}
+        }}),
+        json!({"contentBlockStop": {"contentBlockIndex": 1}}),
+        json!({"messageStop": {"stopReason": "tool_use"}}),
+        json!({"metadata": {
+            "usage": {"inputTokens": 12, "outputTokens": 8, "totalTokens": 20},
+            "metrics": {"latencyMs": 42}
+        }}),
+    ];
+    let provider_chunks = chunks.clone();
+    let provider: LlmStreamExecutionNextFn = Arc::new(move |_request| {
+        let provider_chunks = provider_chunks.clone();
+        Box::pin(async move {
+            Ok(LlmJsonStream::new(futures::stream::iter(
+                provider_chunks.into_iter().map(Ok),
+            )))
+        })
+    });
+    let stream_codec = BedrockConverseStreamingCodec::new();
+    let model_id = "amazon.nova-pro-v1:0";
+    let mut stream = llm_stream_call_execute(
+        LlmStreamCallExecuteParams::builder()
+            .name("aws.bedrock.converse")
+            .request(make_llm_request(json!({
+                "modelId": model_id,
+                "messages": [{"role": "user", "content": [{"text": "Weather?"}]}]
+            })))
+            .func(provider)
+            .model_name(model_id)
+            .codec(Arc::new(BedrockConverseCodec))
+            .collector(stream_codec.collector())
+            .finalizer(stream_codec.finalizer())
+            .response_codec(Arc::new(BedrockConverseCodec))
+            .build(),
+    )
+    .await
+    .unwrap();
+
+    let mut client_chunks = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        client_chunks.push(chunk.unwrap());
+    }
+    stream.close().await.unwrap();
+    assert_eq!(client_chunks, chunks);
+
+    let captured = captured_events_snapshot(&events);
+    let end_event = captured
+        .iter()
+        .find(|event| is_scope_event(event, ScopeType::Llm, ScopeCategory::End))
+        .expect("expected LlmEnd event after ConverseStream drain");
+    let annotated = end_event
+        .annotated_response()
+        .expect("Bedrock stream should produce a normalized final response");
+    assert_eq!(annotated.response_text(), Some("The weather is clear."));
+    assert_eq!(annotated.finish_reason, Some(FinishReason::ToolUse));
+    let tool_calls = annotated.tool_calls.as_ref().expect("tool call decoded");
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].id, "tool-1");
+    assert_eq!(tool_calls[0].name, "get_weather");
+    assert_eq!(tool_calls[0].arguments, json!({"city": "Paris"}));
+    let usage = annotated.usage.as_ref().expect("usage decoded");
+    assert_eq!(usage.prompt_tokens, Some(12));
+    assert_eq!(usage.completion_tokens, Some(8));
+    assert_eq!(usage.total_tokens, Some(20));
+
+    deregister_subscriber("bedrock_converse_stream_pipeline_sub").unwrap();
 }
 
 #[tokio::test]

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -6420,20 +6420,22 @@ fn assert_annotated_turn_state_edge_shapes() {
         }),
         Some(RequestTurnState::Continuation)
     );
-    assert!(annotated_content_starts_new_turn(&MessageContent::Parts(
-        vec![ContentPart::Text {
+    assert!(message_starts_new_user_turn(&Message::User {
+        content: MessageContent::Parts(vec![ContentPart::Text {
             text: "hello".into(),
             extra: Default::default(),
-        },]
-    )));
-    assert!(!annotated_content_starts_new_turn(&MessageContent::Parts(
-        vec![ContentPart::ToolResult {
+        }]),
+        name: None,
+    }));
+    assert!(!message_starts_new_user_turn(&Message::User {
+        content: MessageContent::Parts(vec![ContentPart::ToolResult {
             tool_use_id: "call-1".into(),
             content: json!("done"),
             is_error: None,
             extra: Default::default(),
-        },]
-    )));
+        }]),
+        name: None,
+    }));
     assert_eq!(
         atif_message_from_annotated_response(&AnnotatedLlmResponse {
             message: Some(MessageContent::Parts(vec![])),

--- a/crates/core/tests/unit/codec/bedrock_converse_tests.rs
+++ b/crates/core/tests/unit/codec/bedrock_converse_tests.rs
@@ -1,0 +1,723 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for the Amazon Bedrock Converse codec.
+
+use super::*;
+use serde_json::json;
+
+use super::super::streaming::StreamingCodec;
+
+fn request(content: Json) -> LlmRequest {
+    LlmRequest {
+        headers: serde_json::Map::from_iter([(
+            "x-test-header".into(),
+            Json::String("preserved".into()),
+        )]),
+        content,
+    }
+}
+
+fn full_request() -> LlmRequest {
+    request(json!({
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "system": [
+            {"text": "Follow policy."},
+            {"cachePoint": {"type": "default"}}
+        ],
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"text": "Weather in Montréal?"}
+                ]
+            },
+            {
+                "role": "assistant",
+                "content": [{
+                    "toolUse": {
+                        "toolUseId": "call-1",
+                        "name": "weather",
+                        "input": {"city": "Montréal"}
+                    }
+                }]
+            },
+            {
+                "role": "user",
+                "content": [{
+                    "toolResult": {
+                        "toolUseId": "call-1",
+                        "content": [{"json": {"temperature": 20}}],
+                        "status": "success"
+                    }
+                }]
+            }
+        ],
+        "inferenceConfig": {
+            "maxTokens": 512,
+            "temperature": 0.2,
+            "topP": 0.9,
+            "stopSequences": ["END"]
+        },
+        "toolConfig": {
+            "tools": [
+                {
+                    "toolSpec": {
+                        "name": "weather",
+                        "description": "Read the weather",
+                        "strict": true,
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}}
+                            }
+                        }
+                    }
+                },
+                {"cachePoint": {"type": "default"}}
+            ],
+            "toolChoice": {"auto": {}}
+        },
+        "additionalModelRequestFields": {"thinking": {"type": "enabled"}},
+        "requestMetadata": {"tenant": "example"}
+    }))
+}
+
+#[test]
+fn codec_identity_is_bedrock_converse_builtin() {
+    let codec = BedrockConverseCodec;
+    assert_eq!(
+        LlmCodec::codec_identity(&codec),
+        LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::BedrockConverse)
+    );
+}
+
+#[test]
+fn response_codec_identity_is_bedrock_converse_builtin() {
+    let codec = BedrockConverseCodec;
+    assert_eq!(
+        <BedrockConverseCodec as LlmResponseCodec>::codec_identity(&codec),
+        LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::BedrockConverse)
+    );
+}
+
+#[test]
+fn detector_accepts_the_strong_model_id_shape_and_explicit_hints() {
+    let body = full_request().content;
+    let obj = body.as_object().unwrap();
+    assert!((PROVIDER_SURFACE.detect_request)(obj, None));
+    assert!((PROVIDER_SURFACE.detect_request)(
+        obj,
+        Some("openai.chat_completions")
+    ));
+    assert!((PROVIDER_SURFACE.detect_request)(
+        obj,
+        Some("aws.bedrock.converse")
+    ));
+    assert!((PROVIDER_SURFACE.detect_request)(
+        obj,
+        Some("bedrock.converse")
+    ));
+}
+
+#[test]
+#[allow(clippy::cognitive_complexity)] // Verifies one decoded envelope across every mapped field.
+fn decode_maps_messages_tools_params_and_provider_extras() {
+    let decoded = BedrockConverseCodec.decode(&full_request()).unwrap();
+    assert_eq!(
+        decoded.model.as_deref(),
+        Some("anthropic.claude-3-5-sonnet-20241022-v2:0")
+    );
+    assert_eq!(decoded.messages.len(), 3);
+    assert!(matches!(decoded.messages[0], Message::User { .. }));
+    assert!(matches!(decoded.messages[1], Message::Assistant { .. }));
+    assert!(matches!(decoded.messages[2], Message::User { .. }));
+    let Some(MessageContent::Parts(instructions)) = decoded.instructions.as_ref() else {
+        panic!("expected multipart system context")
+    };
+    assert_eq!(instructions.len(), 2);
+    assert!(matches!(
+        &instructions[0],
+        ContentPart::Text { text, .. } if text == "Follow policy."
+    ));
+    assert!(matches!(
+        &instructions[1],
+        ContentPart::ProviderNative { kind, .. } if kind == "cachePoint"
+    ));
+
+    let params = decoded.params.unwrap();
+    assert_eq!(params.max_tokens, Some(512));
+    assert_eq!(params.temperature, Some(0.2));
+    assert_eq!(params.top_p, Some(0.9));
+    assert_eq!(params.stop, Some(vec!["END".into()]));
+
+    let tools = decoded.tools.unwrap();
+    assert_eq!(tools.len(), 2);
+    match &tools[0] {
+        ToolDefinition::Function { function, extra } => {
+            assert_eq!(function.name, "weather");
+            assert_eq!(function.description.as_deref(), Some("Read the weather"));
+            assert_eq!(function.strict, Some(true));
+            assert_eq!(
+                function.parameters,
+                Some(json!({
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}}
+                }))
+            );
+            assert!(function.extra.is_empty());
+            assert!(extra.is_empty());
+        }
+        other => panic!("expected function tool, got {other:?}"),
+    }
+    assert!(matches!(tools[1], ToolDefinition::ProviderNative { .. }));
+    assert_eq!(decoded.tool_choice, Some(ToolChoice::Auto));
+    assert!(decoded.extra.contains_key("additionalModelRequestFields"));
+    assert!(decoded.extra.contains_key("requestMetadata"));
+}
+
+#[test]
+fn unchanged_encode_is_byte_for_byte_json_equivalent() {
+    let original = full_request();
+    let decoded = BedrockConverseCodec.decode(&original).unwrap();
+    let encoded = BedrockConverseCodec.encode(&decoded, &original).unwrap();
+    assert_eq!(encoded, original);
+}
+
+#[test]
+fn encode_overlays_edits_without_dropping_provider_fields() {
+    let original = full_request();
+    let mut decoded = BedrockConverseCodec.decode(&original).unwrap();
+    decoded.model = Some("amazon.nova-pro-v1:0".into());
+    decoded.params.as_mut().unwrap().max_tokens = Some(1024);
+    let Some(MessageContent::Parts(instructions)) = decoded.instructions.as_mut() else {
+        panic!("expected multipart system context")
+    };
+    let ContentPart::Text { text, .. } = &mut instructions[0] else {
+        panic!("expected system text")
+    };
+    *text = "Follow the updated policy.".into();
+    let Message::User { content, .. } = &mut decoded.messages[0] else {
+        panic!("expected user message")
+    };
+    let MessageContent::Parts(parts) = content else {
+        panic!("expected multipart message")
+    };
+    let ContentPart::Text { text, .. } = &mut parts[0] else {
+        panic!("expected text part")
+    };
+    *text = "Weather in Toronto?".into();
+
+    let encoded = BedrockConverseCodec.encode(&decoded, &original).unwrap();
+    assert_eq!(encoded.headers, original.headers);
+    assert_eq!(encoded.content["modelId"], "amazon.nova-pro-v1:0");
+    assert_eq!(
+        encoded.content["messages"][0]["content"][0]["text"],
+        "Weather in Toronto?"
+    );
+    assert_eq!(
+        encoded.content["system"][0]["text"],
+        "Follow the updated policy."
+    );
+    assert_eq!(
+        encoded.content["system"][1]["cachePoint"]["type"],
+        "default"
+    );
+    assert_eq!(encoded.content["inferenceConfig"]["maxTokens"], 1024);
+    assert_eq!(
+        encoded.content["toolConfig"]["tools"][1]["cachePoint"]["type"],
+        "default"
+    );
+    assert_eq!(
+        encoded.content["additionalModelRequestFields"],
+        original.content["additionalModelRequestFields"]
+    );
+}
+
+#[test]
+fn synthetic_future_fields_survive_unrelated_edits() {
+    // These fields deliberately model a future SDK schema. They are separate
+    // from `full_request`, which stays valid against today's tagged unions.
+    let original = request(json!({
+        "modelId": "amazon.nova-pro-v1:0",
+        "messages": [
+            {"role": "user", "content": [{"text": "hello"}]},
+            {"role": "assistant", "content": [{"toolUse": {
+                "toolUseId": "call-future",
+                "name": "lookup",
+                "input": {"query": "hello"},
+                "futureToolUseField": "keep"
+            }}]}
+        ],
+        "inferenceConfig": {"maxTokens": 32, "futureInferenceField": "keep"},
+        "futureTopLevelField": {"keep": true}
+    }));
+    let mut decoded = BedrockConverseCodec.decode(&original).unwrap();
+    decoded.params.as_mut().unwrap().max_tokens = Some(64);
+    let encoded = BedrockConverseCodec.encode(&decoded, &original).unwrap();
+    assert_eq!(encoded.content["inferenceConfig"]["maxTokens"], 64);
+    assert_eq!(
+        encoded.content["inferenceConfig"]["futureInferenceField"],
+        "keep"
+    );
+    assert_eq!(
+        encoded.content["messages"][1]["content"][0]["toolUse"]["futureToolUseField"],
+        "keep"
+    );
+    assert_eq!(encoded.content["futureTopLevelField"]["keep"], true);
+}
+
+#[test]
+fn unmodeled_content_blocks_remain_provider_native_and_round_trip() {
+    let blocks = vec![
+        json!({
+            "audio": {
+                "format": "mp3",
+                "source": {"bytes": "base64-audio"}
+            }
+        }),
+        json!({
+            "searchResult": {
+                "title": "Relay",
+                "source": "https://example.test/relay",
+                "content": [{"text": "Search result text"}]
+            }
+        }),
+        json!({"toolAddition": {"tool": {"name": "get_weather"}}}),
+        json!({"toolRemoval": {"tool": {"name": "get_time"}}}),
+    ];
+    let original = request(json!({
+        "modelId": "amazon.nova-pro-v1:0",
+        "messages": [{"role": "user", "content": blocks}]
+    }));
+
+    let decoded = BedrockConverseCodec.decode(&original).unwrap();
+    let Message::User { content, .. } = &decoded.messages[0] else {
+        panic!("expected user message")
+    };
+    let MessageContent::Parts(parts) = content else {
+        panic!("expected multipart message")
+    };
+    for (part, expected_kind) in
+        parts
+            .iter()
+            .zip(["audio", "searchResult", "toolAddition", "toolRemoval"])
+    {
+        assert!(matches!(
+            part,
+            ContentPart::ProviderNative { provider, kind, .. }
+                if provider == BEDROCK_PROVIDER && kind == expected_kind
+        ));
+    }
+
+    assert_eq!(
+        BedrockConverseCodec.encode(&decoded, &original).unwrap(),
+        original
+    );
+}
+
+#[test]
+fn mixed_content_block_unions_remain_provider_native_and_round_trip() {
+    let blocks = vec![
+        json!({"text": "do not normalize", "audio": {"format": "mp3"}}),
+        json!({
+            "text": "do not normalize",
+            "searchResult": {
+                "title": "Relay",
+                "source": "https://example.test/relay",
+                "content": [{"text": "Search result text"}]
+            }
+        }),
+        json!({
+            "text": "do not normalize",
+            "toolAddition": {"tool": {"name": "get_weather"}}
+        }),
+        json!({
+            "text": "do not normalize",
+            "toolRemoval": {"tool": {"name": "get_time"}}
+        }),
+    ];
+    let original = request(json!({
+        "modelId": "amazon.nova-pro-v1:0",
+        "messages": [{"role": "user", "content": blocks}]
+    }));
+
+    let decoded = BedrockConverseCodec.decode(&original).unwrap();
+    let Message::User { content, .. } = &decoded.messages[0] else {
+        panic!("expected user message")
+    };
+    let MessageContent::Parts(parts) = content else {
+        panic!("expected multipart message")
+    };
+    assert!(
+        parts
+            .iter()
+            .all(|part| matches!(part, ContentPart::ProviderNative { .. }))
+    );
+
+    assert_eq!(
+        BedrockConverseCodec.encode(&decoded, &original).unwrap(),
+        original
+    );
+}
+
+#[test]
+fn decode_response_maps_text_tools_stop_reason_and_usage() {
+    let raw = json!({
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"text": "Checking now."},
+                    {"toolUse": {
+                        "toolUseId": "call-2",
+                        "name": "weather",
+                        "input": {"city": "Toronto"}
+                    }},
+                    {"reasoningContent": {"reasoningText": {"text": "hidden"}}}
+                ]
+            }
+        },
+        "stopReason": "tool_use",
+        "usage": {
+            "inputTokens": 100,
+            "outputTokens": 25,
+            "totalTokens": 125,
+            "cacheReadInputTokens": 20,
+            "cacheWriteInputTokens": 5,
+            "cacheDetails": [{"ttl": "1h", "inputTokens": 5}]
+        },
+        "metrics": {"latencyMs": 321},
+        "trace": {"guardrail": {"actionReason": "NONE"}}
+    });
+    let decoded = BedrockConverseCodec.decode_response(&raw).unwrap();
+    assert_eq!(decoded.finish_reason, Some(FinishReason::ToolUse));
+    assert!(matches!(
+        decoded.message,
+        Some(MessageContent::Parts(ref parts)) if parts.len() == 3
+    ));
+    let call = &decoded.tool_calls.unwrap()[0];
+    assert_eq!(call.id, "call-2");
+    assert_eq!(call.name, "weather");
+    assert_eq!(call.arguments, json!({"city": "Toronto"}));
+    let usage = decoded.usage.unwrap();
+    assert_eq!(usage.prompt_tokens, Some(100));
+    assert_eq!(usage.completion_tokens, Some(25));
+    assert_eq!(usage.total_tokens, Some(125));
+    assert_eq!(usage.cache_read_tokens, Some(20));
+    assert_eq!(usage.cache_write_tokens, Some(5));
+    assert_eq!(decoded.extra["metrics"]["latencyMs"], 321);
+    match decoded.api_specific.unwrap() {
+        ApiSpecificResponse::Custom { api_name, data } => {
+            assert_eq!(api_name, BEDROCK_PROVIDER);
+            assert_eq!(
+                data,
+                json!({
+                    "stopReason": "tool_use",
+                    "usage": {
+                        "inputTokens": 100,
+                        "outputTokens": 25,
+                        "totalTokens": 125,
+                        "cacheReadInputTokens": 20,
+                        "cacheWriteInputTokens": 5,
+                        "cacheDetails": [{"ttl": "1h", "inputTokens": 5}]
+                    }
+                })
+            );
+        }
+        other => panic!("expected custom Bedrock response data, got {other:?}"),
+    }
+}
+
+#[test]
+fn streaming_accumulator_builds_a_decodable_converse_response() {
+    let codec = BedrockConverseStreamingCodec::new();
+    let mut collect = codec.collector();
+    for event in [
+        json!({"messageStart": {"role": "assistant"}}),
+        json!({"contentBlockDelta": {
+            "contentBlockIndex": 0,
+            "delta": {"text": "Hello "}
+        }}),
+        json!({"contentBlockDelta": {
+            "contentBlockIndex": 0,
+            "delta": {"text": "world"}
+        }}),
+        json!({"contentBlockStop": {"contentBlockIndex": 0}}),
+        json!({"contentBlockStart": {
+            "contentBlockIndex": 1,
+            "start": {"toolUse": {"toolUseId": "call-3", "name": "weather"}}
+        }}),
+        json!({"contentBlockDelta": {
+            "contentBlockIndex": 1,
+            "delta": {"toolUse": {"input": "{\"city\":"}}
+        }}),
+        json!({"contentBlockDelta": {
+            "contentBlockIndex": 1,
+            "delta": {"toolUse": {"input": "\"London\"}"}}
+        }}),
+        json!({"contentBlockStop": {"contentBlockIndex": 1}}),
+        json!({"messageStop": {
+            "stopReason": "tool_use",
+            "additionalModelResponseFields": {"provider": "field"}
+        }}),
+        json!({"metadata": {
+            "usage": {"inputTokens": 4, "outputTokens": 6, "totalTokens": 10},
+            "metrics": {"latencyMs": 12},
+            "trace": {"key": "value"}
+        }}),
+    ] {
+        collect(event).unwrap();
+    }
+    let aggregate = codec.finalizer()();
+    assert_eq!(
+        aggregate["output"]["message"]["content"][0]["text"],
+        "Hello world"
+    );
+    assert_eq!(
+        aggregate["output"]["message"]["content"][1]["toolUse"]["input"],
+        json!({"city": "London"})
+    );
+    assert_eq!(
+        aggregate["additionalModelResponseFields"]["provider"],
+        "field"
+    );
+    assert_eq!(aggregate["trace"]["key"], "value");
+
+    let decoded = BedrockConverseCodec.decode_response(&aggregate).unwrap();
+    assert_eq!(decoded.finish_reason, Some(FinishReason::ToolUse));
+    assert_eq!(decoded.usage.unwrap().total_tokens, Some(10));
+    assert_eq!(decoded.tool_calls.unwrap()[0].name, "weather");
+}
+
+#[test]
+fn streaming_sparse_huge_indices_do_not_allocate_by_index() {
+    let codec = BedrockConverseStreamingCodec::new();
+    let mut collect = codec.collector();
+    for event in [
+        json!({"contentBlockDelta": {
+            "contentBlockIndex": u64::MAX,
+            "delta": {"text": "tail"}
+        }}),
+        json!({"contentBlockStop": {"contentBlockIndex": u64::MAX}}),
+        json!({"contentBlockDelta": {
+            "contentBlockIndex": 0,
+            "delta": {"text": "head"}
+        }}),
+        json!({"contentBlockStop": {"contentBlockIndex": 0}}),
+    ] {
+        collect(event).unwrap();
+    }
+
+    let aggregate = codec.finalizer()();
+    assert_eq!(
+        aggregate["output"]["message"]["content"],
+        json!([{"text": "head"}, {"text": "tail"}])
+    );
+}
+
+#[test]
+fn streaming_exception_is_not_silently_ignored() {
+    let codec = BedrockConverseStreamingCodec::new();
+    let mut collect = codec.collector();
+    let error = collect(json!({
+        "throttlingException": {"message": "slow down"}
+    }))
+    .unwrap_err();
+    match error {
+        FlowError::Upstream(failure) => {
+            assert_eq!(failure.status, Some(429));
+            assert_eq!(failure.class, UpstreamFailureClass::RetryableStatus);
+            assert!(failure.body.contains("throttlingException"));
+            assert!(failure.body.contains("slow down"));
+        }
+        other => panic!("expected a typed upstream failure, got {other:?}"),
+    }
+}
+
+#[test]
+fn streaming_exception_body_is_bounded_on_utf8_boundaries() {
+    let codec = BedrockConverseStreamingCodec::new();
+    let mut collect = codec.collector();
+    let error = collect(json!({
+        "throttlingException": {"message": "é".repeat(40 * 1024)}
+    }))
+    .unwrap_err();
+    let FlowError::Upstream(failure) = error else {
+        panic!("expected typed upstream failure")
+    };
+    assert_eq!(failure.status, Some(429));
+    assert_eq!(failure.class, UpstreamFailureClass::RetryableStatus);
+    assert!(failure.body.len() <= MAX_UPSTREAM_ERROR_BODY_BYTES);
+    assert!(
+        failure
+            .body
+            .starts_with("Bedrock ConverseStream throttlingException:")
+    );
+}
+
+#[test]
+fn malformed_provider_fields_are_rejected() {
+    assert!(
+        BedrockConverseCodec
+            .decode(&request(json!({"modelId": 1, "messages": []})))
+            .is_err()
+    );
+    assert!(
+        BedrockConverseCodec
+            .decode_response(&json!({
+                "output": {"message": {"content": []}},
+                "stopReason": 1
+            }))
+            .is_err()
+    );
+}
+
+#[test]
+fn response_never_invents_or_reads_a_model_id() {
+    let decoded = BedrockConverseCodec
+        .decode_response(&json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+            "stopReason": "end_turn",
+            "modelId": "nonstandard-response-field"
+        }))
+        .unwrap();
+    assert_eq!(decoded.model, None);
+    assert_eq!(decoded.extra["modelId"], "nonstandard-response-field");
+}
+
+#[test]
+fn response_maps_all_documented_stop_reason_classes() {
+    for (reason, expected) in [
+        ("end_turn", FinishReason::Complete),
+        ("stop_sequence", FinishReason::Complete),
+        ("max_tokens", FinishReason::Length),
+        ("tool_use", FinishReason::ToolUse),
+        ("guardrail_intervened", FinishReason::ContentFilter),
+        ("content_filtered", FinishReason::ContentFilter),
+        (
+            "malformed_tool_use",
+            FinishReason::Unknown("malformed_tool_use".into()),
+        ),
+        (
+            "model_context_window_exceeded",
+            FinishReason::Unknown("model_context_window_exceeded".into()),
+        ),
+        (
+            "malformed_model_output",
+            FinishReason::Unknown("malformed_model_output".into()),
+        ),
+    ] {
+        let decoded = BedrockConverseCodec
+            .decode_response(&json!({
+                "output": {"message": {"role": "assistant", "content": []}},
+                "stopReason": reason
+            }))
+            .unwrap();
+        assert_eq!(decoded.finish_reason, Some(expected));
+    }
+}
+
+#[test]
+fn prompt_resource_arn_rejects_forbidden_inline_configuration() {
+    let original = request(json!({
+        "modelId": "arn:aws:bedrock:us-east-1:123456789012:prompt/EXAMPLE",
+        "promptVariables": {"name": {"text": "Relay"}}
+    }));
+    let decoded = BedrockConverseCodec.decode(&original).unwrap();
+    assert_eq!(
+        BedrockConverseCodec.encode(&decoded, &original).unwrap(),
+        original
+    );
+
+    let mut edited = decoded;
+    edited.params = Some(GenerationParams {
+        max_tokens: Some(32),
+        ..Default::default()
+    });
+    let error = BedrockConverseCodec.encode(&edited, &original).unwrap_err();
+    assert!(error.to_string().contains("prompt resource ARN"));
+
+    let original = request(json!({
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "messages": [],
+        "inferenceConfig": {"futureOnlyField": true}
+    }));
+    let mut edited = BedrockConverseCodec.decode(&original).unwrap();
+    assert_eq!(edited.params, None);
+    edited.model = Some("arn:aws:bedrock:us-east-1:123456789012:prompt/EXAMPLE".into());
+    let error = BedrockConverseCodec.encode(&edited, &original).unwrap_err();
+    assert!(error.to_string().contains("prompt resource ARN"));
+}
+
+#[test]
+fn stream_omits_aggregation_for_unknown_or_unsupported_union_members() {
+    let codec = BedrockConverseStreamingCodec::new();
+    let mut collect = codec.collector();
+    collect(json!({"SDK_UNKNOWN_MEMBER": {"name": "futureEvent"}})).unwrap();
+    assert!(codec.finalizer()().is_null());
+
+    let codec = BedrockConverseStreamingCodec::new();
+    let mut collect = codec.collector();
+    collect(json!({"contentBlockDelta": {
+        "contentBlockIndex": 0,
+        "delta": {"reasoningContent": {"text": "hidden"}}
+    }}))
+    .unwrap();
+    assert!(codec.finalizer()().is_null());
+}
+
+#[test]
+fn unsupported_stream_content_releases_and_stops_rebuilding_aggregate_state() {
+    let codec = BedrockConverseStreamingCodec::new();
+    let mut collect = codec.collector();
+    collect(json!({"contentBlockDelta": {
+        "contentBlockIndex": 0,
+        "delta": {"text": "discard me"}
+    }}))
+    .unwrap();
+    assert_eq!(codec.state.lock().unwrap().blocks.len(), 1);
+
+    collect(json!({"contentBlockDelta": {
+        "contentBlockIndex": 1,
+        "delta": {"reasoningContent": {"text": "unsupported"}}
+    }}))
+    .unwrap();
+    {
+        let state = codec.state.lock().unwrap();
+        assert!(!state.aggregation_supported);
+        assert!(state.blocks.is_empty());
+    }
+
+    collect(json!({"contentBlockDelta": {
+        "contentBlockIndex": 2,
+        "delta": {"text": "do not retain me"}
+    }}))
+    .unwrap();
+    assert!(codec.state.lock().unwrap().blocks.is_empty());
+
+    let error = collect(json!({
+        "throttlingException": {"message": "still surface provider failures"}
+    }))
+    .unwrap_err();
+    assert!(matches!(error, FlowError::Upstream(_)));
+    assert!(codec.finalizer()().is_null());
+}
+
+#[test]
+fn stream_forwards_incomplete_tool_json_without_a_partial_aggregate() {
+    let codec = BedrockConverseStreamingCodec::new();
+    let mut collect = codec.collector();
+    collect(json!({"contentBlockStart": {
+        "contentBlockIndex": 0,
+        "start": {"toolUse": {"toolUseId": "call-1", "name": "weather"}}
+    }}))
+    .unwrap();
+    collect(json!({"contentBlockDelta": {
+        "contentBlockIndex": 0,
+        "delta": {"toolUse": {"input": "{\"city\":"}}
+    }}))
+    .unwrap();
+    collect(json!({"contentBlockStop": {"contentBlockIndex": 0}})).unwrap();
+    assert!(codec.finalizer()().is_null());
+}

--- a/crates/core/tests/unit/codec/resolve_tests.rs
+++ b/crates/core/tests/unit/codec/resolve_tests.rs
@@ -23,12 +23,50 @@ fn builtin_provider_surface_registry_keeps_request_priority() {
     assert_eq!(
         surfaces,
         vec![
+            ProviderSurface::BedrockConverse,
             ProviderSurface::OpenAIResponses,
             ProviderSurface::AnthropicMessages,
             ProviderSurface::OCIGenAI,
             ProviderSurface::OpenAIChat,
             ProviderSurface::GeminiGenerateContent,
         ]
+    );
+}
+
+#[test]
+fn detect_request_bedrock_uses_model_id_as_a_strong_signal() {
+    let body = json!({
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "messages": [{"role": "user", "content": [{"text": "hi"}]}]
+    });
+    assert_eq!(
+        detect_request_surface_with_hint(&body, Some("aws.bedrock.converse")),
+        Some(ProviderSurface::BedrockConverse)
+    );
+    assert_eq!(
+        detect_request_surface_with_hint(&body, Some("bedrock.converse")),
+        Some(ProviderSurface::BedrockConverse)
+    );
+    assert_eq!(
+        detect_request_surface(&body),
+        Some(ProviderSurface::BedrockConverse),
+        "modelId distinguishes Converse from otherwise overlapping message shapes"
+    );
+    assert_eq!(
+        detect_request_surface_with_hint(&json!({"messages": []}), Some("aws.bedrock.converse")),
+        Some(ProviderSurface::OpenAIChat),
+        "the Bedrock hint does not claim a call envelope without modelId"
+    );
+}
+
+#[test]
+fn detect_request_bedrock_prompt_arn_without_messages() {
+    assert_eq!(
+        detect_request_surface(&json!({
+            "modelId": "arn:aws:bedrock:us-east-1:123456789012:prompt/EXAMPLE",
+            "promptVariables": {"name": {"text": "Relay"}}
+        })),
+        Some(ProviderSurface::BedrockConverse)
     );
 }
 
@@ -121,6 +159,18 @@ fn detect_response_gemini_by_candidates() {
     assert_eq!(
         detect_response_surface(&json!({"candidates": "not-array"})),
         None
+    );
+}
+
+#[test]
+fn detect_response_bedrock_by_output_message_and_metadata() {
+    assert_eq!(
+        detect_response_surface(&json!({
+            "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2}
+        })),
+        Some(ProviderSurface::BedrockConverse)
     );
 }
 
@@ -448,12 +498,13 @@ fn hint_does_not_classify_non_object_or_keyless() {
 // Provider-codec factory (name<->surface mapping + codec construction)
 // ---------------------------------------------------------------------------
 
-const ALL_SURFACES: [ProviderSurface; 5] = [
+const ALL_SURFACES: [ProviderSurface; 6] = [
     ProviderSurface::OpenAIChat,
     ProviderSurface::OpenAIResponses,
     ProviderSurface::AnthropicMessages,
     ProviderSurface::OCIGenAI,
     ProviderSurface::GeminiGenerateContent,
+    ProviderSurface::BedrockConverse,
 ];
 
 #[test]
@@ -483,6 +534,10 @@ fn codec_name_uses_canonical_spellings() {
         ProviderSurface::GeminiGenerateContent.codec_name(),
         "gemini_generate_content"
     );
+    assert_eq!(
+        ProviderSurface::BedrockConverse.codec_name(),
+        "bedrock_converse"
+    );
 }
 
 #[test]
@@ -511,6 +566,7 @@ fn supported_codec_names_track_the_builtin_registry() {
     assert_eq!(
         supported_codec_names(),
         vec![
+            "bedrock_converse",
             "openai_responses",
             "anthropic_messages",
             "oci_genai",
@@ -571,6 +627,18 @@ fn request_codec_decodes_each_surface() {
             .messages
             .is_empty()
     );
+
+    let bedrock = req(json!({
+        "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "messages": [{"role": "user", "content": [{"text": "hi"}]}]
+    }));
+    assert!(
+        !request_codec(ProviderSurface::BedrockConverse)
+            .decode(&bedrock)
+            .expect("Bedrock Converse request decodes")
+            .messages
+            .is_empty()
+    );
 }
 
 #[test]
@@ -621,6 +689,19 @@ fn response_codec_decodes_each_surface() {
             .expect("gemini response decodes")
             .response_text(),
         Some("hi gemini")
+    );
+
+    let bedrock = json!({
+        "output": {"message": {"role": "assistant", "content": [{"text": "hi bedrock"}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2}
+    });
+    assert_eq!(
+        response_codec(ProviderSurface::BedrockConverse)
+            .decode_response(&bedrock)
+            .expect("Bedrock Converse response decodes")
+            .response_text(),
+        Some("hi bedrock")
     );
 }
 

--- a/crates/core/tests/unit/llm_api_tests.rs
+++ b/crates/core/tests/unit/llm_api_tests.rs
@@ -32,6 +32,7 @@ use crate::api::scope::{COMPACTION_EVENT_NAME, EmitMarkEventParams, event};
 use crate::api::scope::{PopScopeParams, PushScopeParams, ScopeType, pop_scope, push_scope};
 use crate::api::subscriber::{deregister_subscriber, flush_subscribers, register_subscriber};
 use crate::codec::anthropic::AnthropicMessagesCodec;
+use crate::codec::bedrock_converse::BedrockConverseCodec;
 use crate::codec::oci_genai::OCIGenAIChatCodec;
 use crate::codec::openai_chat::OpenAIChatCodec;
 use crate::codec::openai_responses::OpenAIResponsesCodec;
@@ -1124,6 +1125,141 @@ fn request_projection_handles_history_edge_cases() {
     };
     project_llm_request_to_current_user_turn(&mut request, &mut annotated, Some(&OpenAIChatCodec));
     assert!(Arc::ptr_eq(annotated.as_ref().unwrap(), &original));
+}
+
+#[test]
+fn bedrock_tool_result_envelope_continues_the_current_user_turn() {
+    let codec = BedrockConverseCodec;
+    let mut request = LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({
+            "modelId": "amazon.nova-pro-v1:0",
+            "messages": [
+                {"role": "user", "content": [{"text": "earlier question"}]},
+                {"role": "assistant", "content": [{"text": "earlier answer"}]},
+                {"role": "user", "content": [{"text": "latest question"}]},
+                {"role": "assistant", "content": [{"toolUse": {
+                    "toolUseId": "call-1",
+                    "name": "search",
+                    "input": {"query": "latest"}
+                }}]},
+                {"role": "user", "content": [{"toolResult": {
+                    "toolUseId": "call-1",
+                    "content": [{"text": "latest result"}],
+                    "status": "success"
+                }}]}
+            ]
+        }),
+    };
+    let mut annotated = Some(Arc::new(codec.decode(&request).unwrap()));
+
+    project_llm_request_to_current_user_turn(&mut request, &mut annotated, Some(&codec));
+
+    let messages = request.content["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 3);
+    assert_eq!(messages[0]["content"][0]["text"], "latest question");
+    assert!(messages[1]["content"][0].get("toolUse").is_some());
+    assert!(messages[2]["content"][0].get("toolResult").is_some());
+    assert_eq!(annotated.unwrap().messages.len(), 3);
+}
+
+#[test]
+fn managed_bedrock_events_retain_the_complete_tool_continuation() {
+    let _guard = lock_global_runtime();
+    reset_global();
+    set_thread_scope_stack(create_scope_stack());
+
+    let events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let captured = events.clone();
+    register_subscriber(
+        "managed-bedrock-tool-continuation",
+        Arc::new(move |event| captured.lock().unwrap().push(event.clone())),
+    )
+    .unwrap();
+
+    let request = LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({
+            "modelId": "amazon.nova-pro-v1:0",
+            "messages": [
+                {"role": "user", "content": [{"text": "earlier question"}]},
+                {"role": "assistant", "content": [{"text": "earlier answer"}]},
+                {"role": "user", "content": [{"text": "latest question"}]},
+                {"role": "assistant", "content": [{"toolUse": {
+                    "toolUseId": "call-1",
+                    "name": "search",
+                    "input": {"query": "latest"}
+                }}]},
+                {"role": "user", "content": [{"toolResult": {
+                    "toolUseId": "call-1",
+                    "content": [{"text": "latest result"}],
+                    "status": "success"
+                }}]}
+            ]
+        }),
+    };
+    let initial_request = LlmRequest {
+        headers: serde_json::Map::new(),
+        content: json!({
+            "modelId": "amazon.nova-pro-v1:0",
+            "messages": [
+                {"role": "user", "content": [{"text": "earlier question"}]},
+                {"role": "assistant", "content": [{"text": "earlier answer"}]},
+                {"role": "user", "content": [{"text": "latest question"}]}
+            ]
+        }),
+    };
+    let codec: Arc<dyn LlmCodec> = Arc::new(BedrockConverseCodec);
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        for (name, call_request, expected_messages) in [
+            ("bedrock-fresh", initial_request, 3),
+            ("bedrock-continuation", request, 5),
+        ] {
+            llm_call_execute(
+                LlmCallExecuteParams::builder()
+                    .name(name)
+                    .request(call_request)
+                    .func(Arc::new(move |request| {
+                        Box::pin(async move {
+                            assert_eq!(
+                                request.content["messages"].as_array().unwrap().len(),
+                                expected_messages
+                            );
+                            Ok(json!({"response": "ok"}))
+                        })
+                    }))
+                    .codec(codec.clone())
+                    .build(),
+            )
+            .await
+            .unwrap();
+        }
+    });
+
+    flush_subscribers().unwrap();
+    assert!(deregister_subscriber("managed-bedrock-tool-continuation").unwrap());
+    let events = events.lock().unwrap();
+    let start = events
+        .iter()
+        .find(|event| {
+            event.name() == "bedrock-continuation"
+                && event.scope_category() == Some(ScopeCategory::Start)
+        })
+        .expect("missing projected Bedrock LLM start event");
+    let messages = start.input().unwrap()["content"]["messages"]
+        .as_array()
+        .unwrap();
+    assert_eq!(messages.len(), 3);
+    assert_eq!(messages[0]["content"][0]["text"], "latest question");
+    assert!(messages[1]["content"][0].get("toolUse").is_some());
+    assert!(messages[2]["content"][0].get("toolResult").is_some());
+    assert_eq!(start.annotated_request().unwrap().messages.len(), 3);
+    assert!(
+        !serde_json::to_string(start)
+            .unwrap()
+            .contains("earlier question")
+    );
 }
 
 #[test]

--- a/crates/core/tests/unit/native_plugin_tests.rs
+++ b/crates/core/tests/unit/native_plugin_tests.rs
@@ -6263,6 +6263,21 @@ fn native_llm_sanitize_context_preserves_all_codec_identity_states() {
             Some("anthropic_messages"),
         ),
         (
+            LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::GeminiGenerateContent),
+            NemoRelayNativeLlmCodecKind::BuiltIn,
+            Some("gemini_generate_content"),
+        ),
+        (
+            LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::OCIGenAI),
+            NemoRelayNativeLlmCodecKind::BuiltIn,
+            Some("oci_genai"),
+        ),
+        (
+            LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::BedrockConverse),
+            NemoRelayNativeLlmCodecKind::Opaque,
+            None,
+        ),
+        (
             LlmCodecIdentity::Runtime("com.example.chat.v1".into()),
             NemoRelayNativeLlmCodecKind::Runtime,
             Some("com.example.chat.v1"),
@@ -6297,6 +6312,23 @@ fn native_async_llm_sanitize_context_uses_stable_codec_envelope() {
     assert_eq!(
         native_async_codec_identity(&LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::OpenAiChat)),
         json!({"codec_kind": "builtin", "codec_id": "openai_chat"})
+    );
+    assert_eq!(
+        native_async_codec_identity(&LlmCodecIdentity::BuiltIn(
+            BuiltinLlmCodec::GeminiGenerateContent
+        )),
+        json!({"codec_kind": "builtin", "codec_id": "gemini_generate_content"}),
+        "ABI v4 plugins must keep receiving the Gemini ID they were compiled to understand"
+    );
+    assert_eq!(
+        native_async_codec_identity(&LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::OCIGenAI)),
+        json!({"codec_kind": "builtin", "codec_id": "oci_genai"}),
+        "native plugins must keep receiving the already-released OCI built-in ID"
+    );
+    assert_eq!(
+        native_async_codec_identity(&LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::BedrockConverse)),
+        json!({"codec_kind": "opaque", "codec_id": null}),
+        "new hosts must not send a post-v4 Bedrock built-in ID to plugins compiled against ABI v4"
     );
     assert_eq!(
         native_async_codec_identity(&LlmCodecIdentity::Runtime("com.example.chat.v1".into())),

--- a/crates/core/tests/unit/plugins/nemo_guardrails/component_tests.rs
+++ b/crates/core/tests/unit/plugins/nemo_guardrails/component_tests.rs
@@ -646,6 +646,7 @@ fn assert_invalid_local_config() {
     );
 }
 
+#[allow(clippy::cognitive_complexity)] // Keeps related invalid remote configuration cases together.
 fn assert_invalid_remote_identity_and_codec() {
     let remote_missing_identity = validate_plugin_config(&plugin_config(json!({
         "mode": "remote",
@@ -708,6 +709,18 @@ fn assert_invalid_remote_identity_and_codec() {
             ]
             .iter()
             .all(|name| diag.message.contains(name))
+    }));
+
+    let bedrock_codec = validate_plugin_config(&plugin_config(json!({
+        "mode": "local",
+        "codec": "bedrock_converse",
+        "config_path": "/tmp/guardrails"
+    })));
+    assert!(bedrock_codec.has_errors());
+    assert!(bedrock_codec.diagnostics.iter().any(|diag| {
+        diag.field.as_deref() == Some("codec")
+            && diag.message.contains("codec must be one of:")
+            && !diag.message.contains("bedrock_converse")
     }));
 
     let unsupported_remote_codec = validate_plugin_config(&plugin_config(json!({

--- a/crates/core/tests/unit/plugins/nemo_guardrails/local_python_tests.rs
+++ b/crates/core/tests/unit/plugins/nemo_guardrails/local_python_tests.rs
@@ -696,10 +696,15 @@ fn local_codec_and_rewrite_helpers_cover_all_provider_surfaces() {
     ] {
         assert_eq!(codec.provider_surface(), surface);
         assert_eq!(
-            LocalGuardrailsCodec::from_provider_surface(surface).provider_surface(),
+            LocalGuardrailsCodec::from_provider_surface(surface)
+                .expect("supported Guardrails surface")
+                .provider_surface(),
             surface
         );
     }
+    assert!(
+        LocalGuardrailsCodec::from_provider_surface(ProviderSurface::BedrockConverse).is_none()
+    );
 
     let mut config = NeMoGuardrailsConfig {
         input: false,

--- a/crates/node/pii_redaction.d.ts
+++ b/crates/node/pii_redaction.d.ts
@@ -40,7 +40,7 @@ export interface Config {
   tool_output?: boolean;
   mark?: boolean;
   priority?: number;
-  codec?: 'openai_chat' | 'openai_responses' | 'anthropic_messages' | 'oci_genai' | 'gemini_generate_content' | string;
+  codec?: 'openai_chat' | 'openai_responses' | 'anthropic_messages' | 'oci_genai' | 'gemini_generate_content' | 'bedrock_converse' | string;
   builtin?: BuiltinConfig;
   local?: LocalModelConfig;
   policy?: ConfigPolicy;

--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -11,7 +11,7 @@ export type LlmCodecIdentity =
   | { kind: 'none' }
   | {
       kind: 'builtin';
-      id: 'openai_chat' | 'openai_responses' | 'anthropic_messages' | 'oci_genai' | 'gemini_generate_content';
+      id: 'openai_chat' | 'openai_responses' | 'anthropic_messages' | 'oci_genai' | 'gemini_generate_content' | 'bedrock_converse';
     }
   | { kind: 'runtime'; id: string }
   | { kind: 'opaque' };

--- a/crates/node/src/types/mod.rs
+++ b/crates/node/src/types/mod.rs
@@ -698,6 +698,71 @@ impl GeminiGenerateContentCodec {
     }
 }
 
+/// Built-in codec for Amazon Bedrock Converse JSON-compatible SDK call envelopes.
+///
+/// AWS credentials, request signing, retry policy, and EventStream decoding remain
+/// the responsibility of the AWS SDK integration.
+#[napi(js_name = "BedrockConverseCodec")]
+pub struct BedrockConverseCodec {
+    pub(crate) inner_codec: std::sync::Arc<dyn LlmCodec>,
+    pub(crate) inner_response_codec: std::sync::Arc<dyn LlmResponseCodec>,
+}
+
+#[napi]
+impl BedrockConverseCodec {
+    #[napi(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner_codec: std::sync::Arc::new(
+                nemo_relay::codec::bedrock_converse::BedrockConverseCodec,
+            ),
+            inner_response_codec: std::sync::Arc::new(
+                nemo_relay::codec::bedrock_converse::BedrockConverseCodec,
+            ),
+        }
+    }
+
+    /// Decode an opaque LLM request into structured form.
+    #[napi]
+    pub fn decode(&self, request: Json) -> napi::Result<Json> {
+        let request: CoreLlmRequest = serde_json::from_value(request)
+            .map_err(|error| napi::Error::from_reason(format!("invalid LlmRequest: {error}")))?;
+        let annotated = self
+            .inner_codec
+            .decode(&request)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        serde_json::to_value(&annotated)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Merge structured edits into the original Converse call envelope.
+    #[napi]
+    pub fn encode(&self, annotated: Json, original: Json) -> napi::Result<Json> {
+        let annotated: AnnotatedLlmRequest =
+            serde_json::from_value(annotated).map_err(|error| {
+                napi::Error::from_reason(format!("invalid AnnotatedLlmRequest: {error}"))
+            })?;
+        let original: CoreLlmRequest = serde_json::from_value(original)
+            .map_err(|error| napi::Error::from_reason(format!("invalid LlmRequest: {error}")))?;
+        let result = self
+            .inner_codec
+            .encode(&annotated, &original)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        serde_json::to_value(&result).map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
+    /// Decode a buffered Converse response into structured form.
+    #[napi(js_name = "decodeResponse")]
+    pub fn decode_response(&self, response: Json) -> napi::Result<Json> {
+        let annotated = self
+            .inner_response_codec
+            .decode_response(&response)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        serde_json::to_value(&annotated)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+}
+
 /// Built-in codec for the Anthropic Messages API.
 ///
 /// Implements both request codec (decode/encode) and response codec

--- a/crates/node/tests/types_tests.mjs
+++ b/crates/node/tests/types_tests.mjs
@@ -27,6 +27,7 @@ describe('Type constants', () => {
     assert.equal(typeof lib.AnthropicMessagesCodec, 'function');
     assert.equal(typeof lib.OCIGenAIChatCodec, 'function');
     assert.equal(typeof lib.GeminiGenerateContentCodec, 'function');
+    assert.equal(typeof lib.BedrockConverseCodec, 'function');
   });
 
   it('scope type enum values', () => {
@@ -337,5 +338,44 @@ describe('GeminiGenerateContentCodec', () => {
       }),
       /parts.*text must be a string/,
     );
+  });
+});
+
+// ===========================================================================
+// BedrockConverseCodec
+// ===========================================================================
+
+describe('BedrockConverseCodec', () => {
+  const { BedrockConverseCodec } = lib;
+
+  it('round-trips a JSON-compatible SDK envelope', () => {
+    const codec = new BedrockConverseCodec();
+    const request = {
+      headers: {},
+      content: {
+        modelId: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+        inferenceConfig: { temperature: 0.2, maxTokens: 128 },
+        requestMetadata: { tenant: 'example' },
+      },
+    };
+    const annotated = codec.decode(request);
+    assert.equal(annotated.model, request.content.modelId);
+    assert.equal(annotated.messages[0].role, 'user');
+    assert.deepEqual(codec.encode(annotated, request), request);
+  });
+
+  it('decodes response text, usage, and stop reason without inventing a model', () => {
+    const codec = new BedrockConverseCodec();
+    const response = codec.decodeResponse({
+      output: { message: { role: 'assistant', content: [{ text: 'hi' }] } },
+      stopReason: 'end_turn',
+      usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 },
+      metrics: { latencyMs: 12 },
+    });
+    assert.deepEqual(response.message, [{ type: 'text', text: 'hi' }]);
+    assert.equal(response.finish_reason, 'complete');
+    assert.equal(response.model, undefined);
+    assert.equal(response.usage?.prompt_tokens, 4);
   });
 });

--- a/crates/pii-redaction/README.md
+++ b/crates/pii-redaction/README.md
@@ -34,7 +34,7 @@ NeMo Relay PII Redaction allows you to:
   structured secrets, and cloud credentials.
 - Handle codec-aware LLMs with overlay support for `openai_chat`,
   `openai_responses`, `anthropic_messages`, `oci_genai`, and
-  `gemini_generate_content`.
+  `gemini_generate_content`, and `bedrock_converse`.
 - Remove conversational trajectory content while preserving event structure,
   tool-call identity, model attribution, routing, usage, and cost analytics.
 - Use the `local_model` config contract and provider registration surface for

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -571,6 +571,9 @@ impl CompiledBuiltinBackend {
             LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::GeminiGenerateContent) => {
                 Some(ProviderSurface::GeminiGenerateContent)
             }
+            LlmCodecIdentity::BuiltIn(BuiltinLlmCodec::BedrockConverse) => {
+                Some(ProviderSurface::BedrockConverse)
+            }
             LlmCodecIdentity::Runtime(_) | LlmCodecIdentity::Opaque => None,
         }
     }

--- a/crates/pii-redaction/src/component.rs
+++ b/crates/pii-redaction/src/component.rs
@@ -285,7 +285,7 @@ nemo_relay::editor_config! {
         codec => {
             label: "codec",
             kind: Enum,
-            values: ["openai_chat", "openai_responses", "anthropic_messages", "oci_genai", "gemini_generate_content"],
+            values: ["openai_chat", "openai_responses", "anthropic_messages", "oci_genai", "gemini_generate_content", "bedrock_converse"],
             optional: true,
         },
         profiles => { label: "profiles", kind: List, list: &PII_REDACTION_PROFILE_LIST_ITEM },

--- a/crates/pii-redaction/src/overlay.rs
+++ b/crates/pii-redaction/src/overlay.rs
@@ -14,6 +14,7 @@ pub(crate) enum BuiltinCodecName {
     AnthropicMessages,
     OCIGenAI,
     GeminiGenerateContent,
+    BedrockConverse,
 }
 
 impl BuiltinCodecName {
@@ -24,6 +25,7 @@ impl BuiltinCodecName {
             ProviderSurface::AnthropicMessages => Self::AnthropicMessages,
             ProviderSurface::OCIGenAI => Self::OCIGenAI,
             ProviderSurface::GeminiGenerateContent => Self::GeminiGenerateContent,
+            ProviderSurface::BedrockConverse => Self::BedrockConverse,
         }
     }
 
@@ -38,8 +40,77 @@ impl BuiltinCodecName {
             Self::AnthropicMessages => overlay_anthropic_response(payload, annotated),
             Self::OCIGenAI => overlay_oci_genai_response(payload, annotated),
             Self::GeminiGenerateContent => overlay_gemini_response(payload, annotated),
+            Self::BedrockConverse => overlay_bedrock_converse_response(payload, annotated),
         }
     }
+}
+
+fn overlay_bedrock_converse_response(mut payload: Json, annotated: &AnnotatedLlmResponse) -> Json {
+    let Some(blocks) = payload
+        .get_mut("output")
+        .and_then(Json::as_object_mut)
+        .and_then(|output| output.get_mut("message"))
+        .and_then(Json::as_object_mut)
+        .and_then(|message| message.get_mut("content"))
+        .and_then(Json::as_array_mut)
+    else {
+        return payload;
+    };
+
+    let sanitized_parts = match annotated.message.as_ref() {
+        Some(MessageContent::Parts(parts)) => Some(
+            parts
+                .iter()
+                .filter_map(|part| match part {
+                    ContentPart::Text { text, .. } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ),
+        _ => None,
+    };
+    let sanitized_text = annotated_message_text(annotated.message.as_ref());
+    let mut sanitized_parts = sanitized_parts.as_ref().map(|parts| parts.iter());
+    let mut wrote_scalar_text = false;
+    blocks.retain_mut(|block| {
+        let Some(block) = block.as_object_mut() else {
+            return true;
+        };
+        if block.contains_key("text") {
+            let text = match sanitized_parts.as_mut() {
+                Some(parts) => parts.next().copied(),
+                None if !wrote_scalar_text => sanitized_text.as_deref(),
+                None => None,
+            };
+            let Some(text) = text else { return false };
+            block.insert("text".into(), Json::String(text.to_string()));
+            wrote_scalar_text = true;
+        }
+        true
+    });
+
+    let Some(tool_calls) = annotated.tool_calls.as_deref() else {
+        blocks.retain(|block| block.get("toolUse").is_none());
+        return payload;
+    };
+    let mut sanitized_calls = tool_calls.iter();
+    blocks.retain_mut(|block| {
+        let Some(tool_use) = block
+            .as_object_mut()
+            .and_then(|block| block.get_mut("toolUse"))
+            .and_then(Json::as_object_mut)
+        else {
+            return true;
+        };
+        let Some(call) = sanitized_calls.next() else {
+            return false;
+        };
+        set_optional_string_field(tool_use, "toolUseId", Some(call.id.as_str()));
+        set_optional_string_field(tool_use, "name", Some(call.name.as_str()));
+        tool_use.insert("input".into(), call.arguments.clone());
+        true
+    });
+    payload
 }
 
 fn gemini_message_parts_for_overlay(message: Option<&MessageContent>) -> Option<Vec<Json>> {

--- a/crates/pii-redaction/tests/coverage/overlay_tests.rs
+++ b/crates/pii-redaction/tests/coverage/overlay_tests.rs
@@ -923,3 +923,62 @@ fn oci_genai_overlay_maps_every_finish_reason_variant() {
         assert_eq!(overlaid["chatResponse"]["finishReason"], json!(v2));
     }
 }
+
+#[test]
+fn bedrock_converse_overlay_rewrites_text_and_tool_calls_without_touching_native_blocks() {
+    let payload = json!({
+        "output": {"message": {"role": "assistant", "content": [
+            {"text": "Alex Example"},
+            {"reasoningContent": {"reasoningText": {"text": "native"}}},
+            {"toolUse": {
+                "toolUseId": "call-1",
+                "name": "lookup",
+                "input": {"email": "alex@example.com"}
+            }}
+        ]}},
+        "stopReason": "tool_use"
+    });
+    let annotated = AnnotatedLlmResponse {
+        message: Some(MessageContent::Parts(vec![ContentPart::Text {
+            text: "[REDACTED]".into(),
+            extra: Default::default(),
+        }])),
+        tool_calls: Some(vec![tool_call(
+            "call-1",
+            "lookup",
+            json!({"email": "[REDACTED]"}),
+        )]),
+        ..AnnotatedLlmResponse::default()
+    };
+
+    let overlaid = BuiltinCodecName::BedrockConverse.overlay_response_payload(payload, &annotated);
+    let content = &overlaid["output"]["message"]["content"];
+    assert_eq!(content[0]["text"], "[REDACTED]");
+    assert_eq!(
+        content[1]["reasoningContent"]["reasoningText"]["text"],
+        "native"
+    );
+    assert_eq!(content[2]["toolUse"]["input"]["email"], "[REDACTED]");
+}
+
+#[test]
+fn bedrock_converse_overlay_drops_unmatched_tool_uses() {
+    let payload = json!({
+        "output": {"message": {"role": "assistant", "content": [
+            {"toolUse": {"toolUseId": "call-1", "name": "one", "input": {}}},
+            {"toolUse": {"toolUseId": "call-2", "name": "two", "input": {}}}
+        ]}}
+    });
+    let annotated = AnnotatedLlmResponse {
+        tool_calls: Some(vec![tool_call("call-1", "one", json!({}))]),
+        ..AnnotatedLlmResponse::default()
+    };
+    let overlaid = BuiltinCodecName::BedrockConverse.overlay_response_payload(payload, &annotated);
+    assert_eq!(
+        overlaid["output"]["message"]["content"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -29,6 +29,7 @@ use crate::api::tool::{
     ToolCallEndParams, ToolCallExecuteParams, ToolCallParams, ToolExecutionResult, tool_call,
     tool_call_end, tool_call_execute,
 };
+use crate::codec::bedrock_converse::BedrockConverseCodec;
 use crate::codec::openai_chat::OpenAIChatCodec;
 use crate::codec::openai_responses::OpenAIResponsesCodec;
 use crate::codec::request::AnnotatedLlmRequest;
@@ -784,6 +785,91 @@ async fn normalized_llm_response_paths_use_the_active_oci_genai_codec_identity()
         sanitized["chatResponse"]["choices"][0]["message"]["content"][0]["text"],
         json!("[REDACTED]")
     );
+}
+
+#[tokio::test]
+async fn normalized_llm_paths_use_the_active_bedrock_converse_codec_capability() {
+    let backend = crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            action: "regex_replace".to_string(),
+            pattern: Some("sk-[A-Za-z0-9_-]+".to_string()),
+            replacement: Some("[REDACTED]".to_string()),
+            target_paths: vec![
+                "/messages/0/content/0/text".to_string(),
+                "/message/0/text".to_string(),
+            ],
+            ..BuiltinBackendConfig::default()
+        },
+        None,
+    )
+    .unwrap();
+    let sanitize_request = crate::builtin::llm_sanitize_request_callback(backend.clone());
+    let sanitize_response = crate::builtin::llm_sanitize_response_callback(backend);
+
+    let sanitized_request = sanitize_request(
+        LlmRequest {
+            headers: serde_json::Map::new(),
+            content: json!({
+                "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"text": "contact sk-bedrock-request"},
+                        {"image": {"format": "png", "source": {"bytes": "AAAA"}}}
+                    ]
+                }],
+                "inferenceConfig": {"temperature": 0.0},
+                "requestMetadata": {"tenant": "preserved"}
+            }),
+        },
+        LlmSanitizeRequestContext::for_request_codec(Some(Arc::new(BedrockConverseCodec))),
+    )
+    .await
+    .expect("Bedrock request sanitizer should succeed")
+    .expect("Bedrock request sanitizer should retain the payload");
+    assert_eq!(
+        sanitized_request.content["messages"][0]["content"][0]["text"],
+        json!("contact [REDACTED]")
+    );
+    assert_eq!(
+        sanitized_request.content["messages"][0]["content"][1],
+        json!({"image": {"format": "png", "source": {"bytes": "AAAA"}}})
+    );
+    assert_eq!(
+        sanitized_request.content["requestMetadata"]["tenant"],
+        json!("preserved")
+    );
+
+    let sanitized_response = sanitize_response(
+        json!({
+            "output": {"message": {"role": "assistant", "content": [
+                {"text": "result sk-bedrock-response"},
+                {"reasoningContent": {"reasoningText": {"text": "provider-native"}}}
+            ]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10},
+            "metrics": {"latencyMs": 25}
+        }),
+        LlmSanitizeResponseContext::for_response_codec(Some(Arc::new(BedrockConverseCodec))),
+    )
+    .await
+    .expect("Bedrock response sanitizer should succeed")
+    .expect("Bedrock response sanitizer should retain the payload");
+    assert_eq!(
+        sanitized_response["output"]["message"]["content"][0]["text"],
+        json!("result [REDACTED]")
+    );
+    assert_eq!(
+        sanitized_response["output"]["message"]["content"][1],
+        json!({"reasoningContent": {"reasoningText": {"text": "provider-native"}}})
+    );
+    assert_eq!(sanitized_response["usage"]["totalTokens"], json!(10));
+    assert_eq!(sanitized_response["metrics"]["latencyMs"], json!(25));
+
+    let serialized_request = serde_json::to_string(&sanitized_request).unwrap();
+    let serialized_response = serde_json::to_string(&sanitized_response).unwrap();
+    assert!(!serialized_request.contains("sk-bedrock-request"));
+    assert!(!serialized_response.contains("sk-bedrock-response"));
 }
 
 #[tokio::test]

--- a/crates/plugin/tests/typed_callbacks.rs
+++ b/crates/plugin/tests/typed_callbacks.rs
@@ -4375,6 +4375,7 @@ fn typed_async_llm_sanitize_context_decodes_all_builtin_identities() {
         BuiltinLlmCodec::AnthropicMessages,
         BuiltinLlmCodec::OCIGenAI,
         BuiltinLlmCodec::GeminiGenerateContent,
+        BuiltinLlmCodec::BedrockConverse,
     ] {
         let host = test_host_v4();
         let mut ctx = test_context(&host.v3.v1);

--- a/crates/python/src/py_api/mod.rs
+++ b/crates/python/src/py_api/mod.rs
@@ -53,11 +53,11 @@ use uuid::Uuid;
 use crate::convert::{json_to_py, opt_py_to_json, opt_py_to_timestamp, py_to_json};
 use crate::py_callable;
 use crate::py_types::{
-    PyAnnotatedLLMResponse, PyAnthropicMessagesCodec, PyGeminiGenerateContentCodec,
-    PyLLMAttributes, PyLLMHandle, PyLLMRequest, PyLlmStream, PyLogSeverity, PyMetricMeasurement,
-    PyOCIGenAIChatCodec, PyOpenAIChatCodec, PyOpenAIResponsesCodec, PyPropagationContext,
-    PyScopeAttributes, PyScopeHandle, PyScopeStack, PyScopeType, PyThreadScopeStackBinding,
-    PyToolAttributes, PyToolExecutionResult, PyToolHandle,
+    PyAnnotatedLLMResponse, PyAnthropicMessagesCodec, PyBedrockConverseCodec,
+    PyGeminiGenerateContentCodec, PyLLMAttributes, PyLLMHandle, PyLLMRequest, PyLlmStream,
+    PyLogSeverity, PyMetricMeasurement, PyOCIGenAIChatCodec, PyOpenAIChatCodec,
+    PyOpenAIResponsesCodec, PyPropagationContext, PyScopeAttributes, PyScopeHandle, PyScopeStack,
+    PyScopeType, PyThreadScopeStackBinding, PyToolAttributes, PyToolExecutionResult, PyToolHandle,
 };
 
 pub(crate) type RustJsonStream = LlmJsonStream;
@@ -345,6 +345,9 @@ fn py_llm_response_codec(
         if let Ok(builtin) = c.extract::<pyo3::PyRef<'_, PyGeminiGenerateContentCodec>>() {
             return Some(builtin.inner_response_codec.clone());
         }
+        if let Ok(builtin) = c.extract::<pyo3::PyRef<'_, PyBedrockConverseCodec>>() {
+            return Some(builtin.inner_response_codec.clone());
+        }
         // Fall back to wrapping the Python object as a custom response codec
         Some(Arc::new(py_callable::PyLlmResponseCodecWrapper {
             py_codec: c.clone().unbind(),
@@ -370,6 +373,9 @@ fn py_llm_codec(codec: Option<&Bound<'_, PyAny>>) -> Option<Arc<dyn LlmCodec>> {
             return Some(builtin.inner_codec.clone());
         }
         if let Ok(builtin) = codec.extract::<pyo3::PyRef<'_, PyGeminiGenerateContentCodec>>() {
+            return Some(builtin.inner_codec.clone());
+        }
+        if let Ok(builtin) = codec.extract::<pyo3::PyRef<'_, PyBedrockConverseCodec>>() {
             return Some(builtin.inner_codec.clone());
         }
         Some(Arc::new(py_callable::PyLlmCodecWrapper {

--- a/crates/python/src/py_types/codecs.rs
+++ b/crates/python/src/py_types/codecs.rs
@@ -1149,3 +1149,63 @@ impl PyGeminiGenerateContentCodec {
         "<GeminiGenerateContentCodec>"
     }
 }
+
+/// Built-in codec for the Amazon Bedrock Converse API.
+///
+/// Implements request decode/encode and buffered response decode for JSON-compatible
+/// SDK call envelopes. AWS credential, signing, retry, and transport behavior remains
+/// owned by the AWS SDK integration.
+#[pyclass(name = "BedrockConverseCodec")]
+pub struct PyBedrockConverseCodec {
+    pub(crate) inner_codec: Arc<dyn LlmCodec>,
+    pub(crate) inner_response_codec: Arc<dyn LlmResponseCodec>,
+}
+
+#[pymethods]
+impl PyBedrockConverseCodec {
+    #[new]
+    pub(crate) fn new() -> Self {
+        Self {
+            inner_codec: Arc::new(nemo_relay::codec::bedrock_converse::BedrockConverseCodec),
+            inner_response_codec: Arc::new(
+                nemo_relay::codec::bedrock_converse::BedrockConverseCodec,
+            ),
+        }
+    }
+
+    /// Parse an opaque ``LlmRequest`` into a structured ``AnnotatedLLMRequest``.
+    pub(crate) fn decode(&self, request: &PyLLMRequest) -> PyResult<PyAnnotatedLLMRequest> {
+        self.inner_codec
+            .decode(&request.inner)
+            .map(|inner| PyAnnotatedLLMRequest { inner })
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    }
+
+    /// Merge structured changes back into the original Converse call envelope.
+    pub(crate) fn encode(
+        &self,
+        annotated: &PyAnnotatedLLMRequest,
+        original: &PyLLMRequest,
+    ) -> PyResult<PyLLMRequest> {
+        self.inner_codec
+            .encode(&annotated.inner, &original.inner)
+            .map(|inner| PyLLMRequest { inner })
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    }
+
+    /// Parse a buffered Converse response into structured form.
+    pub(crate) fn decode_response(
+        &self,
+        response: &Bound<'_, PyAny>,
+    ) -> PyResult<PyAnnotatedLLMResponse> {
+        let response = py_to_json(response)?;
+        self.inner_response_codec
+            .decode_response(&response)
+            .map(|inner| PyAnnotatedLLMResponse { inner })
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    }
+
+    pub(crate) fn __repr__(&self) -> &'static str {
+        "<BedrockConverseCodec>"
+    }
+}

--- a/crates/python/src/py_types/mod.rs
+++ b/crates/python/src/py_types/mod.rs
@@ -200,6 +200,7 @@ fn register_codec_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAnthropicMessagesCodec>()?;
     m.add_class::<PyOCIGenAIChatCodec>()?;
     m.add_class::<PyGeminiGenerateContentCodec>()?;
+    m.add_class::<PyBedrockConverseCodec>()?;
     Ok(())
 }
 

--- a/crates/types/src/codec/identity.rs
+++ b/crates/types/src/codec/identity.rs
@@ -55,6 +55,8 @@ builtin_llm_codecs! {
     OCIGenAI => "oci_genai",
     /// Gemini generateContent request and response payloads.
     GeminiGenerateContent => "gemini_generate_content",
+    /// Amazon Bedrock Converse request and response payloads.
+    BedrockConverse => "bedrock_converse",
 }
 
 /// Per-call LLM codec identity supplied to sanitizer and SDK callbacks.

--- a/crates/worker/tests/unit/codec_identity_tests.rs
+++ b/crates/worker/tests/unit/codec_identity_tests.rs
@@ -14,6 +14,7 @@ fn known_builtin_codec_identities_decode_as_builtins() {
         BuiltinLlmCodec::AnthropicMessages,
         BuiltinLlmCodec::OCIGenAI,
         BuiltinLlmCodec::GeminiGenerateContent,
+        BuiltinLlmCodec::BedrockConverse,
     ] {
         let proto = ProtoIdentity {
             kind: LlmCodecKind::Builtin as i32,

--- a/docs/about-nemo-relay/concepts/codecs.mdx
+++ b/docs/about-nemo-relay/concepts/codecs.mdx
@@ -99,8 +99,8 @@ changing a key overlays it.
 
 `AnnotatedLlmRequest` separates portable and provider-specific data:
 
-- `instructions` represents Anthropic `system` and OpenAI Responses
-  `instructions`.
+- `instructions` represents Anthropic `system`, Bedrock Converse `system`, and
+  OpenAI Responses `instructions`.
 - `messages`, content parts, function calls and results, tools, and tool choice
   expose portable components when the provider formats have equivalent meaning.
 - `api_specific` is a tagged, mutable field for modeled Anthropic Messages,
@@ -171,8 +171,9 @@ reused without changing public binding APIs.
 ### Provider Schema Extraction
 
 Provider codecs extract provider schema fields. The built-in codecs for OpenAI
-Chat Completions, OpenAI Responses, Anthropic Messages, and Gemini
-`generateContent` recognize their request and response payloads and map them
+Chat Completions, OpenAI Responses, Anthropic Messages, OCI Generative AI,
+Gemini `generateContent`, and Amazon Bedrock Converse recognize their request
+and response payloads and map them
 into `AnnotatedLlmRequest` or `AnnotatedLlmResponse`.
 
 When a managed LLM event already has an annotation, subscribers and exporters
@@ -215,14 +216,17 @@ Provider request extraction can also pass a narrow provider hint into codec
 normalization. For example, the recognized `anthropic` and `anthropic.messages`
 hints let Anthropic Messages requests without a top-level `system` field decode
 through the Anthropic codec instead of being inferred as OpenAI Chat payloads
-from their fields alone.
+from their fields alone. Bedrock Converse is identified by its provider-specific
+`modelId` field plus Converse request fields; `aws.bedrock.converse` and
+`bedrock.converse` can also identify a partially built envelope.
 
 The `nemo-relay` gateway always enables matching OpenAI Chat, OpenAI Responses,
 and Anthropic Messages request codecs for the provider generation routes it
 proxies: `/v1/messages`, `/v1/chat/completions`, and `/v1/responses`, for both
-buffered and streaming execution. Gemini `generateContent` does not yet have a
-gateway route, so `GeminiGenerateContentCodec` is available for direct framework
-use rather than gateway auto-selection. Count-token, model, probe, and non-LLM
+buffered and streaming execution. Gemini `generateContent`, OCI Generative AI,
+and Bedrock Converse do not yet have gateway routes, so their codecs are
+available for direct framework use rather than gateway auto-selection.
+Count-token, model, probe, and non-LLM
 passthrough routes do not enable request codecs automatically. Gateway request
 intercepts must therefore edit generation bodies through `annotated_request`;
 raw `request.content` remains writable on routes without a request codec.

--- a/docs/about-nemo-relay/concepts/middleware.mdx
+++ b/docs/about-nemo-relay/concepts/middleware.mdx
@@ -419,15 +419,20 @@ response: (Json, LlmSanitizeResponseContext) -> Option<Json>
 
 `context.codec` is a binding-native codec identity, not a JSON payload.
 Python and Node.js expose `kind` and, when applicable, `id` properties.
-In-process Rust and the typed native Rust SDK expose enum variants. The raw
-native ABI exposes the same information through `codec_kind` and `codec_id`.
+In-process Rust exposes enum variants, and dynamic workers receive the built-in
+ID as an open string. The raw native ABI v4 and the typed native Rust SDK built
+on it expose the original v4 built-in IDs through `codec_kind` and `codec_id`.
+Newer built-ins cross that compatibility boundary as `opaque` while retaining
+a usable callback-scoped codec handle.
 
 `codec.kind` is `none` for a call with no codec, `builtin` for
-Relay's built-in `openai_chat`, `openai_responses`, `anthropic_messages`, `oci_genai`, and
-`gemini_generate_content`
+Relay's built-in `openai_chat`, `openai_responses`, `anthropic_messages`,
+`oci_genai`, `gemini_generate_content`, and `bedrock_converse`
 codecs, `runtime` for a named runtime-registered codec, and `opaque` for an
 active codec without a registered identity. `codec.id` is present only for
-`builtin` and `runtime`. Do not infer a provider from an opaque request shape.
+`builtin` and `runtime`. In the raw native ABI v4, `bedrock_converse` is
+reported as `opaque` because that identity was introduced after ABI v4.
+Do not infer a provider from an opaque request shape.
 
 Return a payload to continue the sanitizer chain. Return `None` (or `null` in
 JavaScript) only when observing the payload would be unsafe: Relay omits the

--- a/docs/build-plugins/native/native-abi-reference.mdx
+++ b/docs/build-plugins/native/native-abi-reference.mdx
@@ -194,7 +194,10 @@ because the host does not call it again.
 LLM sanitizer contexts report codec kind `None`, `BuiltIn`, `Runtime`, or `Opaque`, an
 optional codec ID, and a borrowed callback-lifetime handle. Built-in IDs are
 `openai_chat`, `openai_responses`, `anthropic_messages`, `oci_genai`, and
-`gemini_generate_content`. Runtime and opaque codecs can still have a usable handle.
+`gemini_generate_content`. The `bedrock_converse` identity was not part of the released
+ABI v4 named-ID contract, so an ABI v4 plugin receives it as `Opaque`; its callback-scoped
+codec handle remains usable.
+Runtime and opaque codecs can still have a usable handle.
 
 Request handles support decode to an annotated request and encode of normalized changes
 onto the original envelope. Response handles support decode to an annotated response.

--- a/docs/build-plugins/workers/grpc-v1-protocol.mdx
+++ b/docs/build-plugins/workers/grpc-v1-protocol.mdx
@@ -237,10 +237,10 @@ its qualification in the host registries.
 
 `LlmCodecKind` has four wire values: unspecified, built-in, runtime, and opaque. A built-in
 identity carries `openai_chat`, `openai_responses`, `anthropic_messages`, `oci_genai`,
-or `gemini_generate_content`; a runtime identity carries its registered ID. An opaque
-identity deliberately withholds an ID. The capability ID is optional and
-invocation-scoped. A worker must treat it as a secret and must not use it after the owner
-invocation ends.
+`gemini_generate_content`, or `bedrock_converse`; a runtime identity carries its
+registered ID. An opaque identity deliberately withholds an ID. The capability ID is
+optional and invocation-scoped. A worker must treat it as a secret and must not use it
+after the owner invocation ends.
 
 ## Host-Runtime Service
 

--- a/docs/configure-plugins/adaptive/response-cache.mdx
+++ b/docs/configure-plugins/adaptive/response-cache.mdx
@@ -305,7 +305,7 @@ Only complete, replayable LLM answers are stored:
   stored interaction (`previous_response_id`), or references server-side state
   (`conversation`, `container`). Their answers depend on state the cache key
   cannot see.
-- Streaming calls are cached too. On a miss the live chunks are forwarded to
+- Supported provider streams are cached too. On a miss the live chunks are forwarded to
   the consumer while being assembled into one aggregate response — the same
   shape a buffered call stores, so buffered and streaming calls share one
   keyspace. On a hit the stored answer is replayed as provider-native chunks
@@ -317,7 +317,9 @@ Only complete, replayable LLM answers are stored:
   Responses answers with `status = "incomplete"`, streams without a terminal
   event, and streams whose content cannot be replayed faithfully are never
   stored. A streaming request whose surface cannot be inferred runs live,
-  uncached.
+  uncached. Amazon Bedrock `ConverseStream` also runs live and uncached in this
+  release because Relay cannot yet synthesize a faithful native event stream
+  from a stored Converse response.
 
 Streaming publication is write-behind: Relay can report end-of-stream before
 the backend write finishes. `wait_for_idle()` does not wait for cache writes.
@@ -370,12 +372,14 @@ normalization:
 
 ### `logical`
 
-Everything keys exactly as `exact_request` except the `tools` array: each tool
-is keyed on its full definition with human-readable `description` text
-removed, and the array is sorted. Rewording a tool description or reordering
-the `tools` array no longer busts the cache; any other change to a tool
-definition — its name, its parameter schema (including constraints such as
-`enum` and `required`), its type, or its settings — still does.
+Everything keys exactly as `exact_request` except the provider's tool array
+(`tools`, or `toolConfig.tools` for Bedrock Converse): each tool is keyed on
+its full definition with human-readable `description` text removed, and the
+array is sorted. Rewording a tool description or reordering the tool array no
+longer busts the cache; any other change to a tool definition — its name, its
+parameter schema (including constraints such as `enum` and `required`), its
+type, or its settings — still does. Controls beside the array, such as Bedrock
+Converse `toolConfig.toolChoice`, remain in the key.
 
 ```toml
 [components.config.response_cache]
@@ -481,8 +485,8 @@ Tool marks use `surface = "tool"`. Unclassified tools that use the default
 policy and explicitly uncacheable tools emit a `bypass` mark with
 `reason = "uncacheable"` before Relay runs the tool.
 
-Other bypass reasons include `sampled`, `stateful_store`, and
-`stream_no_codec`. A failed cache-store operation produces a `miss` with
+Other bypass reasons include `sampled`, `stateful_store`, `stream_no_codec`,
+and `stream_no_replay`. A failed cache-store operation produces a `miss` with
 `reason = "store_error"`.
 
 Cache marks do not contain prompts, answers, or credentials. Treat `key_hash`
@@ -505,7 +509,7 @@ cacheable classes and cacheable overrides, plus the default policy.
 | `namespace` | `""` (unconfigured) | Required non-empty trust-domain partition folded into every key. Empty or whitespace-only values are rejected. |
 | `priority` | `50` | LLM execution intercept priority. Lower values run earlier. |
 | `bypass_rate` | `0.0` | Probability in `[0.0, 1.0]` of running a cacheable call live. A sampled call attempts to refresh the entry when its result is cacheable and the write succeeds. |
-| `cache_nondeterministic` | `false` | Only requests with an explicit numeric `temperature = 0` are eligible. Set `true` to cache and reuse sampled responses. |
+| `cache_nondeterministic` | `false` | Only requests with an explicit numeric `temperature = 0` in the provider's supported request location are eligible. Set `true` to cache and reuse sampled responses. |
 | `key_strategy` | `"exact_request"` | What counts as the same request: `"exact_request"` or `"logical"`. Refer to [Key Strategies](#key-strategies). |
 | `header_allowlist` | `[]` | Trusted, non-secret response-affecting headers folded into the key (case-insensitive). A non-empty normalized allowlist policy also partitions the key. Known auth headers are rejected. |
 | `backend.kind` | `"in_memory"` | `"in_memory"`, or `"redis"` (requires building with the `redis-backend` feature). |

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -134,7 +134,7 @@ The following table compares the available PII redaction backends:
 | Managed `tool_input` | Supported | Not implemented |
 | Managed `tool_output` | Supported | Not implemented |
 | Built-in actions | `remove`, `redact`, `regex_replace`, `hash`, `mask` | N/A |
-| Codec support | `openai_chat`, `openai_responses`, `anthropic_messages`, `oci_genai`, `gemini_generate_content` | Runtime-specific future implementation |
+| Codec support | `openai_chat`, `openai_responses`, `anthropic_messages`, `oci_genai`, `gemini_generate_content`, `bedrock_converse` | Runtime-specific future implementation |
 | Runtime availability | Any runtime that includes the `nemo-relay-pii-redaction` plugin crate | Runtimes that install a local backend provider |
 
 ## Built-in Mode

--- a/docs/integrate-into-frameworks/provider-codecs.mdx
+++ b/docs/integrate-into-frameworks/provider-codecs.mdx
@@ -94,6 +94,7 @@ Use the built-in provider codecs when the framework payload already matches a su
 - `OCIGenAIChatCodec`: OCI Generative AI chat-compatible requests and responses
   in the `GENERIC`, `COHERE`, and `COHEREV2` API formats.
 - `GeminiGenerateContentCodec`: Gemini `generateContent`-compatible requests and responses.
+- `BedrockConverseCodec`: Amazon Bedrock Converse-compatible JSON request envelopes and responses.
 
 ## Provider Codec Roles
 
@@ -111,16 +112,53 @@ The built-in provider codecs expose the same core methods:
 | Anthropic Messages | `nemo_relay.codecs.AnthropicMessagesCodec` | `AnthropicMessagesCodec` from `nemo-relay-node` | `decode`, `encode`, `decode_response` / `decodeResponse` |
 | OCI Generative AI chat | `nemo_relay.codecs.OCIGenAIChatCodec` | `OCIGenAIChatCodec` from `nemo-relay-node` | `decode`, `encode`, `decode_response` / `decodeResponse` |
 | Gemini `generateContent` | `nemo_relay.codecs.GeminiGenerateContentCodec` | `GeminiGenerateContentCodec` from `nemo-relay-node` | `decode`, `encode`, `decode_response` / `decodeResponse` |
+| Amazon Bedrock Converse | `nemo_relay.codecs.BedrockConverseCodec` | `BedrockConverseCodec` from `nemo-relay-node` | `decode`, `encode`, `decode_response` / `decodeResponse` |
 
 Choose the provider codec that matches the payload shape the framework already sends to the provider. Do not translate to a different provider shape only to make the codec fit.
 
 The `nemo-relay` gateway selects the matching request codec automatically on the
 provider generation routes it proxies: `/v1/messages`, `/v1/chat/completions`,
 and `/v1/responses`, for both buffered and streaming calls. Gemini
-`generateContent` and OCI Generative AI chat do not yet have gateway routes,
-so use `GeminiGenerateContentCodec` or `OCIGenAIChatCodec` directly when a
-framework sends those payload shapes. Count-token, model, probe, and non-LLM
-passthrough routes do not use request codecs.
+`generateContent`, OCI Generative AI chat, and Amazon Bedrock Converse do not
+yet have gateway routes. Use their codecs directly when a framework owns those
+provider calls. Count-token, model, probe, and non-LLM passthrough routes do not
+use request codecs.
+
+### Amazon Bedrock Converse Boundary
+
+`BedrockConverseCodec` accepts the JSON-compatible keyword envelope passed to an
+AWS SDK call, including `modelId`, `messages`, `system`, `inferenceConfig`, and
+`toolConfig`. It normalizes text, JSON tool calls/results, common inference
+controls, stop reasons, and token usage while preserving unmodeled Bedrock
+fields in the original payload.
+
+The codec is not an AWS client. The application-owned AWS SDK remains
+responsible for credentials, endpoint selection, SigV4 signing, retries,
+timeouts, and decoding the AWS EventStream returned by `ConverseStream`. Rust
+integrations can obtain Relay's built-in collector with
+`nemo_relay::codec::resolve::streaming_codec(ProviderSurface::BedrockConverse)`
+and feed it decoded event dictionaries. The Python and Node.js codec classes
+currently expose buffered `decode`, `encode`, and response-decode methods only;
+streaming integrations in those languages must provide a collector and
+finalizer to Relay's typed stream APIs. The built-in Rust aggregator
+reconstructs text and JSON tool-use blocks. If it encounters
+reasoning, citation, image, tool-result, or a future union member, it forwards
+the application stream unchanged but omits the normalized final response rather
+than reporting partial coverage. SDK-native `bytes` values used by image and
+document blocks are outside Relay's JSON boundary; use a typed adapter or
+preserve them outside the managed JSON value.
+
+Converse request shapes overlap OpenAI Chat and Anthropic Messages, but the
+provider-specific `modelId` field lets Relay classify ordinary Converse
+envelopes safely. The provider hints `aws.bedrock.converse` and
+`bedrock.converse` remain available for partially built request envelopes. Pass
+the request model ID separately as `model_name` on the managed LLM call because
+Converse responses do not echo it.
+
+Native ABI v4 plugins receive this post-v4 codec identity as `opaque` while
+retaining the callback-scoped codec capability. This keeps plugins built before
+Relay 0.9 from rejecting a new built-in ID; a future versioned capability
+negotiation can expose the named identity safely.
 
 ## Example: Add a System Message with a Provider Codec
 

--- a/docs/integrate-into-frameworks/provider-response-codecs.mdx
+++ b/docs/integrate-into-frameworks/provider-response-codecs.mdx
@@ -349,7 +349,8 @@ No exporter emits a running cross-call total other than ATIF `final_metrics`.
 All normalized fields are optional. A provider can omit a field, while a codec can
 compute one (such as Anthropic's `total_tokens`) and configured pricing can
 synthesize `cost`. `Usage` has no catch-all field, so provider usage fields that
-Relay does not model are dropped.
+Relay does not model are absent from the normalized `Usage` value. A codec can
+still retain provider-specific details under `api_specific`.
 
 | Field | Meaning |
 |---|---|
@@ -362,21 +363,24 @@ Relay does not model are dropped.
 
 Built-in codecs normalize provider field names as follows:
 
-| Normalized Field | OpenAI Chat | OpenAI Responses | Anthropic Messages | OCI Generative AI | Gemini `generateContent` |
-|---|---|---|---|---|---|
-| `prompt_tokens` | `prompt_tokens` | `input_tokens` | `input_tokens` | `promptTokens` | `promptTokenCount` |
-| `completion_tokens` | `completion_tokens` | `output_tokens` | `output_tokens` | `completionTokens` | `candidatesTokenCount` |
-| `total_tokens` | `total_tokens` | `total_tokens` | computed | `totalTokens` | `totalTokenCount` (or computed as prompt + candidates + thinking) |
-| `cache_read_tokens` | `prompt_tokens_details.cached_tokens` | `input_tokens_details.cached_tokens` | `cache_read_input_tokens` | `promptTokensDetails.cachedTokens` | `cachedContentTokenCount` |
-| `cache_write_tokens` | — | — | `cache_creation_input_tokens` | — | — |
-| `cost` | `cost_usd`, structured `cost`, or scalar `cost` (OpenRouter; USD provider-reported total) | `cost_usd` or structured `cost` | `cost_usd` or structured `cost` | — | — |
+| Normalized Field | OpenAI Chat | OpenAI Responses | Anthropic Messages | OCI Generative AI | Gemini `generateContent` | Bedrock Converse |
+|---|---|---|---|---|---|---|
+| `prompt_tokens` | `prompt_tokens` | `input_tokens` | `input_tokens` | `promptTokens` | `promptTokenCount` | `inputTokens` |
+| `completion_tokens` | `completion_tokens` | `output_tokens` | `output_tokens` | `completionTokens` | `candidatesTokenCount` | `outputTokens` |
+| `total_tokens` | `total_tokens` | `total_tokens` | computed | `totalTokens` | `totalTokenCount` (or computed as prompt + candidates + thinking) | `totalTokens` |
+| `cache_read_tokens` | `prompt_tokens_details.cached_tokens` | `input_tokens_details.cached_tokens` | `cache_read_input_tokens` | `promptTokensDetails.cachedTokens` | `cachedContentTokenCount` | `cacheReadInputTokens` |
+| `cache_write_tokens` | — | — | `cache_creation_input_tokens` | — | — | `cacheWriteInputTokens` |
+| `cost` | `cost_usd`, structured `cost`, or scalar `cost` (OpenRouter; USD provider-reported total) | `cost_usd` or structured `cost` | `cost_usd` or structured `cost` | — | — | — |
 
 Gemini `generateContent` thinking tokens (`thoughtsTokenCount`) are stored in `api_specific.thoughts_tokens` rather than `completion_tokens`, because Google bills them as output tokens but reports them separately. The cost estimate folds them into the effective output-token count so that the pricing table reflects the real billing cost.
 
-Built-in codecs preserve only modeled provider-specific usage details under
-`api_specific`; other usage fields are dropped. For example, OpenAI Responses
-reasoning token counts are kept under `api_specific` (`output_tokens_details`),
-but OpenAI Chat `completion_tokens_details` is not.
+Most built-in codecs preserve only modeled provider-specific usage details
+under `api_specific`; other usage fields are dropped. For example, OpenAI
+Responses reasoning token counts are kept under `api_specific`
+(`output_tokens_details`), but OpenAI Chat `completion_tokens_details` is not.
+Bedrock Converse is the exception: it retains the complete provider `usage`
+object under `api_specific`, including fields such as `cacheDetails`, while
+also filling the portable normalized counters above.
 
 ### Cost Fields
 
@@ -449,6 +453,12 @@ The built-in provider codecs also implement response decoding:
 - `AnthropicMessagesCodec` — Anthropic Messages API
 - `OCIGenAIChatCodec` — OCI Generative AI chat API (`GENERIC`, `COHERE`, and `COHEREV2` formats)
 - `GeminiGenerateContentCodec` — Google Gemini `generateContent` API
+- `BedrockConverseCodec` — Amazon Bedrock Converse API (JSON-compatible SDK values)
+
+Bedrock stop reasons with a direct portable meaning are normalized. Provider-
+specific outcomes such as `model_context_window_exceeded` and
+`malformed_model_output` remain `Unknown` with their original string preserved;
+Relay does not misclassify them as an ordinary length or completion result.
 
 Choose the codec that matches the actual provider response shape. For example, do not use `OpenAIChatCodec` for an OpenAI Responses API payload only because both came from an OpenAI-compatible provider.
 

--- a/docs/integrate-into-frameworks/using-codecs.mdx
+++ b/docs/integrate-into-frameworks/using-codecs.mdx
@@ -38,7 +38,7 @@ Typed value codecs are different from provider codecs:
 | Codec Type | Purpose | Common Use |
 |---|---|---|
 | Typed value codec | Converts application values to and from JSON. | Dataclasses, Pydantic models, TypeScript object shapes, custom framework types. |
-| Provider codec | Converts provider-specific LLM requests and responses to annotated NeMo Relay request or response data. | OpenAI Chat, OpenAI Responses, Anthropic Messages, OCI Generative AI chat, Gemini `generateContent`, custom provider payloads. |
+| Provider codec | Converts provider-specific LLM requests and responses to annotated NeMo Relay request or response data. | OpenAI Chat, OpenAI Responses, Anthropic Messages, OCI Generative AI chat, Gemini `generateContent`, Amazon Bedrock Converse, custom provider payloads. |
 
 Use this page for typed value codecs. Use [Provider Codecs](/integrate-into-frameworks/provider-codecs) when request intercepts or request-side middleware need normalized LLM messages, tools, model names, and generation parameters, or when subscribers and exporters need provider response annotations.
 

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -1443,6 +1443,22 @@ class GeminiGenerateContentCodec:
         """Decode a Gemini response into a normalized response view."""
         ...
 
+class BedrockConverseCodec:
+    """Built-in codec for Amazon Bedrock Converse requests and responses."""
+
+    def __init__(self) -> None:
+        """Create a Bedrock Converse codec."""
+        ...
+    def decode(self, request: LLMRequest) -> AnnotatedLLMRequest:
+        """Decode a JSON-compatible Converse SDK call envelope."""
+        ...
+    def encode(self, annotated: AnnotatedLLMRequest, original: LLMRequest) -> LLMRequest:
+        """Merge normalized edits into the original Converse call envelope."""
+        ...
+    def decode_response(self, response: _Json) -> AnnotatedLLMResponse:
+        """Decode a buffered Converse response."""
+        ...
+
 class AdaptiveRuntime:
     """Hosted adaptive runtime bridge implemented by the native extension.
 

--- a/python/nemo_relay/codecs.py
+++ b/python/nemo_relay/codecs.py
@@ -47,6 +47,7 @@ from nemo_relay import Json
 from nemo_relay._native import (
     AnnotatedLLMRequest,
     AnthropicMessagesCodec,
+    BedrockConverseCodec,
     GeminiGenerateContentCodec,
     LLMRequest,
     OCIGenAIChatCodec,
@@ -163,6 +164,7 @@ class LlmResponseCodec(Protocol):
 __all__ = [
     "AnnotatedLLMRequest",
     "AnthropicMessagesCodec",
+    "BedrockConverseCodec",
     "GeminiGenerateContentCodec",
     "LlmCodec",
     "LlmResponseCodec",

--- a/python/nemo_relay/codecs.pyi
+++ b/python/nemo_relay/codecs.pyi
@@ -239,9 +239,24 @@ class GeminiGenerateContentCodec:
         """
         ...
 
+class BedrockConverseCodec:
+    """Built-in codec for Amazon Bedrock Converse requests and responses."""
+
+    def __init__(self) -> None: ...
+    def decode(self, request: LLMRequest) -> AnnotatedLLMRequest:
+        """Decode a JSON-compatible Converse SDK call envelope."""
+        ...
+    def encode(self, annotated: AnnotatedLLMRequest, original: LLMRequest) -> LLMRequest:
+        """Merge normalized edits into the original Converse call envelope."""
+        ...
+    def decode_response(self, response: Json) -> AnnotatedLLMResponse:
+        """Decode a buffered Converse response."""
+        ...
+
 __all__ = [
     "AnnotatedLLMRequest",
     "AnthropicMessagesCodec",
+    "BedrockConverseCodec",
     "GeminiGenerateContentCodec",
     "LlmCodec",
     "LlmResponseCodec",

--- a/python/nemo_relay/pii_redaction.py
+++ b/python/nemo_relay/pii_redaction.py
@@ -139,7 +139,14 @@ class PiiRedactionConfig:
     mark: bool = True
     priority: int = 100
     codec: (
-        Literal["openai_chat", "openai_responses", "anthropic_messages", "oci_genai", "gemini_generate_content"]
+        Literal[
+            "openai_chat",
+            "openai_responses",
+            "anthropic_messages",
+            "oci_genai",
+            "gemini_generate_content",
+            "bedrock_converse",
+        ]
         | str
         | None
     ) = None

--- a/python/nemo_relay/pii_redaction.pyi
+++ b/python/nemo_relay/pii_redaction.pyi
@@ -60,7 +60,14 @@ class PiiRedactionConfig:
     mark: bool = ...
     priority: int = ...
     codec: (
-        Literal["openai_chat", "openai_responses", "anthropic_messages", "oci_genai", "gemini_generate_content"]
+        Literal[
+            "openai_chat",
+            "openai_responses",
+            "anthropic_messages",
+            "oci_genai",
+            "gemini_generate_content",
+            "bedrock_converse",
+        ]
         | str
         | None
     ) = ...

--- a/python/tests/plugin/test_worker_sdk.py
+++ b/python/tests/plugin/test_worker_sdk.py
@@ -1130,7 +1130,9 @@ async def test_llm_sanitizers_receive_codec_context_and_can_omit_payloads():
         (pb.LLM_CODEC_KIND_BUILTIN, "openai_chat"),
         (pb.LLM_CODEC_KIND_BUILTIN, "openai_responses"),
         (pb.LLM_CODEC_KIND_BUILTIN, "anthropic_messages"),
+        (pb.LLM_CODEC_KIND_BUILTIN, "oci_genai"),
         (pb.LLM_CODEC_KIND_BUILTIN, "gemini_generate_content"),
+        (pb.LLM_CODEC_KIND_BUILTIN, "bedrock_converse"),
         (pb.LLM_CODEC_KIND_RUNTIME, "com.example.chat.v1"),
         (pb.LLM_CODEC_KIND_OPAQUE, None),
     ]:
@@ -1164,8 +1166,8 @@ async def test_llm_sanitizers_receive_codec_context_and_can_omit_payloads():
             ),
             AbortContext(),
         )
-        assert request_response.WhichOneof("result") == "empty"
-        assert response_response.WhichOneof("result") == "empty"
+        assert request_response.WhichOneof("result") == "empty", request_response.error
+        assert response_response.WhichOneof("result") == "empty", response_response.error
 
     assert seen == [
         ("request", LlmSanitizeRequestContext(plugin_api.LlmCodecIdentity("none"))),
@@ -1182,8 +1184,12 @@ async def test_llm_sanitizers_receive_codec_context_and_can_omit_payloads():
             "response",
             LlmSanitizeResponseContext(plugin_api.LlmCodecIdentity("builtin", "anthropic_messages")),
         ),
+        ("request", LlmSanitizeRequestContext(plugin_api.LlmCodecIdentity("builtin", "oci_genai"))),
+        ("response", LlmSanitizeResponseContext(plugin_api.LlmCodecIdentity("builtin", "oci_genai"))),
         ("request", LlmSanitizeRequestContext(plugin_api.LlmCodecIdentity("builtin", "gemini_generate_content"))),
         ("response", LlmSanitizeResponseContext(plugin_api.LlmCodecIdentity("builtin", "gemini_generate_content"))),
+        ("request", LlmSanitizeRequestContext(plugin_api.LlmCodecIdentity("builtin", "bedrock_converse"))),
+        ("response", LlmSanitizeResponseContext(plugin_api.LlmCodecIdentity("builtin", "bedrock_converse"))),
         ("request", LlmSanitizeRequestContext(plugin_api.LlmCodecIdentity("runtime", "com.example.chat.v1"))),
         ("response", LlmSanitizeResponseContext(plugin_api.LlmCodecIdentity("runtime", "com.example.chat.v1"))),
         ("request", LlmSanitizeRequestContext(plugin_api.LlmCodecIdentity("opaque"))),

--- a/python/tests/test_builtin_codecs.py
+++ b/python/tests/test_builtin_codecs.py
@@ -5,8 +5,9 @@
 
 Covers:
 - Built-in codec construction for OpenAIChatCodec, OpenAIResponsesCodec,
-  AnthropicMessagesCodec, OCIGenAIChatCodec, and GeminiGenerateContentCodec
-- Built-in codec decode/encode/decode_response methods for all five providers
+  AnthropicMessagesCodec, OCIGenAIChatCodec, GeminiGenerateContentCodec, and
+  BedrockConverseCodec
+- Built-in codec decode/encode/decode_response methods for all six providers
 - LlmResponseCodec protocol
 - response_codec parameter accepts object (not string)
 """
@@ -25,6 +26,7 @@ from nemo_relay import (
 )
 from nemo_relay.codecs import (
     AnthropicMessagesCodec,
+    BedrockConverseCodec,
     GeminiGenerateContentCodec,
     OCIGenAIChatCodec,
     OpenAIChatCodec,
@@ -93,6 +95,12 @@ class TestBuiltinCodecConstruction:
     def test_gemini_codec_has_methods(self):
         """GeminiGenerateContentCodec has decode, encode, decode_response methods."""
         codec = GeminiGenerateContentCodec()
+        assert hasattr(codec, "decode")
+        assert hasattr(codec, "encode")
+        assert hasattr(codec, "decode_response")
+
+    def test_bedrock_converse_codec_constructable(self):
+        codec = BedrockConverseCodec()
         assert hasattr(codec, "decode")
         assert hasattr(codec, "encode")
         assert hasattr(codec, "decode_response")
@@ -475,6 +483,36 @@ class TestBuiltinCodecDecodeResponse:
         assert tool_calls[0]["id"] == "call_abc"
         assert tool_calls[0]["name"] == "get_weather"
 
+    def test_bedrock_converse_codec_round_trip_and_response(self):
+        codec = BedrockConverseCodec()
+        original = LLMRequest(
+            {},
+            {
+                "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                "messages": [{"role": "user", "content": [{"text": "hello"}]}],
+                "inferenceConfig": {"temperature": 0.2, "maxTokens": 128},
+                "requestMetadata": {"tenant": "example"},
+            },
+        )
+        annotated = codec.decode(original)
+        assert annotated.model == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        assert annotated.messages[0]["role"] == "user"
+        assert codec.encode(annotated, original).content == original.content
+
+        response = codec.decode_response(
+            {
+                "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+                "stopReason": "end_turn",
+                "usage": {"inputTokens": 4, "outputTokens": 2, "totalTokens": 6},
+                "metrics": {"latencyMs": 12},
+            }
+        )
+        assert response.response_text() == "hi"
+        assert response.finish_reason == "complete"
+        assert response.model is None
+        assert response.usage is not None
+        assert response.usage["prompt_tokens"] == 4
+
 
 # ---------------------------------------------------------------------------
 # 4. LlmResponseCodec protocol
@@ -498,6 +536,7 @@ class TestLlmResponseCodecProtocol:
         assert isinstance(OCIGenAIChatCodec(), LlmResponseCodec)
 
         assert isinstance(GeminiGenerateContentCodec(), LlmResponseCodec)
+        assert isinstance(BedrockConverseCodec(), LlmResponseCodec)
 
 
 # ---------------------------------------------------------------------------
@@ -772,6 +811,7 @@ class TestBuiltinCodecImports:
         """Built-in codecs are importable from nemo_relay.codecs."""
         from nemo_relay.codecs import (
             AnthropicMessagesCodec,
+            BedrockConverseCodec,
             GeminiGenerateContentCodec,
             OpenAIChatCodec,
             OpenAIResponsesCodec,
@@ -781,6 +821,7 @@ class TestBuiltinCodecImports:
         assert OpenAIResponsesCodec is not None
         assert AnthropicMessagesCodec is not None
         assert GeminiGenerateContentCodec is not None
+        assert BedrockConverseCodec is not None
 
     def test_not_reexported_from_top_level(self):
         """Built-in codecs are not re-exported from nemo_relay."""
@@ -788,3 +829,4 @@ class TestBuiltinCodecImports:
         assert not hasattr(nemo_relay, "OpenAIResponsesCodec")
         assert not hasattr(nemo_relay, "AnthropicMessagesCodec")
         assert not hasattr(nemo_relay, "GeminiGenerateContentCodec")
+        assert not hasattr(nemo_relay, "BedrockConverseCodec")


### PR DESCRIPTION
#### Overview

Adds Amazon Bedrock Converse as a built-in Relay codec for applications that already make their own AWS SDK calls. Relay can normalize Converse requests and responses for middleware and observability, while the application continues to own the Bedrock call.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

**Problem**

Relay currently treats Bedrock Converse payloads as opaque unless an integration supplies its own codec. That means Relay cannot produce the normalized request and response data used by codec-aware middleware and observability.

**Behavior**

- `BedrockConverseCodec` decodes and re-encodes the JSON-compatible arguments passed to the AWS SDK's `Converse` API.
- The codec covers messages, system content, inference settings, tools, tool calls and results, stop reasons, and token usage. Provider fields Relay does not model remain in the original payload.
- Provider-native content blocks remain untouched. Mixed or future union shapes fall back to provider-native data instead of being partially normalized.
- Buffered responses are normalized for `LLMEnd` events and use Relay's existing response-cache path. Bedrock's nested temperature and tool configuration participate in cache eligibility and logical keying.
- The Rust streaming codec consumes events after the AWS SDK has decoded them. It collects text and JSON tool calls, reports Bedrock stream exceptions as Relay errors, and leaves the application stream unchanged when it cannot build a complete normalized response. Sparse block indices do not allocate memory by index.
- Provider detection, PII redaction, worker, and native-plugin paths recognize the new codec. ACG identifies the Bedrock surface but does not currently edit Bedrock requests. Streaming response caching remains disabled because Relay cannot replay AWS EventStream messages.
- Python and Node.js expose the buffered request and response codec methods. Rust also exposes the built-in stream collector.

**Application boundary**

The application and its AWS SDK still handle credentials, SigV4 signing, endpoints, retries, timeouts, binary values, the provider call, and AWS EventStream decoding.

This PR does not add a Bedrock gateway, an AWS client inside Relay, a boto3 adapter, generic `InvokeModel` support, raw EventStream parsing, Python or Node.js stream collectors, or FFI/Go convenience constructors. `Converse` has one common request and response shape across models; `InvokeModel` payloads are model-specific and can be added separately if needed.

**Compatibility**

This adds variants to the public Rust enums `ProviderSurface` and `BuiltinLlmCodec`. Downstream Rust code that exhaustively matches either enum must add the Bedrock case.

Native ABI v4 plugins receive the new codec identity as `opaque` but retain access to the active codec during the callback. Existing native plugins therefore do not need to know the new identity to process the call. Dynamic workers receive the named `bedrock_converse` identity.

**Validation**

Current branch after merging `main`:

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p nemo-relay bedrock` — 26 unit and 2 managed-pipeline tests passed
- [x] Adaptive response-cache tests — 132 passed
- [x] PII-redaction tests — 153 passed
- [x] Python Bedrock codec tests — 2 passed; worker codec-context test passed
- [x] Node.js Bedrock codec tests — 2 passed
- [x] `just docs-linkcheck`

Live AWS validation:

- [x] Live `amazon.nova-micro-v1:0` buffered call in `us-east-1`
- [x] Request-intercept mutation preserved `requestMetadata`
- [x] Forced tool-use round trip, including tool-result encoding and final response
- [x] Live `ConverseStream` events passed through Relay's Rust collector with text, stop reason, usage, and metrics preserved

A post-merge smoke also exercised the application-owned SDK path through a temporary local Hermes adapter. This does not add or claim maintained Hermes support.

- [x] Live `us.amazon.nova-pro-v1:0` tool smoke: 2 model calls, 53 streaming chunks, 1 terminal call, and 5,314 tokens
- [x] Read-only coding smoke against the Relay repository: 2 model calls, 443 streaming chunks, 3 tools (`terminal`, `read_file`, and `search_files`), and 17,586 tokens
- [x] ATOF captured both LLM calls, all tool scopes, normalized tool calls, stop reasons, and usage

The coding smoke exposed an observability projection issue: a Bedrock `toolResult` message was treated as a new user turn, causing the preceding user request and `toolUse` to be omitted from the second `LLMStart` event. Provider execution was unaffected. The current commit fixes the projection and adds a managed two-call regression test. The live capture predates that fix.

#### Where should the reviewer start?

Start with `crates/core/src/codec/bedrock_converse.rs` and its tests in `crates/core/tests/unit/codec/bedrock_converse_tests.rs`. Then review `crates/core/src/codec/resolve.rs` for provider detection and `docs/integrate-into-frameworks/provider-codecs.mdx` for the AWS SDK/Relay boundary.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [RELAY-792](https://linear.app/nvidia/issue/RELAY-792/spike-native-amazon-bedrock-converse-support)
