### PR TITLE
fix: activate static plugins before dynamic loading

### DIFF
--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -985,6 +985,7 @@ impl PluginActivation {
         ensure_builtin_plugins_registered().map_err(|error| {
             CliError::Config(format!("built-in plugin initialization failed: {error}"))
         })?;
+        let static_plugin_config = plugin_config.clone();
         plugin_config
             .components
             .extend(dynamic_plugins.iter().map(|plugin| PluginComponentSpec {
@@ -1050,36 +1051,52 @@ impl PluginActivation {
             .iter()
             .filter_map(|plugin| plugin.activation_snapshot.clone())
             .collect();
-        let native =
-            if native_specs.is_empty() {
+        initialize_plugins_exact(static_plugin_config)
+            .await
+            .map_err(|error| CliError::Config(format!("plugin activation failed: {error}")))?;
+        let activation: Result<Self, CliError> = async {
+            let native = if native_specs.is_empty() {
                 None
             } else {
                 Some(load_native_plugins(native_specs).map_err(|error| {
                     CliError::Config(format!("native plugin load failed: {error}"))
                 })?)
             };
-        for plugin in &dynamic_plugins {
-            if let Some(snapshot) = plugin.activation_snapshot.as_ref() {
-                snapshot.verify_current()?;
+            for plugin in &dynamic_plugins {
+                if let Some(snapshot) = plugin.activation_snapshot.as_ref() {
+                    snapshot.verify_current()?;
+                }
             }
-        }
-        let worker =
-            if worker_specs.is_empty() {
+            let worker = if worker_specs.is_empty() {
                 None
             } else {
                 Some(load_worker_plugins(worker_specs).map_err(|error| {
                     CliError::Config(format!("worker plugin load failed: {error}"))
                 })?)
             };
-        initialize_plugins_exact(plugin_config)
-            .await
-            .map_err(|error| CliError::Config(format!("plugin activation failed: {error}")))?;
-        Ok(Self {
-            active: true,
-            native,
-            worker,
-            _snapshots: snapshots,
-        })
+            clear_plugin_configuration().map_err(|error| {
+                CliError::Config(format!("static plugin teardown failed: {error}"))
+            })?;
+            initialize_plugins_exact(plugin_config)
+                .await
+                .map_err(|error| CliError::Config(format!("plugin activation failed: {error}")))?;
+            Ok(Self {
+                active: true,
+                native,
+                worker,
+                _snapshots: snapshots,
+            })
+        }
+        .await;
+        if let Err(error) = activation {
+            return match clear_plugin_configuration() {
+                Ok(()) => Err(error),
+                Err(cleanup_error) => Err(CliError::Config(format!(
+                    "{error}; plugin activation cleanup failed: {cleanup_error}"
+                ))),
+            };
+        }
+        activation
     }
 
     fn clear(mut self) -> Result<(), CliError> {

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -143,6 +143,14 @@ impl Drop for RequestInterceptCleanup {
     }
 }
 
+struct PluginKindCleanup(&'static str);
+
+impl Drop for PluginKindCleanup {
+    fn drop(&mut self) {
+        let _ = deregister_plugin(self.0);
+    }
+}
+
 fn test_http_client() -> reqwest::Client {
     reqwest::Client::new()
 }
@@ -2148,6 +2156,7 @@ async fn serve_listener_activates_static_plugins_before_dynamic_load_and_cleans_
     GENERIC_TEST_PLUGIN_REGISTRATIONS.store(0, Ordering::SeqCst);
     GENERIC_TEST_PLUGIN_DEREGISTRATIONS.store(0, Ordering::SeqCst);
     register_plugin(Arc::new(GenericTestPlugin)).unwrap();
+    let _plugin_cleanup = PluginKindCleanup(GENERIC_TEST_PLUGIN_KIND);
 
     let temp = tempfile::tempdir().unwrap();
     let manifest_ref = write_missing_native_plugin_manifest(temp.path(), "cli.missing-native");

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -2141,18 +2141,31 @@ async fn serve_listener_rejects_invalid_plugin_config() {
 }
 
 #[tokio::test]
-async fn serve_listener_with_dynamic_reports_native_load_errors() {
+async fn serve_listener_activates_static_plugins_before_dynamic_load_and_cleans_failure() {
     let _guard = PLUGIN_CONFIG_TEST_LOCK.lock().await;
     let _ = nemo_relay::plugin::clear_plugin_configuration();
+    let _ = deregister_plugin(GENERIC_TEST_PLUGIN_KIND);
+    GENERIC_TEST_PLUGIN_REGISTRATIONS.store(0, Ordering::SeqCst);
+    GENERIC_TEST_PLUGIN_DEREGISTRATIONS.store(0, Ordering::SeqCst);
+    register_plugin(Arc::new(GenericTestPlugin)).unwrap();
 
     let temp = tempfile::tempdir().unwrap();
     let manifest_ref = write_missing_native_plugin_manifest(temp.path(), "cli.missing-native");
+    let mut config = test_config();
+    config.plugin_config = Some(json!({
+        "version": 1,
+        "components": [{
+            "kind": GENERIC_TEST_PLUGIN_KIND,
+            "enabled": true,
+            "config": {}
+        }]
+    }));
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     drop(shutdown_tx);
     let error = serve_listener_with_dynamic(
         listener,
-        test_config(),
+        config,
         vec![ActiveDynamicPluginComponent {
             plugin_id: "cli.missing-native".into(),
             kind: DynamicPluginKind::RustDynamic,
@@ -2170,7 +2183,13 @@ async fn serve_listener_with_dynamic_reports_native_load_errors() {
     let error = error.to_string();
     assert!(error.contains("native plugin load failed"), "{error}");
     assert!(error.contains("does not exist"), "{error}");
+    assert_eq!(GENERIC_TEST_PLUGIN_REGISTRATIONS.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        GENERIC_TEST_PLUGIN_DEREGISTRATIONS.load(Ordering::SeqCst),
+        1
+    );
     assert!(nemo_relay::plugin::active_plugin_report().is_none());
+    assert!(deregister_plugin(GENERIC_TEST_PLUGIN_KIND));
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Overview

Activate configured static plugins before loading dynamic plugins so worker registration callbacks can discover runtime registrations, including observability subscribers, during startup.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Activate the static plugin configuration before loading native or worker plugins.
- Replace the temporary static activation with the combined static and dynamic configuration after loading completes.
- Clean up the temporary activation if dynamic loading or final activation fails.
- Add regression coverage proving static plugins activate before a dynamic load attempt and are cleaned up when loading fails.
- Preserve the existing static-only activation lifecycle.

Validation:

- `cargo fmt --all -- --check`
- Focused CLI lifecycle regression tests
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --all-files`

`just test-rust` also ran but encountered an existing CLI global-registry isolation failure reproducible on the unchanged `release/0.8` branch.

#### Where should the reviewer start?

Start with `PluginActivation::initialize()` in `crates/cli/src/server/mod.rs`. The key change is the temporary static activation before dynamic loading, followed by replacement with the combined configuration.

The regression coverage is in `crates/cli/tests/coverage/shared/server_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin startup reliability when combining preconfigured and dynamically loaded plugins.
  * Ensured preconfigured plugins activate before dynamic plugins are loaded.
  * Improved cleanup when dynamic plugin activation fails, including removal of partially initialized plugin state.
  * Added clearer reporting when cleanup encounters an additional error.
* **Tests**
  * Expanded coverage for plugin activation order, failure handling, deregistration, and registry cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->