### PR TITLE
fix: preserve log severity during trajectory redaction

### DIFF
--- a/crates/pii-redaction/README.md
+++ b/crates/pii-redaction/README.md
@@ -150,7 +150,10 @@ metric-schema marks use schema-aware sanitization instead: required measurement
 fields and numeric analytics remain valid for metric export, while descriptions
 and string attribute values are redacted.
 Strings become `[REDACTED]`, numbers become `0`, booleans become `false`, and
-nulls, keys, arrays, and object shape are retained.
+nulls, keys, arrays, and object shape are retained. On every mark, the preset
+preserves the reserved `nemo_relay.log.severity` metadata field in canonical
+form when it contains a supported severity. For opaque custom marks,
+unsupported severity values remain redacted with the other string leaves.
 Known Relay marks are sanitized semantically so their structural and analytical
 fields remain usable. This choice affects canonical event fields before
 subscriber fan-out; exporter-owned resource attributes are outside this

--- a/crates/pii-redaction/README.md
+++ b/crates/pii-redaction/README.md
@@ -152,8 +152,9 @@ and string attribute values are redacted.
 Strings become `[REDACTED]`, numbers become `0`, booleans become `false`, and
 nulls, keys, arrays, and object shape are retained. On every mark, the preset
 preserves the reserved `nemo_relay.log.severity` metadata field in canonical
-form when it contains a supported severity. For opaque custom marks,
-unsupported severity values remain redacted with the other string leaves.
+form when it contains a supported severity. For opaque custom marks that use
+`redact_all_leaves`, unsupported severity values remain redacted with the
+other string leaves.
 Known Relay marks are sanitized semantically so their structural and analytical
 fields remain usable. This choice affects canonical event fields before
 subscriber fan-out; exporter-owned resource attributes are outside this

--- a/crates/pii-redaction/src/trajectory.rs
+++ b/crates/pii-redaction/src/trajectory.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 use serde_json::Value as Json;
 
 use nemo_relay::api::event::{
-    CategoryProfile, Event, METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION, MetricEnvelope,
+    CategoryProfile, Event, LOG_SEVERITY_METADATA_KEY, LogSeverity, METRIC_DATA_SCHEMA_NAME,
+    METRIC_DATA_SCHEMA_VERSION, MetricEnvelope,
 };
 use nemo_relay::codec::request::AnnotatedLlmRequest;
 use nemo_relay::codec::response::AnnotatedLlmResponse;
@@ -130,6 +131,7 @@ impl TrajectorySanitizer {
         event: &Event,
         mut fields: nemo_relay::api::event::EventSanitizeFields,
     ) -> nemo_relay::api::event::EventSanitizeFields {
+        let log_severity = valid_mark_log_severity(event, fields.metadata.as_ref());
         if is_relay_metric_mark(event) {
             fields.data = fields
                 .data
@@ -140,7 +142,7 @@ impl TrajectorySanitizer {
             fields.category_profile = fields
                 .category_profile
                 .and_then(|profile| sanitize_category_profile(profile, &self.replacement));
-            return fields;
+            return restore_log_severity(fields, log_severity);
         }
 
         let category = event.category().map(|category| category.as_str());
@@ -162,7 +164,7 @@ impl TrajectorySanitizer {
                     .category_profile
                     .and_then(|profile| redact_custom_category_profile(profile, self));
             }
-            return fields;
+            return restore_log_severity(fields, log_severity);
         }
 
         if !specialized_scope {
@@ -180,7 +182,7 @@ impl TrajectorySanitizer {
         fields.category_profile = fields
             .category_profile
             .and_then(|profile| sanitize_category_profile(profile, &self.replacement));
-        fields
+        restore_log_severity(fields, log_severity)
     }
 
     /// Redact optional metric text without modifying required export fields.
@@ -200,6 +202,30 @@ impl TrajectorySanitizer {
         envelope.validate().ok()?;
         serde_json::to_value(envelope).ok()
     }
+}
+
+fn valid_mark_log_severity(event: &Event, metadata: Option<&Json>) -> Option<LogSeverity> {
+    if !matches!(event, Event::Mark(_)) {
+        return None;
+    }
+    metadata
+        .and_then(Json::as_object)
+        .and_then(|metadata| metadata.get(LOG_SEVERITY_METADATA_KEY))
+        .and_then(Json::as_str)
+        .and_then(|value| value.parse::<LogSeverity>().ok())
+}
+
+fn restore_log_severity(
+    mut fields: nemo_relay::api::event::EventSanitizeFields,
+    severity: Option<LogSeverity>,
+) -> nemo_relay::api::event::EventSanitizeFields {
+    if let (Some(severity), Some(Json::Object(metadata))) = (severity, fields.metadata.as_mut()) {
+        metadata.insert(
+            LOG_SEVERITY_METADATA_KEY.to_string(),
+            Json::String(severity.as_str().to_string()),
+        );
+    }
+    fields
 }
 
 /// Return whether an event carries Relay's typed metric schema.

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -7,8 +7,8 @@
 use super::*;
 use crate::api::event::{
     BaseEvent, CategoryProfile, DataSchema, Event, EventCategory, EventSanitizeFields,
-    METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION, MarkEvent, MetricEnvelope, ScopeCategory,
-    ScopeEvent,
+    LOG_SEVERITY_METADATA_KEY, LogSeverity, METRIC_DATA_SCHEMA_NAME, METRIC_DATA_SCHEMA_VERSION,
+    MarkEvent, MetricEnvelope, ScopeCategory, ScopeEvent,
 };
 use crate::api::llm::{
     LlmCallExecuteParams, LlmCallParams, LlmRequest, LlmStreamCallExecuteParams, llm_call,
@@ -1133,6 +1133,54 @@ async fn trajectory_custom_mark_policy_is_explicit_and_shape_preserving() {
     let profile = sanitized.category_profile.unwrap();
     assert_eq!(profile.subtype.as_deref(), Some("neutral.plugin"));
     assert_eq!(profile.extra["opaque"]["label"], "[REDACTED]");
+}
+
+#[tokio::test]
+async fn trajectory_custom_mark_preserves_only_valid_log_severity() {
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder().name("neutral.plugin.log").build(),
+        Some(EventCategory::custom()),
+        None,
+    ));
+    let callback =
+        crate::builtin::event_sanitize_callback(trajectory_backend(None, "redact_all_leaves"));
+
+    let sanitized = callback(
+        Arc::new(event.clone()),
+        EventSanitizeFields {
+            data: Some(json!({"message": "private"})),
+            category_profile: None,
+            metadata: Some(json!({
+                LOG_SEVERITY_METADATA_KEY: "warning",
+                "owner": "private owner"
+            })),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(sanitized.data, Some(json!({"message": "[REDACTED]"})));
+    assert_eq!(
+        sanitized.metadata,
+        Some(json!({
+            LOG_SEVERITY_METADATA_KEY: "warn",
+            "owner": "[REDACTED]"
+        }))
+    );
+
+    let sanitized = callback(
+        Arc::new(event),
+        EventSanitizeFields {
+            data: None,
+            category_profile: None,
+            metadata: Some(json!({LOG_SEVERITY_METADATA_KEY: "private severity"})),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        sanitized.metadata,
+        Some(json!({LOG_SEVERITY_METADATA_KEY: "[REDACTED]"}))
+    );
 }
 
 #[tokio::test]
@@ -2708,6 +2756,7 @@ fn sanitized_trajectory_content_never_reaches_subscribers_or_exporters() {
             .name("hermes.checkpoint")
             .data(json!({"content": raw_context, "email": raw_pii, "score": 0.95}))
             .metadata(json!({"reviewer": raw_pii}))
+            .severity(LogSeverity::Warn)
             .build(),
     )
     .unwrap();
@@ -2786,6 +2835,13 @@ fn sanitized_trajectory_content_never_reaches_subscribers_or_exporters() {
         .unwrap();
     assert_eq!(custom_mark.data().unwrap()["content"], "[REDACTED]");
     assert_eq!(custom_mark.data().unwrap()["score"], 0);
+    assert_eq!(
+        custom_mark.metadata().unwrap(),
+        &json!({
+            LOG_SEVERITY_METADATA_KEY: "warn",
+            "reviewer": "[REDACTED]"
+        })
+    );
 
     deregister_subscriber("pii-regression-subscriber").unwrap();
     atof.deregister("pii-regression-atof").unwrap();

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -267,6 +267,11 @@ fields. That preset does not accept `target_paths`. Its
 `custom_mark_payload_policy` applies only to opaque marks in the `custom`
 category; it does not control Relay typed metric envelopes.
 
+On every mark, the preset preserves the reserved `nemo_relay.log.severity`
+metadata field in canonical form when it contains a supported severity. For
+opaque custom marks using `redact_all_leaves`, unsupported severity values and
+all other string leaves remain redacted.
+
 ## Action Semantics
 
 ### `remove`


### PR DESCRIPTION
#### Overview

Preserve valid `nemo_relay.log.severity` metadata during trajectory-context redaction so sanitized semantic logs remain exportable.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Preserve supported log-severity values in canonical form without changing the existing policy for other mark metadata.
- Keep unsupported severity values subject to the configured custom-mark policy; `redact_all_leaves` redacts them.
- Add regression coverage for valid and invalid severity values and downstream subscriber delivery.
- Document the trajectory-context preset behavior.

Validation:

- PII-redaction crate tests: 147 passed
- Focused subscriber/exporter regression passed
- Workspace Clippy passed
- Documentation build passed
- Formatting and diff checks passed

#### Where should the reviewer start?

Start with `crates/pii-redaction/src/trajectory.rs`, especially the severity extraction and restoration around trajectory sanitization. The corresponding regression coverage is in `crates/pii-redaction/tests/unit/component_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #916


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved valid log severity metadata during trajectory sanitization, including after payload, metadata, or category redaction.
  - Normalized supported severity values to a canonical form.
  - Continued redacting invalid or unsupported severity values and other sensitive custom-mark data.

- **Documentation**
  - Clarified severity metadata handling in trajectory export and typed metric mark configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->