### PR TITLE
ci: tighten stale issue and PR timelines

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -16,14 +16,14 @@ jobs:
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
-          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity.'
-          days-before-issue-stale: 60
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          days-before-issue-stale: 30
           days-before-issue-close: 7
           days-before-pr-stale: 30
-          days-before-pr-close: 14
+          days-before-pr-close: 7
           exempt-issue-labels: 'Needs Triage'
           exempt-pr-labels: 'Under Review'
           operations-per-run: 100


### PR DESCRIPTION
#### Overview

Update the stale workflow thresholds for issues and pull requests.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Mark issues stale after 30 days of inactivity.
- Close stale pull requests after 7 additional days of inactivity.
- Update the workflow messages to match the configured timelines.

#### Where should the reviewer start?

Review `.github/workflows/stale.yaml` for the threshold and message changes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue and pull request inactivity timelines.
  * Issues are now marked stale after 30 days.
  * Pull requests are now closed after 7 days of inactivity.
  * Updated related notification messages to reflect the new timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->