### PR TITLE
test: isolate implicit configuration in test builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Install these tools before you start:
 - **just** -- `cargo install just --locked`
 - **Go** >= 1.21
 - **Node.js** (LTS)
+- **cargo-nextest** 0.9.133 -- `cargo install cargo-nextest --version 0.9.133 --locked`
 - **cargo-deny** -- `cargo install cargo-deny`
 - **cargo-about** 0.9.1 -- `cargo install cargo-about --version 0.9.1 --locked --features cli`
 
@@ -45,6 +46,7 @@ git clone <repo-url> && cd NeMo-Relay
 
 uv sync
 cargo install just --locked
+cargo install cargo-nextest --version 0.9.133 --locked
 cargo install cargo-about --version 0.9.1 --locked --features cli
 uv run pre-commit install
 just build-rust

--- a/crates/adaptive/Cargo.toml
+++ b/crates/adaptive/Cargo.toml
@@ -33,6 +33,7 @@ redis = { version = "1.1", features = ["tokio-comp", "connection-manager"], opti
 
 [features]
 redis-backend = ["redis"]
+__skip-implicit-config = ["nemo-relay/__skip-implicit-config"]
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "sync", "time", "test-util", "rt-multi-thread"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,9 @@ workspace = true
 [features]
 default = ["atof-streaming"]
 atof-streaming = ["nemo-relay/atof-streaming"]
+# Private test hooks; never enable for distributed CLI artifacts.
+__test-cli-port-override = []
+__skip-implicit-config = ["nemo-relay/__skip-implicit-config"]
 
 [dependencies]
 nemo-relay = { workspace = true, features = ["guardrails-remote", "object-store", "worker-grpc"] }

--- a/crates/cli/src/configuration/mod.rs
+++ b/crates/cli/src/configuration/mod.rs
@@ -48,6 +48,9 @@ pub(crate) const DEFAULT_MAX_PASSTHROUGH_BODY_BYTES: usize = 100 * 1024 * 1024;
 pub(crate) const GATEWAY_URL_ENV: &str = "NEMO_RELAY_GATEWAY_URL";
 pub(crate) const TRANSPARENT_RUN_ENV: &str = "NEMO_RELAY_TRANSPARENT_RUN";
 
+#[cfg(feature = "__skip-implicit-config")]
+const TEST_SKIP_IMPLICIT_CONFIG_ENV: &str = "NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG";
+
 // TOML file shape grouped by user intent. Sections map 1:1 onto fields already present on
 // `GatewayConfig` / `AgentConfigs`; plugin configuration lives in `plugins.toml`.
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1155,10 +1158,18 @@ pub(crate) fn any_config_file_exists() -> bool {
 // Returns the config search path from lowest to highest precedence. An explicit path replaces the
 // ambient user file; the system layer still applies.
 fn config_paths(explicit: Option<&PathBuf>) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
     if let Some(path) = explicit {
-        paths.push(path.clone());
-    } else if let Some(user) = user_config_path() {
+        let mut paths = vec![path.clone()];
+        if !skip_implicit_config() {
+            paths.push(system_config_dir().join("config.toml"));
+        }
+        return paths;
+    }
+    if skip_implicit_config() {
+        return Vec::new();
+    }
+    let mut paths = Vec::new();
+    if let Some(user) = user_config_path() {
         paths.push(user);
     }
     paths.push(system_config_dir().join("config.toml"));
@@ -1204,9 +1215,19 @@ pub(crate) fn user_plugin_config_path() -> Option<PathBuf> {
 
 pub(crate) fn user_plugin_runtime_config() -> Result<Option<Value>, CliError> {
     Ok(
-        load_plugin_toml_config_from_paths(implicit_plugin_config_paths(user_config_dir()))?
+        load_plugin_toml_config_from_paths(plugin_config_paths(None, None))?
             .and_then(|config| config.value),
     )
+}
+
+#[cfg(feature = "__skip-implicit-config")]
+fn skip_implicit_config() -> bool {
+    env::var(TEST_SKIP_IMPLICIT_CONFIG_ENV).ok().as_deref() == Some("1")
+}
+
+#[cfg(not(feature = "__skip-implicit-config"))]
+fn skip_implicit_config() -> bool {
+    false
 }
 
 pub(crate) fn global_plugin_config_path() -> PathBuf {

--- a/crates/cli/src/installation/marketplace/assets.rs
+++ b/crates/cli/src/installation/marketplace/assets.rs
@@ -93,7 +93,8 @@ pub(super) fn plugin_mcp_config(
     generation_token: &str,
 ) -> Result<Value, String> {
     let generation_fence = absolute_or_self(generation_fence)?;
-    let server = crate::mcp::persistent_server(relay, &generation_fence, generation_token);
+    let server = crate::mcp::persistent_server(relay, &generation_fence, generation_token)
+        .map_err(|error| error.to_string())?;
     host.plugin_mcp_config(server)
 }
 

--- a/crates/cli/src/mcp/mod.rs
+++ b/crates/cli/src/mcp/mod.rs
@@ -106,22 +106,45 @@ pub(crate) async fn run(server_args: &GatewayOverrides) -> Result<ExitCode, CliE
 /// Builds the host-independent persistent MCP launch contract.
 ///
 /// Host adapters add only schema-specific activation and environment-forwarding fields. Keeping
-/// the command, arguments, fixed gateway bind, and generation fence here ensures Codex and Claude
-/// Code launch the same process.
+/// the command, arguments, persistent gateway bind, and generation fence here ensures Codex and
+/// Claude Code launch the same process.
 pub(crate) fn persistent_server(
     relay: &Path,
     generation_file: &Path,
     generation_token: &str,
-) -> Value {
-    json!({
+) -> Result<Value, CliError> {
+    #[cfg(feature = "__test-cli-port-override")]
+    let bind = persistent_gateway_bind()?;
+    #[cfg(not(feature = "__test-cli-port-override"))]
+    let bind = crate::bootstrap::DEFAULT_BIND;
+    Ok(json!({
         "command": relay,
         "args": LAUNCH_ARGS,
         "env": {
-            "NEMO_RELAY_GATEWAY_BIND": crate::bootstrap::DEFAULT_BIND,
+            "NEMO_RELAY_GATEWAY_BIND": bind,
             (GENERATION_FILE_ENV): generation_file,
             (GENERATION_TOKEN_ENV): generation_token
         }
-    })
+    }))
+}
+
+#[cfg(feature = "__test-cli-port-override")]
+fn persistent_gateway_bind() -> Result<String, CliError> {
+    let Some(value) = std::env::var_os("NEMO_RELAY_TEST_GATEWAY_BIND") else {
+        return Ok(crate::bootstrap::DEFAULT_BIND.into());
+    };
+    let value = value.to_string_lossy();
+    let address: SocketAddr = value.parse().map_err(|error| {
+        CliError::Config(format!(
+            "NEMO_RELAY_TEST_GATEWAY_BIND must be a loopback address with a nonzero port: {error}"
+        ))
+    })?;
+    if !address.ip().is_loopback() || address.port() == 0 {
+        return Err(CliError::Config(
+            "NEMO_RELAY_TEST_GATEWAY_BIND must be a loopback address with a nonzero port".into(),
+        ));
+    }
+    Ok(address.to_string())
 }
 
 fn transparent_run_active() -> bool {

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -28,6 +28,30 @@ const BOOTSTRAP_PROTOCOL_VERSION: u64 = 3;
 const CHILD_PROCESS_TIMEOUT_SECONDS: u64 = 5;
 const SIDECAR_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(5);
 
+struct ImplicitConfigEnvScope(Option<std::ffi::OsString>);
+
+impl ImplicitConfigEnvScope {
+    fn without_test_hook() -> Self {
+        let previous = std::env::var_os("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG");
+        // SAFETY: Nextest runs this integration test in its own process, and Drop restores the
+        // inherited value before the test exits.
+        unsafe { std::env::remove_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG") };
+        Self(previous)
+    }
+}
+
+impl Drop for ImplicitConfigEnvScope {
+    fn drop(&mut self) {
+        // SAFETY: see ImplicitConfigEnvScope::without_test_hook.
+        unsafe {
+            match self.0.take() {
+                Some(value) => std::env::set_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", value),
+                None => std::env::remove_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG"),
+            }
+        }
+    }
+}
+
 fn write_active_generation(temp: &std::path::Path) -> std::path::PathBuf {
     let generation = temp.join("plugin/.nemo-relay-generation");
     std::fs::create_dir_all(generation.parent().unwrap()).unwrap();
@@ -1796,6 +1820,30 @@ fn cli_agents_json_emits_supported_agent_shapes() {
     assert!(agents.iter().all(|agent| agent["status"].is_string()));
 }
 
+#[cfg(feature = "__skip-implicit-config")]
+#[test]
+fn cli_test_hook_ignores_ambient_user_configuration() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("xdg/nemo-relay/config.toml");
+    std::fs::create_dir_all(config.parent().unwrap()).unwrap();
+    std::fs::write(&config, "this is not valid TOML = [").unwrap();
+
+    let output = Command::new(gateway_bin())
+        .env("HOME", temp.path())
+        .env("XDG_CONFIG_HOME", temp.path().join("xdg"))
+        .env("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", "1")
+        .args(["agents", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "test hook should bypass ambient configuration: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+}
+
 #[test]
 fn cli_doctor_json_emits_versioned_report() {
     let temp = tempfile::tempdir().unwrap();
@@ -1851,6 +1899,7 @@ fn cli_plugins_validate_json_emits_versioned_success_output() {
 
 #[test]
 fn cli_plugins_validate_rejects_malformed_python_entrypoints_by_path_and_id() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let cwd = temp.path().join("workdir");
     let plugin_dir = cwd.join("plugins").join("acme");
@@ -2012,6 +2061,7 @@ fn cli_plugins_list_all_json_includes_tombstoned_records() {
 
 #[test]
 fn cli_plugins_validate_json_reports_blocked_policy_for_path_target() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let plugin_dir = temp.path().join("plugins").join("acme");
     let xdg = temp.path().join("xdg");
@@ -2059,6 +2109,7 @@ allowed = false
 
 #[test]
 fn cli_plugins_validate_json_reports_verified_signature_for_path_target() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let plugin_dir = temp.path().join("plugins").join("acme");
     let xdg = temp.path().join("xdg");
@@ -2107,6 +2158,7 @@ fn cli_plugins_validate_json_reports_verified_signature_for_path_target() {
 
 #[test]
 fn cli_plugins_validate_json_reports_invalid_signature_for_wrong_trusted_key() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let plugin_dir = temp.path().join("plugins").join("acme");
     let xdg = temp.path().join("xdg");
@@ -2166,6 +2218,7 @@ fn cli_plugins_validate_json_reports_invalid_signature_for_wrong_trusted_key() {
 
 #[test]
 fn cli_plugins_list_json_reports_blocked_policy_for_installed_plugin() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let cwd = temp.path().join("workdir");
     let plugin_dir = cwd.join("plugins").join("acme");
@@ -2241,6 +2294,7 @@ fn cli_plugins_list_json_reports_blocked_policy_for_installed_plugin() {
 
 #[test]
 fn cli_plugins_list_json_reports_invalid_trust_in_validation_state() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let cwd = temp.path().join("workdir");
     let plugin_dir = cwd.join("plugins").join("acme");
@@ -2302,6 +2356,7 @@ fn cli_plugins_list_json_reports_invalid_trust_in_validation_state() {
 
 #[test]
 fn cli_plugins_validate_json_reports_blocked_policy_for_installed_id_target() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let cwd = temp.path().join("workdir");
     let plugin_dir = cwd.join("plugins").join("acme");
@@ -2421,6 +2476,7 @@ fn cli_plugins_inspect_json_emits_installed_plugin_details() {
 
 #[test]
 fn cli_plugins_inspect_json_reports_blocked_policy_for_installed_plugin() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let cwd = temp.path().join("workdir");
     let plugin_dir = cwd.join("plugins").join("acme");
@@ -2807,6 +2863,7 @@ fn cli_model_pricing_add_source_validates_and_updates_user_plugin_config() {
 
 #[test]
 fn cli_model_pricing_resolve_reports_source_match_and_estimate() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let catalog = temp.path().join("pricing.json");
     let xdg = temp.path().join("xdg/nemo-relay");
@@ -3122,6 +3179,7 @@ fn cli_bare_invocation_invokes_setup_when_no_config_found() {
 
 #[test]
 fn cli_bare_invocation_runs_doctor_when_config_exists() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let xdg = temp.path().join("xdg");
     std::fs::create_dir_all(&xdg).unwrap();
@@ -3150,6 +3208,7 @@ fn cli_bare_invocation_runs_doctor_when_config_exists() {
 
 #[test]
 fn cli_bare_invocation_reports_invalid_config_resolution() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let xdg = temp.path().join("xdg");
     std::fs::create_dir_all(&xdg).unwrap();
@@ -3406,6 +3465,7 @@ fn cli_doctor_reports_unsupported_ancestor_project_config() {
 
 #[test]
 fn cli_doctor_json_reports_effective_upstream_auth_presence() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let project = temp.path().join("workspace");
     let nested = project.join("nested");
@@ -4017,6 +4077,7 @@ mode = "append"
 
 #[test]
 fn cli_run_dry_run_reports_effective_upstream_auth_presence() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
     let temp = tempfile::tempdir().unwrap();
     let project = temp.path().join("project");
     let nested = project.join("nested");

--- a/crates/cli/tests/coverage/shared/config_tests.rs
+++ b/crates/cli/tests/coverage/shared/config_tests.rs
@@ -229,6 +229,7 @@ struct PluginConfigDiscoveryScope {
     previous_anthropic_auth_header: Option<OsString>,
     previous_bootstrap_fingerprint: Option<OsString>,
     previous_plugin_idle_timeout: Option<OsString>,
+    previous_test_skip_implicit_config: Option<OsString>,
 }
 
 impl PluginConfigDiscoveryScope {
@@ -246,6 +247,8 @@ impl PluginConfigDiscoveryScope {
         let previous_anthropic_auth_header = std::env::var_os("NEMO_RELAY_ANTHROPIC_AUTH_HEADER");
         let previous_bootstrap_fingerprint = std::env::var_os(BOOTSTRAP_FINGERPRINT_ENV);
         let previous_plugin_idle_timeout = std::env::var_os(PLUGIN_IDLE_TIMEOUT_ENV);
+        let previous_test_skip_implicit_config =
+            std::env::var_os("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG");
         unsafe {
             std::env::set_var("XDG_CONFIG_HOME", xdg_config_home);
             std::env::remove_var("OPENAI_API_KEY");
@@ -255,6 +258,7 @@ impl PluginConfigDiscoveryScope {
             std::env::remove_var("NEMO_RELAY_ANTHROPIC_AUTH_HEADER");
             std::env::remove_var(BOOTSTRAP_FINGERPRINT_ENV);
             std::env::remove_var(PLUGIN_IDLE_TIMEOUT_ENV);
+            std::env::remove_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG");
         }
         std::env::set_current_dir(cwd).unwrap();
         Self {
@@ -269,6 +273,7 @@ impl PluginConfigDiscoveryScope {
             previous_anthropic_auth_header,
             previous_bootstrap_fingerprint,
             previous_plugin_idle_timeout,
+            previous_test_skip_implicit_config,
         }
     }
 
@@ -292,6 +297,14 @@ impl PluginConfigDiscoveryScope {
         unsafe {
             std::env::set_var("NEMO_RELAY_OPENAI_BASE_URL", openai);
             std::env::set_var("NEMO_RELAY_ANTHROPIC_BASE_URL", anthropic);
+        }
+    }
+
+    #[cfg(feature = "__skip-implicit-config")]
+    fn skip_implicit_config(&self) {
+        // SAFETY: This scope holds the process-wide environment mutex.
+        unsafe {
+            std::env::set_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", "1");
         }
     }
 }
@@ -332,8 +345,77 @@ impl Drop for PluginConfigDiscoveryScope {
                 Some(value) => std::env::set_var(PLUGIN_IDLE_TIMEOUT_ENV, value),
                 None => std::env::remove_var(PLUGIN_IDLE_TIMEOUT_ENV),
             }
+            match self.previous_test_skip_implicit_config.take() {
+                Some(value) => std::env::set_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", value),
+                None => std::env::remove_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG"),
+            }
         }
     }
+}
+
+#[cfg(feature = "__skip-implicit-config")]
+#[test]
+fn test_hook_skips_implicit_config_but_retains_explicit_config_and_environment() {
+    let temp = tempfile::tempdir().unwrap();
+    let xdg = temp.path().join("xdg");
+    let user_config = xdg.join("nemo-relay/config.toml");
+    let user_plugins = xdg.join("nemo-relay").join(PLUGINS_TOML);
+    let explicit_config = temp.path().join("explicit/config.toml");
+    let explicit_plugins = explicit_config.parent().unwrap().join(PLUGINS_TOML);
+    std::fs::create_dir_all(user_config.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(explicit_config.parent().unwrap()).unwrap();
+    std::fs::write(
+        &user_config,
+        "[upstream]\nopenai_base_url = 'http://user'\n",
+    )
+    .unwrap();
+    std::fs::write(&user_plugins, "not valid TOML = [").unwrap();
+    std::fs::write(
+        &explicit_config,
+        "[upstream]\nopenai_base_url = 'http://explicit'\n",
+    )
+    .unwrap();
+    let explicit_plugin_dir = explicit_config.parent().unwrap().join("plugins/acme");
+    std::fs::create_dir_all(&explicit_plugin_dir).unwrap();
+    let explicit_manifest = write_dynamic_manifest(&explicit_plugin_dir, "acme.explicit");
+    std::fs::write(
+        &explicit_plugins,
+        r#"
+version = 1
+components = []
+
+[[plugins.dynamic]]
+manifest = "plugins/acme/relay-plugin.toml"
+"#,
+    )
+    .unwrap();
+
+    let scope = PluginConfigDiscoveryScope::enter(temp.path(), &xdg);
+    scope.set_base_urls("http://environment", "http://environment-anthropic");
+    scope.skip_implicit_config();
+
+    assert!(config_paths(None).is_empty());
+    assert!(plugin_config_paths(None, None).is_empty());
+    assert!(!any_config_file_exists());
+    assert_eq!(
+        config_paths(Some(&explicit_config)),
+        vec![explicit_config.clone()]
+    );
+    assert_eq!(
+        plugin_config_paths(Some(&explicit_config), None),
+        vec![explicit_plugins.clone()]
+    );
+
+    let implicit = load_shared_config(None, None).unwrap();
+    assert_eq!(implicit.gateway.openai_base_url, "http://environment");
+    let explicit = load_shared_config(Some(&explicit_config), None).unwrap();
+    assert_eq!(explicit.gateway.openai_base_url, "http://environment");
+    let explicit_plugin_config = load_shared_config(None, Some(&explicit_plugins)).unwrap();
+    assert_eq!(explicit_plugin_config.dynamic_plugins.len(), 1);
+    assert_eq!(
+        explicit_plugin_config.dynamic_plugins[0].manifest_ref,
+        explicit_manifest.canonicalize().unwrap().to_string_lossy()
+    );
 }
 
 fn config() -> GatewayConfig {

--- a/crates/cli/tests/coverage/shared/doctor_tests.rs
+++ b/crates/cli/tests/coverage/shared/doctor_tests.rs
@@ -387,7 +387,10 @@ async fn agents_report_surfaces_merged_config_resolution_errors() {
     let config = config_home.join("nemo-relay").join("config.toml");
     std::fs::create_dir_all(config.parent().unwrap()).unwrap();
     std::fs::write(&config, "[upstream\n").unwrap();
-    let _env = EnvScope::set(&[("XDG_CONFIG_HOME", Some(config_home.as_os_str()))]);
+    let _env = EnvScope::set(&[
+        ("XDG_CONFIG_HOME", Some(config_home.as_os_str())),
+        ("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", None),
+    ]);
 
     let error = agents_report().await.unwrap_err().to_string();
 

--- a/crates/cli/tests/coverage/shared/mcp_tests.rs
+++ b/crates/cli/tests/coverage/shared/mcp_tests.rs
@@ -788,7 +788,8 @@ fn persistent_mcp_server_contract_is_host_neutral_and_generation_fenced() {
         std::path::Path::new("/opt/nemo relay/bin/nemo-relay"),
         std::path::Path::new("/tmp/plugin/.nemo-relay-generation"),
         "generation-token",
-    );
+    )
+    .unwrap();
 
     assert_eq!(server["command"], "/opt/nemo relay/bin/nemo-relay");
     assert_eq!(server["args"], json!(["mcp"]));
@@ -804,4 +805,38 @@ fn persistent_mcp_server_contract_is_host_neutral_and_generation_fenced() {
         server["env"]["NEMO_RELAY_MCP_GENERATION"],
         "generation-token"
     );
+}
+
+#[cfg(feature = "__test-cli-port-override")]
+#[test]
+fn persistent_mcp_server_uses_valid_test_gateway_bind_override() {
+    let _environment = crate::test_support::EnvScope::set(&[(
+        "NEMO_RELAY_TEST_GATEWAY_BIND",
+        Some(std::ffi::OsStr::new("127.0.0.1:47633")),
+    )]);
+    let server = persistent_server(
+        std::path::Path::new("/opt/nemo-relay"),
+        std::path::Path::new("/tmp/plugin/.nemo-relay-generation"),
+        "generation-token",
+    )
+    .unwrap();
+    assert_eq!(server["env"]["NEMO_RELAY_GATEWAY_BIND"], "127.0.0.1:47633");
+}
+
+#[cfg(feature = "__test-cli-port-override")]
+#[test]
+fn persistent_mcp_server_rejects_invalid_test_gateway_bind_override() {
+    for value in ["invalid", "0.0.0.0:47633", "127.0.0.1:0"] {
+        let _environment = crate::test_support::EnvScope::set(&[(
+            "NEMO_RELAY_TEST_GATEWAY_BIND",
+            Some(std::ffi::OsStr::new(value)),
+        )]);
+        let error = persistent_server(
+            std::path::Path::new("/opt/nemo-relay"),
+            std::path::Path::new("/tmp/plugin/.nemo-relay-generation"),
+            "generation-token",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("NEMO_RELAY_TEST_GATEWAY_BIND"));
+    }
 }

--- a/crates/cli/tests/coverage/shared/plugins_lifecycle_tests.rs
+++ b/crates/cli/tests/coverage/shared/plugins_lifecycle_tests.rs
@@ -361,6 +361,7 @@ impl EnvScope {
         Self::set(&[
             ("HOME", Some(temp.path().as_os_str())),
             ("XDG_CONFIG_HOME", Some(xdg.as_os_str())),
+            ("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", None),
             ("NEMO_RELAY_PYTHON", None),
             (ACTIVATION_SNAPSHOT_DIR_ENV, None),
         ])

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,6 +26,8 @@ atof-streaming = [
     "tokio/time",
 ]
 schema = ["dep:schemars", "nemo-relay-types/schema"]
+# Private test hook for suppressing implicit user/system plugin discovery.
+__skip-implicit-config = []
 # Deprecated with the built-in NeMo Guardrails integration; scheduled for removal in 0.9.
 guardrails-remote = []
 object-store = [

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -2277,12 +2277,28 @@ fn validate_unique_component_kinds(path: &Path, document: &Json) -> Result<()> {
 /// by the gateway.
 #[doc(hidden)]
 pub fn default_plugin_config_paths(user_dir: Option<PathBuf>) -> Vec<PathBuf> {
+    if skip_implicit_plugin_config() {
+        return Vec::new();
+    }
     let mut paths = Vec::new();
     if let Some(dir) = user_dir {
         paths.push(dir.join("plugins.toml"));
     }
     paths.push(system_config_dir().join("plugins.toml"));
     paths
+}
+
+#[cfg(feature = "__skip-implicit-config")]
+fn skip_implicit_plugin_config() -> bool {
+    std::env::var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG")
+        .ok()
+        .as_deref()
+        == Some("1")
+}
+
+#[cfg(not(feature = "__skip-implicit-config"))]
+fn skip_implicit_plugin_config() -> bool {
+    false
 }
 
 /// Resolves the platform system configuration directory.

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -1762,6 +1762,7 @@ async fn plugin_host_activation_layers_discovered_static_base_with_dynamic_compo
             .current_dir(environment.path())
             .env("XDG_CONFIG_HOME", &xdg_config_home)
             .env(PLUGIN_DISCOVERY_TEST_CHILD, "1")
+            .env_remove("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG")
             .output()
             .expect("plugin discovery child process should run");
         assert!(

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -62,6 +62,8 @@ static PARTIAL_FAIL_ROLLBACKS: AtomicUsize = AtomicUsize::new(0);
 static RESTORE_FAIL_REGISTRATIONS: AtomicUsize = AtomicUsize::new(0);
 static RESTORE_BREAK_REGISTRATIONS: AtomicUsize = AtomicUsize::new(0);
 static REPLACEMENT_REGISTRATIONS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(feature = "__skip-implicit-config")]
+static TEST_CONFIG_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 fn recorded_names() -> &'static Mutex<Vec<String>> {
     RECORDED_NAMES.get_or_init(|| Mutex::new(Vec::new()))
@@ -3165,6 +3167,13 @@ fn test_plugin_config_loading_reports_read_parse_and_version_type_errors() {
 
 #[test]
 fn test_default_plugin_config_paths_order_user_system() {
+    #[cfg(feature = "__skip-implicit-config")]
+    let previous = std::env::var_os("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG");
+    #[cfg(feature = "__skip-implicit-config")]
+    unsafe {
+        std::env::remove_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG");
+    }
+
     let dir = tempfile::tempdir().unwrap();
     let user = dir.path().join("user");
 
@@ -3175,6 +3184,34 @@ fn test_default_plugin_config_paths_order_user_system() {
             system_config_dir().join("plugins.toml"),
         ]
     );
+
+    #[cfg(feature = "__skip-implicit-config")]
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", value),
+            None => std::env::remove_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG"),
+        }
+    }
+}
+
+#[cfg(feature = "__skip-implicit-config")]
+#[test]
+fn test_hook_skips_implicit_plugin_config_paths() {
+    let _guard = TEST_CONFIG_ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let previous = std::env::var_os("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG");
+    unsafe { std::env::set_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", "1") };
+
+    assert!(default_plugin_config_paths(Some(PathBuf::from("/test/user"))).is_empty());
+
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", value),
+            None => std::env::remove_var("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG"),
+        }
+    }
 }
 
 #[test]

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -16,6 +16,9 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
 
+[features]
+__skip-implicit-config = ["nemo-relay/__skip-implicit-config"]
+
 [dependencies]
 nemo-relay = { workspace = true, features = ["atof-streaming", "worker-grpc"] }
 nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }

--- a/crates/ffi/tests/integration/plugin_activation_tests.rs
+++ b/crates/ffi/tests/integration/plugin_activation_tests.rs
@@ -63,6 +63,7 @@ fn ffi_activation_layers_discovered_static_and_explicit_dynamic_plugins() {
         )
         .arg("--nocapture")
         .env(DISCOVERY_CHILD_ENV, "1")
+        .env_remove("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG")
         .output()
         .expect("discovery child test should start");
     assert!(

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -17,6 +17,9 @@ workspace = true
 crate-type = ["cdylib"]
 test = false
 
+[features]
+__skip-implicit-config = ["nemo-relay/__skip-implicit-config"]
+
 [dependencies]
 nemo-relay = { workspace = true, features = ["atof-streaming", "guardrails-remote", "object-store", "worker-grpc"] }
 nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -17,6 +17,9 @@ workspace = true
 name = "_native"
 crate-type = ["cdylib", "rlib"]
 
+[features]
+__skip-implicit-config = ["nemo-relay/__skip-implicit-config"]
+
 [dependencies]
 nemo-relay = { workspace = true, features = ["atof-streaming", "guardrails-remote", "object-store", "worker-grpc"] }
 nemo-relay-adaptive = { workspace = true, features = ["redis-backend"] }

--- a/docs/build-plugins/language-binding/code-examples.mdx
+++ b/docs/build-plugins/language-binding/code-examples.mdx
@@ -85,7 +85,7 @@ Run and inspect the Rust host as follows:
 
    ```bash
    cd rust
-   cargo test --locked
+   cargo nextest run --locked
    cargo run --locked
    ```
 

--- a/docs/build-plugins/native/build-and-package.mdx
+++ b/docs/build-plugins/native/build-and-package.mdx
@@ -44,7 +44,7 @@ Build and materialize the platform-specific library as follows:
 1. Run the example tests and build the debug library.
 
    ```bash
-   cargo test
+   cargo nextest run
    cargo build
    ```
 

--- a/docs/build-plugins/workers/rust.mdx
+++ b/docs/build-plugins/workers/rust.mdx
@@ -36,7 +36,7 @@ Build the executable and materialize its platform-specific manifest as follows:
 1. Run the example from its own directory.
 
    ```bash
-   cargo test
+   cargo nextest run
    cargo build
    ```
 

--- a/docs/contribute/development-setup.mdx
+++ b/docs/contribute/development-setup.mdx
@@ -29,6 +29,7 @@ Install these tools before you start:
 - `just`
 - Go 1.21 or newer
 - Node.js LTS
+- `cargo-nextest` 0.9.133
 - `cargo-deny`
 - `cargo-about` 0.9.1
 
@@ -41,6 +42,7 @@ Clone the repository and build the workspace:
 git clone <repo-url> && cd NeMo-Relay
 uv sync
 cargo install just --locked
+cargo install cargo-nextest --version 0.9.133 --locked
 cargo install cargo-about --version 0.9.1 --locked --features cli
 uv run pre-commit install
 just build-rust

--- a/docs/contribute/testing-and-docs.mdx
+++ b/docs/contribute/testing-and-docs.mdx
@@ -27,6 +27,9 @@ just test-node
 just test-openclaw
 ```
 
+The Rust-backed test recipes use `cargo-nextest`; install it with
+`cargo install cargo-nextest --version 0.9.133 --locked` before running them.
+
 The Rust, Python, and Go recipes build the native and worker dynamic-plugin test
 fixtures once before starting their test runners. Before a focused raw test that
 uses those fixtures, prepare them explicitly:
@@ -60,8 +63,7 @@ Run the Rust validation loop when a change touches the core runtime or
 Rust-facing API surface.
 
 ```bash
-just build-test-plugin-fixtures
-cargo test --workspace
+just test-rust
 ```
 
 ### Python

--- a/docs/getting-started/prerequisites.mdx
+++ b/docs/getting-started/prerequisites.mdx
@@ -16,6 +16,7 @@ Install the tooling for the binding you plan to use.
 | Node.js | 24 or newer | Node.js bindings and generated Node.js API docs |
 | `uv` | Refer to [Development Setup](/contribute/development-setup). | Python environments, docs builds, and repository setup |
 | `just` | Refer to [Development Setup](/contribute/development-setup). | Repository development, test, build, and docs task aliases |
+| `cargo-nextest` | Refer to [Development Setup](/contribute/development-setup). | Repository Rust tests and Rust-backed binding tests |
 
 The primary documentation track covers Rust, Python, and Node.js. Go and the raw FFI surface are experimental and source-first.
 

--- a/docs/resources/support-and-faqs.mdx
+++ b/docs/resources/support-and-faqs.mdx
@@ -509,7 +509,7 @@ agent skills under `skills/` and keep examples aligned with the public docs.
 
 Choose the smallest validation set that covers the touched surface:
 
-- Rust core or adaptive changes: `cargo test --workspace` or focused crate tests.
+- Rust core or adaptive changes: `just test-rust` or focused `cargo nextest run` commands.
 - Python binding changes: `just build-test-plugin-fixtures && uv run pytest`.
 - Node.js binding changes: `npm test --workspace=nemo-relay-node`.
 - Go binding changes: build the release FFI library first, then run Go tests under `go/nemo_relay`.

--- a/go/nemo_relay/plugin_activation_test.go
+++ b/go/nemo_relay/plugin_activation_test.go
@@ -583,6 +583,7 @@ func TestNilPluginActivationCloseIsSafe(t *testing.T) {
 }
 
 func TestInitializeWithDynamicPluginsLoadsNativePluginThroughCgo(t *testing.T) {
+	t.Setenv("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", "")
 	if err := ClearPluginConfiguration(); err != nil {
 		t.Fatalf(clearConfigurationErrorFmt, err)
 	}

--- a/justfile
+++ b/justfile
@@ -1241,6 +1241,7 @@ test-rust:
     xdg_config_home="$test_config_root/xdg"
     mkdir -p "$xdg_config_home"
     export XDG_CONFIG_HOME="$(native_test_config_path "$xdg_config_home")"
+    export NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG=1
     if [[ "$is_windows" == true ]]; then
         appdata_home="$test_config_root/AppData/Roaming"
         localappdata_home="$test_config_root/AppData/Local"
@@ -1258,7 +1259,7 @@ test-rust:
             prepare_llvm_cov_workspace
         fi
         prepare_test_plugin_fixtures
-        cargo nextest run --locked --workspace --profile ci --no-fail-fast
+        cargo nextest run --locked --workspace --exclude nemo-relay-python --exclude nemo-relay-node --features nemo-relay-cli/__test-cli-port-override,nemo-relay-cli/__skip-implicit-config --profile ci --no-fail-fast
         cp "$NEMO_RELAY_REPO_ROOT/target/nextest/ci/rust_junit_report.xml" "$junit_out"
         if rust_source_coverage_supported; then
             cargo llvm-cov report \
@@ -1268,12 +1269,11 @@ test-rust:
         fi
     else
         prepare_test_plugin_fixtures
-        cargo test --workspace --exclude nemo-relay-ffi
-        cargo test -p nemo-relay-ffi -- --test-threads=1
+        cargo nextest run --locked --workspace --exclude nemo-relay-python --exclude nemo-relay-node --features nemo-relay-cli/__test-cli-port-override,nemo-relay-cli/__skip-implicit-config --profile ci --no-fail-fast
     fi
-    cargo test --manifest-path examples/rust-native-plugin/Cargo.toml
-    cargo test --manifest-path examples/rust-grpc-worker-plugin/Cargo.toml
-    cargo test --manifest-path examples/language-binding-plugin/rust/Cargo.toml
+    cargo nextest run --manifest-path examples/rust-native-plugin/Cargo.toml --config-file "$NEMO_RELAY_REPO_ROOT/.config/nextest.toml" --profile ci
+    cargo nextest run --manifest-path examples/rust-grpc-worker-plugin/Cargo.toml --config-file "$NEMO_RELAY_REPO_ROOT/.config/nextest.toml" --profile ci
+    cargo nextest run --manifest-path examples/language-binding-plugin/rust/Cargo.toml --config-file "$NEMO_RELAY_REPO_ROOT/.config/nextest.toml" --profile ci
 
 # --set [output_dir=<path>] [ci=true|false]
 test-python:
@@ -1288,18 +1288,19 @@ test-python:
     test_config_home="$(mktemp -d)"
     trap 'rm -rf "$test_config_home"' EXIT
     export XDG_CONFIG_HOME="$test_config_home"
+    export NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG=1
+    export_uv_python_runtime
     if is_true "{{ ci }}"; then
         coverage_out="$(prepare_artifact python-coverage.xml)"
         junit_out="$(prepare_artifact python-junit.xml)"
         pytest_cmd+=(--cov=nemo_relay --cov=nemo_relay_plugin --cov-report term-missing --cov-report "xml:$coverage_out")
         pytest_cmd+=(--junit-xml "$junit_out")
-        export_uv_python_runtime
         if rust_source_coverage_supported; then
             rust_coverage_out="$(prepare_artifact python-rust.xml)"
             prepare_llvm_cov_workspace
         fi
-        cargo test -p nemo-relay-python --lib
     fi
+    cargo nextest run --locked -p nemo-relay-python --features __skip-implicit-config --lib --profile ci
     python_executable="$(uv_python_executable)"
     sync_args=(--inexact --all-packages --no-install-project --no-install-package nemo-relay)
     if python_plugin_grpc_dependencies_supported "$python_executable"; then
@@ -1317,7 +1318,7 @@ test-python:
         pytest_cmd+=(--ignore=python/tests/plugin)
     fi
     use_project_python_source "$python_executable"
-    "$python_executable" -m maturin develop --skip-install
+    "$python_executable" -m maturin develop --features __skip-implicit-config --skip-install
     prepare_test_plugin_fixtures
     pytest_cmd+=(--durations=25)
     "$python_executable" -m "${pytest_cmd[@]}" --ignore=python/tests/integrations
@@ -1432,10 +1433,11 @@ test-python-plugin-e2e:
         exit 1
     fi
     NEMO_RELAY_PYTHON_PLUGIN_TEST_ENVIRONMENT="$environment_ref" \
-        cargo test -p nemo-relay --features worker-grpc \
+        cargo nextest run --locked -p nemo-relay --features worker-grpc \
         --test worker_plugin_integration \
-        python_worker_host_runtime_mark_and_mutated_request_round_trip \
-        -- --nocapture
+        -E 'test(python_worker_host_runtime_mark_and_mutated_request_round_trip)' \
+        --no-capture \
+        --profile ci
     kill "$gateway_pid" 2>/dev/null || true
     wait "$gateway_pid" 2>/dev/null || true
     gateway_pid=""
@@ -1447,12 +1449,13 @@ test-python-langchain:
     {{ bash_helpers }}
     pytest_cmd=(pytest)
     cd "$NEMO_RELAY_REPO_ROOT"
+    export NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG=1
     uv sync --inexact --no-install-project --no-install-package nemo-relay --extra langchain --extra langchain-nvidia --extra langgraph --extra deepagents
     activate_project_venv
     export_uv_python_runtime
     python_executable="$(project_python_executable)"
     use_project_python_source "$python_executable"
-    "$python_executable" -m maturin develop --skip-install
+    "$python_executable" -m maturin develop --features __skip-implicit-config --skip-install
     "$python_executable" -m "${pytest_cmd[@]}" \
         python/tests/integrations/deepagents_tests \
         python/tests/integrations/langchain_tests \
@@ -1483,7 +1486,8 @@ test-go:
             ;;
     esac
     cd "$NEMO_RELAY_REPO_ROOT"
-    cargo build $flag -p nemo-relay-ffi
+    export NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG=1
+    cargo build $flag -p nemo-relay-ffi --features __skip-implicit-config
     prepare_test_plugin_fixtures
 
     if [[ "$is_windows" == true ]]; then
@@ -1546,6 +1550,7 @@ test-node:
     test_config_home="$(mktemp -d)"
     trap 'rm -rf "$test_config_home"' EXIT
     export XDG_CONFIG_HOME="$test_config_home"
+    export NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG=1
     if is_true "{{ ci }}"; then
         coverage_out="$(prepare_artifact node-coverage.xml)"
         junit_out="$(prepare_artifact node-junit.xml)"
@@ -1553,8 +1558,8 @@ test-node:
             rust_coverage_out="$(prepare_artifact node-rust.xml)"
             prepare_llvm_cov_workspace
         fi
-        cargo test -p nemo-relay-node --lib
     fi
+    cargo nextest run --locked -p nemo-relay-node --features __skip-implicit-config --lib --profile ci
     npm install --workspace=nemo-relay-node --ignore-scripts
     if is_true "{{ ci }}"; then
         npm run coverage --workspace=nemo-relay-node
@@ -1575,9 +1580,9 @@ test-node:
 
 # run each checked plugin authoring example from its own project directory
 test-plugin-examples:
-    (cd examples/rust-native-plugin && cargo test)
-    (cd examples/rust-grpc-worker-plugin && cargo test)
-    (cd examples/language-binding-plugin/rust && cargo test)
+    (cd examples/rust-native-plugin && cargo nextest run --config-file "$NEMO_RELAY_REPO_ROOT/.config/nextest.toml" --profile ci)
+    (cd examples/rust-grpc-worker-plugin && cargo nextest run --config-file "$NEMO_RELAY_REPO_ROOT/.config/nextest.toml" --profile ci)
+    (cd examples/language-binding-plugin/rust && cargo nextest run --config-file "$NEMO_RELAY_REPO_ROOT/.config/nextest.toml" --profile ci)
     (cd examples/python-grpc-worker-plugin && uv run --locked --group test --reinstall-package nemo-relay-plugin pytest)
     (cd examples/language-binding-plugin/python && uv run --locked --group test --reinstall-package nemo-relay pytest)
     npm test --workspace=nemo-relay-node-language-binding-plugin-example

--- a/python/tests/test_dynamic_plugin_host.py
+++ b/python/tests/test_dynamic_plugin_host.py
@@ -500,6 +500,7 @@ async def test_dynamic_activation_layers_plugins_toml_static_components(
         )
     )
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("NEMO_RELAY_TEST_SKIP_IMPLICIT_CONFIG", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(isolated_user_config))
 
     plugin.register(static_kind, cast(plugin.Plugin, FileStaticPlugin()))

--- a/scripts/test-claude-plugin-e2e.sh
+++ b/scripts/test-claude-plugin-e2e.sh
@@ -11,7 +11,7 @@ if ! command -v claude >/dev/null 2>&1; then
     exit 0
 fi
 
-cargo build -p nemo-relay-cli --bin nemo-relay
+cargo build -p nemo-relay-cli --bin nemo-relay --features __test-cli-port-override
 
 work="$(mktemp -d)"
 provider_pid=""
@@ -56,6 +56,8 @@ export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 export DISABLE_AUTOUPDATER=1
 export NEMO_RELAY_GATEWAY_URL="http://127.0.0.1:1"
 export NEMO_RELAY_PLUGIN_IDLE_TIMEOUT_SECS=1
+gateway_port="$(python3 -c 'import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()')"
+export NEMO_RELAY_TEST_GATEWAY_BIND="127.0.0.1:$gateway_port"
 
 mkdir -p \
     "$HOME" \
@@ -114,6 +116,7 @@ nemo-relay doctor --plugin claude-code --install-dir "$work/install"
 
 python3 - "$plugin_root" <<'PY'
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -124,7 +127,7 @@ relay = [item for item in plugins if item.get("id") == "nemo-relay-plugin@nemo-r
 assert len(relay) == 1, relay
 server = relay[0]["mcpServers"]["nemo-relay"]
 assert server["args"] == ["mcp"], server
-assert server["env"]["NEMO_RELAY_GATEWAY_BIND"] == "127.0.0.1:47632", server
+assert server["env"]["NEMO_RELAY_GATEWAY_BIND"] == os.environ["NEMO_RELAY_TEST_GATEWAY_BIND"], server
 generation = Path(server["env"]["NEMO_RELAY_MCP_GENERATION_FILE"])
 assert generation == plugin_root / ".nemo-relay-generation", generation
 assert generation.is_file(), generation
@@ -134,18 +137,20 @@ assert server["alwaysLoad"] is True, server
 PY
 
 wait_for_relay_port_release() {
-    python3 - <<'PY'
+    python3 - "$gateway_port" <<'PY'
 import socket
+import sys
 import time
 
+port = int(sys.argv[1])
 deadline = time.monotonic() + 8
 while time.monotonic() < deadline:
     with socket.socket() as sock:
         sock.settimeout(0.2)
-        if sock.connect_ex(("127.0.0.1", 47632)) != 0:
+        if sock.connect_ex(("127.0.0.1", port)) != 0:
             raise SystemExit(0)
     time.sleep(0.1)
-raise SystemExit("Relay port 47632 did not become free")
+raise SystemExit(f"Relay port {port} did not become free")
 PY
     return 0
 }

--- a/scripts/test-codex-plugin-e2e.sh
+++ b/scripts/test-codex-plugin-e2e.sh
@@ -11,7 +11,7 @@ if ! command -v codex >/dev/null 2>&1; then
     exit 0
 fi
 
-cargo build -p nemo-relay-cli --bin nemo-relay
+cargo build -p nemo-relay-cli --bin nemo-relay --features __test-cli-port-override
 
 work="$(mktemp -d)"
 provider_pid=""
@@ -112,6 +112,8 @@ export TMPDIR="$work/tmp"
 export PATH="$repo_root/target/debug:$PATH"
 export OPENAI_API_KEY="relay-e2e-key"
 export NEMO_RELAY_PLUGIN_IDLE_TIMEOUT_SECS=1
+gateway_port="$(python3 -c 'import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()')"
+export NEMO_RELAY_TEST_GATEWAY_BIND="127.0.0.1:$gateway_port"
 mkdir -p "$HOME" "$CODEX_HOME" "$XDG_CONFIG_HOME/nemo-relay" "$XDG_DATA_HOME" "$TMPDIR"
 
 provider_ready="$work/provider-ready.json"
@@ -156,18 +158,20 @@ mode = "append"
 EOF
 
 wait_for_relay_port_release() {
-    python3 - <<'PY'
+    python3 - "$gateway_port" <<'PY'
 import socket
+import sys
 import time
 
+port = int(sys.argv[1])
 deadline = time.monotonic() + 6
 while time.monotonic() < deadline:
     with socket.socket() as sock:
         sock.settimeout(0.2)
-        if sock.connect_ex(("127.0.0.1", 47632)) != 0:
+        if sock.connect_ex(("127.0.0.1", port)) != 0:
             raise SystemExit(0)
     time.sleep(0.1)
-raise SystemExit("Relay port 47632 did not become free")
+raise SystemExit(f"Relay port {port} did not become free")
 PY
 }
 
@@ -617,12 +621,14 @@ wait "$second_pid"
 background_pids=("")
 [[ "$(read_sidecar_pid "$sidecar_pid_file")" == "$shared_sidecar_pid" ]]
 kill -0 "$shared_sidecar_pid"
-python3 - <<'PY'
+python3 - "$gateway_port" <<'PY'
 import socket
+import sys
 
+port = int(sys.argv[1])
 with socket.socket() as sock:
     sock.settimeout(0.2)
-    assert sock.connect_ex(("127.0.0.1", 47632)) == 0, "shared Relay gateway stopped early"
+    assert sock.connect_ex(("127.0.0.1", port)) == 0, "shared Relay gateway stopped early"
 PY
 
 owner_file="$(find_sidecar_file 'sidecar-*.owner.json')"


### PR DESCRIPTION
#### Overview

Add test-only controls that isolate implicit configuration discovery and let coding-agent E2E installs use an allocated loopback port.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Gate implicit config and plugin discovery behind the non-default `__skip-implicit-config` feature across the runtime and language bindings.
- Gate the CLI MCP bind override behind `__test-cli-port-override`, including validation and E2E port allocation.
- Run Rust-backed tests through Nextest with isolated test processes, and document `cargo-nextest` as a required development test tool.
- Keep discovery tests explicit by disabling the test hook only within their process-scoped test setup.

#### Where should the reviewer start?

Start with `crates/core/src/plugin.rs`, `crates/cli/src/configuration/mod.rs`, and the Rust test recipes in `justfile`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration isolation so explicit settings and environment overrides remain reliable when implicit system or user configuration is disabled.
  * Added validation for test gateway bindings, rejecting invalid, wildcard, and zero-port values.
  * Improved error reporting when persistent plugin servers fail to start.

* **Documentation**
  * Updated Rust testing instructions to use `cargo-nextest` and the streamlined test commands.

* **Testing**
  * Test suites and end-to-end checks now use isolated configuration and dynamically assigned local ports for more reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->