### PR TITLE
fix(cli): keep Codex routing in exec scope

### DIFF
--- a/crates/cli/src/agents/codex/launch.rs
+++ b/crates/cli/src/agents/codex/launch.rs
@@ -9,7 +9,7 @@ use crate::agents::CodingAgent;
 use crate::configuration::{RELAY_PLUGIN_ID, RELAY_SOURCE_PLUGIN_ID};
 use crate::error::CliError;
 use crate::hooks::{generated_policy_hooks, transparent_hook_forward_commands};
-use crate::process::{PreparedAgentLaunch, insert_after_host};
+use crate::process::PreparedAgentLaunch;
 
 pub(crate) fn prepare(launch: &mut PreparedAgentLaunch, gateway_url: &str) -> Result<(), CliError> {
     let has_openai_key = std::env::var("OPENAI_API_KEY")
@@ -49,8 +49,98 @@ pub(crate) fn prepare(launch: &mut PreparedAgentLaunch, gateway_url: &str) -> Re
     }
     args.push("--config".to_string());
     args.push(session_hook_state_override(&hook_groups)?);
-    insert_after_host(&mut launch.argv, launch.host_index, args);
+    insert_config_in_command_scope(&mut launch.argv, launch.host_index, args);
     Ok(())
+}
+
+fn insert_config_in_command_scope(
+    argv: &mut Vec<String>,
+    host_index: usize,
+    values: impl IntoIterator<Item = String>,
+) {
+    debug_assert!(host_index < argv.len());
+    // Codex accepts configuration at each clap command level, but a nested command's
+    // overrides replace the parent scope. Keep Relay's provider and hook overrides in the
+    // deepest model-running `exec` scope. Parse positions rather than searching values so a
+    // command such as `codex mcp remove exec` keeps the root placement.
+    let Some(exec_index) = command_position(argv, host_index + 1)
+        .filter(|&index| matches!(argv[index].as_str(), "exec" | "e"))
+    else {
+        argv.splice(host_index + 1..host_index + 1, values);
+        return;
+    };
+    let insert_at = command_position(argv, exec_index + 1)
+        .filter(|&index| matches!(argv[index].as_str(), "resume" | "review"))
+        .map_or(exec_index + 1, |index| index + 1);
+    argv.splice(insert_at..insert_at, values);
+}
+
+fn command_position(argv: &[String], mut index: usize) -> Option<usize> {
+    while let Some(argument) = argv.get(index).map(String::as_str) {
+        if argument == "--" {
+            return None;
+        }
+        if option_takes_separate_value(argument) {
+            index += 2;
+        } else if option_is_self_contained(argument) {
+            index += 1;
+        } else {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn option_is_self_contained(argument: &str) -> bool {
+    (argument.starts_with("--") && argument.contains('='))
+        || (argument.starts_with('-') && !argument.starts_with("--") && argument.len() > 2)
+        || matches!(
+            argument,
+            "--strict-config"
+                | "--oss"
+                | "--dangerously-bypass-approvals-and-sandbox"
+                | "--dangerously-bypass-hook-trust"
+                | "--search"
+                | "--no-alt-screen"
+                | "--skip-git-repo-check"
+                | "--ephemeral"
+                | "--ignore-user-config"
+                | "--ignore-rules"
+                | "--json"
+                | "-h"
+                | "--help"
+                | "-V"
+                | "--version"
+        )
+}
+
+fn option_takes_separate_value(argument: &str) -> bool {
+    matches!(
+        argument,
+        "-c" | "--config"
+            | "--enable"
+            | "--disable"
+            | "--remote"
+            | "--remote-auth-token-env"
+            | "-i"
+            | "--image"
+            | "-m"
+            | "--model"
+            | "--local-provider"
+            | "-p"
+            | "--profile"
+            | "-s"
+            | "--sandbox"
+            | "-C"
+            | "--cd"
+            | "--add-dir"
+            | "-a"
+            | "--ask-for-approval"
+            | "--output-schema"
+            | "--color"
+            | "-o"
+            | "--output-last-message"
+    )
 }
 
 pub(crate) fn session_hook_state_override(generated: &Value) -> Result<String, CliError> {

--- a/crates/cli/src/agents/codex/launch.rs
+++ b/crates/cli/src/agents/codex/launch.rs
@@ -70,7 +70,7 @@ fn insert_config_in_command_scope(
         return;
     };
     let insert_at = command_position(argv, exec_index + 1)
-        .filter(|&index| matches!(argv[index].as_str(), "resume" | "review"))
+        .filter(|&index| matches!(argv[index].as_str(), "fork" | "resume" | "review"))
         .map_or(exec_index + 1, |index| index + 1);
     argv.splice(insert_at..insert_at, values);
 }
@@ -97,6 +97,7 @@ fn option_is_self_contained(argument: &str) -> bool {
         || matches!(
             argument,
             "--strict-config"
+                | "--full-auto"
                 | "--oss"
                 | "--dangerously-bypass-approvals-and-sandbox"
                 | "--dangerously-bypass-hook-trust"

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -3935,8 +3935,7 @@ command = "codex exec"
         .lines()
         .find(|line| line.starts_with("argv = "))
         .expect("dry-run output should include argv");
-    assert!(argv.starts_with("argv = codex "), "{stdout}");
-    assert!(argv.ends_with(" exec"), "{stdout}");
+    assert!(argv.starts_with("argv = codex exec --config "), "{stdout}");
 }
 
 #[test]

--- a/crates/cli/tests/coverage/agents/launcher_tests.rs
+++ b/crates/cli/tests/coverage/agents/launcher_tests.rs
@@ -385,6 +385,89 @@ fn prepares_codex_config_overrides_in_exec_scope() {
 }
 
 #[test]
+fn prepares_codex_config_overrides_after_full_auto_in_exec_scope() {
+    let resolved = ResolvedConfig {
+        gateway: GatewayConfig::default(),
+        agents: AgentConfigs::default(),
+        ..ResolvedConfig::default()
+    };
+    let prepared = PreparedAgentLaunch::new(
+        CodingAgent::Codex,
+        vec![
+            "codex".into(),
+            "--full-auto".into(),
+            "exec".into(),
+            "--config".into(),
+            "mcp_servers.example.url=\"http://127.0.0.1:9902\"".into(),
+            "inspect the workspace".into(),
+        ],
+        "http://127.0.0.1:1234",
+        &resolved,
+        false,
+    )
+    .unwrap();
+
+    let exec_index = prepared.argv.iter().position(|arg| arg == "exec").unwrap();
+    let provider_index = prepared
+        .argv
+        .iter()
+        .position(|arg| arg == "model_provider=\"nemo-relay-openai\"")
+        .unwrap();
+    assert!(provider_index > exec_index);
+    assert!(
+        provider_index
+            < prepared
+                .argv
+                .iter()
+                .position(|arg| arg.starts_with("mcp_servers.example.url="))
+                .unwrap()
+    );
+}
+
+#[test]
+fn prepares_codex_config_overrides_in_fork_scope() {
+    let resolved = ResolvedConfig {
+        gateway: GatewayConfig::default(),
+        agents: AgentConfigs::default(),
+        ..ResolvedConfig::default()
+    };
+    let prepared = PreparedAgentLaunch::new(
+        CodingAgent::Codex,
+        vec![
+            "codex".into(),
+            "exec".into(),
+            "--model".into(),
+            "gpt-5.4".into(),
+            "fork".into(),
+            "0198d672-f123-4567-89ab-cdef01234567".into(),
+            "--config".into(),
+            "mcp_servers.example.url=\"http://127.0.0.1:9902\"".into(),
+            "continue".into(),
+        ],
+        "http://127.0.0.1:1234",
+        &resolved,
+        false,
+    )
+    .unwrap();
+
+    let fork_index = prepared.argv.iter().position(|arg| arg == "fork").unwrap();
+    let provider_index = prepared
+        .argv
+        .iter()
+        .position(|arg| arg == "model_provider=\"nemo-relay-openai\"")
+        .unwrap();
+    assert!(provider_index > fork_index);
+    assert!(
+        provider_index
+            < prepared
+                .argv
+                .iter()
+                .position(|arg| arg == "0198d672-f123-4567-89ab-cdef01234567")
+                .unwrap()
+    );
+}
+
+#[test]
 fn prepares_codex_config_overrides_in_resume_scope() {
     let resolved = ResolvedConfig {
         gateway: GatewayConfig::default(),

--- a/crates/cli/tests/coverage/agents/launcher_tests.rs
+++ b/crates/cli/tests/coverage/agents/launcher_tests.rs
@@ -344,6 +344,170 @@ fn prepares_codex_config_overrides() {
 }
 
 #[test]
+fn prepares_codex_config_overrides_in_exec_scope() {
+    let resolved = ResolvedConfig {
+        gateway: GatewayConfig::default(),
+        agents: AgentConfigs::default(),
+        ..ResolvedConfig::default()
+    };
+    let prepared = PreparedAgentLaunch::new(
+        CodingAgent::Codex,
+        vec![
+            "codex".into(),
+            "--profile".into(),
+            "root".into(),
+            "exec".into(),
+            "--config".into(),
+            "mcp_servers.example.url=\"http://127.0.0.1:9902\"".into(),
+            "inspect the workspace".into(),
+        ],
+        "http://127.0.0.1:1234",
+        &resolved,
+        false,
+    )
+    .unwrap();
+
+    let exec_index = prepared.argv.iter().position(|arg| arg == "exec").unwrap();
+    let provider_index = prepared
+        .argv
+        .iter()
+        .position(|arg| arg == "model_provider=\"nemo-relay-openai\"")
+        .unwrap();
+    assert!(provider_index > exec_index);
+    assert!(
+        provider_index
+            < prepared
+                .argv
+                .iter()
+                .position(|arg| arg.starts_with("mcp_servers.example.url="))
+                .unwrap()
+    );
+}
+
+#[test]
+fn prepares_codex_config_overrides_in_resume_scope() {
+    let resolved = ResolvedConfig {
+        gateway: GatewayConfig::default(),
+        agents: AgentConfigs::default(),
+        ..ResolvedConfig::default()
+    };
+    let prepared = PreparedAgentLaunch::new(
+        CodingAgent::Codex,
+        vec![
+            "codex".into(),
+            "exec".into(),
+            "resume".into(),
+            "0198d672-f123-4567-89ab-cdef01234567".into(),
+            "--config".into(),
+            "mcp_servers.example.url=\"http://127.0.0.1:9902\"".into(),
+            "continue".into(),
+        ],
+        "http://127.0.0.1:1234",
+        &resolved,
+        false,
+    )
+    .unwrap();
+
+    let resume_index = prepared
+        .argv
+        .iter()
+        .position(|arg| arg == "resume")
+        .unwrap();
+    let provider_index = prepared
+        .argv
+        .iter()
+        .position(|arg| arg == "model_provider=\"nemo-relay-openai\"")
+        .unwrap();
+    assert!(provider_index > resume_index);
+    assert!(
+        provider_index
+            < prepared
+                .argv
+                .iter()
+                .position(|arg| arg == "0198d672-f123-4567-89ab-cdef01234567")
+                .unwrap()
+    );
+}
+
+#[test]
+fn prepares_codex_config_overrides_in_review_scope() {
+    let resolved = ResolvedConfig {
+        gateway: GatewayConfig::default(),
+        agents: AgentConfigs::default(),
+        ..ResolvedConfig::default()
+    };
+    let prepared = PreparedAgentLaunch::new(
+        CodingAgent::Codex,
+        vec![
+            "codex".into(),
+            "exec".into(),
+            "--model".into(),
+            "gpt-5.4".into(),
+            "review".into(),
+            "--config".into(),
+            "mcp_servers.example.url=\"http://127.0.0.1:9902\"".into(),
+            "inspect the workspace".into(),
+        ],
+        "http://127.0.0.1:1234",
+        &resolved,
+        false,
+    )
+    .unwrap();
+
+    let review_index = prepared
+        .argv
+        .iter()
+        .position(|argument| argument == "review")
+        .unwrap();
+    let provider_index = prepared
+        .argv
+        .iter()
+        .position(|argument| argument == "model_provider=\"nemo-relay-openai\"")
+        .unwrap();
+    assert!(provider_index > review_index);
+    assert!(
+        provider_index
+            < prepared
+                .argv
+                .iter()
+                .position(|argument| argument.starts_with("mcp_servers.example.url="))
+                .unwrap()
+    );
+}
+
+#[test]
+fn prepares_codex_config_at_root_for_non_exec_command_with_exec_argument() {
+    let resolved = ResolvedConfig {
+        gateway: GatewayConfig::default(),
+        agents: AgentConfigs::default(),
+        ..ResolvedConfig::default()
+    };
+    let prepared = PreparedAgentLaunch::new(
+        CodingAgent::Codex,
+        vec!["codex".into(), "mcp".into(), "remove".into(), "exec".into()],
+        "http://127.0.0.1:1234",
+        &resolved,
+        false,
+    )
+    .unwrap();
+
+    assert_eq!(prepared.argv[0], "codex");
+    assert_eq!(prepared.argv[1], "--config");
+    let provider_index = prepared
+        .argv
+        .iter()
+        .position(|argument| argument == "model_provider=\"nemo-relay-openai\"")
+        .unwrap();
+    let mcp_index = prepared
+        .argv
+        .iter()
+        .position(|argument| argument == "mcp")
+        .unwrap();
+    assert!(provider_index < mcp_index);
+    assert_eq!(&prepared.argv[mcp_index..], ["mcp", "remove", "exec"]);
+}
+
+#[test]
 fn prepares_codex_config_overrides_with_versioned_trailing_slash_gateway_url() {
     let _guard = current_dir_lock().lock().unwrap();
     let resolved = ResolvedConfig {


### PR DESCRIPTION
#### Overview

Keep NeMo Relay Codex provider and hook overrides in the active `exec` command scope so caller-supplied command configuration cannot cause transparent runs to bypass Relay.

- [x] I confirm that I have read the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Relay/blob/main/CONTRIBUTING.md) and followed the requirements.
- [x] I searched existing issues and pull requests before opening this contribution.

#### Details

Codex scopes `--config` overrides to the active clap subcommand. Relay previously inserted its generated provider override immediately after the host executable, while callers can append MCP configuration after `exec` or `exec resume`. In that shape, the inner execution can lose the Relay provider and use the normal provider instead.

This change inserts Relay generated configuration after `exec`, or after `exec resume`, while preserving the existing placement for other command shapes. It adds regressions for both forms with caller-supplied command configuration.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy -p nemo-relay-cli --lib -- -D warnings`
- focused Codex launcher tests: 6 passed
- pre-commit hooks for both changed files

No breaking changes.

#### Where should reviewer start?

Start with `insert_config_in_command_scope` in `crates/cli/src/agents/codex/launch.rs`, then the two new launcher tests.

#### Related Issues and/or Pull Requests

- Closes #950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex launch handling for `exec`, `exec fork`, `exec resume`, and `exec review`.
  * Ensured configuration overrides are applied within the correct command scope, including nested commands.
  * Preserved proper ordering before MCP configuration, session arguments, and other command options.
  * Prevented unrelated commands containing `exec` arguments from receiving incorrectly scoped configuration.
  * Improved handling of commands using `--full-auto` and other preceding options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->