### PR TITLE
docs: add 0.8 patch release notes

### DIFF
--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -25,7 +25,71 @@ This is the Release Notes template. Document one release version per page and us
 This page contains the release notes for [NVIDIA NeMo
 Relay](/about-nemo-relay/overview).
 
-## Release 0.8
+## Release 0.8.3
+
+Python release wheels now synchronize the selected release version between the
+package metadata and the compiled native extension. This prevents consumers
+that inspect the native extension version, including native-plugin compatibility
+checks, from observing a stale Relay version.
+
+## Release 0.8.2
+
+### Managed Gateway and Coding-Agent Lifecycle
+
+- The CLI now provides explicit `nemo-relay gateway start` and
+  `nemo-relay gateway stop` commands. Stopping verifies the Relay process at
+  the selected local loopback address before requesting shutdown; Unix callers
+  can use `--force` when graceful shutdown is not possible.
+- Persistent MCP integrations now send a configurable heartbeat. Set
+  `NEMO_RELAY_PLUGIN_HEARTBEAT_INTERVAL_SECS` to a positive value shorter than
+  the gateway idle timeout when the default three-second interval is unsuitable.
+- After upgrading Relay, run `nemo-relay integrations refresh` to replace all
+  Relay-managed Codex and Claude Code integrations and their authenticated
+  sidecars. A newly started managed MCP client can also replace a verified
+  Relay-owned sidecar from a different Relay version; it never replaces a
+  foreign, invalid, or same-version gateway.
+- `nemo-relay uninstall <host> --force` can complete Relay-owned coding-agent
+  cleanup when normal safety checks fail.
+
+### Observability and Logging Fixes
+
+- ATIF exports retain the correct request metadata when LLM end events are
+  interleaved.
+- Set `stderr_enabled = false` under `[logging]` to disable the stderr sink
+  while retaining configured file sinks. See [Operational
+  Logging](/reference/operational-logging).
+
+## Release 0.8.1
+
+### Plugin and Configuration Improvements
+
+- The interactive plugin editor now handles structured maps, nested sections,
+  lists, and discriminator-selected configuration variants.
+- Built-in PII redaction supports `target_path_globs`. A complete `*` JSON
+  Pointer segment matches one object key or array index; existing
+  `target_paths` remain exact selectors. See [PII Redaction
+  Configuration](/configure-plugins/pii-redaction/configuration#path-semantics).
+- Native and worker plugins can register callback-based conditional middleware
+  guardrails. The additions preserve the existing native ABI v4 prefix and
+  `grpc-v1` constant-reason fields, so existing plugins remain compatible.
+- Built-in and configured static plugins now activate before dynamic plugins,
+  allowing dynamic plugin registrations to discover the runtime state required
+  during startup.
+
+### Observability and Security
+
+- OpenTelemetry can promote selected root Scope-start metadata into OTLP
+  resource attributes with `promote_resource_metadata_prefixes`. Each distinct
+  effective resource keeps its own exporter pipeline for the subscriber
+  lifetime. See [Root Resource Metadata
+  Promotion](/configure-plugins/observability/opentelemetry#root-resource-metadata-promotion).
+- Trajectory redaction preserves supported log-severity metadata, so sanitized
+  semantic logs remain exportable.
+- Gateway, permission, dynamic-plugin, observability, and response-cache
+  boundaries were hardened without changing public APIs, ABIs, configuration
+  schemas, or event formats.
+
+## Release 0.8.0
 
 NeMo Relay 0.8 strengthens plugin extensibility, managed tool execution, and
 observability while introducing source-breaking migration steps for native Rust

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -32,6 +32,21 @@ package metadata and the compiled native extension. This prevents consumers
 that inspect the native extension version, including native-plugin compatibility
 checks, from observing a stale Relay version.
 
+### Managed Coding-Agent Reliability Fixes
+
+- `nemo-relay install`, `nemo-relay uninstall`, and
+  `nemo-relay integrations refresh` now recover when an orphaned persisted
+  plugin-state file remains after an interrupted uninstall or manual cleanup.
+  A normal install still refuses to overwrite that state without `--force`.
+- `nemo-relay install codex --force` now resolves the Relay executable the same
+  way when it writes and validates generated hooks. This prevents a
+  self-consistency failure when a different Relay binary appears earlier on
+  `PATH`, such as during local development.
+- Persistent managed gateways that stop answering health checks are now safely
+  terminated and restarted when their recorded Relay process identity matches.
+  Relay continues to leave unverified listeners untouched, and operational logs
+  now classify gateway port conflicts and recovery failures with remediation.
+
 ## Release 0.8.2
 
 ### Managed Gateway and Coding-Agent Lifecycle

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -13,17 +13,21 @@ intervening release in sequence.
 
 ## Upgrade to NeMo Relay 0.8
 
-### Refresh the Installed Codex Provider Configuration
+### Refresh Relay-Managed Coding-Agent Integrations
 
-If you use the persistent Codex integration, cycle its installation after
-upgrading to refresh the `nemo-relay-openai` provider configuration. This fixes
-a routing bug that can prevent Codex image-generation requests from reaching
-Relay:
+After upgrading to 0.8.2 or later, refresh every Relay-managed Codex and Claude
+Code integration before starting a new session:
 
 ```bash
-nemo-relay uninstall codex
-nemo-relay install codex
+nemo-relay integrations refresh
 ```
+
+The command retires old MCP generations and replaces Relay-owned sidecars with
+the current Relay binary. It does not modify manually configured MCP servers.
+For a focused repair of one managed Codex installation, use
+`nemo-relay install codex --force`. This refresh also replaces the older
+uninstall-and-install procedure for the persistent Codex provider configuration
+needed by the initial 0.8 release.
 
 ### Update Exhaustive Cache Configuration Literals
 


### PR DESCRIPTION
#### Overview

Document the 0.8.1, 0.8.2, and 0.8.3 patch releases and update the managed coding-agent upgrade guidance.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add reverse-chronological 0.8.3, 0.8.2, and 0.8.1 release-note sections while retaining the original material as 0.8.0.
- Document gateway lifecycle controls, managed integration refresh, PII redaction path globs, OpenTelemetry resource metadata promotion, and patch fixes.
- Replace the obsolete persistent-Codex uninstall/install procedure with `nemo-relay integrations refresh` for Relay-managed coding-agent integrations.

#### Where should the reviewer start?

Review `docs/about-nemo-relay/release-notes/index.mdx` for the versioned release-note structure, then `docs/reference/migration-guides.mdx` for the upgrade action.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for versions 0.8.1, 0.8.2, and 0.8.3, including gateway lifecycle, integrations, logging, observability, security, compatibility, and version synchronization updates.
  * Clarified migration steps for refreshing Relay-managed Codex and Claude integrations after upgrading to version 0.8.2 or later.
  * Documented replacement of older managed components, preservation of manually configured MCP servers, and an optional forced Codex repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->