### PR TITLE
fix: sync Cargo workspace version with ref_name in package-python

### DIFF
--- a/justfile
+++ b/justfile
@@ -1839,8 +1839,10 @@ package-openclaw:
 package-python:
     #!/usr/bin/env bash
     {{ bash_helpers }}
-    # Uses the workspace version from Cargo.toml, then writes the Python package
-    # version into pyproject.toml using PEP 440 before building a platform wheel.
+    # An explicit ref_name is synced into the Cargo workspace version first,
+    # so the compiled extension embeds the same version reported by the
+    # Python package, then written into pyproject.toml using PEP 440 before
+    # building a platform wheel.
     output_dir="{{ output_dir }}"
     linux_glibc_version="{{ linux_glibc_version }}"
     export_uv_python_runtime
@@ -1856,6 +1858,7 @@ package-python:
         set_python_package_version "${version}+${sha}" true
     else
         echo "Using explicit version {{ ref_name }}"
+        set_cargo_workspace_version "{{ ref_name }}"
         set_python_package_version "{{ ref_name }}" true
     fi
     build_args=()


### PR DESCRIPTION
package-python wrote an explicit ref_name only into pyproject.toml via set_python_package_version, leaving Cargo.toml's workspace version untouched. Since the compiled PyO3 extension embeds CARGO_PKG_VERSION at build time, this produced wheels whose Python package metadata reported the release version while the native extension still reported whatever version Cargo.toml happened to have checked out (0.8.0 for the 0.8.1 and 0.8.2 release tags). Any consumer that reads the embedded version -- such as a native plugin ABI compat check -- sees a stale, incorrect version. package-rust already calls set_cargo_workspace_version when ref_name is set; this mirrors that behavior in package-python.

Verified: a clean `just ref_name=0.8.2 package-python` run now bumps Cargo.toml automatically and produces a wheel whose compiled extension correctly embeds 0.8.2, matching the Python package metadata.

#### Overview

<!-- Describe your pull request here -->

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- Point to the most important file, test, or design decision. -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Python package builds now consistently use the specified release version across the package and compiled extension.
  * Wheel metadata is synchronized with the selected version before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->