### PR TITLE
docs: label Node plugin API entry points

### DIFF
--- a/scripts/docs/generate_node_library_reference.py
+++ b/scripts/docs/generate_node_library_reference.py
@@ -45,6 +45,8 @@ MODULE_TITLES = {
     "nemo-relay-node/plugin": "Plugin Helpers",
     "nemo-relay-node/adaptive": "Adaptive Helpers",
     "nemo-relay-node/observability": "Observability Helpers",
+    "nemo-relay-node/pii_redaction": "PII Redaction Helpers",
+    "nemo-relay-node/model_pricing": "Model Pricing Helpers",
 }
 MODULE_DESCRIPTIONS = {
     "nemo-relay-node": "Main runtime lifecycle, scope, middleware, subscriber, and exporter APIs.",
@@ -52,6 +54,8 @@ MODULE_DESCRIPTIONS = {
     "nemo-relay-node/plugin": "Plugin configuration, validation, activation, and registration helpers.",
     "nemo-relay-node/adaptive": "Adaptive plugin configuration helpers.",
     "nemo-relay-node/observability": "Observability plugin configuration helpers.",
+    "nemo-relay-node/pii_redaction": "PII redaction plugin configuration helpers.",
+    "nemo-relay-node/model_pricing": "Model pricing plugin configuration helpers.",
 }
 BASE_URL = "/reference/api/nodejs-library-reference"
 


### PR DESCRIPTION
#### Overview

- Display the PII redaction and model pricing Node.js API entry points with human-readable titles.
- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add titles and descriptions for `nemo-relay-node/pii_redaction` and `nemo-relay-node/model_pricing` in the Node API-reference generator.
- Preserve the existing public import paths.

#### Where should the reviewer start?

- `scripts/docs/generate_node_library_reference.py`, specifically the Node module title and description mappings.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added titles and descriptions for the `pii_redaction` and `model_pricing` Node.js reference documentation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->