### PR TITLE
ci: update PR size label thresholds

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -95,9 +95,9 @@ jobs:
             esac
           done
 
-          if (( changed_lines <= 10 )); then
+          if (( changed_lines <= 25 )); then
             size_label="size:XS"
-          elif (( changed_lines <= 100 )); then
+          elif (( changed_lines <= 250 )); then
             size_label="size:S"
           elif (( changed_lines <= 500 )); then
             size_label="size:M"


### PR DESCRIPTION
#### Overview

Adjust automated pull-request size labels so XS covers up to 25 changed lines and S covers up to 250.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Updates `.github/workflows/pr-labels.yaml` without changing the M, L, XL, or XXL thresholds.

#### Where should the reviewer start?

Review the size-label classification conditions in `.github/workflows/pr-labels.yaml`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request size-label thresholds so extra-small and small labels apply to larger change sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->