### PR TITLE
fix: refresh managed integrations after Relay upgrade

### DIFF
--- a/crates/cli/src/bootstrap/mod.rs
+++ b/crates/cli/src/bootstrap/mod.rs
@@ -178,11 +178,10 @@ fn acquire_gateway(spec: &GatewaySpec) -> Result<GatewayEndpoint, String> {
             (RelayHealth::Compatible, instance_id) => {
                 return compatible_endpoint(spec.bind, url, instance_id);
             }
-            (RelayHealth::Incompatible, _) => return Err(incompatible_relay_error(&url)),
             // A gateway may already be binding while another MCP process owns the
             // startup lock. Serialize before deciding whether either state is a
-            // genuine conflict.
-            (RelayHealth::Foreign | RelayHealth::Unavailable, _) => {}
+            // genuine conflict or a verified version mismatch that can be replaced.
+            (RelayHealth::Incompatible | RelayHealth::Foreign | RelayHealth::Unavailable, _) => {}
         }
     }
 
@@ -194,7 +193,13 @@ fn acquire_gateway(spec: &GatewaySpec) -> Result<GatewayEndpoint, String> {
     }
     match probe_relay_health_with_instance(&url, spec.bootstrap_fingerprint.as_deref()) {
         (RelayHealth::Compatible, instance_id) => compatible_endpoint(spec.bind, url, instance_id),
-        (RelayHealth::Incompatible, _) => Err(incompatible_relay_error(&url)),
+        (RelayHealth::Incompatible, _) => {
+            if state::stop_version_mismatched_owned_gateway_locked(&state, &url)? {
+                start_gateway(spec, &state)
+            } else {
+                Err(incompatible_relay_error(&url))
+            }
+        }
         (RelayHealth::Foreign, _) => Err(foreign_listener_error(&url)),
         (RelayHealth::Unavailable, _) => start_gateway(spec, &state),
     }

--- a/crates/cli/src/bootstrap/state.rs
+++ b/crates/cli/src/bootstrap/state.rs
@@ -225,9 +225,33 @@ pub(crate) fn stop_owned_and_reset(url: &str) -> Result<(), String> {
         return Ok(());
     }
     let _lock = lock_endpoint(&state, url)?;
-    let path = owner_path(&state, url);
+    stop_owned_and_reset_locked(&state, url).map(|_| ())
+}
+
+/// Stops a version-mismatched, Relay-owned gateway while the caller holds the
+/// endpoint startup lock.
+///
+/// Returns `true` when an owned gateway was stopped or a stale owned record was
+/// removed. Same-version, invalid, and absent records return `false` so callers
+/// can preserve the original incompatible-gateway error.
+pub(crate) fn stop_version_mismatched_owned_gateway_locked(
+    state: &Path,
+    url: &str,
+) -> Result<bool, String> {
+    let path = owner_path(state, url);
     let Some(owner) = read_owner_record(&path)? else {
-        return Ok(());
+        return Ok(false);
+    };
+    if !owner.valid_for(url) || owner.version == env!("CARGO_PKG_VERSION") {
+        return Ok(false);
+    }
+    stop_owned_gateway_locked(&path, &owner, url)
+}
+
+fn stop_owned_and_reset_locked(state: &Path, url: &str) -> Result<bool, String> {
+    let path = owner_path(state, url);
+    let Some(owner) = read_owner_record(&path)? else {
+        return Ok(false);
     };
     if !owner.valid_for(url) {
         return Err(format!(
@@ -235,10 +259,14 @@ pub(crate) fn stop_owned_and_reset(url: &str) -> Result<(), String> {
             path.display()
         ));
     }
+    stop_owned_gateway_locked(&path, &owner, url)
+}
+
+fn stop_owned_gateway_locked(path: &Path, owner: &OwnerRecord, url: &str) -> Result<bool, String> {
     match probe(url, owner.bootstrap_fingerprint.as_deref()) {
         RelayHealth::Unavailable => {
-            remove_if_matches(&path, &owner)?;
-            return Ok(());
+            remove_if_matches(path, owner)?;
+            return Ok(true);
         }
         RelayHealth::Compatible => {}
         RelayHealth::Incompatible | RelayHealth::Foreign => {
@@ -272,7 +300,8 @@ pub(crate) fn stop_owned_and_reset(url: &str) -> Result<(), String> {
             }
         }
     }
-    remove_if_matches(&path, &owner)
+    remove_if_matches(path, owner)?;
+    Ok(true)
 }
 
 fn write_owner_record(path: &Path, record: &OwnerRecord) -> Result<(), String> {

--- a/crates/cli/src/commands/integrations.rs
+++ b/crates/cli/src/commands/integrations.rs
@@ -49,9 +49,11 @@ fn refresh(command: RefreshCommand) -> Result<ExitCode, CliError> {
         })
         .cloned()
         .collect::<Vec<_>>();
-    if !command.dry_run {
-        crate::installation::marketplace::prepare_integrations_for_refresh(&managed_targets)?;
-    }
+    let mut preflight = (!command.dry_run)
+        .then(|| {
+            crate::installation::marketplace::prepare_integrations_for_refresh(&managed_targets)
+        })
+        .transpose()?;
     let mut attempted = 0;
     let mut errors = Vec::new();
 
@@ -77,27 +79,44 @@ fn refresh(command: RefreshCommand) -> Result<ExitCode, CliError> {
             dry_run: command.dry_run,
             skip_doctor: false,
         };
-        match crate::agents::install_integration(agent, request) {
-            Ok(status) if status == ExitCode::SUCCESS => println!(
-                "{} at {}: {}",
-                agent.label(),
-                install_dir.display(),
-                if command.dry_run {
-                    "would refresh — no reconnect required"
-                } else {
-                    "refreshed — reconnect required"
-                }
-            ),
-            Ok(_) => errors.push(format!(
+        let result = match crate::agents::install_integration(agent, request) {
+            Ok(status) if status == ExitCode::SUCCESS => Ok(()),
+            Ok(_) => Err(format!(
                 "{} at {} returned a nonzero status",
                 agent.label(),
                 install_dir.display()
             )),
-            Err(error) => errors.push(format!(
+            Err(error) => Err(format!(
                 "{} at {}: {error}",
                 agent.label(),
                 install_dir.display()
             )),
+        };
+        match result {
+            Ok(()) => {
+                if let Some(preflight) = preflight.as_mut() {
+                    preflight.commit_target(agent, &install_dir);
+                }
+                println!(
+                    "{} at {}: {}",
+                    agent.label(),
+                    install_dir.display(),
+                    if command.dry_run {
+                        "would refresh — no reconnect required"
+                    } else {
+                        "refreshed — reconnect required"
+                    }
+                );
+            }
+            Err(error) => {
+                let restore_error = preflight.as_mut().and_then(|preflight| {
+                    preflight.restore_failed_target(agent, &install_dir).err()
+                });
+                errors.push(match restore_error {
+                    Some(restore_error) => format!("{error}; additionally failed to restore the previous MCP generation: {restore_error}"),
+                    None => error,
+                });
+            }
         }
     }
 

--- a/crates/cli/src/commands/integrations.rs
+++ b/crates/cli/src/commands/integrations.rs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Refreshes persistent coding-agent integrations after a Relay upgrade.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Args, Subcommand};
+
+use crate::agents::CodingAgent;
+use crate::error::CliError;
+use crate::installation::InstallRequest;
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct IntegrationsCommand {
+    #[command(subcommand)]
+    command: IntegrationsSubcommand,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+enum IntegrationsSubcommand {
+    /// Replace Relay-managed Codex and Claude Code integrations with the current Relay binary.
+    Refresh(RefreshCommand),
+}
+
+#[derive(Debug, Clone, Args)]
+struct RefreshCommand {
+    /// Refresh integrations in one install directory and record it for future automatic refreshes.
+    #[arg(long)]
+    install_dir: Option<PathBuf>,
+    /// Show the refresh operations without changing integrations.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+pub(crate) fn execute(command: IntegrationsCommand) -> Result<ExitCode, CliError> {
+    match command.command {
+        IntegrationsSubcommand::Refresh(command) => refresh(command),
+    }
+}
+
+fn refresh(command: RefreshCommand) -> Result<ExitCode, CliError> {
+    let targets = refresh_targets(command.install_dir.as_deref())?;
+    let managed_targets = targets
+        .iter()
+        .filter(|(agent, install_dir)| {
+            crate::installation::marketplace::persisted_state_exists(*agent, install_dir)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if !command.dry_run {
+        crate::installation::marketplace::prepare_integrations_for_refresh(&managed_targets)?;
+    }
+    let mut attempted = 0;
+    let mut errors = Vec::new();
+
+    for (agent, install_dir) in targets {
+        if !crate::installation::marketplace::persisted_state_exists(agent, &install_dir) {
+            if command.install_dir.is_some()
+                && crate::installation::marketplace::local_install_exists(agent, &install_dir)
+            {
+                println!(
+                    "{} at {}: unmanaged/manual — not changed; reinstall with `nemo-relay install {} --force`",
+                    agent.label(),
+                    install_dir.display(),
+                    agent.install_arg()
+                );
+            }
+            continue;
+        }
+
+        attempted += 1;
+        let request = InstallRequest {
+            install_dir: Some(install_dir.clone()),
+            force: true,
+            dry_run: command.dry_run,
+            skip_doctor: false,
+        };
+        match crate::agents::install_integration(agent, request) {
+            Ok(status) if status == ExitCode::SUCCESS => println!(
+                "{} at {}: {}",
+                agent.label(),
+                install_dir.display(),
+                if command.dry_run {
+                    "would refresh — no reconnect required"
+                } else {
+                    "refreshed — reconnect required"
+                }
+            ),
+            Ok(_) => errors.push(format!(
+                "{} at {} returned a nonzero status",
+                agent.label(),
+                install_dir.display()
+            )),
+            Err(error) => errors.push(format!(
+                "{} at {}: {error}",
+                agent.label(),
+                install_dir.display()
+            )),
+        }
+    }
+
+    if attempted == 0 {
+        println!("No Relay-managed Codex or Claude Code integrations found.");
+    }
+    if errors.is_empty() {
+        Ok(ExitCode::SUCCESS)
+    } else {
+        Err(CliError::Install(format!(
+            "failed to refresh one or more integrations after attempting every target: {}",
+            errors.join("; ")
+        )))
+    }
+}
+
+fn refresh_targets(
+    install_dir: Option<&std::path::Path>,
+) -> Result<Vec<(CodingAgent, PathBuf)>, CliError> {
+    let mut targets = Vec::new();
+    if let Some(install_dir) = install_dir {
+        let install_dir = install_dir
+            .canonicalize()
+            .unwrap_or_else(|_| install_dir.to_path_buf());
+        for agent in CodingAgent::ALL {
+            targets.push((agent, install_dir.clone()));
+        }
+    } else {
+        let default = crate::installation::marketplace::default_marketplace_install_dir();
+        for agent in CodingAgent::ALL {
+            targets.push((agent, default.clone()));
+            for install_dir in crate::installation::marketplace::registered_install_dirs(agent)
+                .map_err(CliError::Install)?
+            {
+                if !targets
+                    .iter()
+                    .any(|(existing, directory)| *existing == agent && *directory == install_dir)
+                {
+                    targets.push((agent, install_dir));
+                }
+            }
+        }
+    }
+
+    Ok(targets)
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod diagnostics;
 mod gateway;
 mod hook_forward;
 mod install;
+mod integrations;
 mod logging;
 mod mcp;
 mod model_pricing;
@@ -81,9 +82,12 @@ fn configure_logging(cli: &Cli) -> Result<LoggingSetup, error::CliError> {
 
     let mut fallback_error = None;
     let config = match cli.command.as_ref() {
-        // Uninstall uses persisted integration state, not Relay runtime configuration. Preserve
-        // direct logging settings while avoiding ambient config discovery that could block cleanup.
-        Some(Command::Uninstall(_)) => cli.logging.resolve_without_ambient_config(),
+        // Persistent integration maintenance uses saved integration state, not Relay runtime
+        // configuration. Preserve direct logging settings while avoiding ambient config discovery
+        // that could block cleanup or an upgrade refresh.
+        Some(Command::Uninstall(_) | Command::Integrations(_)) => {
+            cli.logging.resolve_without_ambient_config()
+        }
         Some(Command::Gateway(command)) if command.is_stop() => {
             cli.logging.resolve_without_ambient_config()
         }
@@ -191,6 +195,7 @@ async fn run_command(
         }
         Command::Install(command) => install::install(command),
         Command::Uninstall(command) => install::uninstall(command),
+        Command::Integrations(command) => integrations::execute(command),
         Command::Run(command) => run::execute(command, server).await,
         Command::Claude(command) => run::easy_path(CodingAgent::ClaudeCode, command, server).await,
         Command::Codex(command) => run::easy_path(CodingAgent::Codex, command, server).await,

--- a/crates/cli/src/commands/root.rs
+++ b/crates/cli/src/commands/root.rs
@@ -9,6 +9,7 @@ use super::diagnostics::{AgentsCommand, DoctorCommand};
 use super::gateway::GatewayCommand;
 use super::hook_forward::HookForwardCommand;
 use super::install::{InstallCommand, UninstallCommand};
+use super::integrations::IntegrationsCommand;
 use super::logging::LoggingArgs;
 use super::model_pricing::PricingCommand;
 use super::plugins::PluginsCommand;
@@ -99,6 +100,8 @@ pub(crate) enum Command {
     Install(InstallCommand),
     /// Uninstall coding-agent plugins installed by `nemo-relay install`.
     Uninstall(UninstallCommand),
+    /// Refresh Relay-managed coding-agent integrations after upgrading Relay.
+    Integrations(IntegrationsCommand),
     /// Validate and configure model pricing catalogs.
     ModelPricing(PricingCommand),
     /// Diagnose env, agents, config, observability (use --offline to skip live network probes)
@@ -125,6 +128,7 @@ impl Command {
             Self::Plugins(_) => "plugins",
             Self::Install(_) => "install",
             Self::Uninstall(_) => "uninstall",
+            Self::Integrations(_) => "integrations",
             Self::ModelPricing(_) => "model_pricing",
             Self::Doctor(_) => "doctor",
             Self::Agents(_) => "agents",

--- a/crates/cli/src/installation/generation.rs
+++ b/crates/cli/src/installation/generation.rs
@@ -443,6 +443,37 @@ impl GenerationRetirement {
         self.invalidate_with(|path, retired| replace_generation_marker(path, retired, "invalidate"))
     }
 
+    /// Release the transaction lock while preserving the original marker for a later rollback.
+    ///
+    /// The marker must already be retired. A caller can either commit the replacement once the
+    /// new integration is installed or call [`Self::restore_after_rollback`] after a failure.
+    pub(crate) fn release_transaction_lock_for_refresh(&mut self) -> Result<(), String> {
+        if self.lock_released_for_tree_mutation {
+            return Ok(());
+        }
+        if !self.changed && !self.original.is_retired() {
+            return Err(format!(
+                "cannot release active MCP install generation lock {}",
+                self.original.lock_path().display()
+            ));
+        }
+        let Some(file) = self.lock.take() else {
+            return Err(format!(
+                "MCP install generation {} is not locked",
+                self.path.display()
+            ));
+        };
+        if let Err(error) = unlock_file(&file) {
+            self.lock = Some(file);
+            return Err(format!(
+                "failed to release MCP install generation lock {} before refreshing: {error}",
+                self.original.lock_path().display()
+            ));
+        }
+        self.lock_released_for_tree_mutation = true;
+        Ok(())
+    }
+
     fn invalidate_with(
         &mut self,
         write_retired: impl FnOnce(&Path, &GenerationMarker) -> Result<(), String>,

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -128,6 +128,112 @@ pub(crate) fn marketplace_install_roots(
     (layout.marketplace_root, layout.plugin_root)
 }
 
+pub(crate) fn registered_install_dirs(host: impl MarketplaceHost) -> Result<Vec<PathBuf>, String> {
+    state::registered_install_dirs(host)
+}
+
+/// Check prerequisites before retiring any MCP generation for a refresh.
+pub(crate) fn prepare_integrations_for_refresh(
+    targets: &[(crate::agents::CodingAgent, PathBuf)],
+) -> Result<(), CliError> {
+    prepare_integrations_for_refresh_with_runner(targets, &RealCommandRunner)
+}
+
+fn prepare_integrations_for_refresh_with_runner(
+    targets: &[(crate::agents::CodingAgent, PathBuf)],
+    runner: &dyn CommandRunner,
+) -> Result<(), CliError> {
+    validate_integrations_for_refresh_with_runner(targets, runner)?;
+    retire_integrations_for_refresh(targets)
+}
+
+fn validate_integrations_for_refresh_with_runner(
+    targets: &[(crate::agents::CodingAgent, PathBuf)],
+    runner: &dyn CommandRunner,
+) -> Result<(), CliError> {
+    for (host, install_dir) in targets {
+        let options = PluginInstallOptions {
+            install_dir: install_dir.clone(),
+            operation_lock_dir: PathBuf::new(),
+            force: true,
+            dry_run: false,
+            skip_doctor: false,
+        };
+        let relay = require_relay(&options, runner).map_err(CliError::Install)?;
+        validate_relay_hook_forward(&relay, &options, runner).map_err(CliError::Install)?;
+        validate_relay_mcp(&relay, &options, runner).map_err(CliError::Install)?;
+        require_host_cli(*host, &options, runner).map_err(CliError::Install)?;
+        host::validate_host_version(*host, &options, runner).map_err(CliError::Install)?;
+    }
+    Ok(())
+}
+
+/// Retire every selected MCP generation before a refresh can stop the shared gateway.
+///
+/// Keeping the operation and generation locks until all targets are retired makes this an
+/// all-or-nothing preflight: a failure restores every marker already invalidated. Once the
+/// preflight commits, no old MCP can recover the gateway while the per-host replacements run.
+pub(crate) fn retire_integrations_for_refresh(
+    targets: &[(crate::agents::CodingAgent, PathBuf)],
+) -> Result<(), CliError> {
+    let operation_lock_dir = default_operation_lock_dir().map_err(CliError::Install)?;
+    let mut retirements = Vec::with_capacity(targets.len());
+    for (host, install_dir) in targets {
+        let operation_lock = PluginOperationLock::acquire(
+            host.install_arg(),
+            &operation_lock_dir,
+            install_dir,
+            DEFAULT_OPERATION_LOCK_TIMEOUT,
+        )
+        .map_err(CliError::Install)?;
+        let layout = PluginLayout::new(*host, install_dir);
+        let state = read_state(*host, install_dir).ok_or_else(|| {
+            CliError::Install(format!(
+                "missing persisted {} integration state at {}",
+                host.label(),
+                layout.state_path.display()
+            ))
+        })?;
+        layout
+            .validate_persisted_state(&state)
+            .map_err(CliError::Install)?;
+        let mut retirement = GenerationRetirement::acquire_for_plugin(
+            &layout.generation_fence,
+            &layout.generation_lock,
+        )
+        .map_err(|error| {
+            CliError::Install(invalid_generation_fence_error(
+                *host,
+                &layout.generation_fence,
+                &error,
+            ))
+        })?
+        .ok_or_else(|| {
+            CliError::Install(missing_generation_fence_error(
+                *host,
+                &layout.generation_fence,
+            ))
+        })?;
+        retirement
+            .invalidate_for_replacement()
+            .map_err(CliError::Install)?;
+        retirements.push(RefreshGenerationRetirement {
+            retirement,
+            _operation_lock: operation_lock,
+        });
+    }
+    for retirement in &mut retirements {
+        retirement.retirement.commit_replacement();
+    }
+    Ok(())
+}
+
+struct RefreshGenerationRetirement {
+    // Drop the generation lock before releasing its operation lock.
+    retirement: GenerationRetirement,
+    _operation_lock: PluginOperationLock,
+}
+
 pub(crate) fn collect_marketplace_readiness(
     host: impl MarketplaceHost,
     options: &PluginInstallOptions,
@@ -164,7 +270,24 @@ pub(crate) fn install(
         dry_run: command.dry_run,
         skip_doctor: command.skip_doctor,
     };
-    let result = run_for_host(host, &options, install_host);
+    let result = run_for_host(host, &options, install_host).inspect(|_| {
+        if !command.dry_run
+            && let Err(error) = state::register_managed_integration(host, &options.install_dir)
+        {
+            log::warn!(
+                target: "nemo_relay.installation",
+                event = "managed_integration_registration_failed",
+                host = host_name,
+                error = error.as_str();
+                "Plugin installation completed but automatic refresh registration failed"
+            );
+            eprintln!(
+                "warning: installed {} but could not record it for automatic refresh: {error}; restore access to the user configuration directory, then rerun `nemo-relay install {} --force`",
+                host.label(),
+                host.install_arg()
+            );
+        }
+    });
     match &result {
         Ok(_) => log::info!(
             target: "nemo_relay.installation",
@@ -210,7 +333,23 @@ pub(crate) fn uninstall(
         dry_run: command.dry_run,
         skip_doctor: true,
     };
-    let result = run_for_host(host, &options, uninstall_host);
+    let result = run_for_host(host, &options, uninstall_host).inspect(|_| {
+        if !command.dry_run
+            && let Err(error) = state::unregister_managed_integration(host, &options.install_dir)
+        {
+            log::warn!(
+                target: "nemo_relay.installation",
+                event = "managed_integration_unregistration_failed",
+                host = host_name,
+                error = error.as_str();
+                "Plugin uninstallation completed but automatic refresh cleanup failed"
+            );
+            eprintln!(
+                "warning: uninstalled {} but could not remove its automatic refresh record: {error}; future refreshes will skip the absent integration",
+                host.label()
+            );
+        }
+    });
     match &result {
         Ok(_) => log::info!(
             target: "nemo_relay.installation",

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -134,7 +134,9 @@ pub(crate) fn registered_install_dirs(host: impl MarketplaceHost) -> Result<Vec<
 }
 
 /// Check prerequisites before retiring any MCP generation for a refresh.
-pub(crate) fn prepare_integrations_for_refresh<H>(targets: &[(H, PathBuf)]) -> Result<(), CliError>
+pub(crate) fn prepare_integrations_for_refresh<H>(
+    targets: &[(H, PathBuf)],
+) -> Result<RefreshIntegrationsPreflight<H>, CliError>
 where
     H: MarketplaceHost + Eq + std::hash::Hash + Copy,
 {
@@ -144,7 +146,7 @@ where
 fn prepare_integrations_for_refresh_with_runner<H>(
     targets: &[(H, PathBuf)],
     runner: &dyn CommandRunner,
-) -> Result<(), CliError>
+) -> Result<RefreshIntegrationsPreflight<H>, CliError>
 where
     H: MarketplaceHost + Eq + std::hash::Hash + Copy,
 {
@@ -178,10 +180,12 @@ where
 
 /// Retire every selected MCP generation before a refresh can stop the shared gateway.
 ///
-/// Keeping the operation and generation locks until all targets are retired makes this an
-/// all-or-nothing preflight: a failure restores every marker already invalidated. Once the
-/// preflight commits, no old MCP can recover the gateway while the per-host replacements run.
-pub(crate) fn retire_integrations_for_refresh<H>(targets: &[(H, PathBuf)]) -> Result<(), CliError>
+/// Each retirement retains its original marker until the corresponding replacement succeeds.
+/// A preflight or replacement failure restores every affected marker, while retired markers
+/// prevent old MCP clients from recovering the gateway during the replacement window.
+pub(crate) fn retire_integrations_for_refresh<H>(
+    targets: &[(H, PathBuf)],
+) -> Result<RefreshIntegrationsPreflight<H>, CliError>
 where
     H: MarketplaceHost + Eq + std::hash::Hash + Copy,
 {
@@ -199,7 +203,7 @@ where
             .map_err(CliError::Install)?;
             host_locks.insert(*host, host_lock);
         }
-        let install_root_lock = PluginOperationLock::acquire_install_root(
+        let _install_root_lock = PluginOperationLock::acquire_install_root(
             host.install_arg(),
             &operation_lock_dir,
             install_dir,
@@ -237,21 +241,57 @@ where
         retirement
             .invalidate_for_replacement()
             .map_err(CliError::Install)?;
-        retirements.push(RefreshGenerationRetirement {
-            retirement,
-            _install_root_lock: install_root_lock,
-        });
+        retirement
+            .release_transaction_lock_for_refresh()
+            .map_err(CliError::Install)?;
+        retirements.push((*host, install_dir.clone(), retirement));
     }
-    for retirement in &mut retirements {
-        retirement.retirement.commit_replacement();
-    }
-    Ok(())
+    Ok(RefreshIntegrationsPreflight { retirements })
 }
 
-struct RefreshGenerationRetirement {
-    // Drop the generation lock before releasing its operation lock.
-    retirement: GenerationRetirement,
-    _install_root_lock: PluginOperationLock,
+pub(crate) struct RefreshIntegrationsPreflight<H> {
+    retirements: Vec<(H, PathBuf, GenerationRetirement)>,
+}
+
+impl<H> std::fmt::Debug for RefreshIntegrationsPreflight<H> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RefreshIntegrationsPreflight")
+            .field("retirement_count", &self.retirements.len())
+            .finish()
+    }
+}
+
+impl<H> RefreshIntegrationsPreflight<H>
+where
+    H: Eq,
+{
+    pub(crate) fn commit_target(&mut self, host: H, install_dir: &Path) {
+        if let Some((_, _, retirement)) = self
+            .retirements
+            .iter_mut()
+            .find(|(target_host, target_dir, _)| *target_host == host && target_dir == install_dir)
+        {
+            retirement.commit_replacement();
+        }
+    }
+
+    pub(crate) fn restore_failed_target(
+        &mut self,
+        host: H,
+        install_dir: &Path,
+    ) -> Result<(), CliError> {
+        let Some((_, _, retirement)) = self
+            .retirements
+            .iter_mut()
+            .find(|(target_host, target_dir, _)| *target_host == host && target_dir == install_dir)
+        else {
+            return Ok(());
+        };
+        retirement
+            .restore_after_rollback()
+            .map_err(CliError::Install)
+    }
 }
 
 pub(crate) fn collect_marketplace_readiness(

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod state;
 
 pub(crate) use spec::{MarketplaceHost, PluginSetupSnapshot};
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -133,24 +134,31 @@ pub(crate) fn registered_install_dirs(host: impl MarketplaceHost) -> Result<Vec<
 }
 
 /// Check prerequisites before retiring any MCP generation for a refresh.
-pub(crate) fn prepare_integrations_for_refresh(
-    targets: &[(crate::agents::CodingAgent, PathBuf)],
-) -> Result<(), CliError> {
+pub(crate) fn prepare_integrations_for_refresh<H>(targets: &[(H, PathBuf)]) -> Result<(), CliError>
+where
+    H: MarketplaceHost + Eq + std::hash::Hash + Copy,
+{
     prepare_integrations_for_refresh_with_runner(targets, &RealCommandRunner)
 }
 
-fn prepare_integrations_for_refresh_with_runner(
-    targets: &[(crate::agents::CodingAgent, PathBuf)],
+fn prepare_integrations_for_refresh_with_runner<H>(
+    targets: &[(H, PathBuf)],
     runner: &dyn CommandRunner,
-) -> Result<(), CliError> {
+) -> Result<(), CliError>
+where
+    H: MarketplaceHost + Eq + std::hash::Hash + Copy,
+{
     validate_integrations_for_refresh_with_runner(targets, runner)?;
     retire_integrations_for_refresh(targets)
 }
 
-fn validate_integrations_for_refresh_with_runner(
-    targets: &[(crate::agents::CodingAgent, PathBuf)],
+fn validate_integrations_for_refresh_with_runner<H>(
+    targets: &[(H, PathBuf)],
     runner: &dyn CommandRunner,
-) -> Result<(), CliError> {
+) -> Result<(), CliError>
+where
+    H: MarketplaceHost + Copy,
+{
     for (host, install_dir) in targets {
         let options = PluginInstallOptions {
             install_dir: install_dir.clone(),
@@ -173,13 +181,25 @@ fn validate_integrations_for_refresh_with_runner(
 /// Keeping the operation and generation locks until all targets are retired makes this an
 /// all-or-nothing preflight: a failure restores every marker already invalidated. Once the
 /// preflight commits, no old MCP can recover the gateway while the per-host replacements run.
-pub(crate) fn retire_integrations_for_refresh(
-    targets: &[(crate::agents::CodingAgent, PathBuf)],
-) -> Result<(), CliError> {
+pub(crate) fn retire_integrations_for_refresh<H>(targets: &[(H, PathBuf)]) -> Result<(), CliError>
+where
+    H: MarketplaceHost + Eq + std::hash::Hash + Copy,
+{
     let operation_lock_dir = default_operation_lock_dir().map_err(CliError::Install)?;
+    let mut host_locks = HashMap::new();
     let mut retirements = Vec::with_capacity(targets.len());
     for (host, install_dir) in targets {
-        let operation_lock = PluginOperationLock::acquire(
+        if !host_locks.contains_key(host) {
+            let host_lock = PluginOperationLock::acquire(
+                host.install_arg(),
+                &operation_lock_dir,
+                &operation_lock_dir,
+                DEFAULT_OPERATION_LOCK_TIMEOUT,
+            )
+            .map_err(CliError::Install)?;
+            host_locks.insert(*host, host_lock);
+        }
+        let install_root_lock = PluginOperationLock::acquire_install_root(
             host.install_arg(),
             &operation_lock_dir,
             install_dir,
@@ -219,7 +239,7 @@ pub(crate) fn retire_integrations_for_refresh(
             .map_err(CliError::Install)?;
         retirements.push(RefreshGenerationRetirement {
             retirement,
-            _operation_lock: operation_lock,
+            _install_root_lock: install_root_lock,
         });
     }
     for retirement in &mut retirements {
@@ -231,7 +251,7 @@ pub(crate) fn retire_integrations_for_refresh(
 struct RefreshGenerationRetirement {
     // Drop the generation lock before releasing its operation lock.
     retirement: GenerationRetirement,
-    _operation_lock: PluginOperationLock,
+    _install_root_lock: PluginOperationLock,
 }
 
 pub(crate) fn collect_marketplace_readiness(
@@ -272,19 +292,14 @@ pub(crate) fn install(
     };
     let result = run_for_host(host, &options, install_host).inspect(|_| {
         if !command.dry_run
-            && let Err(error) = state::register_managed_integration(host, &options.install_dir)
+            && state::register_managed_integration(host, &options.install_dir).is_err()
         {
             log::warn!(
                 target: "nemo_relay.installation",
                 event = "managed_integration_registration_failed",
                 host = host_name,
-                error = error.as_str();
+                error_kind = "registry";
                 "Plugin installation completed but automatic refresh registration failed"
-            );
-            eprintln!(
-                "warning: installed {} but could not record it for automatic refresh: {error}; restore access to the user configuration directory, then rerun `nemo-relay install {} --force`",
-                host.label(),
-                host.install_arg()
             );
         }
     });
@@ -335,18 +350,14 @@ pub(crate) fn uninstall(
     };
     let result = run_for_host(host, &options, uninstall_host).inspect(|_| {
         if !command.dry_run
-            && let Err(error) = state::unregister_managed_integration(host, &options.install_dir)
+            && state::unregister_managed_integration(host, &options.install_dir).is_err()
         {
             log::warn!(
                 target: "nemo_relay.installation",
                 event = "managed_integration_unregistration_failed",
                 host = host_name,
-                error = error.as_str();
+                error_kind = "registry";
                 "Plugin uninstallation completed but automatic refresh cleanup failed"
-            );
-            eprintln!(
-                "warning: uninstalled {} but could not remove its automatic refresh record: {error}; future refreshes will skip the absent integration",
-                host.label()
             );
         }
     });

--- a/crates/cli/src/installation/marketplace/state.rs
+++ b/crates/cli/src/installation/marketplace/state.rs
@@ -8,9 +8,11 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::installation::generation::GENERATION_FILE_NAME;
+use crate::installation::operation_lock::{DEFAULT_OPERATION_LOCK_TIMEOUT, PluginOperationLock};
 
 use super::{MarketplaceHost, PLUGIN_NAME};
 
@@ -143,6 +145,123 @@ pub(super) struct PluginState {
     pub(super) host_plugin_removed: bool,
     pub(super) host_marketplace_removed: bool,
     pub(super) plugin_setup_installed: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct ManagedIntegrationRegistry {
+    integrations: Vec<ManagedIntegrationRegistryEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ManagedIntegrationRegistryEntry {
+    host: String,
+    install_dir: PathBuf,
+}
+
+const MANAGED_INTEGRATIONS_REGISTRY: &str = "managed-integrations.json";
+
+fn managed_integrations_registry_path() -> Result<PathBuf, String> {
+    crate::configuration::user_config_dir()
+        .map(|path| path.join(MANAGED_INTEGRATIONS_REGISTRY))
+        .ok_or_else(|| {
+            "cannot determine the user configuration directory for managed integrations".into()
+        })
+}
+
+fn read_managed_integrations_registry() -> Result<ManagedIntegrationRegistry, String> {
+    let path = managed_integrations_registry_path()?;
+    match fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).map_err(|error| {
+            format!(
+                "failed to parse managed integrations registry {}: {error}",
+                path.display()
+            )
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(ManagedIntegrationRegistry::default())
+        }
+        Err(error) => Err(format!(
+            "failed to read managed integrations registry {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn write_managed_integrations_registry(
+    registry: &ManagedIntegrationRegistry,
+) -> Result<(), String> {
+    let path = managed_integrations_registry_path()?;
+    let mut bytes = serde_json::to_vec_pretty(registry)
+        .map_err(|error| format!("failed to encode managed integrations registry: {error}"))?;
+    bytes.push(b'\n');
+    crate::filesystem::atomic_write(&path, &bytes)
+}
+
+fn lock_managed_integrations_registry() -> Result<PluginOperationLock, String> {
+    let path = managed_integrations_registry_path()?;
+    let directory = path.parent().ok_or_else(|| {
+        format!(
+            "managed integrations registry path {} has no parent directory",
+            path.display()
+        )
+    })?;
+    PluginOperationLock::acquire(
+        "managed-integrations",
+        directory,
+        directory,
+        DEFAULT_OPERATION_LOCK_TIMEOUT,
+    )
+}
+
+pub(crate) fn registered_install_dirs(host: impl MarketplaceHost) -> Result<Vec<PathBuf>, String> {
+    Ok(read_managed_integrations_registry()?
+        .integrations
+        .into_iter()
+        .filter(|entry| entry.host == host.install_arg())
+        .map(|entry| entry.install_dir)
+        .collect())
+}
+
+pub(crate) fn register_managed_integration(
+    host: impl MarketplaceHost,
+    install_dir: &Path,
+) -> Result<(), String> {
+    let _lock = lock_managed_integrations_registry()?;
+    let install_dir = install_dir
+        .canonicalize()
+        .unwrap_or_else(|_| install_dir.to_path_buf());
+    let mut registry = read_managed_integrations_registry()?;
+    if !registry
+        .integrations
+        .iter()
+        .any(|entry| entry.host == host.install_arg() && entry.install_dir == install_dir)
+    {
+        registry.integrations.push(ManagedIntegrationRegistryEntry {
+            host: host.install_arg().into(),
+            install_dir,
+        });
+        write_managed_integrations_registry(&registry)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn unregister_managed_integration(
+    host: impl MarketplaceHost,
+    install_dir: &Path,
+) -> Result<(), String> {
+    let _lock = lock_managed_integrations_registry()?;
+    let install_dir = install_dir
+        .canonicalize()
+        .unwrap_or_else(|_| install_dir.to_path_buf());
+    let mut registry = read_managed_integrations_registry()?;
+    let previous = registry.integrations.len();
+    registry
+        .integrations
+        .retain(|entry| entry.host != host.install_arg() || entry.install_dir != install_dir);
+    if registry.integrations.len() != previous {
+        write_managed_integrations_registry(&registry)?;
+    }
+    Ok(())
 }
 
 pub(super) trait CanonicalizeOrSelf {

--- a/crates/cli/src/installation/operation_lock.rs
+++ b/crates/cli/src/installation/operation_lock.rs
@@ -14,7 +14,7 @@ pub(crate) const DEFAULT_OPERATION_LOCK_TIMEOUT: Duration = Duration::from_secs(
 const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(25);
 
 pub(crate) struct PluginOperationLock {
-    _global_file: File,
+    _global_file: Option<File>,
     _root_file: Option<File>,
 }
 
@@ -39,8 +39,29 @@ impl PluginOperationLock {
             )?)
         };
         Ok(Self {
-            _global_file: global_file,
+            _global_file: Some(global_file),
             _root_file: root_file,
+        })
+    }
+
+    /// Acquire only the install-root lock after the caller has already acquired the host lock.
+    pub(crate) fn acquire_install_root(
+        installation_key: &str,
+        global_lock_dir: &Path,
+        install_dir: &Path,
+        timeout: Duration,
+    ) -> Result<Self, String> {
+        if directories_alias(global_lock_dir, install_dir) {
+            return Ok(Self {
+                _global_file: None,
+                _root_file: None,
+            });
+        }
+        let deadline = Instant::now() + timeout;
+        let root_file = acquire_lock_file(installation_key, install_dir, deadline, "install-root")?;
+        Ok(Self {
+            _global_file: None,
+            _root_file: Some(root_file),
         })
     }
 }

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -953,6 +953,95 @@ fn write_installed_state(host: CodingAgent, dir: &Path) {
     mark_plugin_setup_installed(host, &layout, &options(dir)).unwrap();
 }
 
+#[test]
+fn refresh_preflight_retires_every_managed_generation_before_replacement() {
+    let home = tempdir().unwrap();
+    let _home = HomeScope::enter(home.path());
+    let install = tempdir().unwrap();
+    for host in CodingAgent::ALL {
+        write_installed_state(host, install.path());
+    }
+
+    retire_integrations_for_refresh(
+        &CodingAgent::ALL
+            .into_iter()
+            .map(|host| (host, install.path().to_path_buf()))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+
+    for host in CodingAgent::ALL {
+        let layout = PluginLayout::new(host, install.path());
+        assert!(
+            std::fs::read_to_string(layout.generation_fence)
+                .unwrap()
+                .starts_with("retired:"),
+            "{} generation was not retired",
+            host.label()
+        );
+    }
+}
+
+#[test]
+fn refresh_preflight_restores_earlier_generations_when_a_target_is_invalid() {
+    let home = tempdir().unwrap();
+    let _home = HomeScope::enter(home.path());
+    let install = tempdir().unwrap();
+    write_installed_state(CodingAgent::ClaudeCode, install.path());
+
+    let error = retire_integrations_for_refresh(&[
+        (CodingAgent::ClaudeCode, install.path().to_path_buf()),
+        (CodingAgent::Codex, install.path().to_path_buf()),
+    ])
+    .unwrap_err();
+
+    assert!(
+        error.to_string().contains("missing persisted Codex"),
+        "{error}"
+    );
+    let layout = PluginLayout::new(CodingAgent::ClaudeCode, install.path());
+    assert!(
+        !std::fs::read_to_string(layout.generation_fence)
+            .unwrap()
+            .starts_with("retired:"),
+        "the previous generation was not restored"
+    );
+}
+
+#[test]
+fn refresh_preflight_validates_every_target_before_retiring_any_generation() {
+    let install = tempdir().unwrap();
+    for host in CodingAgent::ALL {
+        write_installed_state(host, install.path());
+    }
+    let targets = CodingAgent::ALL
+        .into_iter()
+        .map(|host| (host, install.path().to_path_buf()))
+        .collect::<Vec<_>>();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("claude", "/bin/claude");
+
+    let error = prepare_integrations_for_refresh_with_runner(&targets, &runner).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("required `codex` CLI was not found"),
+        "{error}"
+    );
+    for host in CodingAgent::ALL {
+        let layout = PluginLayout::new(host, install.path());
+        assert!(
+            !std::fs::read_to_string(layout.generation_fence)
+                .unwrap()
+                .starts_with("retired:"),
+            "{} generation was retired before prerequisite validation",
+            host.label()
+        );
+    }
+}
+
 #[cfg(windows)]
 fn replace_generation_with_legacy_marker(layout: &PluginLayout) -> (String, PathBuf) {
     let token = {

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -962,7 +962,7 @@ fn refresh_preflight_retires_every_managed_generation_before_replacement() {
         write_installed_state(host, install.path());
     }
 
-    retire_integrations_for_refresh(
+    let _preflight = retire_integrations_for_refresh(
         &CodingAgent::ALL
             .into_iter()
             .map(|host| (host, install.path().to_path_buf()))
@@ -991,7 +991,7 @@ fn refresh_preflight_retires_multiple_directories_for_one_host() {
     write_installed_state(CodingAgent::Codex, first.path());
     write_installed_state(CodingAgent::Codex, second.path());
 
-    retire_integrations_for_refresh(&[
+    let _preflight = retire_integrations_for_refresh(&[
         (CodingAgent::Codex, first.path().to_path_buf()),
         (CodingAgent::Codex, second.path().to_path_buf()),
     ])
@@ -3268,6 +3268,44 @@ fn force_install_keeps_existing_registration_when_gateway_refresh_fails() {
             "restore snapshot".to_string(),
         ]
     );
+}
+
+#[test]
+fn refresh_restores_preflight_generation_when_force_install_gateway_refresh_fails() {
+    let home = tempdir().unwrap();
+    let _home = HomeScope::enter(home.path());
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_codex_registration(true, true);
+    let setup_runner = MockSetupRunner {
+        failing_call: Some("refresh gateway".into()),
+        ..MockSetupRunner::default()
+    };
+    let options = PluginInstallOptions {
+        force: true,
+        ..options(dir.path())
+    };
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    let previous = InstallGeneration::capture(layout.generation_fence.clone()).unwrap();
+    let mut preflight =
+        retire_integrations_for_refresh(&[(CodingAgent::Codex, dir.path().to_path_buf())]).unwrap();
+
+    let error = install_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap_err();
+
+    assert!(error.contains("refresh gateway failed"));
+    assert!(
+        previous
+            .verify_current()
+            .unwrap_err()
+            .contains("has been retired")
+    );
+    preflight
+        .restore_failed_target(CodingAgent::Codex, dir.path())
+        .unwrap();
+    previous.verify_current().unwrap();
 }
 
 #[test]

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -983,6 +983,31 @@ fn refresh_preflight_retires_every_managed_generation_before_replacement() {
 }
 
 #[test]
+fn refresh_preflight_retires_multiple_directories_for_one_host() {
+    let home = tempdir().unwrap();
+    let _home = HomeScope::enter(home.path());
+    let first = tempdir().unwrap();
+    let second = tempdir().unwrap();
+    write_installed_state(CodingAgent::Codex, first.path());
+    write_installed_state(CodingAgent::Codex, second.path());
+
+    retire_integrations_for_refresh(&[
+        (CodingAgent::Codex, first.path().to_path_buf()),
+        (CodingAgent::Codex, second.path().to_path_buf()),
+    ])
+    .unwrap();
+
+    for install_dir in [first.path(), second.path()] {
+        let layout = PluginLayout::new(CodingAgent::Codex, install_dir);
+        assert!(
+            std::fs::read_to_string(layout.generation_fence)
+                .unwrap()
+                .starts_with("retired:")
+        );
+    }
+}
+
+#[test]
 fn refresh_preflight_restores_earlier_generations_when_a_target_is_invalid() {
     let home = tempdir().unwrap();
     let _home = HomeScope::enter(home.path());

--- a/crates/cli/tests/coverage/commands/main_tests.rs
+++ b/crates/cli/tests/coverage/commands/main_tests.rs
@@ -129,6 +129,23 @@ fn gateway_stop_uses_the_daemon_bind_and_parses_force() {
 }
 
 #[test]
+fn integrations_refresh_parses_the_default_and_legacy_install_directory_forms() {
+    let default = Cli::try_parse_from(["nemo-relay", "integrations", "refresh"]).unwrap();
+    assert_eq!(default.command.unwrap().log_name(), "integrations");
+
+    let explicit = Cli::try_parse_from([
+        "nemo-relay",
+        "integrations",
+        "refresh",
+        "--install-dir",
+        "/managed/plugins",
+        "--dry-run",
+    ])
+    .unwrap();
+    assert_eq!(explicit.command.unwrap().log_name(), "integrations");
+}
+
+#[test]
 fn gateway_stop_selects_only_the_exact_relay_tcp_listener() {
     let bind = "127.0.0.1:4040".parse().unwrap();
     let listeners = [

--- a/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
+++ b/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
@@ -151,7 +151,7 @@ fn stopping_an_absent_or_stale_owned_gateway_is_idempotent() {
 }
 
 #[test]
-fn authenticated_owned_gateway_is_shut_down_and_cleaned_up() {
+fn version_mismatched_owned_gateway_is_shut_down_and_cleaned_up() {
     let dir = tempfile::tempdir().unwrap();
     let config = dir.path().join("config");
     let _scope = EnvScope::set(&[
@@ -165,7 +165,8 @@ fn authenticated_owned_gateway_is_shut_down_and_cleaned_up() {
     let state = state_dir().unwrap();
     create_private_dir(&state).unwrap();
     let path = owner_path(&state, &url);
-    let owner = OwnerRecord::new(42, &url, "shutdown-token", Some("fingerprint"));
+    let mut owner = OwnerRecord::new(42, &url, "shutdown-token", Some("fingerprint"));
+    owner.version = "previous-version".into();
     write_owner_record(&path, &owner).unwrap();
 
     let server = std::thread::spawn(move || {
@@ -215,7 +216,37 @@ fn authenticated_owned_gateway_is_shut_down_and_cleaned_up() {
             .unwrap();
     });
 
-    stop_owned_and_reset(&url).unwrap();
+    let _lock = lock_endpoint(&state, &url).unwrap();
+    assert!(stop_version_mismatched_owned_gateway_locked(&state, &url).unwrap());
     server.join().unwrap();
     assert!(!path.exists());
+}
+
+#[test]
+fn same_version_or_invalid_owned_gateway_is_not_stopped_for_replacement() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config");
+    let _scope = EnvScope::set(&[
+        ("XDG_CONFIG_HOME", Some(config.as_os_str())),
+        ("HOME", Some(dir.path().as_os_str())),
+        ("USERPROFILE", None),
+    ]);
+    let url = "http://127.0.0.1:47632";
+    let state = state_dir().unwrap();
+    create_private_dir(&state).unwrap();
+    let path = owner_path(&state, url);
+    let owner = OwnerRecord::new(42, url, "shutdown-token", Some("fingerprint"));
+    write_owner_record(&path, &owner).unwrap();
+
+    let _lock = lock_endpoint(&state, url).unwrap();
+    assert!(!stop_version_mismatched_owned_gateway_locked(&state, url).unwrap());
+    assert!(path.exists());
+    drop(_lock);
+
+    let mut invalid = owner;
+    invalid.bootstrap_protocol = BOOTSTRAP_PROTOCOL_VERSION.saturating_sub(1);
+    write_owner_record(&path, &invalid).unwrap();
+    let _lock = lock_endpoint(&state, url).unwrap();
+    assert!(!stop_version_mismatched_owned_gateway_locked(&state, url).unwrap());
+    assert!(path.exists());
 }

--- a/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
+++ b/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
@@ -176,8 +176,7 @@ fn version_mismatched_owned_gateway_is_shut_down_and_cleaned_up() {
         let proof = key.proof("fingerprint", &nonce);
         let body = format!(
             "{{\"status\":\"ok\",\"service\":\"nemo-relay\",\"version\":\"{}\",\"bootstrap_protocol\":{},\"instance_id\":\"test-instance\"}}",
-            env!("CARGO_PKG_VERSION"),
-            BOOTSTRAP_PROTOCOL_VERSION
+            "previous-version", BOOTSTRAP_PROTOCOL_VERSION
         );
         health
             .write_all(

--- a/docs/nemo-relay-cli/claude-code.mdx
+++ b/docs/nemo-relay-cli/claude-code.mdx
@@ -88,6 +88,18 @@ wrapper for project-specific `.nemo-relay` configuration. Run
 `nemo-relay install claude-code --force` to replace an existing
 generation-fenced installation safely.
 
+After upgrading Relay, refresh every Relay-managed coding-agent integration
+before starting a new Claude Code session:
+
+```bash
+nemo-relay integrations refresh
+```
+
+The command retires old MCP generations, replaces the authenticated sidecar,
+and requires affected hosts to reconnect. For one Claude Code
+install, `nemo-relay install claude-code --force` remains the focused repair
+command. Manual MCP configurations are not changed.
+
 To explicitly stop the managed shared gateway, first close active MCP clients,
 then run:
 

--- a/docs/nemo-relay-cli/codex.mdx
+++ b/docs/nemo-relay-cli/codex.mdx
@@ -171,6 +171,18 @@ This intentionally interrupts MCP clients still attached to the old gateway.
 Configuration-only compatibility mismatches remain errors and are not replaced
 automatically.
 
+After upgrading Relay, refresh every Relay-managed coding-agent integration
+before starting a new Codex session:
+
+```bash
+nemo-relay integrations refresh
+```
+
+The command retires old MCP generations, replaces the authenticated sidecar,
+and requires affected hosts to reconnect. For one Codex install,
+`nemo-relay install codex --force` remains the focused repair command. Manual
+MCP configurations are not changed.
+
 To explicitly stop the managed shared gateway, first close active MCP clients,
 then run:
 

--- a/docs/nemo-relay-cli/codex.mdx
+++ b/docs/nemo-relay-cli/codex.mdx
@@ -165,6 +165,12 @@ shorter than the idle timeout to override it. The sidecar exits after 300 second
 without activity by default. Relay does not install a wrapper, launch agent,
 system user service, scheduled task, login item, or persistent supervisor.
 
+When a newly launched MCP client detects a verified Relay-owned gateway from a
+different Relay version, it stops that old sidecar and starts a matching one.
+This intentionally interrupts MCP clients still attached to the old gateway.
+Configuration-only compatibility mismatches remain errors and are not replaced
+automatically.
+
 To explicitly stop the managed shared gateway, first close active MCP clients,
 then run:
 

--- a/docs/nemo-relay-cli/plugin-installation.mdx
+++ b/docs/nemo-relay-cli/plugin-installation.mdx
@@ -147,6 +147,12 @@ startup lock serializes launch and recovery, while a small recovery record lets
 overlapping MCP clients share the same restart attempt. The gateway tracks its
 own activity, idle shutdown, and authenticated ownership-record cleanup.
 
+When a newly launched MCP client detects a verified Relay-owned gateway from a
+different Relay version, it stops that old sidecar and starts a matching one.
+This intentionally interrupts MCP clients still attached to the old gateway.
+Configuration-only compatibility mismatches remain errors and are not replaced
+automatically.
+
 Codex marks the MCP server as required, so the captured turn waits for verified
 gateway readiness. Claude Code 2.1.121 or newer uses `alwaysLoad`, which blocks
 session startup until the MCP connection is ready. Installed MCP entries and

--- a/docs/nemo-relay-cli/plugin-installation.mdx
+++ b/docs/nemo-relay-cli/plugin-installation.mdx
@@ -180,7 +180,7 @@ affected host clients afterward. Installations created in a legacy custom
 directory can be refreshed and registered for future automatic discovery with:
 
 ```bash
-nemo-relay integrations refresh --install-dir /path/to/plugins
+nemo-relay integrations refresh --install-dir <path-to-plugins>
 ```
 
 Manual MCP configurations are not changed; reinstall them through Relay if you

--- a/docs/nemo-relay-cli/plugin-installation.mdx
+++ b/docs/nemo-relay-cli/plugin-installation.mdx
@@ -165,6 +165,27 @@ payload once. They never start or recover the gateway, and Relay does not retry
 after payload transmission begins. The MCP server advertises no tools in any
 host.
 
+## Refresh Installed Integrations
+
+After upgrading the `nemo-relay` binary, refresh every Relay-managed Codex and
+Claude Code installation with:
+
+```bash
+nemo-relay integrations refresh
+```
+
+Refresh retires each old MCP generation, stops the authenticated Relay-owned
+sidecar, and republishes the integration from the current binary. Restart the
+affected host clients afterward. Installations created in a legacy custom
+directory can be refreshed and registered for future automatic discovery with:
+
+```bash
+nemo-relay integrations refresh --install-dir /path/to/plugins
+```
+
+Manual MCP configurations are not changed; reinstall them through Relay if you
+want Relay to manage future refreshes.
+
 To explicitly stop the managed shared gateway, first close active MCP clients,
 then run:
 

--- a/docs/nemo-relay-cli/plugin-installation.mdx
+++ b/docs/nemo-relay-cli/plugin-installation.mdx
@@ -176,11 +176,12 @@ nemo-relay integrations refresh
 
 Refresh retires each old MCP generation, stops the authenticated Relay-owned
 sidecar, and republishes the integration from the current binary. Restart the
-affected host clients afterward. Installations created in a legacy custom
-directory can be refreshed and registered for future automatic discovery with:
+affected host clients afterward. To bring a legacy custom-directory installation
+under Relay management, reinstall the appropriate host before refreshing it:
 
 ```bash
-nemo-relay integrations refresh --install-dir <path-to-plugins>
+nemo-relay install codex --install-dir <path-to-plugins> --force
+nemo-relay integrations refresh
 ```
 
 Manual MCP configurations are not changed; reinstall them through Relay if you


### PR DESCRIPTION
#### Overview

Refresh Relay-managed Codex and Claude Code integrations after an upgrade, while preserving the existing safe stale-gateway recovery path.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `nemo-relay integrations refresh` to discover managed installations, validate all selected targets, retire their old MCP generations together, and force-replace each integration from the current Relay binary.
- Add MCP version-aware gateway handoff: when a new MCP process encounters an authenticated Relay-owned gateway from a different Relay version, it safely shuts it down so the host can start the new binary; foreign, invalid, and same-version endpoints are not replaced.
- Persist and serialize managed custom install directories for future refresh discovery.
- Keep registry-record failures non-fatal after a completed install or uninstall, with actionable warnings.
- Preserve authenticated replacement of a version-mismatched Relay-owned gateway and correct its stale-sidecar regression fixture.
- Document the refresh workflow for Codex, Claude Code, and plugin installation.

#### Where should the reviewer start?

Start with `crates/cli/src/commands/integrations.rs`, `crates/cli/src/bootstrap/mod.rs`, and `crates/cli/src/installation/marketplace/mod.rs`: together they define the version-aware gateway handoff plus validation, generation-retirement, sidecar-refresh, and replacement lifecycle.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

#### Validation

- Focused refresh-preflight regressions, `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `just test-rust` passed.
- `just docs` passed with no documentation errors; its external redirect check emitted an FDR 403 warning.
- `uv run pre-commit run --all-files` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `integrations refresh` for Relay-managed Codex and Claude Code integrations, with dry-run support and multiple installation directories.
  * Newly launched MCP clients can replace verified Relay-owned gateways running a different version.
  * Heartbeat intervals support environment-based configuration with validation and safe defaults.
* **Bug Fixes**
  * Foreign, invalid, or same-version gateways are no longer stopped or removed automatically.
  * Refresh operations validate all targets and preserve installations when prerequisites fail.
* **Documentation**
  * Updated gateway replacement, integration refresh, and compatibility guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->