### PR TITLE
fix: initialize builtins before dynamic plugins

### DIFF
--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -24,7 +24,8 @@ use nemo_relay::plugin::dynamic::{
     WorkerPluginLoadSpec, load_native_plugins, load_worker_plugins,
 };
 use nemo_relay::plugin::{
-    PluginComponentSpec, PluginConfig, clear_plugin_configuration, initialize_plugins_exact,
+    PluginComponentSpec, PluginConfig, clear_plugin_configuration,
+    ensure_builtin_plugins_registered, initialize_plugins_exact,
 };
 use nemo_relay_adaptive::plugin_component::register_adaptive_component;
 use nemo_relay_pii_redaction::component::register_pii_redaction_component;
@@ -978,6 +979,12 @@ impl PluginActivation {
         {
             return Err(CliError::Config(error.to_string()));
         }
+        // Reserve and register Relay's built-in plugin kinds before loading
+        // untrusted dynamic plugin code. This keeps the CLI activation path
+        // consistent with the runtime-owned dynamic plugin host.
+        ensure_builtin_plugins_registered().map_err(|error| {
+            CliError::Config(format!("built-in plugin initialization failed: {error}"))
+        })?;
         plugin_config
             .components
             .extend(dynamic_plugins.iter().map(|plugin| PluginComponentSpec {

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -27,7 +27,7 @@ use nemo_relay::api::subscriber::{deregister_subscriber, flush_subscribers, regi
 use nemo_relay::plugin::dynamic::DynamicPluginKind;
 use nemo_relay::plugin::{
     ConfigDiagnostic, Plugin, PluginRegistration, PluginRegistrationContext, deregister_plugin,
-    register_plugin,
+    ensure_builtin_plugins_registered, register_plugin,
 };
 use serde_json::{Map, Value, json};
 use tokio::net::TcpListener;
@@ -148,6 +148,26 @@ fn test_http_client() -> reqwest::Client {
 }
 
 struct GenericTestPlugin;
+
+struct PreclaimedBuiltinPlugin;
+
+impl Plugin for PreclaimedBuiltinPlugin {
+    fn plugin_kind(&self) -> &str {
+        "observability"
+    }
+
+    fn validate(&self, _plugin_config: &Map<String, Value>) -> Vec<ConfigDiagnostic> {
+        vec![]
+    }
+
+    fn register<'a>(
+        &'a self,
+        _plugin_config: &Map<String, Value>,
+        _ctx: &'a mut PluginRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = nemo_relay::plugin::Result<()>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
+    }
+}
 
 impl Plugin for GenericTestPlugin {
     fn plugin_kind(&self) -> &str {
@@ -1952,6 +1972,40 @@ async fn plugin_activation_covers_empty_invalid_and_missing_manifest_paths() {
     .err()
     .expect("worker plugin without a manifest should fail activation");
     assert!(worker.to_string().contains("worker dynamic plugin"));
+}
+
+#[tokio::test]
+async fn dynamic_cli_activation_initializes_builtins_before_loading_dynamic_plugins() {
+    let _guard = PLUGIN_CONFIG_TEST_LOCK.lock().await;
+    let _ = nemo_relay::plugin::clear_plugin_configuration();
+    ensure_builtin_plugins_registered().expect("builtin registration must be available");
+    assert!(deregister_plugin("observability"));
+    register_plugin(Arc::new(PreclaimedBuiltinPlugin))
+        .expect("fixture must claim the builtin kind");
+
+    let error = match PluginActivation::initialize(
+        None,
+        vec![dynamic_component_without_manifest(
+            "fixture.missing",
+            DynamicPluginKind::RustDynamic,
+        )],
+    )
+    .await
+    {
+        Ok(_) => panic!("builtin ownership conflict must stop dynamic loading"),
+        Err(error) => error.to_string(),
+    };
+
+    assert!(
+        error.contains("built-in plugin initialization failed"),
+        "{error}"
+    );
+    assert!(
+        error.contains("reserved builtin plugin 'observability'"),
+        "{error}"
+    );
+    assert!(deregister_plugin("observability"));
+    ensure_builtin_plugins_registered().expect("builtin registration must recover");
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Overview

Initialize Relay built-in plugin kinds before the CLI loads dynamic plugins.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Register built-in plugin kinds in the CLI dynamic activation path before native or worker plugins are loaded.
- Add a regression test that verifies a built-in ownership conflict prevents dynamic loading.

#### Where should the reviewer start?

Start with `crates/cli/src/server/mod.rs`, where the CLI now shares the runtime host's built-in registration ordering.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Built-in plugins are now initialized before dynamically loaded plugins.
  * Plugin configuration errors are reported clearly, and conflicting plugins are prevented from loading.
* **Tests**
  * Added coverage for built-in plugin registration, conflict handling, dynamic loading prevention, and registration restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->