### PR TITLE
Forward-merge release/0.8 into main

### DIFF
--- a/crates/adaptive/src/config.rs
+++ b/crates/adaptive/src/config.rs
@@ -343,10 +343,103 @@ nemo_relay::editor_config! {
     }
 }
 
+fn default_backend_editor_config() -> Json {
+    Json::Object(Map::new())
+}
+
+#[cfg(feature = "redis-backend")]
+fn default_redis_backend_editor_config() -> Json {
+    serde_json::json!({"url": "", "key_prefix": "nemo_relay:"})
+}
+
+static IN_MEMORY_BACKEND_EDITOR_SCHEMA: nemo_relay::config_editor::EditorSchema =
+    nemo_relay::config_editor::EditorSchema { fields: &[] };
+
+#[cfg(feature = "redis-backend")]
+static REDIS_BACKEND_EDITOR_FIELDS: [nemo_relay::config_editor::EditorFieldSpec; 2] = [
+    nemo_relay::config_editor::EditorFieldSpec {
+        name: "url",
+        label: "url",
+        kind: nemo_relay::config_editor::EditorFieldKind::String,
+        enum_values: &[],
+        optional: false,
+        nested_schema: None,
+        nested_default: None,
+        list_item: None,
+        tagged_union: None,
+    },
+    nemo_relay::config_editor::EditorFieldSpec {
+        name: "key_prefix",
+        label: "key_prefix",
+        kind: nemo_relay::config_editor::EditorFieldKind::String,
+        enum_values: &[],
+        optional: true,
+        nested_schema: None,
+        nested_default: None,
+        list_item: None,
+        tagged_union: None,
+    },
+];
+
+#[cfg(feature = "redis-backend")]
+static REDIS_BACKEND_EDITOR_SCHEMA: nemo_relay::config_editor::EditorSchema =
+    nemo_relay::config_editor::EditorSchema {
+        fields: &REDIS_BACKEND_EDITOR_FIELDS,
+    };
+
+fn in_memory_backend_editor_schema() -> &'static nemo_relay::config_editor::EditorSchema {
+    &IN_MEMORY_BACKEND_EDITOR_SCHEMA
+}
+
+#[cfg(feature = "redis-backend")]
+fn redis_backend_editor_schema() -> &'static nemo_relay::config_editor::EditorSchema {
+    &REDIS_BACKEND_EDITOR_SCHEMA
+}
+
+#[cfg(not(feature = "redis-backend"))]
+static BACKEND_EDITOR_VARIANTS: [nemo_relay::config_editor::EditorVariantSpec; 1] =
+    [nemo_relay::config_editor::EditorVariantSpec {
+        label: "In memory",
+        tag: "in_memory",
+        schema: in_memory_backend_editor_schema,
+        default: default_backend_editor_config,
+    }];
+
+#[cfg(feature = "redis-backend")]
+static BACKEND_EDITOR_VARIANTS: [nemo_relay::config_editor::EditorVariantSpec; 2] = [
+    nemo_relay::config_editor::EditorVariantSpec {
+        label: "In memory",
+        tag: "in_memory",
+        schema: in_memory_backend_editor_schema,
+        default: default_backend_editor_config,
+    },
+    nemo_relay::config_editor::EditorVariantSpec {
+        label: "Redis",
+        tag: "redis",
+        schema: redis_backend_editor_schema,
+        default: default_redis_backend_editor_config,
+    },
+];
+
+static BACKEND_EDITOR_CONFIG: nemo_relay::config_editor::EditorTaggedUnionSpec =
+    nemo_relay::config_editor::EditorTaggedUnionSpec {
+        discriminator: "kind",
+        variants: &BACKEND_EDITOR_VARIANTS,
+    };
+
+#[cfg(not(feature = "redis-backend"))]
+nemo_relay::editor_config! {
+    impl BackendSpec {
+        kind => { label: "kind", kind: Enum, values: ["in_memory"] },
+        config => { label: "config", kind: DiscriminatedSection, tagged_union: &BACKEND_EDITOR_CONFIG },
+    }
+}
+
+#[cfg(feature = "redis-backend")]
 nemo_relay::editor_config! {
     impl BackendSpec {
         kind => { label: "kind", kind: Enum, values: ["in_memory", "redis"] },
-        config => { label: "config", kind: Json },
+        config => { label: "config", kind: DiscriminatedSection, tagged_union: &BACKEND_EDITOR_CONFIG },
     }
 }
 
@@ -403,7 +496,7 @@ nemo_relay::editor_config! {
         bypass_rate => { label: "bypass_rate", kind: Float },
         cache_nondeterministic => { label: "cache_nondeterministic", kind: Boolean },
         key_strategy => { label: "key_strategy", kind: String },
-        header_allowlist => { label: "header_allowlist", kind: Json },
+        header_allowlist => { label: "header_allowlist", kind: List, list: &nemo_relay::config_editor::STRING_LIST_ITEM },
         backend => {
             label: "backend",
             kind: Section,

--- a/crates/adaptive/src/response_cache/config.rs
+++ b/crates/adaptive/src/response_cache/config.rs
@@ -50,11 +50,110 @@ impl BackendConfig {
     }
 }
 
+fn default_in_memory_cache_backend_editor_config() -> Json {
+    Json::Object(Map::new())
+}
+
+#[cfg(feature = "redis-backend")]
+fn default_redis_cache_backend_editor_config() -> Json {
+    serde_json::json!({"url": "", "key_prefix": "nemo_relay:"})
+}
+
+static IN_MEMORY_CACHE_BACKEND_EDITOR_FIELDS: [nemo_relay::config_editor::EditorFieldSpec; 1] =
+    [nemo_relay::config_editor::EditorFieldSpec {
+        name: "max_bytes",
+        label: "max_bytes",
+        kind: nemo_relay::config_editor::EditorFieldKind::Integer,
+        enum_values: &[],
+        optional: true,
+        nested_schema: None,
+        nested_default: None,
+        list_item: None,
+        tagged_union: None,
+    }];
+
+static IN_MEMORY_CACHE_BACKEND_EDITOR_SCHEMA: nemo_relay::config_editor::EditorSchema =
+    nemo_relay::config_editor::EditorSchema {
+        fields: &IN_MEMORY_CACHE_BACKEND_EDITOR_FIELDS,
+    };
+
+#[cfg(feature = "redis-backend")]
+static REDIS_CACHE_BACKEND_EDITOR_FIELDS: [nemo_relay::config_editor::EditorFieldSpec; 2] = [
+    nemo_relay::config_editor::EditorFieldSpec {
+        name: "url",
+        label: "url",
+        kind: nemo_relay::config_editor::EditorFieldKind::String,
+        enum_values: &[],
+        optional: false,
+        nested_schema: None,
+        nested_default: None,
+        list_item: None,
+        tagged_union: None,
+    },
+    nemo_relay::config_editor::EditorFieldSpec {
+        name: "key_prefix",
+        label: "key_prefix",
+        kind: nemo_relay::config_editor::EditorFieldKind::String,
+        enum_values: &[],
+        optional: true,
+        nested_schema: None,
+        nested_default: None,
+        list_item: None,
+        tagged_union: None,
+    },
+];
+
+#[cfg(feature = "redis-backend")]
+static REDIS_CACHE_BACKEND_EDITOR_SCHEMA: nemo_relay::config_editor::EditorSchema =
+    nemo_relay::config_editor::EditorSchema {
+        fields: &REDIS_CACHE_BACKEND_EDITOR_FIELDS,
+    };
+
+fn in_memory_cache_backend_editor_schema() -> &'static nemo_relay::config_editor::EditorSchema {
+    &IN_MEMORY_CACHE_BACKEND_EDITOR_SCHEMA
+}
+
+#[cfg(feature = "redis-backend")]
+fn redis_cache_backend_editor_schema() -> &'static nemo_relay::config_editor::EditorSchema {
+    &REDIS_CACHE_BACKEND_EDITOR_SCHEMA
+}
+
+#[cfg(not(feature = "redis-backend"))]
+static CACHE_BACKEND_EDITOR_VARIANTS: [nemo_relay::config_editor::EditorVariantSpec; 1] =
+    [nemo_relay::config_editor::EditorVariantSpec {
+        label: "In memory",
+        tag: "in_memory",
+        schema: in_memory_cache_backend_editor_schema,
+        default: default_in_memory_cache_backend_editor_config,
+    }];
+
+#[cfg(feature = "redis-backend")]
+static CACHE_BACKEND_EDITOR_VARIANTS: [nemo_relay::config_editor::EditorVariantSpec; 2] = [
+    nemo_relay::config_editor::EditorVariantSpec {
+        label: "In memory",
+        tag: "in_memory",
+        schema: in_memory_cache_backend_editor_schema,
+        default: default_in_memory_cache_backend_editor_config,
+    },
+    nemo_relay::config_editor::EditorVariantSpec {
+        label: "Redis",
+        tag: "redis",
+        schema: redis_cache_backend_editor_schema,
+        default: default_redis_cache_backend_editor_config,
+    },
+];
+
+static CACHE_BACKEND_EDITOR_CONFIG: nemo_relay::config_editor::EditorTaggedUnionSpec =
+    nemo_relay::config_editor::EditorTaggedUnionSpec {
+        discriminator: "kind",
+        variants: &CACHE_BACKEND_EDITOR_VARIANTS,
+    };
+
 #[cfg(not(feature = "redis-backend"))]
 nemo_relay::editor_config! {
     impl BackendConfig {
         kind => { label: "kind", kind: Enum, values: ["in_memory"] },
-        config => { label: "config", kind: Json },
+        config => { label: "config", kind: DiscriminatedSection, tagged_union: &CACHE_BACKEND_EDITOR_CONFIG },
     }
 }
 
@@ -62,7 +161,7 @@ nemo_relay::editor_config! {
 nemo_relay::editor_config! {
     impl BackendConfig {
         kind => { label: "kind", kind: Enum, values: ["in_memory", "redis"] },
-        config => { label: "config", kind: Json },
+        config => { label: "config", kind: DiscriminatedSection, tagged_union: &CACHE_BACKEND_EDITOR_CONFIG },
     }
 }
 
@@ -110,8 +209,8 @@ nemo_relay::editor_config! {
             nested: ToolClass,
             default: ToolClass,
         },
-        classes => { label: "classes", kind: Json },
-        overrides => { label: "overrides", kind: Json },
+        classes => { label: "classes", kind: Map, map: &TOOL_CLASS_MAP_VALUE },
+        overrides => { label: "overrides", kind: Map, map: &TOOL_OVERRIDE_MAP_VALUE },
     }
 }
 
@@ -176,6 +275,19 @@ nemo_relay::editor_config! {
     }
 }
 
+fn default_tool_class_editor_value() -> Json {
+    serde_json::to_value(ToolClass::default()).expect("tool class should serialize")
+}
+
+static TOOL_CLASS_MAP_VALUE: nemo_relay::config_editor::EditorListItemSpec =
+    nemo_relay::config_editor::EditorListItemSpec {
+        kind: nemo_relay::config_editor::EditorFieldKind::Section,
+        schema: Some(<ToolClass as nemo_relay::config_editor::EditorConfig>::editor_schema),
+        default: Some(default_tool_class_editor_value),
+        tagged_union: None,
+        list_item: None,
+    };
+
 nemo_relay::editor_config! {
     impl ToolOverride {
         cacheable => { label: "cacheable", kind: Boolean, optional: true },
@@ -190,3 +302,16 @@ nemo_relay::editor_config! {
         },
     }
 }
+
+fn default_tool_override_editor_value() -> Json {
+    serde_json::to_value(ToolOverride::default()).expect("tool override should serialize")
+}
+
+static TOOL_OVERRIDE_MAP_VALUE: nemo_relay::config_editor::EditorListItemSpec =
+    nemo_relay::config_editor::EditorListItemSpec {
+        kind: nemo_relay::config_editor::EditorFieldKind::Section,
+        schema: Some(<ToolOverride as nemo_relay::config_editor::EditorConfig>::editor_schema),
+        default: Some(default_tool_override_editor_value),
+        tagged_union: None,
+        list_item: None,
+    };

--- a/crates/adaptive/tests/unit/config_tests.rs
+++ b/crates/adaptive/tests/unit/config_tests.rs
@@ -151,7 +151,6 @@ fn test_adaptive_editor_schema_covers_canonical_options() {
     let state = schema.field("state").unwrap().schema().unwrap();
     let backend = state.field("backend").unwrap().schema().unwrap();
     assert_eq!(backend.field("kind").unwrap().kind, EditorFieldKind::Enum);
-    assert_eq!(backend.field("config").unwrap().kind, EditorFieldKind::Json);
 
     let telemetry = schema.field("telemetry").unwrap().schema().unwrap();
     let learners = telemetry.field("learners").unwrap();
@@ -220,6 +219,38 @@ fn test_adaptive_editor_schema_covers_canonical_options() {
         tools.field("default").unwrap().kind,
         EditorFieldKind::Section
     );
+}
+
+#[test]
+fn adaptive_editor_schema_describes_structured_collections() {
+    let schema = AdaptiveConfig::editor_schema();
+    let backend = schema
+        .field("state")
+        .unwrap()
+        .schema()
+        .unwrap()
+        .field("backend")
+        .unwrap()
+        .schema()
+        .unwrap();
+    let backend_config = backend.field("config").unwrap();
+    assert_eq!(backend_config.kind, EditorFieldKind::DiscriminatedSection);
+    assert_eq!(backend_config.tagged_union.unwrap().discriminator, "kind");
+
+    let response_cache = schema.field("response_cache").unwrap().schema().unwrap();
+    let header_allowlist = response_cache.field("header_allowlist").unwrap();
+    assert_eq!(header_allowlist.kind, EditorFieldKind::List);
+    assert_eq!(
+        header_allowlist.list_item.unwrap().kind,
+        EditorFieldKind::String
+    );
+
+    let tools = response_cache.field("tools").unwrap().schema().unwrap();
+    for field_name in ["classes", "overrides"] {
+        let field = tools.field(field_name).unwrap();
+        assert_eq!(field.kind, EditorFieldKind::Map);
+        assert_eq!(field.list_item.unwrap().kind, EditorFieldKind::Section);
+    }
 }
 
 #[test]

--- a/crates/cli/src/plugins/editor_model.rs
+++ b/crates/cli/src/plugins/editor_model.rs
@@ -899,6 +899,16 @@ pub(super) fn merge_known_editor_object(
             existing.remove(*key);
             continue;
         };
+        if existing.get(*key) != Some(edited_value) {
+            for dependent in schema.fields.iter().filter(|field| {
+                field.kind == EditorFieldKind::DiscriminatedSection
+                    && field
+                        .tagged_union
+                        .is_some_and(|metadata| metadata.discriminator == *key)
+            }) {
+                existing.remove(dependent.name);
+            }
+        }
         if let Some(field) = schema.field(key)
             && field.kind == EditorFieldKind::Section
             && let Some(nested_schema) = field.schema()
@@ -907,6 +917,60 @@ pub(super) fn merge_known_editor_object(
                 edited_value.as_object(),
             )
         {
+            merge_known_editor_object(
+                existing_object,
+                edited_object.clone(),
+                &nested_editor_keys(nested_schema),
+                nested_schema,
+            );
+            continue;
+        }
+        if let Some(field) = schema.field(key)
+            && field.kind == EditorFieldKind::Map
+            && let Some(item) = field.list_item
+            && let Some(nested_schema) = item.schema.map(|schema| schema())
+            && let (Some(existing_entries), Some(edited_entries)) = (
+                existing.get_mut(*key).and_then(Value::as_object_mut),
+                edited_value.as_object(),
+            )
+        {
+            existing_entries.retain(|entry_key, _| edited_entries.contains_key(entry_key));
+            for (entry_key, edited_entry) in edited_entries {
+                if let (Some(existing_entry), Some(edited_object)) = (
+                    existing_entries
+                        .get_mut(entry_key)
+                        .and_then(Value::as_object_mut),
+                    edited_entry.as_object(),
+                ) {
+                    merge_known_editor_object(
+                        existing_entry,
+                        edited_object.clone(),
+                        &nested_editor_keys(nested_schema),
+                        nested_schema,
+                    );
+                } else {
+                    existing_entries.insert(entry_key.clone(), edited_entry.clone());
+                }
+            }
+            continue;
+        }
+        if let Some(field) = schema.field(key)
+            && field.kind == EditorFieldKind::DiscriminatedSection
+            && let Some(tagged_union) = field.tagged_union
+            && existing.get(tagged_union.discriminator) == edited.get(tagged_union.discriminator)
+            && let Some(tag) = edited
+                .get(tagged_union.discriminator)
+                .and_then(Value::as_str)
+            && let Some(variant) = tagged_union
+                .variants
+                .iter()
+                .find(|variant| variant.tag == tag)
+            && let (Some(existing_object), Some(edited_object)) = (
+                existing.get_mut(*key).and_then(Value::as_object_mut),
+                edited_value.as_object(),
+            )
+        {
+            let nested_schema = (variant.schema)();
             merge_known_editor_object(
                 existing_object,
                 edited_object.clone(),
@@ -946,7 +1010,7 @@ pub(super) fn display_field_value(
                 if items.len() == 1 { "" } else { "s" }
             )
         }
-        (EditorFieldKind::StringMap, Value::Object(entries)) => format!(
+        (EditorFieldKind::StringMap | EditorFieldKind::Map, Value::Object(entries)) => format!(
             "{} entr{}",
             entries.len(),
             if entries.len() == 1 { "y" } else { "ies" }

--- a/crates/cli/src/plugins/prompt.rs
+++ b/crates/cli/src/plugins/prompt.rs
@@ -415,6 +415,25 @@ where
         }
         return Ok(());
     }
+    if field.kind == EditorFieldKind::Map {
+        let item = field.list_item.ok_or_else(|| {
+            CliError::Config(format!("{} does not describe its map values", field.name))
+        })?;
+        let default = section_field_default(section, *field);
+        let mut entries = current
+            .or_else(|| default.clone())
+            .unwrap_or_else(|| json!({}));
+        if edit_map_value(
+            theme,
+            &format!("{}.{}", section.name, field.name),
+            &mut entries,
+            default,
+            item,
+        )? {
+            set_section_field(config, section, field.name, entries)?;
+        }
+        return Ok(());
+    }
     if field.kind == EditorFieldKind::TaggedUnion {
         let tagged_union = field.tagged_union.ok_or_else(|| {
             CliError::Config(format!("{} does not describe its variants", field.name))
@@ -505,16 +524,19 @@ fn edit_list_value(
         match selection {
             MenuResponse::Selected(0) => {
                 let mut entry = new_editor_item(theme, item)?;
+                let original_entry = entry.clone();
                 edit_editor_item(
                     theme,
                     &format!("{prompt}[{}]", entries.len()),
                     &mut entry,
                     item,
                 )?;
-                value
-                    .as_array_mut()
-                    .expect("list value is an array")
-                    .push(entry);
+                if entry != original_entry {
+                    value
+                        .as_array_mut()
+                        .expect("list value is an array")
+                        .push(entry);
+                }
             }
             MenuResponse::Selected(index) if index <= entries.len() => {
                 edit_existing_list_item(theme, prompt, value, index - 1, item)?;
@@ -594,6 +616,105 @@ fn edit_string_map_value(
             }
         }
     }
+}
+
+fn edit_map_value(
+    theme: &ColorfulTheme,
+    prompt: &str,
+    value: &mut Value,
+    default: Option<Value>,
+    item: &nemo_relay::config_editor::EditorListItemSpec,
+) -> Result<bool, CliError> {
+    if !value.is_object() {
+        *value = default.clone().unwrap_or_else(|| json!({}));
+    }
+    let original = value.clone();
+    let mut selected_index = 0;
+    loop {
+        let entries = value.as_object().expect("map value is an object");
+        let keys = entries.keys().cloned().collect::<Vec<_>>();
+        let mut menu = vec![MenuItem::new("Add entry")];
+        menu.extend(keys.iter().map(|key| {
+            MenuItem::new(format!(
+                "Edit {key}: {}",
+                entries
+                    .get(key)
+                    .map(|entry| editor_item_label(entry, item))
+                    .unwrap_or_default()
+            ))
+        }));
+        menu.push(MenuItem::new(shortcut_label("Back", "q")));
+        let selection = prompt_menu(theme, prompt, &menu, selected_index)?;
+        if let Some(selected) = menu_response_index(&selection) {
+            selected_index = selected;
+        }
+        match selection {
+            MenuResponse::Selected(0) => {
+                let key: String = Input::with_theme(theme)
+                    .with_prompt("Entry key")
+                    .interact_text()
+                    .map_err(editor_error)?;
+                let key = key.trim();
+                if key.is_empty() {
+                    println!("  Entry key must not be empty.");
+                    continue;
+                }
+                if string_map_entry_exists(value, key) {
+                    println!("  Entry already exists; select it to edit.");
+                    continue;
+                }
+                let mut entry = new_editor_item(theme, item)?;
+                edit_editor_item(theme, &format!("{prompt}.{key}"), &mut entry, item)?;
+                value
+                    .as_object_mut()
+                    .expect("map value is an object")
+                    .insert(key.to_owned(), entry);
+            }
+            MenuResponse::Selected(index) if index <= keys.len() => {
+                edit_existing_map_entry(theme, prompt, value, &keys[index - 1], item)?;
+            }
+            MenuResponse::Cancel | MenuResponse::Selected(_) => return Ok(*value != original),
+            MenuResponse::Shortcut(MenuShortcut::Help, _) => print_editor_help(),
+            MenuResponse::Shortcut(shortcut @ (MenuShortcut::Reset | MenuShortcut::Clear), _) => {
+                *value = collection_shortcut_value(default.as_ref(), json!({}), shortcut)
+            }
+            MenuResponse::Shortcut(MenuShortcut::Preview | MenuShortcut::Save, _) => {
+                println!("  Preview and save are available from the main plugins.toml menu.");
+            }
+        }
+    }
+}
+
+fn edit_existing_map_entry(
+    theme: &ColorfulTheme,
+    prompt: &str,
+    value: &mut Value,
+    key: &str,
+    item: &nemo_relay::config_editor::EditorListItemSpec,
+) -> Result<(), CliError> {
+    let actions = [
+        MenuItem::new("Edit value"),
+        MenuItem::new("Remove entry"),
+        MenuItem::new(shortcut_label("Back", "q")),
+    ];
+    match prompt_menu(theme, &format!("{prompt}.{key}"), &actions, 0)? {
+        MenuResponse::Selected(0) => {
+            if let Some(entry) = value
+                .as_object_mut()
+                .and_then(|entries| entries.get_mut(key))
+            {
+                edit_editor_item(theme, &format!("{prompt}.{key}"), entry, item)?;
+            }
+        }
+        MenuResponse::Selected(1) | MenuResponse::Shortcut(MenuShortcut::Clear, _) => {
+            value
+                .as_object_mut()
+                .expect("map value is an object")
+                .remove(key);
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn edit_existing_string_map_entry(
@@ -703,6 +824,12 @@ fn edit_editor_item(
         }
         EditorFieldKind::StringMap => {
             let _ = edit_string_map_value(theme, prompt, value, None)?;
+        }
+        EditorFieldKind::Map => {
+            let nested = item.list_item.ok_or_else(|| {
+                CliError::Config("nested map item has no entry description".into())
+            })?;
+            let _ = edit_map_value(theme, prompt, value, None, nested)?;
         }
         kind => {
             let field = EditorFieldSpec {
@@ -870,6 +997,20 @@ where
         return Ok(());
     }
 
+    if field.kind == EditorFieldKind::Map {
+        let item = field.list_item.ok_or_else(|| {
+            CliError::Config(format!("{} does not describe its map values", field.name))
+        })?;
+        let default = default_config_field_value::<T>(field).or_else(|| field.default_value());
+        let mut entries = config_field_value(config, field.name)?
+            .or_else(|| default.clone())
+            .unwrap_or_else(|| json!({}));
+        if edit_map_value(theme, field.name, &mut entries, default, item)? {
+            set_struct_field(config, field.name, entries)?;
+        }
+        return Ok(());
+    }
+
     if field.kind == EditorFieldKind::TaggedUnion {
         let tagged_union = field.tagged_union.ok_or_else(|| {
             CliError::Config(format!("{} does not describe its variants", field.name))
@@ -1013,7 +1154,7 @@ fn edit_selected_value_item(
     selection: usize,
 ) -> Result<bool, CliError> {
     if let Some(field) = schema.fields.get(selection) {
-        edit_value_field(theme, prompt, value, *field, default)?;
+        edit_value_field(theme, prompt, value, schema, *field, default)?;
         return Ok(true);
     }
     if selection == schema.fields.len() {
@@ -1028,6 +1169,7 @@ fn edit_value_field(
     theme: &ColorfulTheme,
     prompt: &str,
     value: &mut Value,
+    schema: &nemo_relay::config_editor::EditorSchema,
     field: EditorFieldSpec,
     default: Option<&Value>,
 ) -> Result<(), CliError> {
@@ -1087,6 +1229,31 @@ fn edit_value_field(
         return Ok(());
     }
 
+    if field.kind == EditorFieldKind::Map {
+        let item = field.list_item.ok_or_else(|| {
+            CliError::Config(format!("{} does not describe its map values", field.name))
+        })?;
+        let field_default = value_field_default(default, field);
+        let mut entries = value_field_value(value, field.name)
+            .or_else(|| field_default.clone())
+            .unwrap_or_else(|| json!({}));
+        if edit_map_value(
+            theme,
+            &format!("{prompt}.{}", field.name),
+            &mut entries,
+            field_default,
+            item,
+        )? {
+            set_value_field(value, field.name, entries);
+        }
+        return Ok(());
+    }
+
+    if field.kind == EditorFieldKind::DiscriminatedSection {
+        edit_discriminated_value_section(theme, prompt, value, field)?;
+        return Ok(());
+    }
+
     if field.kind == EditorFieldKind::TaggedUnion {
         let tagged_union = field.tagged_union.ok_or_else(|| {
             CliError::Config(format!("{} does not describe its variants", field.name))
@@ -1139,11 +1306,19 @@ fn edit_value_field(
     match action {
         MenuResponse::Selected(0) => {
             let field_value = prompt_value(theme, &field, current.as_ref())?;
+            let changed = current.as_ref() != Some(&field_value);
             set_value_field(value, field.name, field_value);
+            if changed {
+                reset_discriminated_value_sections(value, schema, field.name);
+            }
         }
         MenuResponse::Selected(1)
         | MenuResponse::Shortcut(MenuShortcut::Reset | MenuShortcut::Clear, _) => {
-            reset_value_field(value, field, default)
+            let previous = value_field_value(value, field.name);
+            reset_value_field(value, field, default);
+            if value_field_value(value, field.name) != previous {
+                reset_discriminated_value_sections(value, schema, field.name);
+            }
         }
         MenuResponse::Shortcut(MenuShortcut::Help, _) => print_editor_help(),
         MenuResponse::Shortcut(MenuShortcut::Preview | MenuShortcut::Save, _) => {
@@ -1152,6 +1327,72 @@ fn edit_value_field(
         _ => {}
     }
     Ok(())
+}
+
+fn edit_discriminated_value_section(
+    theme: &ColorfulTheme,
+    prompt: &str,
+    value: &mut Value,
+    field: EditorFieldSpec,
+) -> Result<(), CliError> {
+    let tagged_union = field.tagged_union.ok_or_else(|| {
+        CliError::Config(format!("{} does not describe its variants", field.name))
+    })?;
+    let tag = value
+        .get(tagged_union.discriminator)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| {
+            tagged_union
+                .variants
+                .first()
+                .map(|variant| variant.tag)
+                .unwrap_or("")
+        });
+    let variant = tagged_union
+        .variants
+        .iter()
+        .find(|variant| variant.tag == tag)
+        .ok_or_else(|| CliError::Config(format!("unknown {} variant {tag:?}", field.name)))?;
+    let mut nested_value =
+        value_field_value(value, field.name).unwrap_or_else(|| (variant.default)());
+    if edit_value_section(
+        theme,
+        &format!("{prompt}.{}", field.name),
+        &mut nested_value,
+        (variant.schema)(),
+        Some((variant.default)()),
+    )? {
+        set_value_field(value, field.name, nested_value);
+    }
+    Ok(())
+}
+
+fn reset_discriminated_value_sections(
+    value: &mut Value,
+    schema: &nemo_relay::config_editor::EditorSchema,
+    discriminator: &str,
+) {
+    let tag = value
+        .get(discriminator)
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    for field in schema.fields {
+        let Some(tagged_union) = field.tagged_union else {
+            continue;
+        };
+        if field.kind != EditorFieldKind::DiscriminatedSection
+            || tagged_union.discriminator != discriminator
+        {
+            continue;
+        }
+        if let Some(variant) = tagged_union
+            .variants
+            .iter()
+            .find(|variant| Some(variant.tag) == tag.as_deref())
+        {
+            set_value_field(value, field.name, (variant.default)());
+        }
+    }
 }
 
 fn prompt_value(
@@ -1236,7 +1477,10 @@ fn prompt_value(
             "{} is a nested section and cannot be edited as a scalar",
             field.name
         ))),
-        EditorFieldKind::List | EditorFieldKind::TaggedUnion => Err(CliError::Config(format!(
+        EditorFieldKind::List
+        | EditorFieldKind::Map
+        | EditorFieldKind::TaggedUnion
+        | EditorFieldKind::DiscriminatedSection => Err(CliError::Config(format!(
             "{} is a structured value and cannot be edited as a scalar",
             field.name
         ))),

--- a/crates/cli/tests/coverage/shared/plugins_tests.rs
+++ b/crates/cli/tests/coverage/shared/plugins_tests.rs
@@ -298,11 +298,17 @@ fn typed_editor_model_contains_adaptive_options() {
 
     let state = schema.field("state").unwrap().schema().unwrap();
     let backend = state.field("backend").unwrap().schema().unwrap();
-    assert_eq!(
-        backend.field("kind").unwrap().enum_values,
-        &["in_memory", "redis"]
+    assert!(
+        backend
+            .field("kind")
+            .unwrap()
+            .enum_values
+            .contains(&"in_memory")
     );
-    assert_eq!(backend.field("config").unwrap().kind, EditorFieldKind::Json);
+    assert_eq!(
+        backend.field("config").unwrap().kind,
+        EditorFieldKind::DiscriminatedSection
+    );
 
     let telemetry = schema.field("telemetry").unwrap().schema().unwrap();
     assert_eq!(

--- a/crates/core/src/config_editor.rs
+++ b/crates/core/src/config_editor.rs
@@ -30,8 +30,12 @@ pub enum EditorFieldKind {
     Json,
     /// A collection whose entries are edited recursively.
     List,
+    /// A string-keyed map whose values are edited recursively.
+    Map,
     /// A tagged object whose variant is selected from a discriminator field.
     TaggedUnion,
+    /// A nested section selected by a discriminator field in its parent object.
+    DiscriminatedSection,
     /// Nested configuration section.
     Section,
 }
@@ -53,9 +57,11 @@ pub struct EditorFieldSpec {
     pub nested_schema: Option<fn() -> &'static EditorSchema>,
     /// Default value for a nested section.
     pub nested_default: Option<fn() -> Json>,
-    /// Description of list entries, when [`EditorFieldKind::List`] is used.
+    /// Description of collection entries, when [`EditorFieldKind::List`] or
+    /// [`EditorFieldKind::Map`] is used.
     pub list_item: Option<&'static EditorListItemSpec>,
-    /// Variant metadata, when [`EditorFieldKind::TaggedUnion`] is used.
+    /// Variant metadata, when [`EditorFieldKind::TaggedUnion`] or
+    /// [`EditorFieldKind::DiscriminatedSection`] is used.
     pub tagged_union: Option<&'static EditorTaggedUnionSpec>,
 }
 
@@ -175,6 +181,7 @@ macro_rules! editor_config {
                     $(, nested: $nested:ty)?
                     $(, default: $default:ty)?
                     $(, list: $list:expr)?
+                    $(, map: $map:expr)?
                     $(, tagged_union: $tagged_union:expr)?
                     $(,)?
                 }
@@ -200,7 +207,7 @@ macro_rules! editor_config {
                                 optional: $crate::editor_config!(@optional $($optional)?),
                                 nested_schema: $crate::editor_config!(@nested $($nested)?),
                                 nested_default: $crate::editor_config!(@default $($default)?),
-                                list_item: $crate::editor_config!(@list $($list)?),
+                                list_item: $crate::editor_config!(@collection $($list)? $($map)?),
                                 tagged_union: $crate::editor_config!(@tagged_union $($tagged_union)?),
                             }
                         ),*
@@ -223,7 +230,9 @@ macro_rules! editor_config {
     (@kind StringMap) => { $crate::config_editor::EditorFieldKind::StringMap };
     (@kind Json) => { $crate::config_editor::EditorFieldKind::Json };
     (@kind List) => { $crate::config_editor::EditorFieldKind::List };
+    (@kind Map) => { $crate::config_editor::EditorFieldKind::Map };
     (@kind TaggedUnion) => { $crate::config_editor::EditorFieldKind::TaggedUnion };
+    (@kind DiscriminatedSection) => { $crate::config_editor::EditorFieldKind::DiscriminatedSection };
     (@kind Section) => { $crate::config_editor::EditorFieldKind::Section };
 
     (@values) => { &[] };
@@ -245,8 +254,8 @@ macro_rules! editor_config {
         })
     };
 
-    (@list) => { None };
-    (@list $list:expr) => { Some($list) };
+    (@collection) => { None };
+    (@collection $collection:expr) => { Some($collection) };
 
     (@tagged_union) => { None };
     (@tagged_union $tagged_union:expr) => { Some($tagged_union) };

--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -727,6 +727,24 @@ const fn otel_editor_field(
     }
 }
 
+const fn otel_list_editor_field(
+    name: &'static str,
+    optional: bool,
+    item: &'static EditorListItemSpec,
+) -> EditorFieldSpec {
+    EditorFieldSpec {
+        name,
+        label: name,
+        kind: EditorFieldKind::List,
+        enum_values: &[],
+        optional,
+        nested_schema: None,
+        nested_default: None,
+        list_item: Some(item),
+        tagged_union: None,
+    }
+}
+
 impl EditorConfig for OpenTelemetryEndpointConfig {
     fn editor_schema() -> &'static EditorSchema {
         static SCHEMA: EditorSchema = EditorSchema {
@@ -744,7 +762,11 @@ impl EditorConfig for OpenTelemetryEndpointConfig {
                     &["inherit", "event", "tool"],
                     false,
                 ),
-                otel_editor_field("mark_exclude_names", EditorFieldKind::Json, &[], false),
+                otel_list_editor_field(
+                    "mark_exclude_names",
+                    false,
+                    &crate::config_editor::STRING_LIST_ITEM,
+                ),
                 otel_editor_field("attribute_mappings", EditorFieldKind::List, &[], false),
                 otel_editor_field(
                     "promote_metadata_prefixes",
@@ -892,16 +914,74 @@ crate::editor_config! {
 }
 
 crate::editor_config! {
+    impl HttpStorageConfig {
+        endpoint => { label: "endpoint", kind: String },
+        headers => { label: "headers", kind: StringMap },
+        header_env => { label: "header_env", kind: StringMap },
+        timeout_millis => { label: "timeout_millis", kind: Integer },
+    }
+}
+
+crate::editor_config! {
+    impl S3StorageConfig {
+        bucket => { label: "bucket", kind: String },
+        key_prefix => { label: "key_prefix", kind: String, optional: true },
+        access_key_id => { label: "access_key_id", kind: String, optional: true },
+        secret_access_key_var => { label: "secret_access_key_var", kind: String, optional: true },
+        session_token_var => { label: "session_token_var", kind: String, optional: true },
+        region => { label: "region", kind: String, optional: true },
+        endpoint_url => { label: "endpoint_url", kind: String, optional: true },
+        allow_http => { label: "allow_http", kind: Boolean, optional: true },
+    }
+}
+
+fn default_http_storage_editor_value() -> Json {
+    serde_json::json!({"type": "http", "endpoint": "", "headers": {}, "header_env": {}, "timeout_millis": 3000})
+}
+
+fn default_s3_storage_editor_value() -> Json {
+    serde_json::json!({"type": "s3", "bucket": ""})
+}
+
+static ATIF_STORAGE_VARIANTS: [EditorVariantSpec; 2] = [
+    EditorVariantSpec {
+        label: "HTTP",
+        tag: "http",
+        schema: <HttpStorageConfig as EditorConfig>::editor_schema,
+        default: default_http_storage_editor_value,
+    },
+    EditorVariantSpec {
+        label: "S3",
+        tag: "s3",
+        schema: <S3StorageConfig as EditorConfig>::editor_schema,
+        default: default_s3_storage_editor_value,
+    },
+];
+
+static ATIF_STORAGE_TAGGED_UNION: EditorTaggedUnionSpec = EditorTaggedUnionSpec {
+    discriminator: "type",
+    variants: &ATIF_STORAGE_VARIANTS,
+};
+
+static ATIF_STORAGE_LIST: EditorListItemSpec = EditorListItemSpec {
+    kind: EditorFieldKind::Section,
+    schema: None,
+    default: None,
+    tagged_union: Some(&ATIF_STORAGE_TAGGED_UNION),
+    list_item: None,
+};
+
+crate::editor_config! {
     impl AtifSectionConfig {
         enabled => { label: "enabled", kind: Boolean },
         agent_name => { label: "agent_name", kind: String },
         agent_version => { label: "agent_version", kind: String },
         model_name => { label: "model_name", kind: String },
-        tool_definitions => { label: "tool_definitions", kind: Json, optional: true },
+        tool_definitions => { label: "tool_definitions", kind: List, optional: true, list: &crate::config_editor::JSON_LIST_ITEM },
         extra => { label: "extra", kind: Json, optional: true },
         output_directory => { label: "output_directory", kind: String, optional: true },
         filename_template => { label: "filename_template", kind: String },
-        storage => { label: "storage", kind: Json, optional: true },
+        storage => { label: "storage", kind: List, optional: true, list: &ATIF_STORAGE_LIST },
     }
 }
 

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -5008,11 +5008,25 @@ fn atif_storage_http_header_env_present_env_is_accepted() {
 }
 
 #[test]
-fn atif_storage_editor_field_is_optional_json() {
+fn atif_storage_editor_field_is_optional_typed_list() {
     let schema = AtifSectionConfig::editor_schema();
     let storage = schema.field("storage").expect("storage editor field");
-    assert_eq!(storage.kind, EditorFieldKind::Json);
+    assert_eq!(storage.kind, EditorFieldKind::List);
     assert!(storage.optional);
+    let tagged_union = storage
+        .list_item
+        .expect("storage list metadata")
+        .tagged_union
+        .expect("storage tagged-union metadata");
+    assert_eq!(tagged_union.discriminator, "type");
+    assert_eq!(
+        tagged_union
+            .variants
+            .iter()
+            .map(|variant| variant.tag)
+            .collect::<Vec<_>>(),
+        vec!["http", "s3"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
#### Overview

Resolve the release/0.8 forward-merge conflict while preserving the release changes and main’s typed response-cache strategy metadata.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Merge `release/0.8` into `main` with a merge commit.
- Retain typed response-cache `key_strategy` enum metadata.
- Replace the generic `Json` editor metadata for `header_allowlist` with its proper typed list metadata.

#### Where should the reviewer start?

Review `crates/adaptive/src/config.rs` and its editor-schema coverage in `crates/adaptive/tests/unit/config_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured configuration editing for maps and variant-based settings.
  - Added support for editing nested map entries, including creating, updating, removing, resetting, and validating values.
  - Added guided configuration for in-memory and Redis backends when available.
  - Added typed storage configuration for HTTP and S3 options.
  - Improved editing for string lists, tool cache settings, and response-cache fields.

- **Bug Fixes**
  - Dependent settings now reset appropriately when a selected configuration variant changes.
  - List items are added only after being modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->