### PR TITLE
fix: avoid duplicate ATIF turns for response-less retries

### DIFF
--- a/crates/core/src/observability/atif.rs
+++ b/crates/core/src/observability/atif.rs
@@ -1727,7 +1727,162 @@ fn build_llm_dedupe(events: &[&Event]) -> LlmDedupeLookups {
         }
     }
 
+    suppress_response_less_retries(events, &mut lookups);
+
     lookups
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LlmRetryTerminalState {
+    ResponseLessError,
+    SuccessfulResponse,
+    Other,
+}
+
+#[derive(Debug, Clone)]
+struct LlmRetryCandidate {
+    uuid: Uuid,
+    parent_uuid: Uuid,
+    start_ts: DateTime<Utc>,
+    end_ts: DateTime<Utc>,
+    operation: String,
+    model_name: String,
+    request: Json,
+    correlation_id: String,
+    terminal_state: LlmRetryTerminalState,
+}
+
+#[derive(Default)]
+struct LlmRetrySpanParts<'a> {
+    starts: Vec<&'a Event>,
+    ends: Vec<&'a Event>,
+}
+
+/// Avoid projecting a transport failure as a second user turn when a later
+/// response is provably a retry of the same request.
+///
+/// This is deliberately stricter than the overlapping hook/gateway dedupe.
+/// Missing or ambiguous identity leaves every event visible.
+fn suppress_response_less_retries(events: &[&Event], lookups: &mut LlmDedupeLookups) {
+    let attempts = collect_llm_retry_candidates(events);
+    let suppress = attempts
+        .iter()
+        .filter(|attempt| {
+            attempt.terminal_state == LlmRetryTerminalState::ResponseLessError
+                && !lookups.suppressed_events.contains(&attempt.uuid)
+        })
+        .filter_map(|failed| {
+            let mut matching_successes = attempts.iter().filter(|candidate| {
+                candidate.terminal_state == LlmRetryTerminalState::SuccessfulResponse
+                    && !lookups.suppressed_events.contains(&candidate.uuid)
+                    && is_proven_retry(failed, candidate)
+            });
+            matching_successes.next()?;
+            matching_successes.next().is_none().then_some(failed.uuid)
+        })
+        .collect::<Vec<_>>();
+
+    lookups.suppressed_events.extend(suppress);
+}
+
+fn collect_llm_retry_candidates(events: &[&Event]) -> Vec<LlmRetryCandidate> {
+    let mut spans: HashMap<Uuid, LlmRetrySpanParts<'_>> = HashMap::new();
+    for event in events {
+        if event.category().map(|category| category.as_str()) != Some("llm") {
+            continue;
+        }
+        let parts = spans.entry(event.uuid()).or_default();
+        match event.scope_category() {
+            Some(crate::api::event::ScopeCategory::Start) => parts.starts.push(event),
+            Some(crate::api::event::ScopeCategory::End) => parts.ends.push(event),
+            None => {}
+        }
+    }
+
+    spans
+        .into_iter()
+        .filter_map(|(uuid, parts)| {
+            let [start] = parts.starts.as_slice() else {
+                return None;
+            };
+            let [end] = parts.ends.as_slice() else {
+                return None;
+            };
+            LlmRetryCandidate::from_events(uuid, start, end)
+        })
+        .collect()
+}
+
+impl LlmRetryCandidate {
+    fn from_events(uuid: Uuid, start: &Event, end: &Event) -> Option<Self> {
+        let parent_uuid = start.parent_uuid()?;
+        if end.parent_uuid() != Some(parent_uuid)
+            || start.name() != end.name()
+            || start.name().trim().is_empty()
+            || start.timestamp() >= end.timestamp()
+        {
+            return None;
+        }
+
+        let start_correlation = exact_llm_request_correlation_id(start)?;
+        let end_correlation = exact_llm_request_correlation_id(end)?;
+        if start_correlation != end_correlation {
+            return None;
+        }
+
+        let raw_response = end.data();
+        let terminal_state = if exact_otel_status(end) == Some("ERROR")
+            && raw_response.is_none()
+            && end.annotated_response().is_none()
+        {
+            LlmRetryTerminalState::ResponseLessError
+        } else if exact_otel_status(end) == Some("OK")
+            && raw_response.is_some_and(|response| !response.is_null())
+        {
+            LlmRetryTerminalState::SuccessfulResponse
+        } else {
+            LlmRetryTerminalState::Other
+        };
+
+        let model_name = model_name_for_llm_event(start)?;
+        if model_name.trim().is_empty() || model_name.trim() != model_name {
+            return None;
+        }
+
+        Some(Self {
+            uuid,
+            parent_uuid,
+            start_ts: *start.timestamp(),
+            end_ts: *end.timestamp(),
+            operation: start.name().to_string(),
+            model_name,
+            request: unwrap_llm_request(start.data()?),
+            correlation_id: start_correlation.to_string(),
+            terminal_state,
+        })
+    }
+}
+
+fn exact_llm_request_correlation_id(event: &Event) -> Option<&str> {
+    event
+        .metadata()?
+        .get("llm_correlation_request_id")?
+        .as_str()
+        .filter(|value| !value.trim().is_empty() && value.trim() == *value)
+}
+
+fn exact_otel_status(event: &Event) -> Option<&str> {
+    event.metadata()?.get("otel.status_code")?.as_str()
+}
+
+fn is_proven_retry(failed: &LlmRetryCandidate, candidate: &LlmRetryCandidate) -> bool {
+    failed.uuid != candidate.uuid
+        && failed.end_ts < candidate.start_ts
+        && failed.parent_uuid == candidate.parent_uuid
+        && failed.operation == candidate.operation
+        && failed.model_name == candidate.model_name
+        && failed.request == candidate.request
+        && failed.correlation_id == candidate.correlation_id
 }
 
 fn collect_llm_span_candidates(events: &[&Event]) -> Vec<LlmSpanCandidate> {

--- a/crates/core/tests/unit/atif_tests.rs
+++ b/crates/core/tests/unit/atif_tests.rs
@@ -4207,6 +4207,457 @@ fn test_exporter_skips_marks_regardless_of_name() {
     assert!(trajectory.steps.is_empty());
 }
 
+fn retry_test_metadata(correlation_id: Option<&str>, status: Option<&str>) -> Option<Json> {
+    let mut metadata = serde_json::Map::new();
+    if let Some(correlation_id) = correlation_id {
+        metadata.insert(
+            "llm_correlation_request_id".to_string(),
+            json!(correlation_id),
+        );
+    }
+    if let Some(status) = status {
+        metadata.insert("otel.status_code".to_string(), json!(status));
+    }
+    (!metadata.is_empty()).then_some(Json::Object(metadata))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn retry_test_span_with_identity(
+    uuid: Uuid,
+    start_parent: Uuid,
+    end_parent: Uuid,
+    operation: &str,
+    model: &str,
+    start_correlation: Option<&str>,
+    end_correlation: Option<&str>,
+    end_status: Option<&str>,
+    request: Json,
+    output: Option<Json>,
+    annotated_response: Option<AnnotatedLlmResponse>,
+) -> (Event, Event) {
+    let mut start = event_builder(uuid, EventType::Start)
+        .name(operation)
+        .parent_uuid(start_parent)
+        .scope_type(ScopeType::Llm)
+        .model_name(model)
+        .input(request);
+    if let Some(metadata) = retry_test_metadata(start_correlation, None) {
+        start = start.metadata(metadata);
+    }
+
+    let mut end = event_builder(uuid, EventType::End)
+        .name(operation)
+        .parent_uuid(end_parent)
+        .scope_type(ScopeType::Llm)
+        .model_name(model);
+    if let Some(metadata) = retry_test_metadata(end_correlation, end_status) {
+        end = end.metadata(metadata);
+    }
+    if let Some(output) = output {
+        end = end.output(output);
+    }
+    if let Some(annotated_response) = annotated_response {
+        end = end.annotated_response(annotated_response);
+    }
+
+    (start.build(), end.build())
+}
+
+fn retry_test_span(
+    uuid: Uuid,
+    parent_uuid: Uuid,
+    correlation_id: &str,
+    end_status: &str,
+    request: Json,
+    output: Option<Json>,
+    annotated_response: Option<AnnotatedLlmResponse>,
+) -> (Event, Event) {
+    retry_test_span_with_identity(
+        uuid,
+        parent_uuid,
+        parent_uuid,
+        "openai.chat_completions",
+        "test-model",
+        Some(correlation_id),
+        Some(correlation_id),
+        Some(end_status),
+        request,
+        output,
+        annotated_response,
+    )
+}
+
+fn retry_test_request(message: &str) -> Json {
+    json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": message}],
+        "temperature": 0
+    })
+}
+
+fn retry_test_response(message: &str) -> Json {
+    json!({
+        "model": "test-model",
+        "choices": [{
+            "finish_reason": "stop",
+            "message": {"role": "assistant", "content": message}
+        }]
+    })
+}
+
+fn set_retry_test_timestamps(events: &mut [&mut Event]) {
+    set_sequential_event_timestamps(events, base_timestamp(), chrono::Duration::milliseconds(1));
+}
+
+#[test]
+fn test_exporter_suppresses_response_less_retry_user_step() {
+    let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());
+    let parent_uuid = Uuid::now_v7();
+    let request = retry_test_request("Answer once.");
+    let mut response = retry_test_response("Recovered.");
+    response["model"] = json!("provider-resolved-model");
+    let (mut first_start, mut first_end) = retry_test_span(
+        Uuid::now_v7(),
+        parent_uuid,
+        "logical-request-1",
+        "ERROR",
+        request.clone(),
+        None,
+        None,
+    );
+    let (mut second_start, mut second_end) = retry_test_span(
+        Uuid::now_v7(),
+        parent_uuid,
+        "logical-request-1",
+        "ERROR",
+        request.clone(),
+        None,
+        None,
+    );
+    let (mut success_start, mut success_end) = retry_test_span(
+        Uuid::now_v7(),
+        parent_uuid,
+        "logical-request-1",
+        "OK",
+        request,
+        Some(response),
+        None,
+    );
+    set_retry_test_timestamps(&mut [
+        &mut first_start,
+        &mut first_end,
+        &mut second_start,
+        &mut second_end,
+        &mut success_start,
+        &mut success_end,
+    ]);
+
+    {
+        let mut state = exporter.state.lock().unwrap();
+        state.events.extend([
+            first_start,
+            first_end,
+            second_start,
+            second_end,
+            success_start,
+            success_end,
+        ]);
+    }
+
+    let trajectory = exporter.export().unwrap();
+    assert_atif_v17_shape(&trajectory);
+    assert_eq!(
+        trajectory
+            .steps
+            .iter()
+            .map(|step| (step.source.as_str(), step.message.clone()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("user", json!("Answer once.")),
+            ("agent", json!("Recovered.")),
+        ]
+    );
+}
+
+#[test]
+fn test_response_less_retry_requires_complete_identity_and_serial_order() {
+    let base = base_timestamp();
+    let parent_uuid = Uuid::now_v7();
+    let failed = LlmRetryCandidate {
+        uuid: Uuid::now_v7(),
+        parent_uuid,
+        start_ts: base,
+        end_ts: base + chrono::Duration::milliseconds(1),
+        operation: "openai.chat_completions".to_string(),
+        model_name: "test-model".to_string(),
+        request: retry_test_request("Identity check."),
+        correlation_id: "logical-request-3".to_string(),
+        terminal_state: LlmRetryTerminalState::ResponseLessError,
+    };
+    let success = LlmRetryCandidate {
+        uuid: Uuid::now_v7(),
+        parent_uuid,
+        start_ts: base + chrono::Duration::milliseconds(2),
+        end_ts: base + chrono::Duration::milliseconds(3),
+        operation: failed.operation.clone(),
+        model_name: failed.model_name.clone(),
+        request: failed.request.clone(),
+        correlation_id: failed.correlation_id.clone(),
+        terminal_state: LlmRetryTerminalState::SuccessfulResponse,
+    };
+    assert!(is_proven_retry(&failed, &success));
+
+    let mut variants = Vec::new();
+    let mut candidate = success.clone();
+    candidate.uuid = failed.uuid;
+    variants.push(candidate);
+    let mut candidate = success.clone();
+    candidate.parent_uuid = Uuid::now_v7();
+    variants.push(candidate);
+    let mut candidate = success.clone();
+    candidate.start_ts = failed.end_ts;
+    variants.push(candidate);
+    let mut candidate = success.clone();
+    candidate.operation = "anthropic.messages".to_string();
+    variants.push(candidate);
+    let mut candidate = success.clone();
+    candidate.model_name = "other-model".to_string();
+    variants.push(candidate);
+    let mut candidate = success.clone();
+    candidate.request["temperature"] = json!(1);
+    variants.push(candidate);
+    let mut candidate = success;
+    candidate.correlation_id = "other-request".to_string();
+    variants.push(candidate);
+
+    assert!(
+        variants
+            .iter()
+            .all(|candidate| !is_proven_retry(&failed, candidate))
+    );
+}
+
+#[test]
+fn test_response_less_retry_keeps_response_bearing_and_unproven_failures() {
+    let parent_uuid = Uuid::now_v7();
+    let request = retry_test_request("Preserve uncertain evidence.");
+    let exact_failed_uuid = Uuid::now_v7();
+    let response_bearing_uuid = Uuid::now_v7();
+    let null_response_uuid = Uuid::now_v7();
+    let annotated_uuid = Uuid::now_v7();
+    let lowercase_status_uuid = Uuid::now_v7();
+    let mut events = Vec::new();
+
+    for (uuid, correlation, status, output, annotated) in [
+        (exact_failed_uuid, "exact", "ERROR", None, None),
+        (
+            response_bearing_uuid,
+            "response-bearing",
+            "ERROR",
+            Some(json!({"choices": []})),
+            None,
+        ),
+        (
+            null_response_uuid,
+            "null-response",
+            "ERROR",
+            Some(Json::Null),
+            None,
+        ),
+        (
+            annotated_uuid,
+            "annotated",
+            "ERROR",
+            None,
+            Some(annotated_response_with_usage(
+                "test-model",
+                Usage::default(),
+            )),
+        ),
+        (lowercase_status_uuid, "lowercase", "error", None, None),
+    ] {
+        let failed = retry_test_span(
+            uuid,
+            parent_uuid,
+            correlation,
+            status,
+            request.clone(),
+            output,
+            annotated,
+        );
+        let success = retry_test_span(
+            Uuid::now_v7(),
+            parent_uuid,
+            correlation,
+            "OK",
+            request.clone(),
+            Some(retry_test_response("Recovered.")),
+            None,
+        );
+        events.extend([failed.0, failed.1, success.0, success.1]);
+    }
+    for (idx, event) in events.iter_mut().enumerate() {
+        set_event_timestamp(
+            event,
+            base_timestamp() + chrono::Duration::milliseconds(idx as i64),
+        );
+    }
+    let refs = events.iter().collect::<Vec<_>>();
+    let lookups = build_llm_dedupe(&refs);
+
+    assert!(lookups.suppressed_events.contains(&exact_failed_uuid));
+    assert!(!lookups.suppressed_events.contains(&response_bearing_uuid));
+    assert!(!lookups.suppressed_events.contains(&null_response_uuid));
+    assert!(!lookups.suppressed_events.contains(&annotated_uuid));
+    assert!(!lookups.suppressed_events.contains(&lowercase_status_uuid));
+}
+
+#[test]
+fn test_response_less_retry_keeps_incomplete_or_conflicting_lifecycle_identity() {
+    let parent_uuid = Uuid::now_v7();
+    let other_parent = Uuid::now_v7();
+    let request = retry_test_request("Reject incomplete identity.");
+    let mut events = Vec::new();
+    let mut failed_uuids = Vec::new();
+
+    for (start_correlation, end_correlation, start_parent, end_parent) in [
+        (None, None, parent_uuid, parent_uuid),
+        (None, Some("missing-start"), parent_uuid, parent_uuid),
+        (Some("missing-end"), None, parent_uuid, parent_uuid),
+        (Some(" "), Some(" "), parent_uuid, parent_uuid),
+        (Some("left"), Some("right"), parent_uuid, parent_uuid),
+        (
+            Some("parent-conflict"),
+            Some("parent-conflict"),
+            parent_uuid,
+            other_parent,
+        ),
+    ] {
+        let failed_uuid = Uuid::now_v7();
+        failed_uuids.push(failed_uuid);
+        let failed = retry_test_span_with_identity(
+            failed_uuid,
+            start_parent,
+            end_parent,
+            "openai.chat_completions",
+            "test-model",
+            start_correlation,
+            end_correlation,
+            Some("ERROR"),
+            request.clone(),
+            None,
+            None,
+        );
+        let correlation = start_correlation.or(end_correlation).unwrap_or("fallback");
+        let success = retry_test_span(
+            Uuid::now_v7(),
+            parent_uuid,
+            correlation,
+            "OK",
+            request.clone(),
+            Some(retry_test_response("Recovered.")),
+            None,
+        );
+        events.extend([failed.0, failed.1, success.0, success.1]);
+    }
+
+    let duplicate_uuid = Uuid::now_v7();
+    failed_uuids.push(duplicate_uuid);
+    let duplicate_failed = retry_test_span(
+        duplicate_uuid,
+        parent_uuid,
+        "duplicate-start",
+        "ERROR",
+        request.clone(),
+        None,
+        None,
+    );
+    let duplicate_start = duplicate_failed.0.clone();
+    let duplicate_success = retry_test_span(
+        Uuid::now_v7(),
+        parent_uuid,
+        "duplicate-start",
+        "OK",
+        request,
+        Some(retry_test_response("Recovered.")),
+        None,
+    );
+    events.extend([
+        duplicate_failed.0,
+        duplicate_start,
+        duplicate_failed.1,
+        duplicate_success.0,
+        duplicate_success.1,
+    ]);
+
+    for (idx, event) in events.iter_mut().enumerate() {
+        set_event_timestamp(
+            event,
+            base_timestamp() + chrono::Duration::milliseconds(idx as i64),
+        );
+    }
+    let refs = events.iter().collect::<Vec<_>>();
+    let lookups = build_llm_dedupe(&refs);
+
+    assert!(
+        failed_uuids
+            .iter()
+            .all(|uuid| !lookups.suppressed_events.contains(uuid))
+    );
+}
+
+#[test]
+fn test_response_less_retry_keeps_ambiguous_successes() {
+    let parent_uuid = Uuid::now_v7();
+    let failed_uuid = Uuid::now_v7();
+    let request = retry_test_request("Do not choose between successes.");
+    let failed = retry_test_span(
+        failed_uuid,
+        parent_uuid,
+        "ambiguous-request",
+        "ERROR",
+        request.clone(),
+        None,
+        None,
+    );
+    let first_success = retry_test_span(
+        Uuid::now_v7(),
+        parent_uuid,
+        "ambiguous-request",
+        "OK",
+        request.clone(),
+        Some(retry_test_response("First.")),
+        None,
+    );
+    let second_success = retry_test_span(
+        Uuid::now_v7(),
+        parent_uuid,
+        "ambiguous-request",
+        "OK",
+        request,
+        Some(retry_test_response("Second.")),
+        None,
+    );
+    let mut events = [
+        failed.0,
+        failed.1,
+        first_success.0,
+        first_success.1,
+        second_success.0,
+        second_success.1,
+    ];
+    for (idx, event) in events.iter_mut().enumerate() {
+        set_event_timestamp(
+            event,
+            base_timestamp() + chrono::Duration::milliseconds(idx as i64),
+        );
+    }
+    let refs = events.iter().collect::<Vec<_>>();
+    let lookups = build_llm_dedupe(&refs);
+
+    assert!(!lookups.suppressed_events.contains(&failed_uuid));
+}
+
 #[test]
 fn test_exporter_dedupes_overlapping_hook_and_gateway_llm_spans() {
     let exporter = AtifExporter::new("session-1".to_string(), make_agent_info());


### PR DESCRIPTION
#### Overview

Prevent a failed, response-less LLM attempt from becoming an extra user turn in ATIF when a later response is provably a retry of the same logical request.

Targets `main` for Relay 0.9 development; no 0.8 backport is proposed.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Before this change, ATIF projected every LLM start as a user step. An end event with `otel.status_code = "ERROR"` and no response produced no agent step, but a later successful retry projected the same request again. A single logical call could therefore look like multiple user turns.

The exporter now suppresses the failed ATIF span only when all of the following are true:

- the failed and successful spans each contain exactly one start and one end event;
- start and end identity agree within each span;
- both attempts have the same parent, operation, requested model, full unwrapped request, and exact non-empty `llm_correlation_request_id`;
- the failed end has exact `ERROR` status and no raw or annotated response;
- exactly one later, non-overlapping candidate has exact `OK` status and a non-null raw response.

Missing, conflicting, concurrent, response-bearing, or ambiguous evidence preserves the existing ATIF output. The requested model is compared rather than the provider-reported response model so a provider resolving an alias does not break valid retry correlation.

This is intentionally narrower than selecting an accepted response or hiding response-bearing attempts. ATOF remains unchanged and retains every physical failure and retry. There are no public API, binding, configuration, packaging, or documentation changes.

Live replay used six captured Hermes + Relay ATOF runs:

- all three baseline runs projected `3` steps: `1` user, `2` agent, `1` tool call;
- all three treatment runs projected `4` steps: `1` user, `3` agent, `2` tool calls;
- runs containing one to three response-less provider failures no longer gained duplicate user turns.

Validation:

- `cargo test -p nemo-relay --lib observability::atif::tests::` — 111 passed
- `cargo test -p nemo-relay --lib --quiet -- --test-threads=1` — 1,583 passed
- `uv run pre-commit run --files crates/core/src/observability/atif.rs crates/core/tests/unit/atif_tests.rs` — passed
- six real ATOF files replayed through the final exporter implementation with the expected step, source, and tool counts
- `git diff --check` — passed

The full core suite was run serially because an existing test temporarily changes the process working directory and can race with another test under parallel execution; that test also passed by itself.

#### Where should the reviewer start?

Start with `suppress_response_less_retries` in `crates/core/src/observability/atif.rs`, then review `test_exporter_suppresses_response_less_retry_user_step` and the conservative negative cases in `crates/core/tests/unit/atif_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- No tracking issue; discovered while qualifying the Hermes → Relay → ATIF → Gym flow.
