### PR TITLE
fix(install): recover from orphaned plugin state in install, uninstall, and refresh

### DIFF
--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -51,7 +51,7 @@ use state::{
 pub(super) use crate::bootstrap::DEFAULT_URL as DEFAULT_GATEWAY_URL;
 pub(super) const MARKETPLACE_NAME: &str = "nemo-relay-local";
 pub(super) const PLUGIN_NAME: &str = "nemo-relay-plugin";
-pub(crate) const RELAY_COMMAND: &str = "nemo-relay";
+pub(super) const RELAY_COMMAND: &str = "nemo-relay";
 
 fn default_operation_lock_dir() -> Result<PathBuf, String> {
     std::env::var_os("HOME")
@@ -605,9 +605,9 @@ fn prepare_install_transaction<H: MarketplaceHost>(
         None
     };
     if !options.force
-        && plugin_preflight
-            .as_ref()
-            .is_some_and(|preflight| preflight.previous_install_exists)
+        && plugin_preflight.as_ref().is_some_and(|preflight| {
+            preflight.previous_install_exists || preflight.previous_state_exists
+        })
     {
         return Err(existing_plugin_install_requires_force_error(host));
     }
@@ -1940,6 +1940,11 @@ struct PluginInstallPreflight {
     marketplace_registered: bool,
     previous_setup_installed: bool,
     previous_install_exists: bool,
+    // Tracked separately from `previous_install_exists`: an orphaned state file is not an install
+    // to retire, but it is still state a non-forced install must refuse to overwrite. Notably
+    // `force_uninstall_host_locked` writes one back as the cleanup-retry marker that
+    // `installed_integrations` relies on to keep offering cleanup.
+    previous_state_exists: bool,
     generation_retirement: Option<GenerationRetirement>,
 }
 
@@ -1987,14 +1992,13 @@ fn prepare_plugin_install(
         &previous_generation_fence,
     );
     // A persisted state file that merely parses is not proof of an install to protect: if it was
-    // orphaned by a manual cleanup or an interrupted uninstall, its own referenced roots are gone
-    // too. Require at least one of those roots to still exist before trusting the state file, so a
-    // stale state file alone can't manufacture a "missing generation marker" failure.
-    let state_root_exists = persisted
-        .as_ref()
-        .is_some_and(|state| state.marketplace_root.exists() || state.plugin_root.exists());
+    // orphaned by a manual cleanup or an interrupted uninstall, the install it describes is gone
+    // while the file remains. Decide what to retire from what is actually on disk and registered
+    // with the host, so a stale state file alone can't manufacture a "missing generation marker"
+    // failure. `validate_persisted_state` above already guarantees the state names this layout's
+    // roots, so `local_install_exists` covers everything the state file could point at.
     let previous_install_exists =
-        state_root_exists || local_install_exists || plugin_registered || marketplace_registered;
+        local_install_exists || plugin_registered || marketplace_registered;
     let generation_retirement = if previous_install_exists {
         if !previous_generation_fence.exists() {
             if legacy_plugin_without_mcp(host, &previous_plugin_root)? {
@@ -2020,6 +2024,7 @@ fn prepare_plugin_install(
     } else {
         None
     };
+    let state_bytes_present = state_bytes.is_some();
     Ok(PluginInstallPreflight {
         persisted,
         state_bytes,
@@ -2030,6 +2035,7 @@ fn prepare_plugin_install(
         marketplace_registered,
         previous_setup_installed,
         previous_install_exists,
+        previous_state_exists: state_bytes_present,
         generation_retirement,
     })
 }
@@ -2197,6 +2203,7 @@ fn begin_force_replacement(
         marketplace_registered,
         previous_setup_installed,
         previous_install_exists: _,
+        previous_state_exists: _,
         generation_retirement,
     } = preflight;
     let setup_snapshot = setup_runner.snapshot(host.install_arg())?;

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -51,7 +51,7 @@ use state::{
 pub(super) use crate::bootstrap::DEFAULT_URL as DEFAULT_GATEWAY_URL;
 pub(super) const MARKETPLACE_NAME: &str = "nemo-relay-local";
 pub(super) const PLUGIN_NAME: &str = "nemo-relay-plugin";
-pub(super) const RELAY_COMMAND: &str = "nemo-relay";
+pub(crate) const RELAY_COMMAND: &str = "nemo-relay";
 
 fn default_operation_lock_dir() -> Result<PathBuf, String> {
     std::env::var_os("HOME")
@@ -1986,10 +1986,15 @@ fn prepare_plugin_install(
         &previous_plugin_manifest,
         &previous_generation_fence,
     );
-    let previous_install_exists = state_bytes.is_some()
-        || local_install_exists
-        || plugin_registered
-        || marketplace_registered;
+    // A persisted state file that merely parses is not proof of an install to protect: if it was
+    // orphaned by a manual cleanup or an interrupted uninstall, its own referenced roots are gone
+    // too. Require at least one of those roots to still exist before trusting the state file, so a
+    // stale state file alone can't manufacture a "missing generation marker" failure.
+    let state_root_exists = persisted
+        .as_ref()
+        .is_some_and(|state| state.marketplace_root.exists() || state.plugin_root.exists());
+    let previous_install_exists =
+        state_root_exists || local_install_exists || plugin_registered || marketplace_registered;
     let generation_retirement = if previous_install_exists {
         if !previous_generation_fence.exists() {
             if legacy_plugin_without_mcp(host, &previous_plugin_root)? {

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -221,6 +221,18 @@ where
         layout
             .validate_persisted_state(&state)
             .map_err(CliError::Install)?;
+        // An orphaned state file names no live install, so there is no generation to retire and no
+        // reason to fail the whole refresh. Leave the target to the forced install that follows,
+        // which recovers it. A target with artifacts on disk still demands its fence below, so a
+        // genuinely corrupt install keeps failing loudly.
+        if !host.local_install_exists(
+            &layout.marketplace_root,
+            &layout.plugin_root,
+            &layout.plugin_manifest,
+            &layout.generation_fence,
+        ) {
+            continue;
+        }
         let mut retirement = GenerationRetirement::acquire_for_plugin(
             &layout.generation_fence,
             &layout.generation_lock,
@@ -1101,7 +1113,16 @@ fn uninstall_host_locked(
         .as_ref()
         .map(|state| state.plugin_root.as_path())
         .unwrap_or(&layout.plugin_root);
-    let local_install_exists = state.is_some() || layout.marketplace_root.exists();
+    // Same rule, and the same predicate, as the install path: neither a state file that merely
+    // parses nor a leftover generation lock is an install to retire. `retire_installed_generation`
+    // still re-checks host registration when the fence is missing, so an install that lost its
+    // marketplace root but stayed registered with the host is unaffected.
+    let local_install_exists = host.local_install_exists(
+        &layout.marketplace_root,
+        plugin_root,
+        &plugin_manifest_path(host, plugin_root),
+        &plugin_root.join(GENERATION_FILE_NAME),
+    );
     let mut generation_retirement = retire_installed_generation(
         host,
         plugin_root,

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -3546,6 +3546,35 @@ fn first_install_cleans_generated_marketplace_after_state_write_failure() {
 }
 
 #[test]
+fn force_install_recovers_from_orphaned_state_with_no_matching_disk_or_host_install() {
+    // Regression test for a state file left behind by a partial/manual cleanup: it still parses
+    // and names roots, but neither those roots nor any host registration exist anymore. Install
+    // must treat this as "nothing to safely replace" rather than failing with a "missing
+    // generation marker" error that blames a real install that isn't actually there.
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_codex_registration(false, false);
+    let setup_runner = MockSetupRunner::default();
+    let options = PluginInstallOptions {
+        force: true,
+        ..options(dir.path())
+    };
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    std::fs::remove_dir_all(&layout.marketplace_root).unwrap();
+    assert!(layout.state_path.exists());
+    assert!(!layout.marketplace_root.exists());
+    assert!(!layout.plugin_root.exists());
+
+    install_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap();
+
+    assert!(layout.marketplace_root.exists());
+    assert!(layout.generation_fence.exists());
+}
+
+#[test]
 fn force_replacement_restoration_aggregates_independent_cleanup_failures() {
     let dir = tempdir().unwrap();
     let install_file = dir.path().join("install-file");

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -3574,7 +3574,6 @@ fn force_install_recovers_from_orphaned_state_with_no_matching_disk_or_host_inst
 }
 
 #[test]
-#[ignore = "known gap: the uninstall path still treats a lone state file as an install"]
 fn uninstall_recovers_from_orphaned_state_with_no_matching_disk_or_host_install() {
     // Companion to the force-install regression above: the same orphaned state file must not make
     // `uninstall` fail with a "missing generation marker" error either. This path matters because
@@ -3603,7 +3602,6 @@ fn uninstall_recovers_from_orphaned_state_with_no_matching_disk_or_host_install(
 }
 
 #[test]
-#[ignore = "known gap: integrations refresh still requires a generation fence for any state file"]
 fn refresh_preflight_tolerates_an_orphaned_state_file() {
     // `integrations refresh` selects managed targets purely by "a state file exists", then runs
     // this preflight before any install. An orphaned state file must not abort the whole command
@@ -3620,6 +3618,43 @@ fn refresh_preflight_tolerates_an_orphaned_state_file() {
     let _preflight =
         retire_integrations_for_refresh(&[(CodingAgent::Codex, install.path().to_path_buf())])
             .unwrap();
+}
+
+#[test]
+fn refresh_preflight_retires_healthy_targets_alongside_an_orphaned_one() {
+    // The user-facing shape of the bug: one orphaned state file must not abort `integrations
+    // refresh` for the hosts that are still installed correctly.
+    let home = tempdir().unwrap();
+    let _home = HomeScope::enter(home.path());
+    let install = tempdir().unwrap();
+    for host in CodingAgent::ALL {
+        write_installed_state(host, install.path());
+    }
+    let orphaned = PluginLayout::new(CodingAgent::Codex, install.path());
+    std::fs::remove_dir_all(&orphaned.marketplace_root).unwrap();
+
+    let _preflight = retire_integrations_for_refresh(
+        &CodingAgent::ALL
+            .into_iter()
+            .map(|host| (host, install.path().to_path_buf()))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+
+    for host in CodingAgent::ALL {
+        if host == CodingAgent::Codex {
+            continue;
+        }
+        let layout = PluginLayout::new(host, install.path());
+        assert!(
+            std::fs::read_to_string(layout.generation_fence)
+                .unwrap()
+                .starts_with("retired:"),
+            "{} generation was not retired",
+            host.label()
+        );
+    }
+    assert!(!orphaned.marketplace_root.exists());
 }
 
 #[test]

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -3566,12 +3566,124 @@ fn force_install_recovers_from_orphaned_state_with_no_matching_disk_or_host_inst
     std::fs::remove_dir_all(&layout.marketplace_root).unwrap();
     assert!(layout.state_path.exists());
     assert!(!layout.marketplace_root.exists());
-    assert!(!layout.plugin_root.exists());
 
     install_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap();
 
     assert!(layout.marketplace_root.exists());
     assert!(layout.generation_fence.exists());
+}
+
+#[test]
+#[ignore = "known gap: the uninstall path still treats a lone state file as an install"]
+fn uninstall_recovers_from_orphaned_state_with_no_matching_disk_or_host_install() {
+    // Companion to the force-install regression above: the same orphaned state file must not make
+    // `uninstall` fail with a "missing generation marker" error either. This path matters because
+    // the remediation text emitted by the install path tells the user to run uninstall afterwards.
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_codex_registration(false, false);
+    let setup_runner = MockSetupRunner::default();
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    std::fs::remove_dir_all(&layout.marketplace_root).unwrap();
+    assert!(layout.state_path.exists());
+    assert!(!layout.marketplace_root.exists());
+
+    uninstall_host(
+        CodingAgent::Codex,
+        &options(dir.path()),
+        &runner,
+        &setup_runner,
+    )
+    .unwrap();
+
+    assert!(!layout.state_path.exists());
+}
+
+#[test]
+#[ignore = "known gap: integrations refresh still requires a generation fence for any state file"]
+fn refresh_preflight_tolerates_an_orphaned_state_file() {
+    // `integrations refresh` selects managed targets purely by "a state file exists", then runs
+    // this preflight before any install. An orphaned state file must not abort the whole command
+    // with a "missing generation marker" error, or the install-side recovery never gets to run.
+    let home = tempdir().unwrap();
+    let _home = HomeScope::enter(home.path());
+    let install = tempdir().unwrap();
+    write_installed_state(CodingAgent::Codex, install.path());
+    let layout = PluginLayout::new(CodingAgent::Codex, install.path());
+    std::fs::remove_dir_all(&layout.marketplace_root).unwrap();
+    assert!(layout.state_path.exists());
+    assert!(!layout.marketplace_root.exists());
+
+    let _preflight =
+        retire_integrations_for_refresh(&[(CodingAgent::Codex, install.path().to_path_buf())])
+            .unwrap();
+}
+
+#[test]
+fn force_install_recovers_from_a_bare_marketplace_root_for_claude_code() {
+    // Claude Code deliberately does not count a bare marketplace root as an install: it requires a
+    // plugin manifest, an .mcp.json, or a generation fence. A partial cleanup that leaves only the
+    // empty directory tree plus the state file is the same "nothing to safely replace" situation
+    // the orphaned-state regression covers, so install must recover rather than refuse.
+    let home = tempdir().unwrap();
+    let _home = HomeScope::enter(home.path());
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("claude", "/bin/claude");
+    let setup_runner = MockSetupRunner::default();
+    let options = PluginInstallOptions {
+        force: true,
+        ..options(dir.path())
+    };
+    write_installed_state(CodingAgent::ClaudeCode, dir.path());
+    let layout = PluginLayout::new(CodingAgent::ClaudeCode, dir.path());
+    for leftover in [
+        layout.plugin_root.join(".mcp.json"),
+        layout.generation_fence.clone(),
+        layout.plugin_manifest.clone(),
+    ] {
+        let _ = std::fs::remove_file(&leftover);
+        assert!(!leftover.exists());
+    }
+    assert!(layout.state_path.exists());
+    assert!(layout.marketplace_root.exists());
+
+    install_host(CodingAgent::ClaudeCode, &options, &runner, &setup_runner).unwrap();
+
+    assert!(layout.generation_fence.exists());
+}
+
+#[test]
+fn install_without_force_still_refuses_to_overwrite_an_orphaned_state_file() {
+    // Dropping the state file from `previous_install_exists` must not leak into the non-forced
+    // path: `force_uninstall_host_locked` deliberately writes the state file back (without its
+    // marketplace root) as the cleanup-retry marker that `installed_integrations` reads, so a
+    // plain install has to refuse rather than silently overwrite it.
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_codex_registration(false, false);
+    let setup_runner = MockSetupRunner::default();
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    std::fs::remove_dir_all(&layout.marketplace_root).unwrap();
+    let state_before = std::fs::read(&layout.state_path).unwrap();
+
+    let error = install_host(
+        CodingAgent::Codex,
+        &options(dir.path()),
+        &runner,
+        &setup_runner,
+    )
+    .unwrap_err();
+
+    assert!(error.contains("--force"), "unexpected error: {error}");
+    assert_eq!(std::fs::read(&layout.state_path).unwrap(), state_before);
 }
 
 #[test]
@@ -3702,6 +3814,7 @@ fn force_replacement_moves_and_restores_a_separate_plugin_tree() {
         marketplace_registered: false,
         previous_setup_installed: false,
         previous_install_exists: true,
+        previous_state_exists: false,
         generation_retirement: None,
     };
     let setup_runner = MockSetupRunner::default();


### PR DESCRIPTION
#### Overview

An orphaned plugin state file — one left behind by a partial/manual cleanup or an interrupted uninstall, which still parses while the install it describes is gone — was treated as proof of an existing install. That made `install`, `uninstall`, and `integrations refresh` all fail with a "missing generation marker" error whose suggested remediation (close clients, remove the marketplace/plugin via the host CLI) doesn't apply, because none of those things exist.

Fixes #963.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

All three commands now decide what to retire from what is actually on disk and registered with the host, using one shared predicate (`MarketplaceHost::local_install_exists`) instead of three subtly different checks.

**`install`** — `previous_install_exists` no longer counts `state_bytes.is_some()`.

Removing the state file from that flag would also have relaxed the non-forced path, which shares it to decide whether a plain `install` must refuse. That would let `install` silently overwrite the cleanup-retry state `force_uninstall_host_locked` writes back after a failed host-setup removal, which `installed_integrations` reads to keep offering cleanup. `previous_state_exists` is tracked separately so the require-force refusal still sees the state file while generation retirement does not.

**`uninstall`** — `uninstall_host_locked` derived `local_install_exists` from `state.is_some()`. This path matters because the install-side remediation text tells the user to run exactly that command afterward. `retire_installed_generation` still re-checks host registration when the fence is missing, so an install that lost its marketplace root but stayed registered is unaffected.

**`integrations refresh`** — `retire_integrations_for_refresh` demanded a generation fence for every target carrying a state file. Since refresh selects targets purely by "a state file exists", one orphaned file aborted the whole command for every host, including correctly installed ones, before any install could recover it. Such a target is now skipped and left to the forced install that follows; a target with artifacts still on disk keeps failing loudly, which is the genuine corruption case.

**Generation locks.** The free `local_install_exists` helper also counts `generation_lock.exists()`. That lock sits outside the marketplace root and survives a manual cleanup exactly like the state file, so it is no more evidence of an install — and a lone lock cannot retire anything without its fence. The host-aware predicate used here ignores it.

#### Where should the reviewer start?

`prepare_plugin_install` in `crates/cli/src/installation/marketplace/mod.rs`, then the two sibling call sites (`uninstall_host_locked`, `retire_integrations_for_refresh`).

The design decision worth a second opinion is `force_install_recovers_from_a_bare_marketplace_root_for_claude_code`. Claude Code deliberately does not count a bare marketplace root as an install — it requires a plugin manifest, an `.mcp.json`, or a generation fence — so that test asserts a bare root plus a state file should recover. If the intent is that a bare root *should* be protected for Claude Code, the test and the condition both need to flip.

#### Test plan

- [x] `force_install_recovers_from_orphaned_state_with_no_matching_disk_or_host_install` — the original #963 scenario.
- [x] `force_install_recovers_from_a_bare_marketplace_root_for_claude_code` — pins the host-aware predicate; the Codex-only test above passes with or without it.
- [x] `install_without_force_still_refuses_to_overwrite_an_orphaned_state_file` — asserts both the error and that the state file is left byte-identical.
- [x] `uninstall_recovers_from_orphaned_state_with_no_matching_disk_or_host_install`
- [x] `refresh_preflight_tolerates_an_orphaned_state_file` and `refresh_preflight_retires_healthy_targets_alongside_an_orphaned_one` — the latter pins that one orphaned target does not stop healthy targets from being retired.
- [x] `cargo test -p nemo-relay-cli --lib installation::marketplace` — 140 passed, 0 failed, 0 ignored.
- [x] `cargo test -p nemo-relay-cli --lib` — 25 pre-existing failures (mostly `sessions::tests::*atif*`), byte-identical to the set on a clean baseline at this PR's original head; unrelated to this change.
- [x] `cargo fmt -p nemo-relay-cli -- --check`
- [x] `cargo clippy -p nemo-relay-cli --lib --tests -- -D warnings`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #963
