### PR TITLE
ci: remove release 0.8 nightly alpha branch

### DIFF
--- a/.github/nightly-alpha-branches.yaml
+++ b/.github/nightly-alpha-branches.yaml
@@ -3,4 +3,3 @@
 
 branches:
   - main
-  - release/0.8


### PR DESCRIPTION
#### Overview

- Remove the retired `release/0.8` branch from nightly alpha branch selection.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Keep `main` as the only configured nightly alpha branch.

#### Where should the reviewer start?

- `.github/nightly-alpha-branches.yaml`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly alpha branch configuration to run only for the `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->