### PR TITLE
fix: support stderr opt-out in CLI config

### DIFF
--- a/crates/cli/src/configuration/logging.rs
+++ b/crates/cli/src/configuration/logging.rs
@@ -19,6 +19,7 @@ use super::CliError;
 #[serde(deny_unknown_fields)]
 pub(super) struct FileLoggingConfig {
     level: Option<String>,
+    stderr_enabled: Option<bool>,
     stderr_format: Option<String>,
     /// Optional advanced: periodic flush interval in ms applied to all file sinks (default
     /// [`DEFAULT_FILE_FLUSH_INTERVAL_MILLIS`]). `0` means flush only on shutdown.
@@ -50,6 +51,9 @@ pub(super) fn apply_file_logging_config(
     };
     if let Some(level) = config.level.as_deref() {
         logging.level = LogLevel::parse(level).map_err(logging_parse_error)?;
+    }
+    if let Some(stderr_enabled) = config.stderr_enabled {
+        logging.stderr_enabled = stderr_enabled;
     }
     if let Some(stderr_format) = config.stderr_format.as_deref() {
         logging.stderr_format = LogFormat::parse(stderr_format).map_err(logging_parse_error)?;

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -1866,6 +1866,37 @@ fn cli_doctor_json_emits_versioned_report() {
 }
 
 #[test]
+fn cli_doctor_accepts_discovered_stderr_logging_opt_out() {
+    let _implicit_config = ImplicitConfigEnvScope::without_test_hook();
+    let temp = tempfile::tempdir().unwrap();
+    let xdg = temp.path().join("xdg");
+    let cwd = temp.path().join("workdir");
+    std::fs::create_dir_all(&cwd).unwrap();
+    std::fs::create_dir_all(xdg.join("nemo-relay")).unwrap();
+    std::fs::write(
+        xdg.join("nemo-relay/config.toml"),
+        "[logging]\nstderr_enabled = false\n",
+    )
+    .unwrap();
+
+    let output = Command::new(gateway_bin())
+        .current_dir(&cwd)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env("HOME", temp.path())
+        .args(["doctor", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr was:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["configuration"]["resolution"]["status"], "pass");
+}
+
+#[test]
 fn cli_plugins_validate_json_emits_versioned_success_output() {
     let temp = tempfile::tempdir().unwrap();
     let plugin_dir = temp.path().join("plugins").join("acme");

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -1892,6 +1892,11 @@ fn cli_doctor_accepts_discovered_stderr_logging_opt_out() {
         "stderr was:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
+    assert!(
+        output.stderr.is_empty(),
+        "doctor emitted unexpected stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(report["configuration"]["resolution"]["status"], "pass");
 }

--- a/crates/cli/tests/coverage/shared/config_tests.rs
+++ b/crates/cli/tests/coverage/shared/config_tests.rs
@@ -4042,6 +4042,7 @@ fn logging_parses_global_settings_and_file_sinks() {
             r#"
 [logging]
 level = "debug"
+stderr_enabled = false
 stderr_format = "human"
 flush_interval_millis = 250
 
@@ -4068,6 +4069,7 @@ format = "human"
     let resolved = resolve_server_config(&args).unwrap();
 
     assert_eq!(resolved.logging.level, LogLevel::Debug);
+    assert!(!resolved.logging.stderr_enabled);
     assert_eq!(resolved.logging.stderr_format, LogFormat::Human);
     assert_eq!(resolved.logging.flush_interval_millis, 250);
     assert_eq!(resolved.logging.sinks.len(), 2);


### PR DESCRIPTION
#### Overview

Allow `stderr_enabled = false` in CLI-managed Relay configuration files so the documented logging opt-out works for normal startup and `nemo-relay doctor`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `stderr_enabled` to the CLI logging TOML schema and apply it to the resolved logging configuration.
- Cover both configuration resolution and discovered-config `nemo-relay doctor --json` behavior.

#### Where should the reviewer start?

Start with `crates/cli/src/configuration/logging.rs`, then review the focused resolver and doctor regression tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes RELAY-802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable logging to stderr.
  * Existing stderr logging behavior remains unchanged when the option is omitted.

* **Bug Fixes**
  * Configuration diagnostics now correctly succeed when stderr logging is disabled.
  * JSON diagnostics produce no stderr output when configured accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->