### PR TITLE
enhancement(pii): allow bounded metric string attributes

### DIFF
--- a/crates/pii-redaction/README.md
+++ b/crates/pii-redaction/README.md
@@ -149,6 +149,22 @@ profile fields are replaced while typed category identity remains valid. Relay
 metric-schema marks use schema-aware sanitization instead: required measurement
 fields and numeric analytics remain valid for metric export, while descriptions
 and string attribute values are redacted.
+
+The preset can preserve explicitly approved, bounded string metric dimensions
+without exposing arbitrary text:
+
+```toml
+[components.config.profiles.builtin.metric_string_attribute_allowlist]
+"gen_ai.operation.name" = ["chat", "text_completion"]
+```
+
+Relay compares both the attribute name and value exactly and case-sensitively.
+For string arrays, each element is checked separately. Unlisted attributes and
+unexpected values remain redacted. The allowlist is empty by default and does
+not apply to descriptions, mark metadata, category profiles, or non-metric
+marks. Configure only fixed constants or bounded enum values; do not add
+free-form identifiers or user-provided text.
+
 Strings become `[REDACTED]`, numbers become `0`, booleans become `false`, and
 nulls, keys, arrays, and object shape are retained.
 Known Relay marks are sanitized semantically so their structural and analytical

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -23,7 +23,7 @@ use nemo_relay::codec::resolve::{
 use nemo_relay::codec::traits::{LlmCodec, LlmResponseCodec};
 use nemo_relay::plugin::{PluginError, Result as PluginResult};
 
-use super::component::BuiltinBackendConfig;
+use super::component::{BuiltinBackendConfig, validate_metric_string_attribute_allowlist};
 use super::detectors::BuiltinDetector;
 use super::overlay::BuiltinCodecName;
 use super::trajectory::{CustomMarkPayloadPolicy, TrajectorySanitizer, is_relay_metric_mark};
@@ -83,6 +83,10 @@ impl CompiledBuiltinBackend {
         }
         let trajectory = match config.preset.as_deref() {
             Some("trajectory_context") => {
+                validate_metric_string_attribute_allowlist(
+                    &config.metric_string_attribute_allowlist,
+                )
+                .map_err(PluginError::InvalidConfig)?;
                 if config.detector.is_some()
                     || config.pattern.is_some()
                     || !config.target_paths.is_empty()
@@ -108,12 +112,19 @@ impl CompiledBuiltinBackend {
                         .clone()
                         .unwrap_or_else(|| "[REDACTED]".to_string()),
                     policy,
+                    config.metric_string_attribute_allowlist.clone(),
                 ))
             }
             Some(other) => {
                 return Err(PluginError::InvalidConfig(format!(
                     "unsupported builtin preset '{other}'"
                 )));
+            }
+            None if !config.metric_string_attribute_allowlist.is_empty() => {
+                return Err(PluginError::InvalidConfig(
+                    "builtin.metric_string_attribute_allowlist requires builtin.preset = 'trajectory_context'"
+                        .to_string(),
+                ));
             }
             None => None,
         };

--- a/crates/pii-redaction/src/component.rs
+++ b/crates/pii-redaction/src/component.rs
@@ -3,6 +3,7 @@
 
 //! PII redaction plugin component contract.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -218,6 +219,9 @@ pub struct BuiltinBackendConfig {
         schemars(schema_with = "custom_mark_payload_policy_schema")
     )]
     pub custom_mark_payload_policy: String,
+    /// Exact string values that the trajectory preset may preserve for each typed metric attribute.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metric_string_attribute_allowlist: BTreeMap<String, Vec<String>>,
 }
 
 impl Default for BuiltinBackendConfig {
@@ -233,6 +237,7 @@ impl Default for BuiltinBackendConfig {
             unmasked_prefix: None,
             unmasked_suffix: None,
             custom_mark_payload_policy: default_custom_mark_payload_policy(),
+            metric_string_attribute_allowlist: BTreeMap::new(),
         }
     }
 }
@@ -389,6 +394,10 @@ nemo_relay::editor_config! {
             label: "custom_mark_payload_policy",
             kind: Enum,
             values: ["preserve", "redact_all_leaves"],
+        },
+        metric_string_attribute_allowlist => {
+            label: "metric_string_attribute_allowlist",
+            kind: Json,
         },
     }
 }
@@ -658,6 +667,7 @@ fn validate_pii_redaction_plugin_config_with_policy(
             "unmasked_prefix",
             "unmasked_suffix",
             "custom_mark_payload_policy",
+            "metric_string_attribute_allowlist",
         ],
     );
     validate_section_fields(
@@ -760,6 +770,7 @@ fn validate_profile_configuration(
                 "unmasked_prefix",
                 "unmasked_suffix",
                 "custom_mark_payload_policy",
+                "metric_string_attribute_allowlist",
             ],
         );
         validate_section_fields(
@@ -958,6 +969,22 @@ fn validate_builtin_action_requirements(
         );
     }
 
+    let metric_allowlist_configured = plugin_config
+        .get("builtin")
+        .and_then(Json::as_object)
+        .is_some_and(|builtin| builtin.contains_key("metric_string_attribute_allowlist"));
+    if metric_allowlist_configured {
+        push_policy_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "pii_redaction.unsupported_value",
+            Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+            Some("builtin.metric_string_attribute_allowlist".to_string()),
+            "builtin.metric_string_attribute_allowlist requires builtin.preset = 'trajectory_context'"
+                .to_string(),
+        );
+    }
+
     if !matches!(
         builtin.action.as_str(),
         "remove" | "redact" | "regex_replace" | "hash" | "mask"
@@ -1077,6 +1104,18 @@ fn validate_builtin_preset_requirements(
                 .to_string(),
         );
     }
+    if let Err(message) =
+        validate_metric_string_attribute_allowlist(&builtin.metric_string_attribute_allowlist)
+    {
+        push_policy_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "pii_redaction.unsupported_value",
+            Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+            Some("builtin.metric_string_attribute_allowlist".to_string()),
+            message,
+        );
+    }
     let raw_builtin = plugin_config.get("builtin").and_then(Json::as_object);
     for field in [
         "action",
@@ -1098,6 +1137,38 @@ fn validate_builtin_preset_requirements(
             );
         }
     }
+}
+
+pub(super) fn validate_metric_string_attribute_allowlist(
+    allowlist: &BTreeMap<String, Vec<String>>,
+) -> Result<(), String> {
+    for (attribute, values) in allowlist {
+        if attribute.trim().is_empty() {
+            return Err(
+                "builtin.metric_string_attribute_allowlist keys must not be blank".to_string(),
+            );
+        }
+        if values.is_empty() {
+            return Err(format!(
+                "builtin.metric_string_attribute_allowlist['{attribute}'] must contain at least one value"
+            ));
+        }
+
+        let mut seen = BTreeSet::new();
+        for (index, value) in values.iter().enumerate() {
+            if value.trim().is_empty() {
+                return Err(format!(
+                    "builtin.metric_string_attribute_allowlist['{attribute}'][{index}] must not be blank"
+                ));
+            }
+            if !seen.insert(value) {
+                return Err(format!(
+                    "builtin.metric_string_attribute_allowlist['{attribute}'] contains duplicate value '{value}'"
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn validate_version(diagnostics: &mut Vec<ConfigDiagnostic>, policy: &ConfigPolicy, version: u32) {

--- a/crates/pii-redaction/src/trajectory.rs
+++ b/crates/pii-redaction/src/trajectory.rs
@@ -3,6 +3,7 @@
 
 //! Structure-preserving removal of conversational trajectory content.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use serde_json::Value as Json;
@@ -54,13 +55,24 @@ impl CustomMarkPayloadPolicy {
 pub(super) struct TrajectorySanitizer {
     replacement: Arc<String>,
     custom_mark_payload_policy: CustomMarkPayloadPolicy,
+    metric_string_attribute_allowlist: Arc<BTreeMap<String, BTreeSet<String>>>,
 }
 
 impl TrajectorySanitizer {
-    pub(super) fn new(replacement: String, policy: CustomMarkPayloadPolicy) -> Self {
+    pub(super) fn new(
+        replacement: String,
+        policy: CustomMarkPayloadPolicy,
+        metric_string_attribute_allowlist: BTreeMap<String, Vec<String>>,
+    ) -> Self {
         Self {
             replacement: Arc::new(replacement),
             custom_mark_payload_policy: policy,
+            metric_string_attribute_allowlist: Arc::new(
+                metric_string_attribute_allowlist
+                    .into_iter()
+                    .map(|(attribute, values)| (attribute, values.into_iter().collect()))
+                    .collect(),
+            ),
         }
     }
 
@@ -192,10 +204,13 @@ impl TrajectorySanitizer {
                 .description
                 .take()
                 .map(|_| (*self.replacement).clone());
-            measurement.attributes = measurement
-                .attributes
-                .take()
-                .map(|attributes| redact_metric_string_attributes(attributes, &self.replacement));
+            measurement.attributes = measurement.attributes.take().map(|attributes| {
+                redact_metric_string_attributes(
+                    attributes,
+                    &self.replacement,
+                    &self.metric_string_attribute_allowlist,
+                )
+            });
         }
         envelope.validate().ok()?;
         serde_json::to_value(envelope).ok()
@@ -211,12 +226,19 @@ pub(crate) fn is_relay_metric_mark(event: &Event) -> bool {
 }
 
 /// Redact strings in a typed metric attribute object.
-fn redact_metric_string_attributes(value: Json, replacement: &str) -> Json {
+fn redact_metric_string_attributes(
+    value: Json,
+    replacement: &str,
+    allowlist: &BTreeMap<String, BTreeSet<String>>,
+) -> Json {
     match value {
         Json::Object(values) => Json::Object(
             values
                 .into_iter()
-                .map(|(key, value)| (key, redact_metric_string_attribute(value, replacement)))
+                .map(|(key, value)| {
+                    let value = redact_metric_string_attribute(&key, value, replacement, allowlist);
+                    (key, value)
+                })
                 .collect(),
         ),
         value => value,
@@ -224,17 +246,49 @@ fn redact_metric_string_attributes(value: Json, replacement: &str) -> Json {
 }
 
 /// Redact an individual typed metric attribute when it contains text.
-fn redact_metric_string_attribute(value: Json, replacement: &str) -> Json {
+fn redact_metric_string_attribute(
+    attribute: &str,
+    value: Json,
+    replacement: &str,
+    allowlist: &BTreeMap<String, BTreeSet<String>>,
+) -> Json {
     match value {
-        Json::String(_) => Json::String(replacement.to_string()),
+        Json::String(value) => Json::String(
+            if metric_string_value_is_allowed(allowlist, attribute, &value) {
+                value
+            } else {
+                replacement.to_string()
+            },
+        ),
         Json::Array(values) if values.iter().all(Json::is_string) => Json::Array(
             values
                 .into_iter()
-                .map(|_| Json::String(replacement.to_string()))
+                .map(|value| {
+                    let Json::String(value) = value else {
+                        unreachable!("checked that every metric attribute value is a string");
+                    };
+                    Json::String(
+                        if metric_string_value_is_allowed(allowlist, attribute, &value) {
+                            value
+                        } else {
+                            replacement.to_string()
+                        },
+                    )
+                })
                 .collect(),
         ),
         value => value,
     }
+}
+
+fn metric_string_value_is_allowed(
+    allowlist: &BTreeMap<String, BTreeSet<String>>,
+    attribute: &str,
+    value: &str,
+) -> bool {
+    allowlist
+        .get(attribute)
+        .is_some_and(|values| values.contains(value))
 }
 
 fn sanitize_scope_metadata(value: Json, replacement: &str) -> Json {
@@ -276,14 +330,22 @@ fn sanitize_category_profile(
     replacement: &str,
 ) -> Option<CategoryProfile> {
     profile.annotated_request = profile.annotated_request.as_ref().and_then(|request| {
-        TrajectorySanitizer::new(replacement.to_string(), CustomMarkPayloadPolicy::Preserve)
-            .sanitize_annotated_request((**request).clone())
-            .map(Arc::new)
+        TrajectorySanitizer::new(
+            replacement.to_string(),
+            CustomMarkPayloadPolicy::Preserve,
+            BTreeMap::new(),
+        )
+        .sanitize_annotated_request((**request).clone())
+        .map(Arc::new)
     });
     profile.annotated_response = profile.annotated_response.as_ref().and_then(|response| {
-        TrajectorySanitizer::new(replacement.to_string(), CustomMarkPayloadPolicy::Preserve)
-            .sanitize_annotated_response((**response).clone())
-            .map(Arc::new)
+        TrajectorySanitizer::new(
+            replacement.to_string(),
+            CustomMarkPayloadPolicy::Preserve,
+            BTreeMap::new(),
+        )
+        .sanitize_annotated_response((**response).clone())
+        .map(Arc::new)
     });
     profile.extra = profile
         .extra

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -201,9 +201,19 @@ fn builtin_backend_config_default_matches_documented_action_default() {
     assert!(config.preset.is_none());
     assert_eq!(config.action, "remove");
     assert_eq!(config.custom_mark_payload_policy, "preserve");
+    assert!(config.metric_string_attribute_allowlist.is_empty());
     assert!(config.target_paths.is_empty());
     assert!(config.pattern.is_none());
     assert!(config.detector.is_none());
+}
+
+#[test]
+fn builtin_backend_editor_exposes_metric_string_allowlist_as_json() {
+    let schema = <BuiltinBackendConfig as nemo_relay::config_editor::EditorConfig>::editor_schema();
+    let field = schema
+        .field("metric_string_attribute_allowlist")
+        .expect("metric string allowlist should be editable");
+    assert_eq!(field.kind, nemo_relay::config_editor::EditorFieldKind::Json);
 }
 
 #[test]
@@ -278,6 +288,122 @@ fn trajectory_preset_validates_without_an_action_and_rejects_matcher_fields() {
     }));
 }
 
+#[test]
+fn trajectory_metric_string_allowlist_validation_is_fail_closed() {
+    let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
+    reset_runtime();
+    ensure_builtin_plugins_registered().unwrap();
+
+    let valid = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [{
+            "mode": "builtin",
+            "builtin": {
+                "preset": "trajectory_context",
+                "metric_string_attribute_allowlist": {
+                    "query.source": ["main", "subagent"]
+                }
+            }
+        }]
+    })));
+    assert!(!valid.has_errors(), "{:#?}", valid.diagnostics);
+
+    let valid_legacy = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "mode": "builtin",
+        "builtin": {
+            "preset": "trajectory_context",
+            "metric_string_attribute_allowlist": {"query.source": ["main"]}
+        }
+    })));
+    assert!(
+        !valid_legacy.has_errors(),
+        "{:#?}",
+        valid_legacy.diagnostics
+    );
+
+    let without_preset = validate_plugin_config(&plugin_config(json!({
+        "codec": "openai_chat",
+        "profiles": [{
+            "mode": "builtin",
+            "builtin": {
+                "metric_string_attribute_allowlist": {"query.source": ["main"]}
+            }
+        }]
+    })));
+    assert!(
+        without_preset.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref()
+                == Some("profiles[0].builtin.metric_string_attribute_allowlist")
+                && diagnostic.message.contains("requires builtin.preset")
+        }),
+        "{:#?}",
+        without_preset.diagnostics
+    );
+
+    for (allowlist, expected_message) in [
+        (json!({" ": ["main"]}), "keys must not be blank"),
+        (
+            json!({"query.source": []}),
+            "must contain at least one value",
+        ),
+        (json!({"query.source": [" "]}), "must not be blank"),
+        (
+            json!({"query.source": ["main", "main"]}),
+            "contains duplicate value",
+        ),
+    ] {
+        let report = validate_plugin_config(&plugin_config(json!({
+            "codec": "openai_chat",
+            "profiles": [{
+                "mode": "builtin",
+                "builtin": {
+                    "preset": "trajectory_context",
+                    "metric_string_attribute_allowlist": allowlist
+                }
+            }]
+        })));
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref()
+                == Some("profiles[0].builtin.metric_string_attribute_allowlist")
+                && diagnostic.message.contains(expected_message)
+        }));
+    }
+
+    let runtime_error = crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            metric_string_attribute_allowlist: BTreeMap::from([(
+                "query.source".into(),
+                vec!["main".into()],
+            )]),
+            ..BuiltinBackendConfig::default()
+        },
+        None,
+    )
+    .err()
+    .expect("runtime construction must reject an allowlist without the trajectory preset");
+    assert!(
+        runtime_error
+            .to_string()
+            .contains("requires builtin.preset")
+    );
+
+    let runtime_error = crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            preset: Some("trajectory_context".into()),
+            metric_string_attribute_allowlist: BTreeMap::from([(
+                "query.source".into(),
+                vec!["main".into(), "main".into()],
+            )]),
+            ..BuiltinBackendConfig::default()
+        },
+        None,
+    )
+    .err()
+    .expect("runtime construction must reject invalid allowlist entries");
+    assert!(runtime_error.to_string().contains("duplicate value"));
+}
+
 fn trajectory_backend(codec: Option<&str>, policy: &str) -> crate::builtin::CompiledBuiltinBackend {
     crate::builtin::CompiledBuiltinBackend::new(
         BuiltinBackendConfig {
@@ -286,6 +412,20 @@ fn trajectory_backend(codec: Option<&str>, policy: &str) -> crate::builtin::Comp
             ..BuiltinBackendConfig::default()
         },
         codec.map(str::to_string),
+    )
+    .unwrap()
+}
+
+fn trajectory_backend_with_metric_allowlist(
+    allowlist: BTreeMap<String, Vec<String>>,
+) -> crate::builtin::CompiledBuiltinBackend {
+    crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            preset: Some("trajectory_context".into()),
+            metric_string_attribute_allowlist: allowlist,
+            ..BuiltinBackendConfig::default()
+        },
+        None,
     )
     .unwrap()
 }
@@ -1222,6 +1362,78 @@ async fn trajectory_metric_marks_preserve_typed_measurements_and_redact_text() {
 }
 
 #[tokio::test]
+async fn trajectory_metric_string_allowlist_requires_exact_key_and_value() {
+    let data = json!({
+        "measurements": [{
+            "name": "example.request_count",
+            "kind": "counter",
+            "value_type": "u64",
+            "value": 1,
+            "description": "private request count",
+            "attributes": {
+                "query.source": "main",
+                "operation": "private operation",
+                "unapproved.key": "main",
+                "execution.modes": ["main", "private mode"],
+                "attempt": 2,
+                "sampled": true
+            }
+        }]
+    });
+    let event = Event::Mark(MarkEvent::new(
+        BaseEvent::builder()
+            .name("example.metrics")
+            .data(data.clone())
+            .data_schema(
+                DataSchema::builder()
+                    .name(METRIC_DATA_SCHEMA_NAME)
+                    .version(METRIC_DATA_SCHEMA_VERSION)
+                    .build(),
+            )
+            .build(),
+        None,
+        None,
+    ));
+    let callback = crate::builtin::event_sanitize_callback(
+        trajectory_backend_with_metric_allowlist(BTreeMap::from([
+            ("query.source".into(), vec!["main".into()]),
+            ("operation".into(), vec!["chat".into()]),
+            ("execution.modes".into(), vec!["main".into()]),
+        ])),
+    );
+    let sanitized = callback(
+        Arc::new(event),
+        EventSanitizeFields {
+            data: Some(data),
+            category_profile: Some(CategoryProfile {
+                extra: BTreeMap::from([("query.source".into(), json!("main"))]),
+                ..CategoryProfile::default()
+            }),
+            metadata: Some(json!({"query.source": "main"})),
+        },
+    )
+    .await
+    .unwrap();
+
+    let data = sanitized.data.unwrap();
+    let envelope = serde_json::from_value::<MetricEnvelope>(data.clone()).unwrap();
+    envelope.validate().unwrap();
+    let attributes = &data["measurements"][0]["attributes"];
+    assert_eq!(attributes["query.source"], "main");
+    assert_eq!(attributes["operation"], "[REDACTED]");
+    assert_eq!(attributes["unapproved.key"], "[REDACTED]");
+    assert_eq!(attributes["execution.modes"], json!(["main", "[REDACTED]"]));
+    assert_eq!(attributes["attempt"], 2);
+    assert_eq!(attributes["sampled"], true);
+    assert_eq!(data["measurements"][0]["description"], "[REDACTED]");
+    assert_eq!(sanitized.metadata.unwrap()["query.source"], "[REDACTED]");
+    assert_eq!(
+        sanitized.category_profile.unwrap().extra["query.source"],
+        "[REDACTED]"
+    );
+}
+
+#[tokio::test]
 async fn builtin_metric_marks_preserve_typed_measurements() {
     let data = json!({
         "measurements": [{
@@ -1651,6 +1863,11 @@ fn typed_trajectory_preset_omits_the_legacy_default_action() {
     assert_eq!(serialized["preset"], "trajectory_context");
     assert!(serialized.get("action").is_none());
     assert!(serialized.get("custom_mark_payload_policy").is_none());
+    assert!(
+        serialized
+            .get("metric_string_attribute_allowlist")
+            .is_none()
+    );
 }
 
 #[test]

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -240,6 +240,7 @@ The `builtin` section contains:
 | `mask_char` | Masking token used when `action = "mask"`. Defaults to `*`. |
 | `unmasked_prefix` | Leading character count to keep when `action = "mask"`. Defaults to `0`, unless a detector-specific masking preset is active. |
 | `unmasked_suffix` | Trailing character count to keep when `action = "mask"`. Defaults to `0`, unless a detector-specific masking preset is active. |
+| `metric_string_attribute_allowlist` | Exact typed metric attribute names and bounded string values that `trajectory_context` may preserve. Empty by default. |
 
 ## Typed Metric Marks
 
@@ -266,6 +267,33 @@ attributes with its configured replacement while retaining the required metric
 fields. That preset does not accept `target_paths`. Its
 `custom_mark_payload_policy` applies only to opaque marks in the `custom`
 category; it does not control Relay typed metric envelopes.
+
+To retain bounded string dimensions, configure exact attribute/value pairs on
+the trajectory preset:
+
+```toml
+[[components]]
+kind = "pii_redaction"
+
+[components.config]
+version = 1
+
+[[components.config.profiles]]
+mode = "builtin"
+
+[components.config.profiles.builtin]
+preset = "trajectory_context"
+
+[components.config.profiles.builtin.metric_string_attribute_allowlist]
+"gen_ai.operation.name" = ["chat", "text_completion"]
+```
+
+Matching is case-sensitive and requires both the attribute name and value. Each
+element of a string-array attribute is evaluated independently. Values under an
+unlisted key and unexpected values under a listed key remain redacted. This
+allowlist does not apply to descriptions, mark metadata, category profiles, or
+non-metric marks. Configure fixed constants or bounded enums only; do not list
+free-form identifiers or user-provided text.
 
 ## Action Semantics
 


### PR DESCRIPTION
#### Overview

Allow the `trajectory_context` PII-redaction preset to preserve explicitly approved, bounded string values in typed metric attributes. All unlisted attributes and unexpected values remain redacted.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `metric_string_attribute_allowlist` to the built-in PII-redaction configuration.
- Require exact, case-sensitive matches on both attribute name and value.
- Evaluate string-array elements independently.
- Keep the allowlist empty by default and restrict it to typed metric attributes.
- Reject blank keys, empty value lists, blank values, duplicates, and use without the `trajectory_context` preset.
- Document the configuration and add regressions covering validation, redaction boundaries, and serialization.

Validation:

- `cargo test -p nemo-relay-pii-redaction`
- `cargo test -p nemo-relay-pii-redaction --features schema metric_string -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all`
- `just docs`
- `uv run pre-commit run --all-files`

#### Where should the reviewer start?

Start with `crates/pii-redaction/src/trajectory.rs`, where approved metric attribute values are preserved while all other strings remain redacted. Configuration and validation are in `crates/pii-redaction/src/component.rs`, with contract coverage in `crates/pii-redaction/tests/unit/component_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an allowlist for preserving approved metric string attributes and values in the `trajectory_context` PII redaction preset.
  * Supports exact, case-sensitive matching for individual strings and string-array elements.

* **Bug Fixes**
  * Added validation to reject malformed allowlists or use outside the supported preset.

* **Documentation**
  * Documented configuration, defaults, matching behavior, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->