### PR TITLE
fix(uninstall): add forced coding-agent cleanup

### DIFF
--- a/crates/cli/src/agents/mod.rs
+++ b/crates/cli/src/agents/mod.rs
@@ -521,7 +521,7 @@ pub(crate) fn detected_install_integrations(candidates: &[CodingAgent]) -> Vec<C
         .collect()
 }
 
-/// Returns hosts with persisted state, optionally including stale local marketplace trees.
+/// Returns hosts with persisted state, optionally including force-cleanup targets.
 pub(crate) fn installed_integrations(
     candidates: &[CodingAgent],
     install_dir: Option<&Path>,
@@ -536,7 +536,10 @@ pub(crate) fn installed_integrations(
         .filter(|agent| {
             crate::installation::marketplace::persisted_state_exists(*agent, &install_dir)
                 || (include_local_install
-                    && crate::installation::marketplace::local_install_exists(*agent, &install_dir))
+                    && crate::installation::marketplace::force_cleanup_target_exists(
+                        *agent,
+                        &install_dir,
+                    ))
         })
         .collect()
 }

--- a/crates/cli/src/agents/mod.rs
+++ b/crates/cli/src/agents/mod.rs
@@ -521,6 +521,7 @@ pub(crate) fn detected_install_integrations(candidates: &[CodingAgent]) -> Vec<C
         .collect()
 }
 
+/// Returns hosts with persisted state, optionally including stale local marketplace trees.
 pub(crate) fn installed_integrations(
     candidates: &[CodingAgent],
     install_dir: Option<&Path>,

--- a/crates/cli/src/agents/mod.rs
+++ b/crates/cli/src/agents/mod.rs
@@ -524,6 +524,7 @@ pub(crate) fn detected_install_integrations(candidates: &[CodingAgent]) -> Vec<C
 pub(crate) fn installed_integrations(
     candidates: &[CodingAgent],
     install_dir: Option<&Path>,
+    include_local_install: bool,
 ) -> Vec<CodingAgent> {
     let install_dir = install_dir
         .map(Path::to_path_buf)
@@ -533,6 +534,8 @@ pub(crate) fn installed_integrations(
         .copied()
         .filter(|agent| {
             crate::installation::marketplace::persisted_state_exists(*agent, &install_dir)
+                || (include_local_install
+                    && crate::installation::marketplace::local_install_exists(*agent, &install_dir))
         })
         .collect()
 }
@@ -562,7 +565,7 @@ pub(crate) fn collect_default_integration_readiness()
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
     let install_dir = crate::installation::marketplace::default_marketplace_install_dir();
-    let agents = installed_integrations(&CodingAgent::ALL, Some(&install_dir));
+    let agents = installed_integrations(&CodingAgent::ALL, Some(&install_dir), false);
     let pending = agents
         .into_iter()
         .map(|agent| spawn_integration_readiness(agent, install_dir.clone()))

--- a/crates/cli/src/commands/diagnostics.rs
+++ b/crates/cli/src/commands/diagnostics.rs
@@ -60,7 +60,7 @@ fn execute_plugin_doctor(
 ) -> Result<ExitCode, CliError> {
     let candidates = plugin.agents();
     let agents = if plugin.is_all() {
-        crate::agents::installed_integrations(&candidates, install_dir.as_deref())
+        crate::agents::installed_integrations(&candidates, install_dir.as_deref(), false)
     } else {
         candidates
     };

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -29,6 +29,9 @@ pub(crate) struct UninstallCommand {
     pub(crate) host: InstallTarget,
     #[arg(long)]
     pub(crate) install_dir: Option<PathBuf>,
+    /// Attempt all Relay-owned cleanup steps even when normal uninstall safety checks fail.
+    #[arg(long)]
+    pub(crate) force: bool,
     #[arg(long)]
     pub(crate) dry_run: bool,
 }
@@ -71,6 +74,7 @@ impl UninstallCommand {
     pub(crate) fn into_runtime(self) -> crate::installation::UninstallRequest {
         crate::installation::UninstallRequest {
             install_dir: self.install_dir,
+            force: self.force,
             dry_run: self.dry_run,
         }
     }
@@ -103,7 +107,11 @@ pub(super) fn uninstall(command: UninstallCommand) -> Result<ExitCode, CliError>
     let request = command.into_runtime();
     let candidates = target.agents();
     let agents = if target.is_all() {
-        crate::agents::installed_integrations(&candidates, request.install_dir.as_deref())
+        crate::agents::installed_integrations(
+            &candidates,
+            request.install_dir.as_deref(),
+            request.force,
+        )
     } else {
         candidates
     };

--- a/crates/cli/src/commands/logging.rs
+++ b/crates/cli/src/commands/logging.rs
@@ -42,8 +42,25 @@ impl LoggingArgs {
         &self,
         explicit_config: Option<&Path>,
     ) -> Result<LoggingConfig, CliError> {
+        if let Some(config) = self.resolve_explicit()? {
+            return Ok(config);
+        }
+
+        crate::configuration::resolve_logging_config(explicit_config)
+    }
+
+    /// Resolves direct logging settings without consulting Relay configuration files discovered
+    /// from the environment. Commands that repair or remove Relay state use this so malformed
+    /// ambient configuration cannot block the operation.
+    pub(super) fn resolve_without_ambient_config(&self) -> Result<LoggingConfig, CliError> {
+        Ok(self.resolve_explicit()?.unwrap_or_default())
+    }
+
+    fn resolve_explicit(&self) -> Result<Option<LoggingConfig>, CliError> {
         if let Some(path) = &self.config_path {
-            return LoggingConfig::from_file_path(path).map_err(logging_config_error);
+            return LoggingConfig::from_file_path(path)
+                .map(Some)
+                .map_err(logging_config_error);
         }
 
         if self.level.is_some() || self.stderr_format.is_some() {
@@ -55,14 +72,10 @@ impl LoggingArgs {
                 config.stderr_format =
                     LogFormat::parse(stderr_format).map_err(logging_config_error)?;
             }
-            return Ok(config);
+            return Ok(Some(config));
         }
 
-        if let Some(config) = LoggingConfig::from_environment().map_err(logging_config_error)? {
-            return Ok(config);
-        }
-
-        crate::configuration::resolve_logging_config(explicit_config)
+        LoggingConfig::from_environment().map_err(logging_config_error)
     }
 }
 

--- a/crates/cli/src/commands/logging.rs
+++ b/crates/cli/src/commands/logging.rs
@@ -56,6 +56,7 @@ impl LoggingArgs {
         Ok(self.resolve_explicit()?.unwrap_or_default())
     }
 
+    /// Resolves only command-line, log-file, and environment logging sources.
     fn resolve_explicit(&self) -> Result<Option<LoggingConfig>, CliError> {
         if let Some(path) = &self.config_path {
             return LoggingConfig::from_file_path(path)

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -73,13 +73,18 @@ fn configure_logging(cli: &Cli) -> Result<LoggingSetup, error::CliError> {
         });
     }
 
-    let explicit_config = match cli.command.as_ref() {
-        Some(Command::Mcp) => None,
-        Some(Command::Run(command)) => command.config.as_deref().or(cli.server.config.as_deref()),
-        _ => cli.server.config.as_deref(),
-    };
     let mut fallback_error = None;
-    let config = match cli.logging.resolve(explicit_config) {
+    let config = match cli.command.as_ref() {
+        // Uninstall uses persisted integration state, not Relay runtime configuration. Preserve
+        // direct logging settings while avoiding ambient config discovery that could block cleanup.
+        Some(Command::Uninstall(_)) => cli.logging.resolve_without_ambient_config(),
+        Some(Command::Mcp) => cli.logging.resolve(None),
+        Some(Command::Run(command)) => cli
+            .logging
+            .resolve(command.config.as_deref().or(cli.server.config.as_deref())),
+        _ => cli.logging.resolve(cli.server.config.as_deref()),
+    };
+    let config = match config {
         Ok(config) => config,
         Err(error) if matches!(cli.command.as_ref(), Some(Command::Doctor(_))) => {
             fallback_error = Some(error);

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -282,6 +282,7 @@ pub(crate) fn default_marketplace_install_dir() -> PathBuf {
     default_install_dir().canonicalize_or_self()
 }
 
+/// Returns whether the host's deterministic Relay marketplace tree still exists.
 pub(crate) fn local_install_exists(host: impl MarketplaceHost, install_dir: &Path) -> bool {
     PluginLayout::new(host, install_dir)
         .marketplace_root
@@ -932,6 +933,7 @@ fn uninstall_host_locked(
     result
 }
 
+/// Attempts every deterministic Relay-owned cleanup step and reports all failures together.
 fn force_uninstall_host_locked(
     host: impl MarketplaceHost,
     options: &PluginInstallOptions,
@@ -964,7 +966,14 @@ fn force_uninstall_host_locked(
         errors.push(error);
     }
     if !options.dry_run {
-        remove_generation_lock_best_effort(&layout.generation_lock);
+        match fs::remove_file(&layout.generation_lock) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => errors.push(format!(
+                "failed to remove MCP generation lock {}: {error}",
+                layout.generation_lock.display()
+            )),
+        }
     }
 
     if errors.is_empty() {

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -288,6 +288,31 @@ pub(crate) fn local_install_exists(host: impl MarketplaceHost, install_dir: &Pat
     layout.marketplace_root.exists() || layout.generation_lock.exists()
 }
 
+/// Returns whether force cleanup has a local artifact or live host registration to remove.
+pub(crate) fn force_cleanup_target_exists(host: impl MarketplaceHost, install_dir: &Path) -> bool {
+    force_cleanup_target_exists_with_runner(host, install_dir, &RealCommandRunner)
+}
+
+fn force_cleanup_target_exists_with_runner(
+    host: impl MarketplaceHost,
+    install_dir: &Path,
+    runner: &dyn CommandRunner,
+) -> bool {
+    if local_install_exists(host, install_dir) {
+        return true;
+    }
+    let options = PluginInstallOptions {
+        install_dir: install_dir.to_path_buf(),
+        operation_lock_dir: PathBuf::new(),
+        force: true,
+        dry_run: false,
+        skip_doctor: true,
+    };
+    host_registration_report(host, &options, runner).is_ok_and(|registration| {
+        registration.host_plugin_registered || registration.host_marketplace_registered
+    })
+}
+
 pub(crate) fn persisted_state_exists(host: impl MarketplaceHost, install_dir: &Path) -> bool {
     state_path(host, install_dir).exists()
 }

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -282,11 +282,10 @@ pub(crate) fn default_marketplace_install_dir() -> PathBuf {
     default_install_dir().canonicalize_or_self()
 }
 
-/// Returns whether the host's deterministic Relay marketplace tree still exists.
+/// Returns whether deterministic Relay artifacts for the host still exist locally.
 pub(crate) fn local_install_exists(host: impl MarketplaceHost, install_dir: &Path) -> bool {
-    PluginLayout::new(host, install_dir)
-        .marketplace_root
-        .exists()
+    let layout = PluginLayout::new(host, install_dir);
+    layout.marketplace_root.exists() || layout.generation_lock.exists()
 }
 
 pub(crate) fn persisted_state_exists(host: impl MarketplaceHost, install_dir: &Path) -> bool {

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -994,6 +994,14 @@ fn force_uninstall_host_locked(
     if host_setup_removed && let Err(error) = remove_path(&layout.state_path, options) {
         errors.push(error);
     }
+    if !host_setup_removed
+        && !layout.state_path.exists()
+        && let Err(error) = write_state(&layout, options)
+    {
+        errors.push(format!(
+            "failed to preserve Relay cleanup retry state: {error}"
+        ));
+    }
     if !options.dry_run {
         match fs::remove_file(&layout.generation_lock) {
             Ok(()) => {}

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -972,9 +972,14 @@ fn force_uninstall_host_locked(
     {
         errors.push(format!("failed to stop the Relay-owned gateway: {error}"));
     }
-    if let Err(error) = run_plugin_uninstall(host, &layout.plugin_root, options, setup_runner) {
-        errors.push(format!("failed to remove Relay host setup: {error}"));
-    }
+    let host_setup_removed =
+        match run_plugin_uninstall(host, &layout.plugin_root, options, setup_runner) {
+            Ok(()) => true,
+            Err(error) => {
+                errors.push(format!("failed to remove Relay host setup: {error}"));
+                false
+            }
+        };
     if let Err(error) = run_host_plugin_removal(host, options, runner) {
         errors.push(format!("failed to unregister the host plugin: {error}"));
     }
@@ -986,7 +991,7 @@ fn force_uninstall_host_locked(
     if let Err(error) = remove_path(&layout.marketplace_root, options) {
         errors.push(error);
     }
-    if let Err(error) = remove_path(&layout.state_path, options) {
+    if host_setup_removed && let Err(error) = remove_path(&layout.state_path, options) {
         errors.push(error);
     }
     if !options.dry_run {

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -206,7 +206,7 @@ pub(crate) fn uninstall(
             .unwrap_or_else(default_install_dir)
             .canonicalize_or_self(),
         operation_lock_dir,
-        force: false,
+        force: command.force,
         dry_run: command.dry_run,
         skip_doctor: true,
     };
@@ -280,6 +280,12 @@ pub(crate) fn doctor_marketplace_report(
 
 pub(crate) fn default_marketplace_install_dir() -> PathBuf {
     default_install_dir().canonicalize_or_self()
+}
+
+pub(crate) fn local_install_exists(host: impl MarketplaceHost, install_dir: &Path) -> bool {
+    PluginLayout::new(host, install_dir)
+        .marketplace_root
+        .exists()
 }
 
 pub(crate) fn persisted_state_exists(host: impl MarketplaceHost, install_dir: &Path) -> bool {
@@ -868,6 +874,9 @@ fn uninstall_host_locked(
     runner: &dyn CommandRunner,
     setup_runner: &dyn PluginSetupRunner,
 ) -> Result<(), String> {
+    if options.force {
+        return force_uninstall_host_locked(host, options, runner, setup_runner);
+    }
     let state = read_state(host, &options.install_dir);
     let layout = PluginLayout::new(host, &options.install_dir);
     if let Some(state) = state.as_ref() {
@@ -921,6 +930,53 @@ fn uninstall_host_locked(
         }
     }
     result
+}
+
+fn force_uninstall_host_locked(
+    host: impl MarketplaceHost,
+    options: &PluginInstallOptions,
+    runner: &dyn CommandRunner,
+    setup_runner: &dyn PluginSetupRunner,
+) -> Result<(), String> {
+    let layout = PluginLayout::new(host, &options.install_dir);
+    let mut errors = Vec::new();
+
+    if !options.dry_run
+        && let Err(error) = setup_runner.refresh_gateway()
+    {
+        errors.push(format!("failed to stop the Relay-owned gateway: {error}"));
+    }
+    if let Err(error) = run_plugin_uninstall(host, &layout.plugin_root, options, setup_runner) {
+        errors.push(format!("failed to remove Relay host setup: {error}"));
+    }
+    if let Err(error) = run_host_plugin_removal(host, options, runner) {
+        errors.push(format!("failed to unregister the host plugin: {error}"));
+    }
+    if let Err(error) = run_host_marketplace_removal(host, options, runner) {
+        errors.push(format!(
+            "failed to unregister the host marketplace: {error}"
+        ));
+    }
+    if let Err(error) = remove_path(&layout.marketplace_root, options) {
+        errors.push(error);
+    }
+    if let Err(error) = remove_path(&layout.state_path, options) {
+        errors.push(error);
+    }
+    if !options.dry_run {
+        remove_generation_lock_best_effort(&layout.generation_lock);
+    }
+
+    if errors.is_empty() {
+        println!("force-uninstalled {} plugin", host.label());
+        Ok(())
+    } else {
+        Err(format!(
+            "forced {} cleanup completed with errors: {}",
+            host.label(),
+            errors.join("; ")
+        ))
+    }
 }
 
 fn retire_installed_generation(

--- a/crates/cli/src/installation/mod.rs
+++ b/crates/cli/src/installation/mod.rs
@@ -20,5 +20,6 @@ pub(crate) struct InstallRequest {
 #[derive(Debug, Clone)]
 pub(crate) struct UninstallRequest {
     pub(crate) install_dir: Option<PathBuf>,
+    pub(crate) force: bool,
     pub(crate) dry_run: bool,
 }

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -2032,6 +2032,7 @@ fn top_level_install_uninstall_and_doctor_report_empty_host_selection() {
         crate::agents::installed_integrations(
             &CodingAgent::ALL,
             Some(&dir.path().join("install")),
+            false,
         )
         .is_empty()
     );
@@ -2068,6 +2069,7 @@ fn top_level_install_uninstall_and_doctor_report_empty_host_selection() {
             CodingAgent::Codex,
             crate::installation::UninstallRequest {
                 install_dir: Some(dir.path().join("dry-run-uninstall")),
+                force: false,
                 dry_run: true,
             },
         )
@@ -2091,6 +2093,7 @@ fn top_level_install_uninstall_and_doctor_report_empty_host_selection() {
         CodingAgent::Codex,
         crate::installation::UninstallRequest {
             install_dir: Some(dir.path().join("failed-uninstall")),
+            force: false,
             dry_run: false,
         },
     )
@@ -2108,8 +2111,25 @@ fn installed_selection_uses_persisted_integration_state() {
         r#"{"marketplaceRoot":"/tmp/m","pluginRoot":"/tmp/p"}"#,
     )
     .unwrap();
-    let selected = crate::agents::installed_integrations(&CodingAgent::ALL, Some(dir.path()));
+    let selected =
+        crate::agents::installed_integrations(&CodingAgent::ALL, Some(dir.path()), false);
     assert_eq!(selected, vec![CodingAgent::ClaudeCode]);
+}
+
+#[test]
+fn force_selection_includes_a_stale_local_install_without_state() {
+    let dir = tempdir().unwrap();
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    std::fs::create_dir_all(&layout.marketplace_root).unwrap();
+
+    assert!(
+        crate::agents::installed_integrations(&CodingAgent::ALL, Some(dir.path()), false)
+            .is_empty()
+    );
+    assert_eq!(
+        crate::agents::installed_integrations(&CodingAgent::ALL, Some(dir.path()), true),
+        vec![CodingAgent::Codex]
+    );
 }
 
 #[test]
@@ -4315,6 +4335,36 @@ fn uninstall_continues_when_relay_is_missing() {
             .calls()
             .iter()
             .any(|call| call == &format!("uninstall codex {DEFAULT_GATEWAY_URL}"))
+    );
+}
+
+#[test]
+fn force_uninstall_continues_after_setup_failure_and_removes_local_state() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default().with_executable("codex", "/bin/codex");
+    let setup_runner = MockSetupRunner {
+        failing_call: Some(format!("uninstall codex {DEFAULT_GATEWAY_URL}")),
+        ..MockSetupRunner::default()
+    };
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let mut options = options(dir.path());
+    options.force = true;
+
+    let error = uninstall_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap_err();
+
+    assert!(error.contains("failed to remove Relay host setup"));
+    assert!(!layout.marketplace_root.exists());
+    assert!(!layout.state_path.exists());
+    assert!(runner
+        .commands()
+        .iter()
+        .any(|command| command == "/bin/codex plugin remove nemo-relay-plugin@nemo-relay-local"));
+    assert!(
+        runner
+            .commands()
+            .iter()
+            .any(|command| command == "/bin/codex plugin marketplace remove nemo-relay-local")
     );
 }
 

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -4369,6 +4369,26 @@ fn force_uninstall_continues_after_setup_failure_and_removes_local_state() {
 }
 
 #[test]
+fn force_uninstall_reports_a_generation_lock_cleanup_failure() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default().with_executable("codex", "/bin/codex");
+    let setup_runner = MockSetupRunner::default();
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    write_installed_state(CodingAgent::Codex, dir.path());
+    std::fs::remove_file(&layout.generation_lock).unwrap();
+    std::fs::create_dir(&layout.generation_lock).unwrap();
+    let mut options = options(dir.path());
+    options.force = true;
+
+    let error = uninstall_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap_err();
+
+    assert!(error.contains("failed to remove MCP generation lock"));
+    assert!(layout.generation_lock.is_dir());
+    assert!(!layout.marketplace_root.exists());
+    assert!(!layout.state_path.exists());
+}
+
+#[test]
 fn doctor_json_uses_quiet_plugin_report() {
     let dir = tempdir().unwrap();
     let runner = MockRunner::default()

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -4409,6 +4409,35 @@ fn force_uninstall_preserves_state_after_setup_failure_for_retry() {
 }
 
 #[test]
+fn force_uninstall_creates_state_after_setup_failure_without_prior_state() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("codex", "/bin/codex")
+        .with_codex_registration_sequence(&[(true, false), (false, false)]);
+    let setup_runner = MockSetupRunner {
+        failing_call: Some(format!("uninstall codex {DEFAULT_GATEWAY_URL}")),
+        ..MockSetupRunner::default()
+    };
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    let mut options = options(dir.path());
+    options.force = true;
+
+    assert!(force_cleanup_target_exists_with_runner(
+        CodingAgent::Codex,
+        dir.path(),
+        &runner
+    ));
+    let error = uninstall_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap_err();
+
+    assert!(error.contains("failed to remove Relay host setup"));
+    assert!(layout.state_path.exists());
+    assert_eq!(
+        crate::agents::installed_integrations(&[CodingAgent::Codex], Some(dir.path()), true),
+        vec![CodingAgent::Codex]
+    );
+}
+
+#[test]
 fn force_uninstall_reports_a_generation_lock_cleanup_failure() {
     let dir = tempdir().unwrap();
     let runner = MockRunner::default().with_executable("codex", "/bin/codex");

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -4375,7 +4375,7 @@ fn uninstall_continues_when_relay_is_missing() {
 }
 
 #[test]
-fn force_uninstall_continues_after_setup_failure_and_removes_local_state() {
+fn force_uninstall_preserves_state_after_setup_failure_for_retry() {
     let dir = tempdir().unwrap();
     let runner = MockRunner::default().with_executable("codex", "/bin/codex");
     let setup_runner = MockSetupRunner {
@@ -4391,7 +4391,11 @@ fn force_uninstall_continues_after_setup_failure_and_removes_local_state() {
 
     assert!(error.contains("failed to remove Relay host setup"));
     assert!(!layout.marketplace_root.exists());
-    assert!(!layout.state_path.exists());
+    assert!(layout.state_path.exists());
+    assert_eq!(
+        crate::agents::installed_integrations(&[CodingAgent::Codex], Some(dir.path()), true),
+        vec![CodingAgent::Codex]
+    );
     assert!(runner
         .commands()
         .iter()

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -2119,6 +2119,9 @@ fn installed_selection_uses_persisted_integration_state() {
 #[test]
 fn force_selection_includes_a_stale_local_install_without_state() {
     let dir = tempdir().unwrap();
+    let empty_path = dir.path().join("empty-path");
+    std::fs::create_dir_all(&empty_path).unwrap();
+    let _path = PathScope::set_isolated(&empty_path, &dir.path().join("home"));
     let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
     std::fs::create_dir_all(&layout.marketplace_root).unwrap();
 
@@ -2135,6 +2138,9 @@ fn force_selection_includes_a_stale_local_install_without_state() {
 #[test]
 fn force_selection_includes_a_generation_lock_without_other_install_artifacts() {
     let dir = tempdir().unwrap();
+    let empty_path = dir.path().join("empty-path");
+    std::fs::create_dir_all(&empty_path).unwrap();
+    let _path = PathScope::set_isolated(&empty_path, &dir.path().join("home"));
     let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
     std::fs::write(&layout.generation_lock, "lock").unwrap();
 
@@ -2146,6 +2152,20 @@ fn force_selection_includes_a_generation_lock_without_other_install_artifacts() 
         crate::agents::installed_integrations(&CodingAgent::ALL, Some(dir.path()), true),
         vec![CodingAgent::Codex]
     );
+}
+
+#[test]
+fn force_selection_includes_live_host_registration_without_local_artifacts() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("codex", "/bin/codex")
+        .with_codex_registration(true, false);
+
+    assert!(force_cleanup_target_exists_with_runner(
+        CodingAgent::Codex,
+        dir.path(),
+        &runner
+    ));
 }
 
 #[test]
@@ -4402,6 +4422,37 @@ fn force_uninstall_reports_a_generation_lock_cleanup_failure() {
     assert!(layout.generation_lock.is_dir());
     assert!(!layout.marketplace_root.exists());
     assert!(!layout.state_path.exists());
+    assert!(force_cleanup_target_exists_with_runner(
+        CodingAgent::Codex,
+        dir.path(),
+        &runner
+    ));
+}
+
+#[test]
+fn force_selection_retains_a_host_after_registration_removal_fails() {
+    let dir = tempdir().unwrap();
+    let mut runner = MockRunner::default()
+        .with_executable("codex", "/bin/codex")
+        .with_codex_registration(true, false);
+    runner.failing_suffix = Some("plugin remove nemo-relay-plugin@nemo-relay-local".into());
+    let setup_runner = MockSetupRunner::default();
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let mut options = options(dir.path());
+    options.force = true;
+
+    let error = uninstall_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap_err();
+
+    assert!(error.contains("failed to unregister the host plugin"));
+    assert!(!layout.marketplace_root.exists());
+    assert!(!layout.state_path.exists());
+    assert!(!layout.generation_lock.exists());
+    assert!(force_cleanup_target_exists_with_runner(
+        CodingAgent::Codex,
+        dir.path(),
+        &runner
+    ));
 }
 
 #[test]

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -2133,6 +2133,22 @@ fn force_selection_includes_a_stale_local_install_without_state() {
 }
 
 #[test]
+fn force_selection_includes_a_generation_lock_without_other_install_artifacts() {
+    let dir = tempdir().unwrap();
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    std::fs::write(&layout.generation_lock, "lock").unwrap();
+
+    assert!(
+        crate::agents::installed_integrations(&CodingAgent::ALL, Some(dir.path()), false)
+            .is_empty()
+    );
+    assert_eq!(
+        crate::agents::installed_integrations(&CodingAgent::ALL, Some(dir.path()), true),
+        vec![CodingAgent::Codex]
+    );
+}
+
+#[test]
 fn install_codex_generates_marketplace_and_runs_setup() {
     let dir = tempdir().unwrap();
     let runner = MockRunner::default()

--- a/crates/cli/tests/coverage/commands/main_tests.rs
+++ b/crates/cli/tests/coverage/commands/main_tests.rs
@@ -282,6 +282,62 @@ fn command_logging_policy_excludes_only_configuration_editors() {
 }
 
 #[test]
+fn uninstall_logging_ignores_malformed_ambient_relay_config() {
+    let _cwd = crate::test_support::CwdTestScope::locked();
+    let temp = tempfile::tempdir().unwrap();
+    let xdg = temp.path().join("xdg");
+    let config_path = xdg.join("nemo-relay/config.toml");
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(&config_path, "[logging\n").unwrap();
+    let _environment = crate::test_support::EnvScope::set(&[
+        ("NEMO_RELAY_LOG", None),
+        ("NEMO_RELAY_LOG_STDERR", None),
+        ("NEMO_RELAY_LOG_STDERR_FORMAT", None),
+        ("NEMO_RELAY_LOG_CONFIG_PATH", None),
+        ("XDG_CONFIG_HOME", Some(xdg.as_os_str())),
+        ("HOME", Some(temp.path().as_os_str())),
+    ]);
+    let cli = Cli::try_parse_from(["nemo-relay", "uninstall", "all"]).unwrap();
+
+    let config = cli.logging.resolve_without_ambient_config().unwrap();
+
+    assert_eq!(config, nemo_relay::logging::LoggingConfig::default());
+}
+
+#[test]
+fn uninstall_logging_rejects_an_explicit_malformed_logging_config() {
+    let _environment = crate::test_support::EnvScope::set(&[
+        ("NEMO_RELAY_LOG", None),
+        ("NEMO_RELAY_LOG_STDERR", None),
+        ("NEMO_RELAY_LOG_STDERR_FORMAT", None),
+        ("NEMO_RELAY_LOG_CONFIG_PATH", None),
+    ]);
+    let temp = tempfile::tempdir().unwrap();
+    let config_path = temp.path().join("logging.toml");
+    std::fs::write(&config_path, "[logging\n").unwrap();
+    let cli = Cli::try_parse_from(vec![
+        OsString::from("nemo-relay"),
+        OsString::from("--log-config-path"),
+        config_path.into_os_string(),
+        OsString::from("uninstall"),
+        OsString::from("all"),
+    ])
+    .unwrap();
+
+    cli.logging.resolve_without_ambient_config().unwrap_err();
+}
+
+#[test]
+fn cli_parses_force_uninstall() {
+    let cli = Cli::try_parse_from(["nemo-relay", "uninstall", "all", "--force"]).unwrap();
+
+    let Command::Uninstall(command) = cli.command.unwrap() else {
+        panic!("expected uninstall command");
+    };
+    assert!(command.force);
+}
+
+#[test]
 fn cli_parses_config_edit_scopes_and_rejects_conflicts() {
     let legacy = Cli::try_parse_from(["nemo-relay", "config", "codex"]).unwrap();
     let Command::Config(command) = legacy.command.unwrap() else {

--- a/integrations/coding-agents/README.md
+++ b/integrations/coding-agents/README.md
@@ -22,7 +22,8 @@ wrappers remain available as `nemo-relay claude` and `nemo-relay codex`.
 
 If normal removal is blocked by stale Relay state or MCP generation metadata,
 use `nemo-relay uninstall <host> --force`. It attempts each Relay-owned cleanup
-step independently, then reports any steps that could not complete.
+step independently, then reports any steps that could not complete. If host
+setup cleanup fails, Relay keeps its state so a later forced uninstall can retry.
 
 Host-specific source notes live in:
 

--- a/integrations/coding-agents/README.md
+++ b/integrations/coding-agents/README.md
@@ -20,6 +20,10 @@ Use `nemo-relay doctor --plugin <host>` to verify an installation and
 `nemo-relay uninstall <host>` to remove Relay-owned host state. The transparent
 wrappers remain available as `nemo-relay claude` and `nemo-relay codex`.
 
+If normal removal is blocked by stale Relay state or MCP generation metadata,
+use `nemo-relay uninstall <host> --force`. It attempts each Relay-owned cleanup
+step independently, then reports any steps that could not complete.
+
 Host-specific source notes live in:
 
 - [`claude-code/`](claude-code/README.md)

--- a/integrations/coding-agents/claude-code/README.md
+++ b/integrations/coding-agents/claude-code/README.md
@@ -325,3 +325,8 @@ the marketplace registration, and remove the generated marketplace directory:
 ```bash
 nemo-relay uninstall claude-code
 ```
+
+If stale Relay install state prevents normal removal, use
+`nemo-relay uninstall claude-code --force`. It attempts the Claude Code
+settings, registration, marketplace, and deterministic local Relay cleanup
+independently, then reports any steps that could not complete.

--- a/integrations/coding-agents/claude-code/README.md
+++ b/integrations/coding-agents/claude-code/README.md
@@ -329,4 +329,5 @@ nemo-relay uninstall claude-code
 If stale Relay install state prevents normal removal, use
 `nemo-relay uninstall claude-code --force`. It attempts the Claude Code
 settings, registration, marketplace, and deterministic local Relay cleanup
-independently, then reports any steps that could not complete.
+independently, then reports any steps that could not complete. If settings
+cleanup fails, Relay keeps its state so a later forced uninstall can retry.

--- a/integrations/coding-agents/codex/README.md
+++ b/integrations/coding-agents/codex/README.md
@@ -441,7 +441,8 @@ nemo-relay uninstall codex
 If stale Relay state or MCP generation metadata prevents normal removal, use
 `nemo-relay uninstall codex --force`. It attempts the Codex configuration,
 registration, marketplace, and deterministic local Relay cleanup independently,
-then reports any steps that could not complete.
+then reports any steps that could not complete. If Codex configuration cleanup
+fails, Relay keeps its state so a later forced uninstall can retry.
 
 Codex can request `/models` during provider discovery before it launches plugin
 MCP servers. A cold start can produce transient connection failures that

--- a/integrations/coding-agents/codex/README.md
+++ b/integrations/coding-agents/codex/README.md
@@ -438,6 +438,11 @@ directory:
 nemo-relay uninstall codex
 ```
 
+If stale Relay state or MCP generation metadata prevents normal removal, use
+`nemo-relay uninstall codex --force`. It attempts the Codex configuration,
+registration, marketplace, and deterministic local Relay cleanup independently,
+then reports any steps that could not complete.
+
 Codex can request `/models` during provider discovery before it launches plugin
 MCP servers. A cold start can produce transient connection failures that
 Codex retries. Because the MCP server is required, Codex does not begin the


### PR DESCRIPTION
#### Overview

Make coding-agent uninstallation resilient when Relay configuration or persisted
installation state is malformed, and provide a force-enabled escape hatch.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Keep uninstall logging independent of ambient Relay configuration while still
  validating direct logging inputs.
- Add `--force` to `uninstall codex`, `uninstall claude-code`, and
  `uninstall all`, so Relay-owned setup, host registration, marketplace, and
  deterministic local-state cleanup are attempted independently.
- Add regression coverage for malformed ambient and explicit logging
  configuration, stale local installations, and cleanup after setup failures.
- Document the force cleanup escape hatch for the coding-agent integrations.

#### Where should the reviewer start?

Start with `crates/cli/src/installation/marketplace/mod.rs`, which defines the
force cleanup behavior and its error aggregation. Then review the command
logging policy in `crates/cli/src/commands/mod.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-805](https://linear.app/nvidia/issue/RELAY-805/ensure-uninstall-all-does-not-load-malformed-relay-configuration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--force` support for uninstalling integrations when stale installation data blocks normal removal.
  * Forced uninstall independently attempts cleanup of settings, registrations, marketplace data, and local installation state, reporting incomplete steps.
  * Improved detection of locally installed integrations during forced operations.

* **Bug Fixes**
  * Uninstall now handles malformed ambient logging configuration without failing unnecessarily.

* **Documentation**
  * Documented forced-uninstall behavior, cleanup results, and recovery steps for supported coding-agent integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->