### PR TITLE
fix: recover unhealthy managed MCP gateways

### DIFF
--- a/crates/cli/src/bootstrap/mod.rs
+++ b/crates/cli/src/bootstrap/mod.rs
@@ -90,7 +90,8 @@ impl GatewaySpec {
                 log::error!(
                     target: "nemo_relay.bootstrap",
                     event = "gateway_acquisition_failed",
-                    bind = self.bind.to_string().as_str();
+                    bind = self.bind.to_string().as_str(),
+                    error = error.as_str();
                     "Gateway acquisition failed"
                 );
                 Err(error)
@@ -120,7 +121,8 @@ impl GatewaySpec {
                 log::error!(
                     target: "nemo_relay.bootstrap",
                     event = "gateway_recovery_failed",
-                    instance_id = expected_instance;
+                    instance_id = expected_instance,
+                    error = error.as_str();
                     "Gateway recovery failed"
                 );
                 Err(error)
@@ -200,8 +202,17 @@ fn acquire_gateway(spec: &GatewaySpec) -> Result<GatewayEndpoint, String> {
                 Err(incompatible_relay_error(&url))
             }
         }
-        (RelayHealth::Foreign, _) => Err(foreign_listener_error(&url)),
-        (RelayHealth::Unavailable, _) => start_gateway(spec, &state),
+        (RelayHealth::Foreign, _) => {
+            if state::stop_unhealthy_owned_gateway_locked(&state, &url)? {
+                start_gateway(spec, &state)
+            } else {
+                Err(foreign_listener_error(&url))
+            }
+        }
+        (RelayHealth::Unavailable, _) => {
+            state::stop_unhealthy_owned_gateway_locked(&state, &url)?;
+            start_gateway(spec, &state)
+        }
     }
 }
 
@@ -285,12 +296,28 @@ fn compatible_endpoint(
 }
 
 fn foreign_listener_error(url: &str) -> String {
+    log::error!(
+        target: "nemo_relay.bootstrap",
+        event = "gateway_port_conflict",
+        endpoint = url,
+        observed_health = "unverified_listener",
+        remediation = "stop_listener_or_configure_another_port";
+        "Gateway endpoint is occupied by an unverified listener"
+    );
     format!(
         "{url} is occupied by a service that is not a compatible NeMo Relay gateway; stop that service or configure another port"
     )
 }
 
 fn incompatible_relay_error(url: &str) -> String {
+    log::error!(
+        target: "nemo_relay.bootstrap",
+        event = "gateway_port_conflict",
+        endpoint = url,
+        observed_health = "incompatible_relay",
+        remediation = "stop_gateway_wait_for_idle_shutdown_or_reinstall_with_force";
+        "Gateway endpoint is occupied by an incompatible NeMo Relay gateway"
+    );
     format!(
         "{url} is occupied by NeMo Relay with a different version or persistent configuration; stop it, wait for idle shutdown, or reinstall the integration with --force"
     )

--- a/crates/cli/src/bootstrap/mod.rs
+++ b/crates/cli/src/bootstrap/mod.rs
@@ -90,7 +90,8 @@ impl GatewaySpec {
                 log::error!(
                     target: "nemo_relay.bootstrap",
                     event = "gateway_acquisition_failed",
-                    bind = self.bind.to_string().as_str();
+                    bind = self.bind.to_string().as_str(),
+                    failure_kind = bootstrap_failure_kind(&error);
                     "Gateway acquisition failed"
                 );
                 Err(error)
@@ -120,7 +121,8 @@ impl GatewaySpec {
                 log::error!(
                     target: "nemo_relay.bootstrap",
                     event = "gateway_recovery_failed",
-                    instance_id = expected_instance;
+                    instance_id = expected_instance,
+                    failure_kind = bootstrap_failure_kind(&error);
                     "Gateway recovery failed"
                 );
                 Err(error)
@@ -230,7 +232,9 @@ fn recover_gateway(spec: &GatewaySpec, expected_instance: &str) -> Result<Gatewa
             }
             (RelayHealth::Incompatible, _) => return Err(incompatible_relay_error(&requested_url)),
             (RelayHealth::Foreign, _) => return Err(foreign_listener_error(&requested_url)),
-            (RelayHealth::Unavailable, _) => {}
+            (RelayHealth::Unavailable, _) => {
+                state::stop_unhealthy_owned_gateway_locked(&state, &requested_url)?;
+            }
         }
     }
 
@@ -319,6 +323,20 @@ fn incompatible_relay_error(url: &str) -> String {
     format!(
         "{url} is occupied by NeMo Relay with a different version or persistent configuration; stop it, wait for idle shutdown, or reinstall the integration with --force"
     )
+}
+
+fn bootstrap_failure_kind(error: &str) -> &'static str {
+    if error.contains("not a compatible NeMo Relay gateway") {
+        "foreign_listener"
+    } else if error.contains("different version or persistent configuration") {
+        "incompatible_gateway"
+    } else if error.contains("became unhealthy") {
+        "unhealthy_gateway"
+    } else if error.contains("did not become ready") {
+        "gateway_readiness_timeout"
+    } else {
+        "bootstrap_failure"
+    }
 }
 
 fn start_gateway(spec: &GatewaySpec, state: &Path) -> Result<GatewayEndpoint, String> {

--- a/crates/cli/src/bootstrap/mod.rs
+++ b/crates/cli/src/bootstrap/mod.rs
@@ -90,8 +90,7 @@ impl GatewaySpec {
                 log::error!(
                     target: "nemo_relay.bootstrap",
                     event = "gateway_acquisition_failed",
-                    bind = self.bind.to_string().as_str(),
-                    error = error.as_str();
+                    bind = self.bind.to_string().as_str();
                     "Gateway acquisition failed"
                 );
                 Err(error)
@@ -121,8 +120,7 @@ impl GatewaySpec {
                 log::error!(
                     target: "nemo_relay.bootstrap",
                     event = "gateway_recovery_failed",
-                    instance_id = expected_instance,
-                    error = error.as_str();
+                    instance_id = expected_instance;
                     "Gateway recovery failed"
                 );
                 Err(error)

--- a/crates/cli/src/bootstrap/mod.rs
+++ b/crates/cli/src/bootstrap/mod.rs
@@ -231,7 +231,11 @@ fn recover_gateway(spec: &GatewaySpec, expected_instance: &str) -> Result<Gatewa
                 return compatible_endpoint(spec.bind, requested_url, instance_id);
             }
             (RelayHealth::Incompatible, _) => return Err(incompatible_relay_error(&requested_url)),
-            (RelayHealth::Foreign, _) => return Err(foreign_listener_error(&requested_url)),
+            (RelayHealth::Foreign, _) => {
+                if !state::stop_unhealthy_owned_gateway_locked(&state, &requested_url)? {
+                    return Err(foreign_listener_error(&requested_url));
+                }
+            }
             (RelayHealth::Unavailable, _) => {
                 state::stop_unhealthy_owned_gateway_locked(&state, &requested_url)?;
             }

--- a/crates/cli/src/bootstrap/state.rs
+++ b/crates/cli/src/bootstrap/state.rs
@@ -30,7 +30,7 @@ pub(super) struct OwnerRecord {
     bootstrap_protocol: u64,
     pid: u32,
     #[serde(default)]
-    process_start_time: Option<u64>,
+    process_identity: Option<u64>,
     url: String,
     shutdown_token: String,
     bootstrap_fingerprint: Option<String>,
@@ -50,7 +50,7 @@ impl OwnerRecord {
             version: env!("CARGO_PKG_VERSION").into(),
             bootstrap_protocol: BOOTSTRAP_PROTOCOL_VERSION,
             pid,
-            process_start_time: process_start_time(pid),
+            process_identity: process_identity(pid),
             url: url.into(),
             shutdown_token: shutdown_token.into(),
             bootstrap_fingerprint: fingerprint.map(str::to_owned),
@@ -360,24 +360,77 @@ fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
     }
 }
 
-#[cfg(any(unix, windows))]
-fn process_start_time(pid: u32) -> Option<u64> {
-    use sysinfo::{Pid, System};
-
-    let system = System::new_all();
-    system
-        .process(Pid::from_u32(pid))
-        .map(|process| process.start_time())
+#[cfg(target_os = "linux")]
+fn process_identity(pid: u32) -> Option<u64> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    // `comm` is parenthesized and may contain spaces, so process fields only
+    // after the final `)` character.
+    stat.rsplit_once(')')?
+        .1
+        .split_whitespace()
+        // Field 22 is process start time in clock ticks. The first field here
+        // is field 3 (`state`).
+        .nth(19)?
+        .parse()
+        .ok()
 }
 
-#[cfg(not(any(unix, windows)))]
-fn process_start_time(_pid: u32) -> Option<u64> {
+#[cfg(target_os = "macos")]
+fn process_identity(pid: u32) -> Option<u64> {
+    let pid = i32::try_from(pid).ok()?;
+    // SAFETY: `info` is initialized and passed with its exact size for the
+    // documented PROC_PIDTBSDINFO query.
+    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let result = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            (&raw mut info).cast(),
+            i32::try_from(std::mem::size_of::<libc::proc_bsdinfo>()).ok()?,
+        )
+    };
+    (result == std::mem::size_of::<libc::proc_bsdinfo>() as i32)
+        .then(|| {
+            info.pbi_start_tvsec
+                .checked_mul(1_000_000)?
+                .checked_add(info.pbi_start_tvusec)
+        })
+        .flatten()
+}
+
+#[cfg(windows)]
+fn process_identity(pid: u32) -> Option<u64> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+    use windows_sys::Win32::System::Threading::{
+        GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // A handle keeps the queried process instance stable while its creation
+    // identity is read, even if this PID is recycled concurrently.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        return None;
+    }
+    let mut creation: FILETIME = unsafe { std::mem::zeroed() };
+    let mut exit: FILETIME = unsafe { std::mem::zeroed() };
+    let mut kernel: FILETIME = unsafe { std::mem::zeroed() };
+    let mut user: FILETIME = unsafe { std::mem::zeroed() };
+    let result =
+        unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
+    unsafe { CloseHandle(handle) };
+    (result != 0)
+        .then(|| (u64::from(creation.dwHighDateTime) << 32) | u64::from(creation.dwLowDateTime))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+fn process_identity(_pid: u32) -> Option<u64> {
     None
 }
 
 fn owner_process_identity_matches(owner: &OwnerRecord) -> bool {
-    owner.process_start_time.is_some_and(|start_time| {
-        process_start_time(owner.pid).is_some_and(|current| current == start_time)
+    owner.process_identity.is_some_and(|identity| {
+        process_identity(owner.pid).is_some_and(|current| current == identity)
     })
 }
 
@@ -485,7 +538,7 @@ fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
 
 #[cfg(windows)]
 fn windows_process_is_running(pid: u32) -> bool {
-    process_start_time(pid).is_some()
+    process_identity(pid).is_some()
 }
 
 #[cfg(windows)]

--- a/crates/cli/src/bootstrap/state.rs
+++ b/crates/cli/src/bootstrap/state.rs
@@ -455,28 +455,46 @@ fn termination_target_is_running(target: GatewayTerminationTarget) -> bool {
 
 #[cfg(windows)]
 fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
+    if !windows_process_is_running(pid) {
+        return Ok(false);
+    }
+
     log_unhealthy_gateway_termination_started(pid as i32);
-    let graceful = std::process::Command::new("taskkill")
+    let _graceful = std::process::Command::new("taskkill")
         .args(["/PID", &pid.to_string(), "/T"])
         .status();
-    if graceful.is_ok_and(|status| status.success()) {
+    if wait_for_windows_process_exit(pid, UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT) {
         return Ok(true);
     }
-    thread::sleep(UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT);
+
     log_unhealthy_gateway_termination_escalated(pid as i32);
-    let forced = std::process::Command::new("taskkill")
+    let _forced = std::process::Command::new("taskkill")
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .status()
         .map_err(|error| {
             format!("failed to force-kill managed Relay gateway process {pid}: {error}")
         })?;
-    if forced.success() {
+    if wait_for_windows_process_exit(pid, UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT) {
         Ok(true)
     } else {
         Err(format!(
             "managed Relay gateway process {pid} did not terminate"
         ))
     }
+}
+
+#[cfg(windows)]
+fn windows_process_is_running(pid: u32) -> bool {
+    process_start_time(pid).is_some()
+}
+
+#[cfg(windows)]
+fn wait_for_windows_process_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while windows_process_is_running(pid) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(50));
+    }
+    !windows_process_is_running(pid)
 }
 
 fn log_unhealthy_gateway_termination_started(pid: i32) {

--- a/crates/cli/src/bootstrap/state.rs
+++ b/crates/cli/src/bootstrap/state.rs
@@ -344,14 +344,14 @@ fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
     }
 
     log_unhealthy_gateway_termination_started(pid);
-    signal_gateway_process_group(pid, libc::SIGTERM)?;
-    if wait_for_process_exit(pid, UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT) {
+    let target = signal_gateway_process_group(pid, libc::SIGTERM)?;
+    if wait_for_termination(target, UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT) {
         return Ok(true);
     }
 
     log_unhealthy_gateway_termination_escalated(pid);
-    signal_gateway_process_group(pid, libc::SIGKILL)?;
-    if wait_for_process_exit(pid, UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT) {
+    signal_gateway_termination_target(target, libc::SIGKILL)?;
+    if wait_for_termination(target, UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT) {
         Ok(true)
     } else {
         Err(format!(
@@ -382,12 +382,19 @@ fn owner_process_identity_matches(owner: &OwnerRecord) -> bool {
 }
 
 #[cfg(unix)]
-fn signal_gateway_process_group(pid: i32, signal: i32) -> Result<(), String> {
+#[derive(Clone, Copy)]
+enum GatewayTerminationTarget {
+    ProcessGroup(i32),
+    Process(i32),
+}
+
+#[cfg(unix)]
+fn signal_gateway_process_group(pid: i32, signal: i32) -> Result<GatewayTerminationTarget, String> {
     // Detached gateways call setsid, making their PID the process-group ID.
     // Fall back to the direct PID for an older or otherwise non-detached sidecar.
     let group_result = unsafe { libc::kill(-pid, signal) };
     if group_result == 0 {
-        return Ok(());
+        return Ok(GatewayTerminationTarget::ProcessGroup(pid));
     }
     let group_error = std::io::Error::last_os_error();
     if group_error.raw_os_error() != Some(libc::ESRCH) {
@@ -396,13 +403,31 @@ fn signal_gateway_process_group(pid: i32, signal: i32) -> Result<(), String> {
         ));
     }
     if unsafe { libc::kill(pid, signal) } == 0 {
-        Ok(())
+        Ok(GatewayTerminationTarget::Process(pid))
     } else {
         let error = std::io::Error::last_os_error();
         (error.raw_os_error() == Some(libc::ESRCH))
-            .then_some(())
+            .then_some(GatewayTerminationTarget::Process(pid))
             .ok_or_else(|| format!("failed to signal managed Relay gateway process {pid}: {error}"))
     }
+}
+
+#[cfg(unix)]
+fn signal_gateway_termination_target(
+    target: GatewayTerminationTarget,
+    signal: i32,
+) -> Result<(), String> {
+    let (pid, target_pid) = match target {
+        GatewayTerminationTarget::ProcessGroup(pid) => (pid, -pid),
+        GatewayTerminationTarget::Process(pid) => (pid, pid),
+    };
+    if unsafe { libc::kill(target_pid, signal) } == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    (error.raw_os_error() == Some(libc::ESRCH))
+        .then_some(())
+        .ok_or_else(|| format!("failed to signal managed Relay gateway process {pid}: {error}"))
 }
 
 #[cfg(unix)]
@@ -412,12 +437,20 @@ fn process_is_running(pid: i32) -> bool {
 }
 
 #[cfg(unix)]
-fn wait_for_process_exit(pid: i32, timeout: Duration) -> bool {
+fn wait_for_termination(target: GatewayTerminationTarget, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
-    while process_is_running(pid) && Instant::now() < deadline {
+    while termination_target_is_running(target) && Instant::now() < deadline {
         thread::sleep(Duration::from_millis(50));
     }
-    !process_is_running(pid)
+    !termination_target_is_running(target)
+}
+
+#[cfg(unix)]
+fn termination_target_is_running(target: GatewayTerminationTarget) -> bool {
+    match target {
+        GatewayTerminationTarget::ProcessGroup(pid) => process_is_running(-pid),
+        GatewayTerminationTarget::Process(pid) => process_is_running(pid),
+    }
 }
 
 #[cfg(windows)]

--- a/crates/cli/src/bootstrap/state.rs
+++ b/crates/cli/src/bootstrap/state.rs
@@ -29,6 +29,8 @@ pub(super) struct OwnerRecord {
     version: String,
     bootstrap_protocol: u64,
     pid: u32,
+    #[serde(default)]
+    process_start_time: Option<u64>,
     url: String,
     shutdown_token: String,
     bootstrap_fingerprint: Option<String>,
@@ -48,6 +50,7 @@ impl OwnerRecord {
             version: env!("CARGO_PKG_VERSION").into(),
             bootstrap_protocol: BOOTSTRAP_PROTOCOL_VERSION,
             pid,
+            process_start_time: process_start_time(pid),
             url: url.into(),
             shutdown_token: shutdown_token.into(),
             bootstrap_fingerprint: fingerprint.map(str::to_owned),
@@ -265,6 +268,10 @@ pub(crate) fn stop_unhealthy_owned_gateway_locked(state: &Path, url: &str) -> Re
     if probe(url, owner.bootstrap_fingerprint.as_deref()) == RelayHealth::Compatible {
         return Ok(false);
     }
+    if !owner_process_identity_matches(&owner) {
+        remove_if_matches(&path, &owner)?;
+        return Ok(false);
+    }
 
     let was_running = terminate_owned_gateway_process(owner.pid)?;
     remove_if_matches(&path, &owner)?;
@@ -329,8 +336,9 @@ fn stop_owned_gateway_locked(path: &Path, owner: &OwnerRecord, url: &str) -> Res
 
 #[cfg(unix)]
 fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
-    let pid =
-        i32::try_from(pid).map_err(|_| format!("invalid managed gateway process ID {pid}"))?;
+    let Ok(pid) = i32::try_from(pid) else {
+        return Ok(false);
+    };
     if !process_is_running(pid) {
         return Ok(false);
     }
@@ -350,6 +358,27 @@ fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
             "managed Relay gateway process {pid} did not terminate"
         ))
     }
+}
+
+#[cfg(any(unix, windows))]
+fn process_start_time(pid: u32) -> Option<u64> {
+    use sysinfo::{Pid, System};
+
+    let system = System::new_all();
+    system
+        .process(Pid::from_u32(pid))
+        .map(|process| process.start_time())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_start_time(_pid: u32) -> Option<u64> {
+    None
+}
+
+fn owner_process_identity_matches(owner: &OwnerRecord) -> bool {
+    owner.process_start_time.is_some_and(|start_time| {
+        process_start_time(owner.pid).is_some_and(|current| current == start_time)
+    })
 }
 
 #[cfg(unix)]

--- a/crates/cli/src/bootstrap/state.rs
+++ b/crates/cli/src/bootstrap/state.rs
@@ -21,6 +21,7 @@ use crate::gateway::client::{RelayHealth, probe, request_shutdown};
 pub(crate) const BOOTSTRAP_STATE_DIR_ENV: &str = "NEMO_RELAY_BOOTSTRAP_STATE_DIR";
 pub(crate) const BOOTSTRAP_SHUTDOWN_TOKEN_ENV: &str = "NEMO_RELAY_BOOTSTRAP_SHUTDOWN_TOKEN";
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub(super) struct OwnerRecord {
@@ -248,6 +249,28 @@ pub(crate) fn stop_version_mismatched_owned_gateway_locked(
     stop_owned_gateway_locked(&path, &owner, url)
 }
 
+/// Terminates a managed gateway whose health endpoint is unavailable so its
+/// listener cannot block a replacement process from binding the endpoint.
+///
+/// The caller holds the endpoint startup lock. A valid ownership record is the
+/// authority for signalling the process; listeners without one remain untouched.
+pub(crate) fn stop_unhealthy_owned_gateway_locked(state: &Path, url: &str) -> Result<bool, String> {
+    let path = owner_path(state, url);
+    let Some(owner) = read_owner_record(&path)? else {
+        return Ok(false);
+    };
+    if !owner.valid_for(url) {
+        return Ok(false);
+    }
+    if probe(url, owner.bootstrap_fingerprint.as_deref()) == RelayHealth::Compatible {
+        return Ok(false);
+    }
+
+    let was_running = terminate_owned_gateway_process(owner.pid)?;
+    remove_if_matches(&path, &owner)?;
+    Ok(was_running)
+}
+
 fn stop_owned_and_reset_locked(state: &Path, url: &str) -> Result<bool, String> {
     let path = owner_path(state, url);
     let Some(owner) = read_owner_record(&path)? else {
@@ -302,6 +325,121 @@ fn stop_owned_gateway_locked(path: &Path, owner: &OwnerRecord, url: &str) -> Res
     }
     remove_if_matches(path, owner)?;
     Ok(true)
+}
+
+#[cfg(unix)]
+fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
+    let pid =
+        i32::try_from(pid).map_err(|_| format!("invalid managed gateway process ID {pid}"))?;
+    if !process_is_running(pid) {
+        return Ok(false);
+    }
+
+    log_unhealthy_gateway_termination_started(pid);
+    signal_gateway_process_group(pid, libc::SIGTERM)?;
+    if wait_for_process_exit(pid, UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT) {
+        return Ok(true);
+    }
+
+    log_unhealthy_gateway_termination_escalated(pid);
+    signal_gateway_process_group(pid, libc::SIGKILL)?;
+    if wait_for_process_exit(pid, UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT) {
+        Ok(true)
+    } else {
+        Err(format!(
+            "managed Relay gateway process {pid} did not terminate"
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn signal_gateway_process_group(pid: i32, signal: i32) -> Result<(), String> {
+    // Detached gateways call setsid, making their PID the process-group ID.
+    // Fall back to the direct PID for an older or otherwise non-detached sidecar.
+    let group_result = unsafe { libc::kill(-pid, signal) };
+    if group_result == 0 {
+        return Ok(());
+    }
+    let group_error = std::io::Error::last_os_error();
+    if group_error.raw_os_error() != Some(libc::ESRCH) {
+        return Err(format!(
+            "failed to signal managed Relay gateway process {pid}: {group_error}"
+        ));
+    }
+    if unsafe { libc::kill(pid, signal) } == 0 {
+        Ok(())
+    } else {
+        let error = std::io::Error::last_os_error();
+        (error.raw_os_error() == Some(libc::ESRCH))
+            .then_some(())
+            .ok_or_else(|| format!("failed to signal managed Relay gateway process {pid}: {error}"))
+    }
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: i32) -> bool {
+    (unsafe { libc::kill(pid, 0) }) == 0
+        || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(unix)]
+fn wait_for_process_exit(pid: i32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while process_is_running(pid) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(50));
+    }
+    !process_is_running(pid)
+}
+
+#[cfg(windows)]
+fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
+    log_unhealthy_gateway_termination_started(pid as i32);
+    let graceful = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T"])
+        .status();
+    if graceful.is_ok_and(|status| status.success()) {
+        return Ok(true);
+    }
+    thread::sleep(UNHEALTHY_GATEWAY_TERMINATION_TIMEOUT);
+    log_unhealthy_gateway_termination_escalated(pid as i32);
+    let forced = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .status()
+        .map_err(|error| {
+            format!("failed to force-kill managed Relay gateway process {pid}: {error}")
+        })?;
+    if forced.success() {
+        Ok(true)
+    } else {
+        Err(format!(
+            "managed Relay gateway process {pid} did not terminate"
+        ))
+    }
+}
+
+fn log_unhealthy_gateway_termination_started(pid: i32) {
+    log::warn!(
+        target: "nemo_relay.bootstrap",
+        event = "unhealthy_gateway_termination_started",
+        process_id = pid;
+        "Terminating unhealthy managed gateway"
+    );
+}
+
+fn log_unhealthy_gateway_termination_escalated(pid: i32) {
+    log::warn!(
+        target: "nemo_relay.bootstrap",
+        event = "unhealthy_gateway_termination_escalated",
+        process_id = pid;
+        "Force-killing unhealthy managed gateway after graceful termination timeout"
+    );
+}
+
+#[cfg(not(any(unix, windows)))]
+fn terminate_owned_gateway_process(pid: u32) -> Result<bool, String> {
+    Err(format!(
+        "cannot terminate unhealthy managed Relay gateway process {pid} on this platform"
+    ))
 }
 
 fn write_owner_record(path: &Path, record: &OwnerRecord) -> Result<(), String> {

--- a/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
+++ b/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
@@ -23,6 +23,20 @@ fn owner_records_are_versioned_endpoint_scoped_and_round_trip() {
     assert_eq!(lock_name("not a url/with spaces"), "not_a_url_with_spaces");
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos", windows))]
+#[test]
+fn live_owner_record_uses_a_process_instance_identity() {
+    let owner = OwnerRecord::new(
+        std::process::id(),
+        "http://127.0.0.1:47632",
+        "shutdown",
+        Some("fingerprint"),
+    );
+
+    assert!(owner.process_identity.is_some());
+    assert!(owner_process_identity_matches(&owner));
+}
+
 #[test]
 fn recovery_records_preserve_pending_and_ready_attempts() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
+++ b/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
@@ -255,7 +255,7 @@ fn stale_unhealthy_gateway_owner_is_removed() {
     let dir = tempfile::tempdir().unwrap();
     let url = "http://127.0.0.1:9";
     let path = owner_path(dir.path(), url);
-    let owner = OwnerRecord::new(42, url, "shutdown-token", Some("fingerprint"));
+    let owner = OwnerRecord::new(u32::MAX, url, "shutdown-token", Some("fingerprint"));
     write_owner_record(&path, &owner).unwrap();
 
     assert!(!stop_unhealthy_owned_gateway_locked(dir.path(), url).unwrap());
@@ -265,18 +265,46 @@ fn stale_unhealthy_gateway_owner_is_removed() {
 #[cfg(unix)]
 #[test]
 fn unhealthy_owned_gateway_is_force_killed_after_the_grace_period() {
+    use std::os::unix::process::CommandExt;
+
     let dir = tempfile::tempdir().unwrap();
     let url = "http://127.0.0.1:9";
     let path = owner_path(dir.path(), url);
-    let mut child = std::process::Command::new("sh")
-        .args(["-c", "trap '' TERM; while :; do sleep 1; done"])
-        .spawn()
-        .unwrap();
+    let child_pid_path = dir.path().join("child.pid");
+    let mut command = std::process::Command::new("sh");
+    command.args([
+        "-c",
+        "trap '' TERM; sh -c 'trap \"\" TERM; while :; do sleep 60; done' & echo $! > \"$1\"; wait",
+        "sh",
+        child_pid_path.to_str().unwrap(),
+    ]);
+    // SAFETY: The child calls only async-signal-safe `setsid` before exec.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    let child_pid = loop {
+        if let Ok(value) = std::fs::read_to_string(&child_pid_path) {
+            break value.trim().parse::<i32>().unwrap();
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
     let owner = OwnerRecord::new(child.id(), url, "shutdown-token", Some("fingerprint"));
     write_owner_record(&path, &owner).unwrap();
     let waiter = std::thread::spawn(move || child.wait());
 
     assert!(stop_unhealthy_owned_gateway_locked(dir.path(), url).unwrap());
     assert!(!waiter.join().unwrap().unwrap().success());
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while process_is_running(child_pid) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(!process_is_running(child_pid));
     assert!(!path.exists());
 }

--- a/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
+++ b/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
@@ -274,7 +274,7 @@ fn unhealthy_owned_gateway_is_force_killed_after_the_grace_period() {
     let mut command = std::process::Command::new("sh");
     command.args([
         "-c",
-        "trap '' TERM; sh -c 'trap \"\" TERM; while :; do sleep 60; done' & echo $! > \"$1\"; wait",
+        "sh -c 'trap \"\" TERM; while :; do sleep 60; done' & echo $! > \"$1\"; wait",
         "sh",
         child_pid_path.to_str().unwrap(),
     ]);

--- a/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
+++ b/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
@@ -234,7 +234,7 @@ fn same_version_or_invalid_owned_gateway_is_not_stopped_for_replacement() {
     let state = state_dir().unwrap();
     create_private_dir(&state).unwrap();
     let path = owner_path(&state, url);
-    let owner = OwnerRecord::new(42, url, "shutdown-token", Some("fingerprint"));
+    let owner = OwnerRecord::new(i32::MAX as u32, url, "shutdown-token", Some("fingerprint"));
     write_owner_record(&path, &owner).unwrap();
 
     let _lock = lock_endpoint(&state, url).unwrap();

--- a/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
+++ b/crates/cli/tests/coverage/shared/bootstrap_state_tests.rs
@@ -249,3 +249,34 @@ fn same_version_or_invalid_owned_gateway_is_not_stopped_for_replacement() {
     assert!(!stop_version_mismatched_owned_gateway_locked(&state, url).unwrap());
     assert!(path.exists());
 }
+
+#[test]
+fn stale_unhealthy_gateway_owner_is_removed() {
+    let dir = tempfile::tempdir().unwrap();
+    let url = "http://127.0.0.1:9";
+    let path = owner_path(dir.path(), url);
+    let owner = OwnerRecord::new(42, url, "shutdown-token", Some("fingerprint"));
+    write_owner_record(&path, &owner).unwrap();
+
+    assert!(!stop_unhealthy_owned_gateway_locked(dir.path(), url).unwrap());
+    assert!(!path.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn unhealthy_owned_gateway_is_force_killed_after_the_grace_period() {
+    let dir = tempfile::tempdir().unwrap();
+    let url = "http://127.0.0.1:9";
+    let path = owner_path(dir.path(), url);
+    let mut child = std::process::Command::new("sh")
+        .args(["-c", "trap '' TERM; while :; do sleep 1; done"])
+        .spawn()
+        .unwrap();
+    let owner = OwnerRecord::new(child.id(), url, "shutdown-token", Some("fingerprint"));
+    write_owner_record(&path, &owner).unwrap();
+    let waiter = std::thread::spawn(move || child.wait());
+
+    assert!(stop_unhealthy_owned_gateway_locked(dir.path(), url).unwrap());
+    assert!(!waiter.join().unwrap().unwrap().success());
+    assert!(!path.exists());
+}


### PR DESCRIPTION
#### Overview

Recover managed MCP gateways that stop answering health checks, while making port conflicts actionable in operational logs.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Terminate an unhealthy managed gateway, wait one second, then force-kill its detached process tree before bootstrap starts a replacement.
- Preserve unmanaged-listener protection and add endpoint, health classification, remediation, and detailed failure context to bootstrap conflict logs.
- Add stale-owner and forced-termination regression coverage.
- Validated with `just test-rust`, focused bootstrap tests, commit hooks, and `cargo clippy -p nemo-relay-cli --all-targets -- -D warnings`.

#### Where should the reviewer start?

Start with `crates/cli/src/bootstrap/mod.rs` for bootstrap classification and conflict events, then `crates/cli/src/bootstrap/state.rs` for process termination.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unhealthy managed gateways are now stopped before replacement gateways start.
  * Stale ownership records for unreachable gateways are cleaned up safely.
  * Managed gateway cleanup verifies ownership before stopping processes, leaving unowned gateways unaffected.
  * Gateway processes and related child processes are fully terminated when necessary.
  * Gateway conflicts and recovery failures now provide clearer diagnostic details, including failure classification and remediation information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->