### PR TITLE
fix(codex): resolve the relay binary the same way when writing and validating hooks

### DIFF
--- a/crates/cli/src/agents/codex/host.rs
+++ b/crates/cli/src/agents/codex/host.rs
@@ -586,13 +586,24 @@ pub(crate) fn expected_plugin_hook_command(
     expected_plugin_hook_command_with_token(plugin_hooks_path, None)
 }
 
+/// Resolves the relay binary the same way the installer's `require_relay()` does: prefer whatever
+/// `nemo-relay` is found on `$PATH`, falling back to the currently running executable. Generated
+/// hooks are validated against this same resolution immediately after being written, so diverging
+/// from `require_relay()`'s order here would make that validation fail whenever a different
+/// `nemo-relay` sits earlier on `$PATH` than the binary performing the install.
+fn resolve_relay_executable() -> Result<PathBuf, String> {
+    let relay = crate::process::resolve_executable(crate::installation::marketplace::RELAY_COMMAND)
+        .map(Ok)
+        .unwrap_or_else(current_exe)?;
+    let relay = relay.canonicalize().unwrap_or(relay);
+    Ok(portable_executable_path(relay))
+}
+
 fn expected_plugin_hook_command_with_token(
     plugin_hooks_path: &Path,
     generation_token: Option<&str>,
 ) -> Result<crate::hooks::GeneratedHookCommands, String> {
-    let relay = current_exe()?;
-    let relay = relay.canonicalize().unwrap_or(relay);
-    let relay = portable_executable_path(relay);
+    let relay = resolve_relay_executable()?;
     let generation_path = plugin_generation_file(plugin_hooks_path)?;
     let captured;
     let generation_token = match generation_token {

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -51,7 +51,7 @@ use state::{
 pub(super) use crate::bootstrap::DEFAULT_URL as DEFAULT_GATEWAY_URL;
 pub(super) const MARKETPLACE_NAME: &str = "nemo-relay-local";
 pub(super) const PLUGIN_NAME: &str = "nemo-relay-plugin";
-pub(super) const RELAY_COMMAND: &str = "nemo-relay";
+pub(crate) const RELAY_COMMAND: &str = "nemo-relay";
 
 fn default_operation_lock_dir() -> Result<PathBuf, String> {
     std::env::var_os("HOME")

--- a/crates/cli/tests/coverage/agents/plugin_host_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_host_tests.rs
@@ -2215,6 +2215,9 @@ fn codex_hooks_installed_requires_generated_plugin_local_groups() {
 
 #[test]
 fn codex_setup_can_validate_hooks_while_installer_holds_the_generation_lock() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let plugin_root = dir.path().join("plugin");
     let hooks_path = plugin_root.join("hooks").join("hooks.json");

--- a/crates/cli/tests/coverage/agents/plugin_host_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_host_tests.rs
@@ -159,17 +159,32 @@ fn codex_expected_plugin_hooks_prefer_path_relay_over_current_exe() {
 
     let commands = expected_plugin_hook_command(&hooks_path).unwrap();
 
-    let expected_relay = fake_relay.canonicalize().unwrap_or(fake_relay);
-    let expected_relay = portable_executable_path(expected_relay);
+    // Compare whole generated commands rather than substring-matching the relay path: on Windows
+    // the path is embedded inside a base64 UTF-16 `-EncodedCommand` payload, so it never appears
+    // as plain text in the command string.
+    let generation_path = hooks_path
+        .parent()
+        .and_then(Path::parent)
+        .unwrap()
+        .join(crate::installation::generation::GENERATION_FILE_NAME);
+    let build_expectation = |relay: PathBuf| {
+        let relay = relay.canonicalize().unwrap_or(relay);
+        codex_plugin_hook_command(
+            &portable_executable_path(relay),
+            &generation_path,
+            TEST_PLUGIN_GENERATION,
+        )
+        .unwrap()
+    };
+
     let command = commands.for_event("SessionStart");
-    assert!(
-        command.contains(expected_relay.to_str().unwrap()),
-        "{command}"
+    assert_eq!(
+        command,
+        build_expectation(fake_relay).for_event("SessionStart")
     );
-    let real_current_exe = current_exe().unwrap();
-    assert!(
-        !command.contains(real_current_exe.to_str().unwrap()),
-        "{command}"
+    assert_ne!(
+        command,
+        build_expectation(current_exe().unwrap()).for_event("SessionStart")
     );
 }
 

--- a/crates/cli/tests/coverage/agents/plugin_host_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_host_tests.rs
@@ -89,7 +89,11 @@ impl CodexHooksClient for FakeCodexHooksClient {
 }
 
 fn expected_plugin_command() -> crate::hooks::GeneratedHookCommands {
-    let relay = current_exe().unwrap();
+    // Mirrors source resolution order (crate::process::resolve_executable("nemo-relay"), falling
+    // back to current_exe()) so this helper stays correct on machines that happen to have a real
+    // `nemo-relay` on $PATH, rather than assuming current_exe() is always what gets embedded.
+    let relay =
+        crate::process::resolve_executable("nemo-relay").unwrap_or_else(|| current_exe().unwrap());
     let relay = relay.canonicalize().unwrap_or(relay);
     let relay = portable_executable_path(relay);
     codex_plugin_hook_command(
@@ -131,6 +135,39 @@ fn expected_plugin_command_for_hooks(path: &Path, event: &str) -> String {
                 .map(str::to_owned)
         })
         .unwrap_or_else(|| expected_plugin_command().for_event(event).to_owned())
+}
+
+#[test]
+fn codex_expected_plugin_hooks_prefer_path_relay_over_current_exe() {
+    // Regression test: the plugin marketplace writer resolves the relay binary via $PATH first,
+    // falling back to current_exe() (see require_relay()). Hook validation must resolve the same
+    // way, or install deterministically fails its own consistency check whenever a different
+    // `nemo-relay` sits earlier on $PATH than the binary performing the install.
+    let dir = tempdir().unwrap();
+    let _home = HomeScope::enter(dir.path());
+    let bin_dir = dir.path().join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let fake_relay = bin_dir.join("nemo-relay");
+    fs::write(&fake_relay, b"#!/bin/sh\n").unwrap();
+    let _path = EnvVarGuard::set_path("PATH", &bin_dir);
+
+    let hooks_path = dir.path().join("plugin").join("hooks").join("hooks.json");
+    write_plugin_generation_for_hooks(&hooks_path);
+
+    let commands = expected_plugin_hook_command(&hooks_path).unwrap();
+
+    let expected_relay = fake_relay.canonicalize().unwrap_or(fake_relay);
+    let expected_relay = portable_executable_path(expected_relay);
+    let command = commands.for_event("SessionStart");
+    assert!(
+        command.contains(expected_relay.to_str().unwrap()),
+        "{command}"
+    );
+    let real_current_exe = current_exe().unwrap();
+    assert!(
+        !command.contains(real_current_exe.to_str().unwrap()),
+        "{command}"
+    );
 }
 
 fn empty_codex_hooks_client() -> FakeCodexHooksClient {
@@ -2118,7 +2155,11 @@ fn codex_setup_can_validate_hooks_while_installer_holds_the_generation_lock() {
         &generation_lock,
     )
     .unwrap();
-    let relay = current_exe().unwrap();
+    // Matches source resolution order (crate::process::resolve_executable("nemo-relay"), falling
+    // back to current_exe()) so this test stays correct on machines that happen to have a real
+    // `nemo-relay` on $PATH, rather than assuming current_exe() is always what gets embedded.
+    let relay =
+        crate::process::resolve_executable("nemo-relay").unwrap_or_else(|| current_exe().unwrap());
     let relay = portable_executable_path(relay.canonicalize().unwrap_or(relay));
     let command = codex_plugin_hook_command(&relay, &generation_path, &token).unwrap();
     fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();

--- a/crates/cli/tests/coverage/agents/plugin_host_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_host_tests.rs
@@ -147,7 +147,14 @@ fn codex_expected_plugin_hooks_prefer_path_relay_over_current_exe() {
     let _home = HomeScope::enter(dir.path());
     let bin_dir = dir.path().join("bin");
     fs::create_dir_all(&bin_dir).unwrap();
-    let fake_relay = bin_dir.join("nemo-relay");
+    // Windows resolution only ever considers `nemo-relay` plus a PATHEXT suffix; the bare name is
+    // never a candidate (see process::executable_extensions), so an extensionless fixture would
+    // silently fall through to current_exe() and fail this test on Windows only.
+    let fake_relay = bin_dir.join(if cfg!(windows) {
+        "nemo-relay.exe"
+    } else {
+        "nemo-relay"
+    });
     fs::write(&fake_relay, b"#!/bin/sh\n").unwrap();
     let _path = EnvVarGuard::set_path("PATH", &bin_dir);
 
@@ -417,6 +424,19 @@ fn home_env_lock() -> &'static Mutex<()> {
     &crate::test_support::ENV_TEST_LOCK
 }
 
+/// Takes the process-wide environment lock without changing any variable.
+///
+/// Generating a hook command now resolves the relay binary through `$PATH` (see
+/// `resolve_relay_executable`), so a test that compares a helper-computed expectation against a
+/// source-computed command reads `$PATH` twice. Without this guard those two reads can straddle
+/// another test's `$PATH` override and disagree. `HomeScope` is the wrong tool here because these
+/// tests want the ambient `HOME`/`CODEX_HOME`; they only need the mutual exclusion.
+fn env_read_guard() -> std::sync::MutexGuard<'static, ()> {
+    home_env_lock()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+}
+
 struct HomeScope<'a> {
     _guard: std::sync::MutexGuard<'a, ()>,
     prev_home: Option<std::ffi::OsString>,
@@ -551,6 +571,9 @@ fn atomic_write_replaces_existing_destination() {
 
 #[test]
 fn codex_auto_trusts_only_exact_generated_plugin_hooks_and_verifies_them() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let hooks_path = dir.path().join("plugin").join("hooks.json");
     let config_path = dir.path().join(".codex").join("config.toml");
@@ -614,6 +637,9 @@ fn codex_auto_trusts_only_exact_generated_plugin_hooks_and_verifies_them() {
 
 #[test]
 fn codex_auto_trust_refuses_missing_required_hook_without_writing_state() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let hooks_path = dir.path().join("plugin").join("hooks.json");
     let config_path = dir.path().join(".codex").join("config.toml");
@@ -640,6 +666,9 @@ fn codex_auto_trust_refuses_missing_required_hook_without_writing_state() {
 
 #[test]
 fn codex_auto_trust_refuses_duplicate_discovered_handler() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     fs::write(&config_path, "").unwrap();
@@ -666,6 +695,9 @@ fn codex_auto_trust_refuses_duplicate_discovered_handler() {
 
 #[test]
 fn every_generated_codex_hook_is_required_exactly_once_and_trusted() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     for (event, display) in [
         ("session_start", "SessionStart"),
         ("user_prompt_submit", "UserPromptSubmit"),
@@ -747,6 +779,9 @@ fn every_generated_codex_hook_is_required_exactly_once_and_trusted() {
 
 #[test]
 fn codex_auto_trust_reverifies_every_generated_hook_after_writing() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     for event in [
         "session_start",
         "user_prompt_submit",
@@ -811,6 +846,9 @@ fn codex_auto_trust_reverifies_every_generated_hook_after_writing() {
 
 #[test]
 fn codex_auto_trust_rejects_targeted_hook_that_disappears_after_write() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     fs::write(&config_path, "").unwrap();
@@ -843,6 +881,9 @@ fn codex_auto_trust_rejects_targeted_hook_that_disappears_after_write() {
 
 #[test]
 fn codex_auto_trust_rejects_targeted_hook_that_changes_key_after_write() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     fs::write(&config_path, "").unwrap();
@@ -874,6 +915,9 @@ fn codex_auto_trust_rejects_targeted_hook_that_changes_key_after_write() {
 
 #[test]
 fn codex_auto_trust_restores_exact_prior_state_after_verification_failure() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     fs::write(
@@ -927,6 +971,9 @@ custom = "preserve"
 
 #[test]
 fn codex_auto_trust_aggregates_original_and_rollback_errors() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     fs::write(&config_path, "").unwrap();
@@ -952,6 +999,9 @@ fn codex_auto_trust_aggregates_original_and_rollback_errors() {
 
 #[test]
 fn codex_auto_trust_does_not_depend_on_reported_plugin_source_path() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let reported_hooks_path = dir.path().join("codex-cache").join("hooks.json");
     let config_path = dir.path().join(".codex").join("config.toml");
@@ -977,6 +1027,9 @@ fn codex_auto_trust_does_not_depend_on_reported_plugin_source_path() {
 
 #[test]
 fn codex_auto_trust_rejects_modified_loaded_plugin_hook_file() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let reported_hooks_path = dir.path().join("codex-cache").join("hooks.json");
     fs::create_dir_all(reported_hooks_path.parent().unwrap()).unwrap();
@@ -1016,6 +1069,9 @@ fn codex_auto_trust_rejects_modified_loaded_plugin_hook_file() {
 
 #[test]
 fn codex_hook_trust_report_distinguishes_modified_disabled_and_missing_hooks() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let hooks_path = dir.path().join(".codex").join("hooks.json");
     let hooks = vec![
@@ -1065,6 +1121,9 @@ fn codex_hook_trust_report_distinguishes_modified_disabled_and_missing_hooks() {
 
 #[test]
 fn codex_hook_trust_report_recognizes_legacy_generated_hooks_as_stale() {
+    // Holds the environment lock: this test compares a helper-computed relay path against the
+    // one the source resolves, and both reads go through $PATH.
+    let _env = env_read_guard();
     let dir = tempdir().unwrap();
     let hooks_path = dir.path().join(".codex").join("hooks.json");
     let expected = expected_plugin_command();

--- a/crates/cli/tests/coverage/agents/plugin_host_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_host_tests.rs
@@ -150,11 +150,7 @@ fn codex_expected_plugin_hooks_prefer_path_relay_over_current_exe() {
     // Windows resolution only ever considers `nemo-relay` plus a PATHEXT suffix; the bare name is
     // never a candidate (see process::executable_extensions), so an extensionless fixture would
     // silently fall through to current_exe() and fail this test on Windows only.
-    let fake_relay = bin_dir.join(if cfg!(windows) {
-        "nemo-relay.exe"
-    } else {
-        "nemo-relay"
-    });
+    let fake_relay = bin_dir.join(format!("nemo-relay{}", std::env::consts::EXE_SUFFIX));
     fs::write(&fake_relay, b"#!/bin/sh\n").unwrap();
     let _path = EnvVarGuard::set_path("PATH", &bin_dir);
 


### PR DESCRIPTION
## Summary

Fixes #964.

`nemo-relay install codex --force` deterministically fails a self-consistency check on its own freshly-generated `hooks.json` whenever a *different* `nemo-relay` binary exists earlier on `$PATH` than the one actually invoked to run the install. This makes it impossible to install from an explicitly-specified binary (e.g. a locally built branch/worktree binary) on a machine that also has another `nemo-relay` installed system-wide — a common local-dev scenario.

Two code paths resolved "the relay binary to embed in generated hooks" differently:

- `require_relay()` (`installation/marketplace/host.rs`) prefers `$PATH` (`resolve_executable("nemo-relay")`), falling back to `current_executable()`. Used when **writing** `hooks.json`.
- `expected_plugin_hook_command_with_token()` (`agents/codex/host.rs`) always used `current_exe()` with no `$PATH` preference. Used to **validate** the just-written `hooks.json` immediately after install.

When a different `nemo-relay` is resolvable via `$PATH`, the writer embeds that binary's path, but the validator recomputes "expected" using the executing binary's own path — these never match, so validation always fails and the install fully rolls back, even though the write itself was internally consistent.

## Fix

`expected_plugin_hook_command_with_token()` now resolves the relay binary the same way `require_relay()` does (prefer `$PATH`, fall back to `current_exe()`), via a new `resolve_relay_executable()` helper. Widens `RELAY_COMMAND` to `pub(crate)` so `codex::host` can reference the same constant `require_relay()` uses.

Note: the `RELAY_COMMAND` visibility line also appears in #965 (both fixes touch `installation/marketplace/mod.rs`) — it's an identical one-line change in both branches, so it's a no-op duplicate regardless of which PR merges first.

`require_relay()` itself is intentionally left untouched — its `$PATH`-first behavior is required by the "refresh managed integrations after Relay upgrade" flow, which deliberately wants installs to re-point at the upgraded `$PATH` binary regardless of which process triggers the refresh.

## Test plan

- [x] Added `codex_expected_plugin_hooks_prefer_path_relay_over_current_exe`, deterministically proving the validator now resolves via a controlled `$PATH` fixture rather than always `current_exe()`
- [x] Updated two existing tests (`expected_plugin_command()` helper and `codex_setup_can_validate_hooks_while_installer_holds_the_generation_lock`) that hardcoded `current_exe()` for their expected value — these were silently relying on the local machine having no `nemo-relay` on `$PATH`, and would fail on a machine that does (as this one does)
- [x] `cargo test -p nemo-relay-cli --lib codex` (143 passed)
- [x] `cargo fmt -p nemo-relay-cli -- --check`
- [x] `cargo clippy -p nemo-relay-cli --lib --tests -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Codex plugin hooks now use the appropriate `nemo-relay` executable found on your system’s PATH.
  * Added a fallback to the current executable when no separate relay executable is available.
  * Improved executable path normalization, including support for platform-specific executable extensions.

* **Tests**
  * Added coverage verifying PATH-selected relay binaries and fallback behavior in Codex plugin hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->