### PR TITLE
feat(cli): forward launched pi model calls to named upstreams

### DIFF
--- a/crates/cli/assets/pi-extension/index.ts
+++ b/crates/cli/assets/pi-extension/index.ts
@@ -45,8 +45,9 @@
  *
  * **Model redirection.** pi resolves a base URL per model from a generated
  * catalog, so the extension points the active model's provider at the gateway
- * itself -- but only when the gateway forwards to the endpoint that model would
- * otherwise call. See `src/provider-redirect.ts`.
+ * itself. Under a launched session it also names the endpoint the gateway
+ * should forward to, so a provider the gateway was never configured for is
+ * still reachable. See `src/provider-redirect.ts`.
  *
  * Environment (set by the launcher, overridable by hand):
  * - `NEMO_RELAY_PI_GATEWAY_URL`  gateway base URL (default `http://127.0.0.1:4040`)

--- a/crates/cli/assets/pi-extension/index.ts
+++ b/crates/cli/assets/pi-extension/index.ts
@@ -290,6 +290,14 @@ export default function nemoRelayExtension(pi: ExtensionAPI): void {
         headers: {
           'x-nemo-relay-session-id': sessionKey,
           ...(redirect.proxyToken ? { 'x-nemo-relay-proxy-token': redirect.proxyToken } : {}),
+          // Only when the gateway does not already front this endpoint. It rides on
+          // the registration for the same reason the credential does -- the scope is
+          // structural, so a provider we left alone never names an upstream -- and
+          // the gateway ignores it unless the proxy credential above is present and
+          // matches, which is what stops any other local process steering it.
+          ...(decision.namedUpstream
+            ? { 'x-nemo-relay-upstream-base-url': decision.namedUpstream }
+            : {}),
         },
       });
       redirectedProviders.add(decision.provider);

--- a/crates/cli/assets/pi-extension/src/provider-redirect.ts
+++ b/crates/cli/assets/pi-extension/src/provider-redirect.ts
@@ -106,7 +106,23 @@ export type RedirectSkipCode =
   | 'provider-mixed-endpoints';
 
 export type RedirectDecision =
-  | { kind: 'redirect'; provider: string; api: string; upstream: string; reason: string }
+  | {
+      kind: 'redirect';
+      provider: string;
+      api: string;
+      upstream: string;
+      reason: string;
+      /**
+       * The endpoint the gateway must be told to forward to, when it does not
+       * already front it.
+       *
+       * Absent on a static redirect, where the gateway's configured upstream is
+       * the destination and saying so again would only add a header. Present
+       * means every request for this provider carries it, so the gateway can
+       * reach a provider it was never configured for.
+       */
+      namedUpstream?: string;
+    }
   | { kind: 'skip'; code: RedirectSkipCode; provider?: string; api?: string; reason: string };
 
 /**
@@ -122,6 +138,62 @@ function isSafeToRedirect(model: RedirectModel, config: RedirectConfig): boolean
   const upstream = family === 'openai' ? config.openaiUpstream : config.anthropicUpstream;
   if (!upstream) return false;
   return normalizeBaseUrl(upstream) === normalizeBaseUrl(model.baseUrl);
+}
+
+/**
+ * Whether this invocation may tell the gateway where to forward.
+ *
+ * The gateway honors a named upstream only from a request carrying this run's
+ * proxy credential, so without one the header would be ignored and the redirect
+ * would land on the gateway's own configured upstream -- the wrong provider,
+ * which is the failure the static check exists to prevent. Having the credential
+ * is therefore the precondition for redirecting past a mismatch, not a detail of
+ * how the request is authenticated.
+ */
+function canNameUpstream(config: RedirectConfig): boolean {
+  return Boolean(config.proxyToken);
+}
+
+/**
+ * Redirect a provider the gateway does not front, by naming its endpoint.
+ *
+ * The sibling scan survives from the static path but changes its question. There
+ * it asked whether every model already targets the gateway's configured
+ * upstream; here one endpoint is named for the whole provider, so it asks
+ * whether every model shares the endpoint about to be named. A provider mixing
+ * endpoints is still refused -- naming one of them would point the rest at a host
+ * that has never heard of them, which is the same broken session the static path
+ * refuses to create.
+ */
+function nameUpstream(
+  model: RedirectModel,
+  siblings: readonly RedirectModel[],
+): RedirectDecision {
+  const target = normalizeBaseUrl(model.baseUrl);
+  const unsafe = siblings.find(
+    (sibling) =>
+      !SERVICEABLE_APIS.has(sibling.api) || normalizeBaseUrl(sibling.baseUrl) !== target,
+  );
+  if (unsafe) {
+    return {
+      kind: 'skip',
+      code: 'provider-mixed-endpoints',
+      provider: model.provider,
+      api: model.api,
+      reason:
+        `redirecting ${model.provider} would also move its ${unsafe.api} models, and ` +
+        `${unsafe.id} targets ${unsafe.baseUrl} rather than ${model.baseUrl}; ` +
+        `a provider is named one endpoint, so its models must share one`,
+    };
+  }
+  return {
+    kind: 'redirect',
+    provider: model.provider,
+    api: model.api,
+    upstream: model.baseUrl,
+    namedUpstream: model.baseUrl,
+    reason: `the gateway does not front ${model.baseUrl}, so each request names it`,
+  };
 }
 
 /** Whether this outcome explains something a trace reader would otherwise have to guess. */
@@ -221,6 +293,12 @@ export function decideRedirect(
   }
 
   if (!upstream) {
+    // Not knowing the gateway's upstream stops mattering once we can name ours:
+    // the comparison existed to prove a redirect lands on the right provider, and
+    // naming the endpoint proves it directly.
+    if (canNameUpstream(config)) {
+      return nameUpstream(model, siblings);
+    }
     // Launched outside `nemo-relay run --agent pi`, so the gateway's upstream
     // is unknown. Staying put is the safe default: a wrong redirect breaks the
     // session, a skipped one only costs spans.
@@ -241,6 +319,13 @@ export function decideRedirect(
   // `provider-mixed-endpoints`, naming the selected model as the sibling that
   // blocked it. Same decision either way; this is the code an operator can act on.
   if (normalizeBaseUrl(upstream) !== normalizeBaseUrl(model.baseUrl)) {
+    // A mismatch is the ordinary case for pi's arbitrary providers: 32 of its 39
+    // speak an API the gateway serves, but only the two it is configured for are
+    // the endpoint a model already calls. Naming the endpoint turns that from a
+    // refusal into a redirect.
+    if (canNameUpstream(config)) {
+      return nameUpstream(model, siblings);
+    }
     return {
       kind: 'skip',
       code: 'upstream-mismatch',

--- a/crates/cli/assets/pi-extension/src/provider-redirect.ts
+++ b/crates/cli/assets/pi-extension/src/provider-redirect.ts
@@ -19,18 +19,24 @@
  * `streamSimple` and re-implement a provider protocol; the extension stays a
  * thin client.
  *
- * **Redirection is conditional, and the condition is the whole design.** The
- * gateway forwards to one statically configured upstream per API family and a
- * client cannot override it per request -- inbound internal dispatch headers
- * are stripped. So sending a model's traffic to the gateway is only correct
- * when the gateway's upstream *is* the endpoint that model would otherwise
- * call. Redirecting an NVIDIA model into a gateway configured for
- * `api.openai.com` does not degrade to "no spans"; it breaks the session.
+ * **The gateway has to know where to forward, and there are two ways to tell
+ * it.** It sends each API family to one statically configured upstream, so
+ * redirecting a model whose endpoint is not that upstream would reach the wrong
+ * provider: an NVIDIA model in a gateway configured for `api.openai.com` does
+ * not degrade to "no spans", it breaks the session.
  *
- * The launcher therefore passes the gateway's own upstreams
- * (`NEMO_RELAY_PI_OPENAI_UPSTREAM`, `NEMO_RELAY_PI_ANTHROPIC_UPSTREAM`) and
- * this module redirects only on a match. Unmatched models keep their own
- * endpoint and produce no LLM spans, which is the honest outcome.
+ * - **The endpoint already matches.** The launcher passes the gateway's own
+ *   upstreams (`NEMO_RELAY_PI_OPENAI_UPSTREAM`,
+ *   `NEMO_RELAY_PI_ANTHROPIC_UPSTREAM`), and a model already targeting one of
+ *   them is redirected as it is.
+ * - **The endpoint is named.** Otherwise, when this run holds the launcher's
+ *   proxy credential, the redirect carries `x-nemo-relay-upstream-base-url` and
+ *   the gateway forwards there instead. This is what makes pi's arbitrary
+ *   providers reachable.
+ *
+ * Without that credential the header would be ignored, so a standalone daemon
+ * redirects only on a match and unmatched models keep their own endpoint and
+ * produce no LLM spans.
  */
 
 /**

--- a/crates/cli/src/agents/pi/alignment.rs
+++ b/crates/cli/src/agents/pi/alignment.rs
@@ -97,6 +97,16 @@ pub(crate) fn client_named_upstream_base(
     if !url.username().is_empty() || url.password().is_some() {
         return NamedUpstream::Rejected("upstream base URL must not carry credentials");
     }
+    // A base is a prefix, and the request path is appended to it as text. Neither of these can
+    // survive that: a query would end up before the path (`...?version=1/chat/completions`), and
+    // a fragment would swallow it entirely, since everything after `#` is never sent to the
+    // server. Both would route somewhere other than the endpoint that was named.
+    if url.query().is_some() {
+        return NamedUpstream::Rejected("upstream base URL must not carry a query string");
+    }
+    if url.fragment().is_some() {
+        return NamedUpstream::Rejected("upstream base URL must not carry a fragment");
+    }
     // Cleartext only where it cannot leave the machine.
     //
     // A named destination is forwarded the provider credential the request carried, so plain

--- a/crates/cli/src/agents/pi/alignment.rs
+++ b/crates/cli/src/agents/pi/alignment.rs
@@ -38,38 +38,64 @@ use reqwest::Url;
 /// and this one is meant to arrive from a client.
 pub(crate) const UPSTREAM_BASE_URL_HEADER: &str = "x-nemo-relay-upstream-base-url";
 
+/// What a request asked for, and whether it may have it.
+///
+/// The three states are distinct on purpose. Collapsing "asked for something we refuse" into
+/// "asked for nothing" is not a safe default here: the caller registered this gateway as its
+/// provider and is sending a prompt and a provider credential intended for the endpoint it
+/// named. Quietly forwarding that to the configured OpenAI or Anthropic upstream instead
+/// would deliver both to the wrong company. A refusal has to be visible.
+pub(crate) enum NamedUpstream {
+    /// No opinion. Configured routing applies, which is the ordinary path for every other agent.
+    Absent,
+    /// Use this base.
+    Named(String),
+    /// A destination was named that may not be used. Refuse the request rather than reroute it.
+    Rejected(&'static str),
+}
+
 /// The upstream this request asks for, when the request is entitled to ask.
 ///
-/// Returns the base URL as written rather than a reserialized one, so an operator's `/v1` or
-/// path prefix survives; composing it with the request path stays in `ProviderRoute`, which is
-/// where the OpenAI `/v1` normalization already lives.
+/// Returns the base URL as written rather than a reserialized one, so the endpoint the caller
+/// named is the endpoint it gets.
 pub(crate) fn client_named_upstream_base(
     headers: &HeaderMap,
     invocation_authenticated: bool,
-) -> Option<String> {
+) -> NamedUpstream {
     // Checked before the header is even read: an unauthenticated request has no say in where
-    // this gateway sends traffic, and treating the header as absent keeps the fallback to
-    // configured routing on exactly one path.
+    // this gateway sends traffic. `Absent` rather than `Rejected` deliberately -- a standalone
+    // daemon serves clients that never had a credential to present, and its documented
+    // behaviour is that the header is inert there, not that such requests fail.
     if !invocation_authenticated {
-        return None;
+        return NamedUpstream::Absent;
     }
 
-    let raw = headers.get(UPSTREAM_BASE_URL_HEADER)?.to_str().ok()?.trim();
+    let Some(raw) = headers.get(UPSTREAM_BASE_URL_HEADER) else {
+        return NamedUpstream::Absent;
+    };
+    let Ok(raw) = raw.to_str() else {
+        return NamedUpstream::Rejected("upstream base URL header is not valid text");
+    };
+    let raw = raw.trim();
     if raw.is_empty() {
-        return None;
+        return NamedUpstream::Rejected("upstream base URL header is empty");
     }
 
-    let url = Url::parse(raw).ok()?;
+    let Ok(url) = Url::parse(raw) else {
+        return NamedUpstream::Rejected("upstream base URL header is not an absolute URL");
+    };
     // An absolute http(s) URL with a host, and nothing else. A relative URL would resolve
     // against the gateway itself, a non-http scheme reaches schemes reqwest treats very
     // differently (`file:`), and credentials in the authority would be forwarded to whatever
     // host follows them.
     if !matches!(url.scheme(), "http" | "https") {
-        return None;
+        return NamedUpstream::Rejected("upstream base URL must use http or https");
     }
-    url.host_str()?;
+    if url.host_str().is_none() {
+        return NamedUpstream::Rejected("upstream base URL has no host");
+    }
     if !url.username().is_empty() || url.password().is_some() {
-        return None;
+        return NamedUpstream::Rejected("upstream base URL must not carry credentials");
     }
     // Cleartext only where it cannot leave the machine.
     //
@@ -79,10 +105,12 @@ pub(crate) fn client_named_upstream_base(
     // model server -- Ollama, vLLM, LM Studio -- is exactly the kind of provider this feature
     // exists to reach, and its traffic never reaches a network.
     if url.scheme() == "http" && !is_loopback(&url) {
-        return None;
+        return NamedUpstream::Rejected(
+            "upstream base URL must use https unless it is a loopback address",
+        );
     }
 
-    Some(raw.to_string())
+    NamedUpstream::Named(raw.to_string())
 }
 
 /// Whether this host is one that cannot be reached from off the machine.

--- a/crates/cli/src/agents/pi/alignment.rs
+++ b/crates/cli/src/agents/pi/alignment.rs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A client-named upstream, for pi models the gateway does not statically front.
+//!
+//! The gateway forwards to one configured upstream per API family, so redirecting pi's model
+//! traffic is only correct when that upstream is already the endpoint the selected model would
+//! otherwise call. pi resolves a base URL per model from a catalog of dozens of providers, so
+//! for most of them it is not, and the extension refuses to redirect rather than break the
+//! session. The cost is that those models produce no LLM spans and get no model-call
+//! enforcement.
+//!
+//! This lets the extension name the endpoint instead, in a request header, so one gateway can
+//! front a provider it was never configured for.
+//!
+//! **Why this is not simply reusing the internal dispatch header.**
+//! `x-nemo-relay-internal-dispatch-url` already redirects a single request, and the gateway
+//! strips it from every inbound request precisely so a client cannot steer it: that header is
+//! for a request intercept, which is trusted plugin code running inside the gateway. Widening
+//! it to inbound traffic would hand the same authority to anything that can reach the port.
+//! A separate header keeps that boundary intact and readable -- internal dispatch stays
+//! intercept-only, and this one is client-supplied and therefore has to earn its trust.
+//!
+//! **What earns it.** The request must carry this invocation's transparent proxy credential,
+//! which the launcher generates per run and gives only to the process it starts. That is a
+//! real bound rather than a nominal one: a gateway is being told where to send credentialed
+//! traffic, so the question that matters is whether the caller is the agent this invocation
+//! launched, and the credential is the only thing that answers it. A standalone
+//! `nemo-relay --bind` daemon issues no credential and so never honors this header; its
+//! upstreams stay static, which is the conservative outcome for the shared case.
+
+use axum::http::HeaderMap;
+use reqwest::Url;
+
+/// Header naming the provider endpoint the gateway should forward this request to.
+///
+/// Not prefixed `x-nemo-relay-internal-`: those are stripped from inbound requests by design,
+/// and this one is meant to arrive from a client.
+pub(crate) const UPSTREAM_BASE_URL_HEADER: &str = "x-nemo-relay-upstream-base-url";
+
+/// The upstream this request asks for, when the request is entitled to ask.
+///
+/// Returns the base URL as written rather than a reserialized one, so an operator's `/v1` or
+/// path prefix survives; composing it with the request path stays in `ProviderRoute`, which is
+/// where the OpenAI `/v1` normalization already lives.
+pub(crate) fn client_named_upstream_base(
+    headers: &HeaderMap,
+    invocation_authenticated: bool,
+) -> Option<String> {
+    // Checked before the header is even read: an unauthenticated request has no say in where
+    // this gateway sends traffic, and treating the header as absent keeps the fallback to
+    // configured routing on exactly one path.
+    if !invocation_authenticated {
+        return None;
+    }
+
+    let raw = headers.get(UPSTREAM_BASE_URL_HEADER)?.to_str().ok()?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let url = Url::parse(raw).ok()?;
+    // An absolute http(s) URL with a host, and nothing else. A relative URL would resolve
+    // against the gateway itself, a non-http scheme reaches schemes reqwest treats very
+    // differently (`file:`), and credentials in the authority would be forwarded to whatever
+    // host follows them.
+    if !matches!(url.scheme(), "http" | "https") {
+        return None;
+    }
+    url.host_str()?;
+    if !url.username().is_empty() || url.password().is_some() {
+        return None;
+    }
+
+    Some(raw.to_string())
+}
+
+#[cfg(test)]
+#[path = "../../../tests/coverage/agents/pi_alignment_tests.rs"]
+mod tests;

--- a/crates/cli/src/agents/pi/alignment.rs
+++ b/crates/cli/src/agents/pi/alignment.rs
@@ -71,8 +71,38 @@ pub(crate) fn client_named_upstream_base(
     if !url.username().is_empty() || url.password().is_some() {
         return None;
     }
+    // Cleartext only where it cannot leave the machine.
+    //
+    // A named destination is forwarded the provider credential the request carried, so plain
+    // `http` to a remote host would put that key on the wire in the clear. Loopback is the
+    // exception every secure-context rule makes, and it is the case that matters here: a local
+    // model server -- Ollama, vLLM, LM Studio -- is exactly the kind of provider this feature
+    // exists to reach, and its traffic never reaches a network.
+    if url.scheme() == "http" && !is_loopback(&url) {
+        return None;
+    }
 
     Some(raw.to_string())
+}
+
+/// Whether this host is one that cannot be reached from off the machine.
+///
+/// Deliberately narrow: the loopback IP ranges and the literal `localhost`. A name merely
+/// ending in `.localhost` is reserved for loopback by RFC 6761 but still resolves through
+/// whatever the host's resolver says, so it is left to the `https` requirement rather than
+/// trusted here.
+fn is_loopback(url: &Url) -> bool {
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    // `host_str` brackets an IPv6 literal, which `IpAddr` does not parse.
+    host.trim_start_matches('[')
+        .trim_end_matches(']')
+        .parse::<std::net::IpAddr>()
+        .is_ok_and(|address| address.is_loopback())
 }
 
 #[cfg(test)]

--- a/crates/cli/src/agents/pi/launch.rs
+++ b/crates/cli/src/agents/pi/launch.rs
@@ -44,12 +44,11 @@ pub(crate) fn prepare(
 
     // Tell the extension what this gateway actually forwards to.
     //
-    // Redirection is only correct when the gateway's upstream is the same endpoint the selected
-    // model would otherwise call: the gateway resolves one OpenAI base and one Anthropic base from
-    // static configuration (`ProviderRoute::upstream_url`) and there is no per-request override a
-    // client can set -- inbound internal dispatch headers are stripped. Without these two values
-    // the extension would have to redirect blind, and pointing (say) an NVIDIA model at a gateway
-    // configured for `api.openai.com` breaks a session that worked a moment earlier.
+    // Still sent even though a launched session can name its own upstream (see
+    // `pi::alignment`): the named path is what makes an arbitrary provider work, and these two
+    // are what let the extension recognise the case where naming is unnecessary because the
+    // gateway already fronts the model's endpoint. Without them every redirect would carry a
+    // header, including the common one where it changes nothing.
     set_env(launch, PI_OPENAI_UPSTREAM_ENV, &gateway.openai_base_url);
     set_env(
         launch,

--- a/crates/cli/src/agents/pi/launch.rs
+++ b/crates/cli/src/agents/pi/launch.rs
@@ -108,15 +108,17 @@ pub(crate) fn prepare(
         ["-e".to_string(), rendered],
     );
 
-    // Redirection is conditional, so say what the condition is rather than promising LLM spans.
+    // A launched session can name its own upstream, so this names the cases that still do not
+    // reach the gateway rather than the far larger set that once did not.
     launch.notes.push(format!(
         "pi tool and turn activity is reported to NeMo Relay by the extension. Model calls are \
-         routed through the gateway only when the selected model's provider already targets this \
-         gateway's upstream (openai={openai}, anthropic={anthropic}); pi resolves a base URL per \
-         model from a generated catalog, and the gateway forwards to one statically configured \
-         upstream per API family. A model on any other provider keeps calling its own endpoint \
-         and produces no LLM spans -- select a matching model, or start the gateway with \
-         --openai-base-url / --anthropic-base-url pointing at that provider",
+         routed through the gateway: a model already targeting this gateway's upstream \
+         (openai={openai}, anthropic={anthropic}) is redirected as it is, and a model on any \
+         other provider is redirected with its own endpoint named on each request. Two cases \
+         still produce no LLM spans -- a model whose API the gateway has no route for, and a \
+         provider whose models span more than one endpoint unless both --openai-base-url and \
+         --anthropic-base-url already point at it, because a provider is redirected as a whole. \
+         The model_redirect mark on the session scope names the outcome either way",
         openai = gateway.openai_base_url,
         anthropic = gateway.anthropic_base_url,
     ));

--- a/crates/cli/src/agents/pi/mod.rs
+++ b/crates/cli/src/agents/pi/mod.rs
@@ -14,6 +14,7 @@ use semver::Version;
 
 use super::AgentDescriptor;
 
+pub(crate) mod alignment;
 pub(crate) mod assets;
 pub(crate) mod doctor;
 pub(crate) mod install;

--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -1280,8 +1280,9 @@ pub(crate) async fn models(
         .map(|p| p.as_str())
         .unwrap_or(parts.uri.path());
     let authorization = state.authorize_provider_request(&mut parts.headers)?;
-    let allow_environment_provider_auth = authorization.allow_environment_provider_auth;
+    let mut allow_environment_provider_auth = authorization.allow_environment_provider_auth;
     parts.headers.remove(BOOTSTRAP_CLIENT_TOKEN_HEADER);
+    let mut named_by_client = false;
     let upstream_url = gateway_upstream_url_override(
         provider,
         &parts.headers,
@@ -1290,14 +1291,21 @@ pub(crate) async fn models(
         &state.config,
     )
     .or_else(|| {
-        crate::gateway::routes::client_named_upstream_url(
+        let named = crate::gateway::routes::client_named_upstream_url(
             provider,
             &parts.headers,
             path_and_query,
             authorization.source_credential.is_relay_proxy_credential(),
-        )
+        );
+        named_by_client = named.is_some();
+        named
     })
     .unwrap_or_else(|| provider.upstream_url(&state.config, path_and_query));
+    if named_by_client {
+        // Same reasoning as the passthrough path: naming a destination is not a way to obtain a
+        // credential for it. See `gateway::request::prepare_gateway_request`.
+        allow_environment_provider_auth = false;
+    }
     let sanitized = strip_replaceable_agent_auth_headers(
         &parts.headers,
         provider,

--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -1283,24 +1283,34 @@ pub(crate) async fn models(
     let mut allow_environment_provider_auth = authorization.allow_environment_provider_auth;
     parts.headers.remove(BOOTSTRAP_CLIENT_TOKEN_HEADER);
     let mut named_by_client = false;
-    let upstream_url = gateway_upstream_url_override(
+    let agent_override = gateway_upstream_url_override(
         provider,
         &parts.headers,
         path_and_query,
         allow_environment_provider_auth,
         &state.config,
-    )
-    .or_else(|| {
-        let named = crate::gateway::routes::client_named_upstream_url(
+    );
+    let upstream_url = match agent_override {
+        Some(url) => url,
+        None => match crate::gateway::routes::client_named_upstream_url(
             provider,
             &parts.headers,
             path_and_query,
             authorization.source_credential.is_relay_proxy_credential(),
-        );
-        named_by_client = named.is_some();
-        named
-    })
-    .unwrap_or_else(|| provider.upstream_url(&state.config, path_and_query));
+        ) {
+            crate::agents::pi::alignment::NamedUpstream::Named(url) => {
+                named_by_client = true;
+                url
+            }
+            // Refuse rather than reroute; see `gateway::request::prepare_gateway_request`.
+            crate::agents::pi::alignment::NamedUpstream::Rejected(reason) => {
+                return Err(CliError::InvalidPayload(reason.to_string()));
+            }
+            crate::agents::pi::alignment::NamedUpstream::Absent => {
+                provider.upstream_url(&state.config, path_and_query)
+            }
+        },
+    };
     if named_by_client {
         // Same reasoning as the passthrough path: naming a destination is not a way to obtain a
         // credential for it. See `gateway::request::prepare_gateway_request`.

--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -1289,6 +1289,14 @@ pub(crate) async fn models(
         allow_environment_provider_auth,
         &state.config,
     )
+    .or_else(|| {
+        crate::gateway::routes::client_named_upstream_url(
+            provider,
+            &parts.headers,
+            path_and_query,
+            authorization.source_credential.is_relay_proxy_credential(),
+        )
+    })
     .unwrap_or_else(|| provider.upstream_url(&state.config, path_and_query));
     let sanitized = strip_replaceable_agent_auth_headers(
         &parts.headers,

--- a/crates/cli/src/gateway/mod.rs
+++ b/crates/cli/src/gateway/mod.rs
@@ -184,7 +184,7 @@ async fn run_unmanaged_gateway(
         return passthrough_streaming(state, prepared).await;
     }
     let response = forward_upstream_request(
-        &state.http,
+        upstream_client(&state, prepared.client_named_upstream),
         &prepared.method,
         &prepared.upstream_url,
         &prepared.body_bytes,
@@ -331,7 +331,7 @@ fn build_buffered_func(
     prepared: &PreparedGatewayRequest,
     upstream_failures: CapturedUpstreamFailuresRef,
 ) -> LlmExecutionNextFn {
-    let http = state.http.clone();
+    let http = upstream_client(&state, prepared.client_named_upstream).clone();
     let method = prepared.method.clone();
     let url = prepared.upstream_url.clone();
     let body_bytes = prepared.body_bytes.clone();
@@ -525,7 +525,7 @@ fn build_streaming_func(
     prepared: &PreparedGatewayRequest,
     upstream_failures: CapturedUpstreamFailuresRef,
 ) -> LlmStreamExecutionNextFn {
-    let http = state.http.clone();
+    let http = upstream_client(&state, prepared.client_named_upstream).clone();
     let method = prepared.method.clone();
     let url = prepared.upstream_url.clone();
     let body_bytes = prepared.body_bytes.clone();
@@ -1116,7 +1116,7 @@ async fn passthrough_streaming(
     prepared: PreparedGatewayRequest,
 ) -> Result<Response<Body>, CliError> {
     let response = forward_upstream_request(
-        &state.http,
+        upstream_client(&state, prepared.client_named_upstream),
         &prepared.method,
         &prepared.upstream_url,
         &prepared.body_bytes,
@@ -1163,6 +1163,20 @@ fn selected_upstream_failure(failure: CapturedUpstreamFailure) -> Result<Respons
             bytes,
         } => build_response(status, headers, Body::from(bytes)),
         CapturedUpstreamFailure::Transport(error) => Err(CliError::Upstream(error)),
+    }
+}
+
+/// The HTTP client to dispatch with, chosen by where the destination came from.
+///
+/// A caller-named destination gets the client that does not follow redirects. Validation
+/// applies to the URL that was named; a redirect names a different one, and following it would
+/// carry the caller's provider credential to a host nothing checked -- possibly over plain
+/// http, which the named URL itself would have been refused for.
+fn upstream_client(state: &AppState, client_named_upstream: bool) -> &reqwest::Client {
+    if client_named_upstream {
+        &state.http_no_redirect
+    } else {
+        &state.http
     }
 }
 
@@ -1322,7 +1336,11 @@ pub(crate) async fn models(
         allow_environment_provider_auth,
         configured_auth_header,
     );
-    let mut upstream = state.http.get(upstream_url);
+    let mut upstream = if named_by_client {
+        state.http_no_redirect.get(upstream_url)
+    } else {
+        state.http.get(upstream_url)
+    };
     for (name, value) in &sanitized {
         if should_forward_request_header(name, &sanitized) {
             upstream = upstream.header(name, value);

--- a/crates/cli/src/gateway/request.rs
+++ b/crates/cli/src/gateway/request.rs
@@ -64,6 +64,7 @@ pub(super) async fn prepare_gateway_request(
     // request that names its own upstream is consulted only when nothing else claimed the route.
     // The two cannot both apply in practice -- one is inferred from a ChatGPT token, the other is
     // sent by the pi extension -- so the order records precedence rather than resolving a clash.
+    let mut named_by_client = false;
     let upstream_url = gateway_upstream_url_override(
         provider,
         &parts.headers,
@@ -72,14 +73,32 @@ pub(super) async fn prepare_gateway_request(
         config,
     )
     .or_else(|| {
-        super::routes::client_named_upstream_url(
+        let named = super::routes::client_named_upstream_url(
             provider,
             &parts.headers,
             path_and_query,
             authorization.source_credential.is_relay_proxy_credential(),
-        )
+        );
+        named_by_client = named.is_some();
+        named
     })
     .unwrap_or_else(|| provider.upstream_url(config, path_and_query));
+    if named_by_client {
+        // A client-named destination gets only the credentials the client itself sent.
+        //
+        // Naming a destination must not also be a way to *obtain* one. Environment and
+        // configured provider auth exist for the upstream this gateway was configured for, and
+        // injection fires precisely when the request carries no credential of its own -- so
+        // without this, a request naming any host would have `OPENAI_API_KEY`,
+        // `ANTHROPIC_API_KEY` or the configured `Authorization` value attached on the way out.
+        // The invocation credential proves the caller is the agent this run launched; it is not
+        // an authorization to export a secret this gateway holds to an address the caller chose.
+        //
+        // Source credentials are deliberately left in place, unlike the intercept-named
+        // `ExplicitTarget` path that strips them: pi sends the provider's own key for the
+        // provider it named, and that is the credential the request is supposed to travel with.
+        authorization.allow_environment_provider_auth = false;
+    }
     parts.headers = super::routes::strip_replaceable_agent_auth_headers(
         &parts.headers,
         provider,

--- a/crates/cli/src/gateway/request.rs
+++ b/crates/cli/src/gateway/request.rs
@@ -33,6 +33,11 @@ pub(super) struct PreparedGatewayRequest {
     pub(super) request_json: Value,
     pub(super) streaming: bool,
     pub(super) authorization: crate::provider_auth::ProviderRequestAuthorization,
+    /// Whether the destination came from the caller rather than from configuration.
+    ///
+    /// Carried through to dispatch because such a request must not follow redirects: the
+    /// validation applies to the URL that was named, and a redirect names a different one.
+    pub(super) client_named_upstream: bool,
 }
 
 pub(super) async fn prepare_gateway_request(
@@ -134,6 +139,7 @@ pub(super) async fn prepare_gateway_request(
         request_json,
         streaming,
         authorization,
+        client_named_upstream: named_by_client,
     })
 }
 

--- a/crates/cli/src/gateway/request.rs
+++ b/crates/cli/src/gateway/request.rs
@@ -60,6 +60,10 @@ pub(super) async fn prepare_gateway_request(
         .path_and_query()
         .map(|path| path.as_str())
         .unwrap_or(parts.uri.path());
+    // Agent-implied routing first, so an existing harness override keeps its exact behavior; a
+    // request that names its own upstream is consulted only when nothing else claimed the route.
+    // The two cannot both apply in practice -- one is inferred from a ChatGPT token, the other is
+    // sent by the pi extension -- so the order records precedence rather than resolving a clash.
     let upstream_url = gateway_upstream_url_override(
         provider,
         &parts.headers,
@@ -67,6 +71,14 @@ pub(super) async fn prepare_gateway_request(
         authorization.allow_environment_provider_auth,
         config,
     )
+    .or_else(|| {
+        super::routes::client_named_upstream_url(
+            provider,
+            &parts.headers,
+            path_and_query,
+            authorization.source_credential.is_relay_proxy_credential(),
+        )
+    })
     .unwrap_or_else(|| provider.upstream_url(config, path_and_query));
     parts.headers = super::routes::strip_replaceable_agent_auth_headers(
         &parts.headers,

--- a/crates/cli/src/gateway/request.rs
+++ b/crates/cli/src/gateway/request.rs
@@ -65,24 +65,36 @@ pub(super) async fn prepare_gateway_request(
     // The two cannot both apply in practice -- one is inferred from a ChatGPT token, the other is
     // sent by the pi extension -- so the order records precedence rather than resolving a clash.
     let mut named_by_client = false;
-    let upstream_url = gateway_upstream_url_override(
+    let agent_override = gateway_upstream_url_override(
         provider,
         &parts.headers,
         path_and_query,
         authorization.allow_environment_provider_auth,
         config,
-    )
-    .or_else(|| {
-        let named = super::routes::client_named_upstream_url(
+    );
+    let upstream_url = match agent_override {
+        Some(url) => url,
+        None => match super::routes::client_named_upstream_url(
             provider,
             &parts.headers,
             path_and_query,
             authorization.source_credential.is_relay_proxy_credential(),
-        );
-        named_by_client = named.is_some();
-        named
-    })
-    .unwrap_or_else(|| provider.upstream_url(config, path_and_query));
+        ) {
+            crate::agents::pi::alignment::NamedUpstream::Named(url) => {
+                named_by_client = true;
+                url
+            }
+            // Refuse rather than reroute. The caller registered this gateway as its provider and
+            // is sending a prompt and a provider credential meant for the endpoint it named;
+            // falling back to the configured upstream would deliver both to a different company.
+            crate::agents::pi::alignment::NamedUpstream::Rejected(reason) => {
+                return Err(CliError::InvalidPayload(reason.to_string()));
+            }
+            crate::agents::pi::alignment::NamedUpstream::Absent => {
+                provider.upstream_url(config, path_and_query)
+            }
+        },
+    };
     if named_by_client {
         // A client-named destination gets only the credentials the client itself sent.
         //

--- a/crates/cli/src/gateway/response.rs
+++ b/crates/cli/src/gateway/response.rs
@@ -63,6 +63,10 @@ pub(super) fn should_forward_request_header(name: &HeaderName, headers: &HeaderM
         && name != http::header::CONTENT_LENGTH
         && name.as_str() != BOOTSTRAP_CLIENT_TOKEN_HEADER
         && name.as_str() != crate::provider_auth::TRANSPARENT_PROXY_CREDENTIAL_HEADER
+        // A routing directive addressed to this gateway, not to the provider. Forwarding it would
+        // tell the upstream which endpoint we were steered to, which is infrastructure detail it
+        // has no use for, and it is meaningless to every provider API.
+        && name.as_str() != crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER
         // Strip Accept-Encoding so upstreams return identity-encoded bodies; otherwise the
         // observability capture (`output.value` on LLM spans, ATIF trajectory bodies) records
         // gzip/br/zstd bytes that downstream consumers can't read. Bandwidth cost is paid only

--- a/crates/cli/src/gateway/routes.rs
+++ b/crates/cli/src/gateway/routes.rs
@@ -214,6 +214,23 @@ pub(super) fn gateway_upstream_url_override(
     )
 }
 
+// The upstream this request names for itself, composed with the request path.
+//
+// Separate from `gateway_upstream_url_override` because the two answer different questions: that
+// one asks alignment which upstream a *harness* implies, from evidence the client did not choose
+// (a ChatGPT token's shape); this one is the client stating a destination outright, which is only
+// honored when it proved it is this invocation's own agent. Composition stays here so the OpenAI
+// `/v1` normalization has one home.
+pub(super) fn client_named_upstream_url(
+    route: ProviderRoute,
+    headers: &HeaderMap,
+    path_and_query: &str,
+    invocation_authenticated: bool,
+) -> Option<String> {
+    crate::agents::pi::alignment::client_named_upstream_base(headers, invocation_authenticated)
+        .map(|base| route.upstream_url_with_base(&base, path_and_query))
+}
+
 pub(super) fn gateway_upstream_url_override_with_openai_key_state(
     route: ProviderRoute,
     headers: &HeaderMap,

--- a/crates/cli/src/gateway/routes.rs
+++ b/crates/cli/src/gateway/routes.rs
@@ -221,14 +221,35 @@ pub(super) fn gateway_upstream_url_override(
 // (a ChatGPT token's shape); this one is the client stating a destination outright, which is only
 // honored when it proved it is this invocation's own agent. Composition stays here so the OpenAI
 // `/v1` normalization has one home.
+// Composed by plain concatenation, deliberately *not* through `upstream_url_with_base`.
+//
+// That helper normalizes `/v1` for a *configured* base, where the operator may or may not have
+// included it and Relay has to reconcile the two. A named base is not that: it is the endpoint
+// the client would otherwise have called itself, and the path is the one its own SDK produced.
+// Reconciling them changes the destination. Concretely, Relay registers its root as pi's base,
+// so pi's OpenAI SDK sends `/chat/completions`; normalizing that against a base of
+// `https://api.example.com` yields `https://api.example.com/v1/chat/completions`, while pi
+// unredirected would have called `https://api.example.com/chat/completions`. Bases that already
+// end in `/v1` hide the difference, which is why it survived a live run against one.
 pub(super) fn client_named_upstream_url(
     route: ProviderRoute,
     headers: &HeaderMap,
     path_and_query: &str,
     invocation_authenticated: bool,
-) -> Option<String> {
-    crate::agents::pi::alignment::client_named_upstream_base(headers, invocation_authenticated)
-        .map(|base| route.upstream_url_with_base(&base, path_and_query))
+) -> crate::agents::pi::alignment::NamedUpstream {
+    let _ = route;
+    match crate::agents::pi::alignment::client_named_upstream_base(
+        headers,
+        invocation_authenticated,
+    ) {
+        crate::agents::pi::alignment::NamedUpstream::Named(base) => {
+            crate::agents::pi::alignment::NamedUpstream::Named(format!(
+                "{}{path_and_query}",
+                base.trim_end_matches('/')
+            ))
+        }
+        other => other,
+    }
 }
 
 pub(super) fn gateway_upstream_url_override_with_openai_key_state(

--- a/crates/cli/src/provider_auth.rs
+++ b/crates/cli/src/provider_auth.rs
@@ -140,6 +140,15 @@ impl SourceCredentialDisposition {
         }
     }
 
+    /// Whether this request proved it belongs to the invocation that started this gateway.
+    ///
+    /// The launcher mints the credential per run and hands it only to the process it starts, so
+    /// this is the question to ask before honoring anything a client asks the gateway to *do*
+    /// rather than merely send -- naming an upstream, for one.
+    pub(crate) const fn is_relay_proxy_credential(self) -> bool {
+        matches!(self, Self::RelayProxyCredential { .. })
+    }
+
     pub(crate) const fn provider_credential_present(self) -> bool {
         match self {
             Self::RelayProxyCredential {

--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -58,6 +58,8 @@ pub(crate) struct AppState {
     pub(crate) transparent_proxy_credential:
         Option<crate::provider_auth::TransparentProxyCredential>,
     pub(crate) http: Client,
+    /// Client for caller-named destinations; does not follow redirects. See `upstream_client`.
+    pub(crate) http_no_redirect: Client,
     pub(crate) sessions: SessionManager,
     pub(crate) last_activity: Arc<Mutex<Instant>>,
     pub(crate) bootstrap_shutdown: Option<BootstrapShutdown>,
@@ -511,6 +513,20 @@ impl AppState {
             .read_timeout(HTTP_READ_TIMEOUT)
             .build()
             .expect("gateway HTTP client configuration is valid");
+        // A second client for destinations the caller named, which must not follow redirects.
+        //
+        // Validation applies to the URL that was named; a redirect names a different one, and
+        // reqwest would follow up to ten of them. Its sensitive-header stripping does not help
+        // here either -- it covers `Authorization` across origins, and provider keys travel in
+        // `x-api-key` and friends, which are ordinary headers to it. So a validated `https`
+        // endpoint could 307 a caller's provider key to any host, including over plain http.
+        let http_no_redirect = Client::builder()
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .read_timeout(HTTP_READ_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("gateway HTTP client configuration is valid");
         Self {
             config,
             bootstrap_fingerprint,
@@ -518,6 +534,7 @@ impl AppState {
             require_provider_client_token,
             transparent_proxy_credential,
             http,
+            http_no_redirect,
             sessions,
             last_activity: Arc::new(Mutex::new(Instant::now())),
             bootstrap_shutdown,

--- a/crates/cli/tests/coverage/agents/pi_alignment_tests.rs
+++ b/crates/cli/tests/coverage/agents/pi_alignment_tests.rs
@@ -139,3 +139,25 @@ fn a_remote_upstream_must_use_https() {
         Some("https://integrate.api.nvidia.com/v1")
     );
 }
+
+/// A base is a prefix and the request path is appended to it, so neither of these survives.
+///
+/// A query would land before the path, and a fragment would swallow it — everything after `#`
+/// is never sent to the server at all. Either one routes somewhere other than the endpoint the
+/// caller named, which is the failure this whole path exists to avoid.
+#[test]
+fn a_base_carrying_a_query_or_fragment_is_refused() {
+    for rejected in [
+        "https://provider.example/api?version=1",
+        "https://provider.example/api#section",
+        "https://provider.example/api?version=1#section",
+        // Empty but present still changes the composed URL.
+        "https://provider.example/api?",
+        "https://provider.example/api#",
+    ] {
+        assert!(
+            is_rejected(client_named_upstream_base(&headers_naming(rejected), true)),
+            "{rejected} cannot have a request path appended to it"
+        );
+    }
+}

--- a/crates/cli/tests/coverage/agents/pi_alignment_tests.rs
+++ b/crates/cli/tests/coverage/agents/pi_alignment_tests.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::http::{HeaderMap, HeaderValue};
+
+use super::*;
+
+fn headers_naming(upstream: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        UPSTREAM_BASE_URL_HEADER,
+        HeaderValue::from_str(upstream).expect("test upstream must be a legal header value"),
+    );
+    headers
+}
+
+#[test]
+fn an_authenticated_request_names_its_own_upstream() {
+    let headers = headers_naming("https://integrate.api.nvidia.com/v1");
+
+    assert_eq!(
+        client_named_upstream_base(&headers, true).as_deref(),
+        Some("https://integrate.api.nvidia.com/v1"),
+        "the base is returned as written, so an operator's path prefix survives"
+    );
+}
+
+/// The whole security boundary, stated as a test.
+///
+/// Without the invocation credential this is an unauthenticated local caller telling a gateway
+/// where to send traffic that carries provider keys. It has to read as absent, not as an error,
+/// so the request still completes against the configured upstream.
+#[test]
+fn an_unauthenticated_request_cannot_name_an_upstream() {
+    let headers = headers_naming("https://integrate.api.nvidia.com/v1");
+
+    assert_eq!(client_named_upstream_base(&headers, false), None);
+}
+
+#[test]
+fn a_request_without_the_header_names_nothing() {
+    assert_eq!(client_named_upstream_base(&HeaderMap::new(), true), None);
+}
+
+#[test]
+fn a_blank_header_names_nothing() {
+    assert_eq!(
+        client_named_upstream_base(&headers_naming("   "), true),
+        None
+    );
+}
+
+/// Each of these would reach somewhere the caller should not be able to send credentialed traffic.
+#[test]
+fn only_absolute_http_urls_with_a_bare_host_are_accepted() {
+    for rejected in [
+        // Resolves against the gateway itself rather than naming a destination.
+        "/v1/chat/completions",
+        "api.openai.com/v1",
+        // Non-http schemes reqwest treats very differently.
+        "file:///etc/passwd",
+        "ftp://example.com",
+        // Credentials in the authority would travel to whatever host follows them.
+        "https://user:secret@example.com/v1",
+        "https://user@example.com/v1",
+        // Parses, but there is no host to forward to.
+        "https://",
+    ] {
+        assert_eq!(
+            client_named_upstream_base(&headers_naming(rejected), true),
+            None,
+            "{rejected} must not be accepted as an upstream"
+        );
+    }
+}
+
+#[test]
+fn loopback_and_plain_http_upstreams_are_allowed() {
+    // A local model server or an on-prem proxy is a legitimate destination, and the credential
+    // already establishes that the caller is this invocation's own agent.
+    for accepted in ["http://127.0.0.1:8000/v1", "http://localhost:11434/v1"] {
+        assert_eq!(
+            client_named_upstream_base(&headers_naming(accepted), true).as_deref(),
+            Some(accepted)
+        );
+    }
+}

--- a/crates/cli/tests/coverage/agents/pi_alignment_tests.rs
+++ b/crates/cli/tests/coverage/agents/pi_alignment_tests.rs
@@ -74,14 +74,49 @@ fn only_absolute_http_urls_with_a_bare_host_are_accepted() {
     }
 }
 
+/// Cleartext is allowed only where it cannot leave the machine.
+///
+/// A local model server is exactly the kind of provider this feature exists to reach, and its
+/// traffic never touches a network, so requiring TLS there would cost the main use case
+/// without protecting anything.
 #[test]
-fn loopback_and_plain_http_upstreams_are_allowed() {
-    // A local model server or an on-prem proxy is a legitimate destination, and the credential
-    // already establishes that the caller is this invocation's own agent.
-    for accepted in ["http://127.0.0.1:8000/v1", "http://localhost:11434/v1"] {
+fn loopback_upstreams_may_use_plain_http() {
+    for accepted in [
+        "http://127.0.0.1:8000/v1",
+        "http://localhost:11434/v1",
+        "http://[::1]:8000/v1",
+        "http://127.2.3.4:8000/v1",
+    ] {
         assert_eq!(
             client_named_upstream_base(&headers_naming(accepted), true).as_deref(),
-            Some(accepted)
+            Some(accepted),
+            "{accepted} is unreachable from off the machine and must be allowed"
         );
     }
+}
+
+/// The named destination is forwarded the provider credential the request carried, so plain
+/// `http` to anywhere reachable would put that key on the wire in the clear.
+#[test]
+fn a_remote_upstream_must_use_https() {
+    for rejected in [
+        "http://integrate.api.nvidia.com/v1",
+        "http://192.168.1.10:8000/v1",
+        "http://example.com/v1",
+        // Reserved for loopback by RFC 6761, but it still resolves through the host's resolver.
+        "http://ollama.localhost/v1",
+    ] {
+        assert_eq!(
+            client_named_upstream_base(&headers_naming(rejected), true),
+            None,
+            "{rejected} would carry a provider credential in cleartext off the machine"
+        );
+    }
+
+    // The same hosts over TLS are fine.
+    assert_eq!(
+        client_named_upstream_base(&headers_naming("https://integrate.api.nvidia.com/v1"), true)
+            .as_deref(),
+        Some("https://integrate.api.nvidia.com/v1")
+    );
 }

--- a/crates/cli/tests/coverage/agents/pi_alignment_tests.rs
+++ b/crates/cli/tests/coverage/agents/pi_alignment_tests.rs
@@ -5,6 +5,18 @@ use axum::http::{HeaderMap, HeaderValue};
 
 use super::*;
 
+/// The base a decision names, or `None` for anything that is not a usable destination.
+fn named(decision: NamedUpstream) -> Option<String> {
+    match decision {
+        NamedUpstream::Named(base) => Some(base),
+        _ => None,
+    }
+}
+
+fn is_rejected(decision: NamedUpstream) -> bool {
+    matches!(decision, NamedUpstream::Rejected(_))
+}
+
 fn headers_naming(upstream: &str) -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -19,7 +31,7 @@ fn an_authenticated_request_names_its_own_upstream() {
     let headers = headers_naming("https://integrate.api.nvidia.com/v1");
 
     assert_eq!(
-        client_named_upstream_base(&headers, true).as_deref(),
+        named(client_named_upstream_base(&headers, true)).as_deref(),
         Some("https://integrate.api.nvidia.com/v1"),
         "the base is returned as written, so an operator's path prefix survives"
     );
@@ -34,20 +46,26 @@ fn an_authenticated_request_names_its_own_upstream() {
 fn an_unauthenticated_request_cannot_name_an_upstream() {
     let headers = headers_naming("https://integrate.api.nvidia.com/v1");
 
-    assert_eq!(client_named_upstream_base(&headers, false), None);
+    assert!(matches!(
+        client_named_upstream_base(&headers, false),
+        NamedUpstream::Absent
+    ));
 }
 
 #[test]
 fn a_request_without_the_header_names_nothing() {
-    assert_eq!(client_named_upstream_base(&HeaderMap::new(), true), None);
+    assert!(matches!(
+        client_named_upstream_base(&HeaderMap::new(), true),
+        NamedUpstream::Absent
+    ));
 }
 
 #[test]
 fn a_blank_header_names_nothing() {
-    assert_eq!(
-        client_named_upstream_base(&headers_naming("   "), true),
-        None
-    );
+    assert!(is_rejected(client_named_upstream_base(
+        &headers_naming("   "),
+        true
+    )));
 }
 
 /// Each of these would reach somewhere the caller should not be able to send credentialed traffic.
@@ -66,10 +84,9 @@ fn only_absolute_http_urls_with_a_bare_host_are_accepted() {
         // Parses, but there is no host to forward to.
         "https://",
     ] {
-        assert_eq!(
-            client_named_upstream_base(&headers_naming(rejected), true),
-            None,
-            "{rejected} must not be accepted as an upstream"
+        assert!(
+            is_rejected(client_named_upstream_base(&headers_naming(rejected), true)),
+            "{rejected} must be refused, not silently ignored"
         );
     }
 }
@@ -88,7 +105,7 @@ fn loopback_upstreams_may_use_plain_http() {
         "http://127.2.3.4:8000/v1",
     ] {
         assert_eq!(
-            client_named_upstream_base(&headers_naming(accepted), true).as_deref(),
+            named(client_named_upstream_base(&headers_naming(accepted), true)).as_deref(),
             Some(accepted),
             "{accepted} is unreachable from off the machine and must be allowed"
         );
@@ -106,17 +123,19 @@ fn a_remote_upstream_must_use_https() {
         // Reserved for loopback by RFC 6761, but it still resolves through the host's resolver.
         "http://ollama.localhost/v1",
     ] {
-        assert_eq!(
-            client_named_upstream_base(&headers_naming(rejected), true),
-            None,
+        assert!(
+            is_rejected(client_named_upstream_base(&headers_naming(rejected), true)),
             "{rejected} would carry a provider credential in cleartext off the machine"
         );
     }
 
     // The same hosts over TLS are fine.
     assert_eq!(
-        client_named_upstream_base(&headers_naming("https://integrate.api.nvidia.com/v1"), true)
-            .as_deref(),
+        named(client_named_upstream_base(
+            &headers_naming("https://integrate.api.nvidia.com/v1"),
+            true
+        ))
+        .as_deref(),
         Some("https://integrate.api.nvidia.com/v1")
     );
 }

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -20,6 +20,15 @@ fn test_http_client() -> Client {
     Client::new()
 }
 
+/// Mirrors the production client used for caller-named destinations.
+fn test_http_client_no_redirect() -> Client {
+    crate::test_support::enable_operational_logs();
+    Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("test client configuration is valid")
+}
+
 fn environment_authorization() -> crate::provider_auth::ProviderRequestAuthorization {
     crate::provider_auth::ProviderRequestAuthorization {
         source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
@@ -1080,6 +1089,7 @@ async fn streaming_provider_error_does_not_poison_the_next_request() {
             source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
             allow_environment_provider_auth: false,
         },
+        client_named_upstream: false,
     };
     let func = build_streaming_func(
         state,
@@ -1149,6 +1159,7 @@ async fn buffered_body_read_failure_stays_structured() {
             source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
             allow_environment_provider_auth: false,
         },
+        client_named_upstream: false,
     };
     let func = build_buffered_func(
         state,
@@ -1201,6 +1212,7 @@ async fn buffered_invalid_json_becomes_safe_upstream_failure() {
             source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
             allow_environment_provider_auth: false,
         },
+        client_named_upstream: false,
     };
     let func = build_buffered_func(
         state,
@@ -1400,6 +1412,7 @@ fn build_llm_gateway_start_uses_alignment_identifiers_and_metadata() {
             source_credential: crate::provider_auth::SourceCredentialDisposition::Absent,
             allow_environment_provider_auth: true,
         },
+        client_named_upstream: false,
     };
 
     let start = build_llm_gateway_start(&prepared);
@@ -1978,6 +1991,7 @@ async fn passthrough_rejects_unsupported_provider_path_directly() {
         require_provider_client_token: false,
         transparent_proxy_credential: None,
         http: test_http_client(),
+        http_no_redirect: test_http_client_no_redirect(),
         sessions: SessionManager::new(config),
         last_activity: std::sync::Arc::new(std::sync::Mutex::new(std::time::Instant::now())),
         bootstrap_shutdown: None,
@@ -2016,6 +2030,7 @@ async fn models_rejects_non_get_requests_directly() {
         require_provider_client_token: false,
         transparent_proxy_credential: None,
         http: test_http_client(),
+        http_no_redirect: test_http_client_no_redirect(),
         sessions: SessionManager::new(config),
         last_activity: std::sync::Arc::new(std::sync::Mutex::new(std::time::Instant::now())),
         bootstrap_shutdown: None,
@@ -2413,6 +2428,7 @@ async fn models_refuses_an_unusable_named_upstream() {
             crate::provider_auth::TransparentProxyCredential::from_static("nrp_models_named"),
         ),
         http: test_http_client(),
+        http_no_redirect: test_http_client_no_redirect(),
         sessions: SessionManager::new(config),
         last_activity: std::sync::Arc::new(std::sync::Mutex::new(std::time::Instant::now())),
         bootstrap_shutdown: None,

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -2383,3 +2383,62 @@ fn a_refused_named_upstream_is_rejected_rather_than_rerouted() {
         crate::agents::pi::alignment::NamedUpstream::Rejected(_)
     ));
 }
+
+/// The `/v1/models` route resolves a named upstream too, so it has to refuse one the same way.
+///
+/// Covered separately from the passthrough path because it is a second, hand-rolled copy of the
+/// same resolution: it does not share `prepare_gateway_request`, so a fix applied only there
+/// would leave this route silently rerouting to the configured provider.
+#[tokio::test]
+async fn models_refuses_an_unusable_named_upstream() {
+    let config = GatewayConfig {
+        bind: "127.0.0.1:0".parse().unwrap(),
+        // Nothing must reach this. If the refusal fell back to configured routing, the request
+        // would be sent here instead of failing.
+        openai_base_url: "http://127.0.0.1:1".into(),
+        openai_auth_header: None,
+        anthropic_base_url: "http://127.0.0.1:1".into(),
+        anthropic_auth_header: None,
+        metadata: None,
+        plugin_config: None,
+        max_hook_payload_bytes: crate::configuration::DEFAULT_MAX_HOOK_PAYLOAD_BYTES,
+        max_passthrough_body_bytes: crate::configuration::DEFAULT_MAX_PASSTHROUGH_BODY_BYTES,
+    };
+    let state = AppState {
+        config: config.clone(),
+        bootstrap_fingerprint: None,
+        bootstrap_challenge_key: None,
+        require_provider_client_token: false,
+        transparent_proxy_credential: Some(
+            crate::provider_auth::TransparentProxyCredential::from_static("nrp_models_named"),
+        ),
+        http: test_http_client(),
+        sessions: SessionManager::new(config),
+        last_activity: std::sync::Arc::new(std::sync::Mutex::new(std::time::Instant::now())),
+        bootstrap_shutdown: None,
+        instance_id: "test-instance".into(),
+        bootstrap_tls: None,
+        local_address: None,
+    };
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/v1/models")
+        .header(
+            crate::provider_auth::TRANSPARENT_PROXY_CREDENTIAL_HEADER,
+            "nrp_models_named",
+        )
+        // Plain http to a host that is not loopback: refused.
+        .header(
+            crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
+            "http://onprem.example.com/v1",
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let error = models(State(state), request).await.unwrap_err();
+
+    assert!(
+        matches!(error, crate::error::CliError::InvalidPayload(_)),
+        "a named destination that cannot be used must fail the request: {error}"
+    );
+}

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -2289,23 +2289,54 @@ fn the_client_named_upstream_header_is_not_forwarded_upstream() {
 /// A named upstream is composed with the request path by the same code that composes a
 /// configured one, so an operator's `/v1` prefix is not doubled.
 #[test]
-fn a_named_upstream_composes_through_the_route() {
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
-        HeaderValue::from_static("https://integrate.api.nvidia.com/v1"),
-    );
+fn a_named_upstream_is_the_destination_the_client_would_have_called() {
+    // Relay registers its own root as pi's base, so pi's OpenAI SDK sends `/chat/completions`.
+    // The named base is joined to that path untouched: the point is to reach the endpoint the
+    // client would have reached on its own, and `/v1` reconciliation is a rule for *configured*
+    // bases, where the operator may or may not have included it.
+    for (base, expected) in [
+        // Already carries `/v1`, as pi's NVIDIA catalog entry does.
+        (
+            "https://integrate.api.nvidia.com/v1",
+            "https://integrate.api.nvidia.com/v1/chat/completions",
+        ),
+        // Does not. Normalizing would send this to `/v1/chat/completions`, which is not where
+        // pi would have gone.
+        (
+            "https://api.example.com",
+            "https://api.example.com/chat/completions",
+        ),
+        // A trailing slash must not double up.
+        (
+            "https://api.example.com/",
+            "https://api.example.com/chat/completions",
+        ),
+        // A base with its own path prefix keeps it.
+        (
+            "https://api.example.com/inference/v1",
+            "https://api.example.com/inference/v1/chat/completions",
+        ),
+    ] {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
+            HeaderValue::from_str(base).unwrap(),
+        );
 
-    assert_eq!(
-        crate::gateway::routes::client_named_upstream_url(
+        let named = crate::gateway::routes::client_named_upstream_url(
             crate::gateway::routes::ProviderRoute::OpenAiChatCompletions,
             &headers,
-            "/v1/chat/completions",
+            "/chat/completions",
             true,
-        )
-        .as_deref(),
-        Some("https://integrate.api.nvidia.com/v1/chat/completions")
-    );
+        );
+        assert!(
+            matches!(
+                &named,
+                crate::agents::pi::alignment::NamedUpstream::Named(url) if url == expected
+            ),
+            "{base} should reach {expected}"
+        );
+    }
 }
 
 /// The gateway falls back to configured routing rather than failing, so an unauthenticated
@@ -2318,13 +2349,37 @@ fn an_unauthenticated_caller_gets_no_named_upstream() {
         HeaderValue::from_static("https://integrate.api.nvidia.com/v1"),
     );
 
-    assert_eq!(
+    assert!(matches!(
         crate::gateway::routes::client_named_upstream_url(
             crate::gateway::routes::ProviderRoute::OpenAiChatCompletions,
             &headers,
-            "/v1/chat/completions",
+            "/chat/completions",
             false,
         ),
-        None
+        crate::agents::pi::alignment::NamedUpstream::Absent
+    ));
+}
+
+/// A destination that is named but refused must not fall back to configured routing.
+///
+/// The caller registered this gateway as its provider and is sending a prompt and a provider
+/// credential meant for the endpoint it named. Treating a refusal like an absent header would
+/// forward both to the configured OpenAI or Anthropic upstream -- a different company.
+#[test]
+fn a_refused_named_upstream_is_rejected_rather_than_rerouted() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
+        HeaderValue::from_static("http://onprem.example.com/v1"),
     );
+
+    assert!(matches!(
+        crate::gateway::routes::client_named_upstream_url(
+            crate::gateway::routes::ProviderRoute::OpenAiChatCompletions,
+            &headers,
+            "/chat/completions",
+            true,
+        ),
+        crate::agents::pi::alignment::NamedUpstream::Rejected(_)
+    ));
 }

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -2271,3 +2271,60 @@ async fn streaming_body_records_final_response_for_turn_output() {
 // `llm_stream_call_execute`. The runtime now owns stream-end lifecycle (start/end events emitted
 // by `LlmStreamWrapper`); core tests cover that contract, and the gateway no longer carries a
 // stream preview/truncation helper.
+
+/// A routing directive addressed to this gateway must not travel to the provider.
+///
+/// It names infrastructure and means nothing to any provider API, so forwarding it would be
+/// leaking a detail of our own deployment into a third party's request log.
+#[test]
+fn the_client_named_upstream_header_is_not_forwarded_upstream() {
+    let headers = HeaderMap::new();
+
+    assert!(!should_forward_request_header(
+        &HeaderName::from_static(crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER),
+        &headers
+    ));
+}
+
+/// A named upstream is composed with the request path by the same code that composes a
+/// configured one, so an operator's `/v1` prefix is not doubled.
+#[test]
+fn a_named_upstream_composes_through_the_route() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
+        HeaderValue::from_static("https://integrate.api.nvidia.com/v1"),
+    );
+
+    assert_eq!(
+        crate::gateway::routes::client_named_upstream_url(
+            crate::gateway::routes::ProviderRoute::OpenAiChatCompletions,
+            &headers,
+            "/v1/chat/completions",
+            true,
+        )
+        .as_deref(),
+        Some("https://integrate.api.nvidia.com/v1/chat/completions")
+    );
+}
+
+/// The gateway falls back to configured routing rather than failing, so an unauthenticated
+/// caller simply does not get a say.
+#[test]
+fn an_unauthenticated_caller_gets_no_named_upstream() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
+        HeaderValue::from_static("https://integrate.api.nvidia.com/v1"),
+    );
+
+    assert_eq!(
+        crate::gateway::routes::client_named_upstream_url(
+            crate::gateway::routes::ProviderRoute::OpenAiChatCompletions,
+            &headers,
+            "/v1/chat/completions",
+            false,
+        ),
+        None
+    );
+}

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -5574,3 +5574,74 @@ async fn a_refused_named_upstream_never_reaches_the_configured_provider() {
         "the configured provider must never see a prompt addressed to somewhere else"
     );
 }
+
+/// A named destination must not be able to hand the request onward via a redirect.
+///
+/// Validation applies to the URL that was named. A `307` names a different one, and reqwest
+/// would follow up to ten of them — carrying the caller's provider key to a host nothing
+/// checked, possibly over plain `http`, which the named URL itself would have been refused for.
+/// Its own sensitive-header stripping does not cover this: that guards `Authorization` across
+/// origins, and provider keys travel in `x-api-key` and friends, which are ordinary headers.
+#[tokio::test]
+async fn a_named_upstream_redirect_is_not_followed() {
+    // Where the redirect points. Nothing may arrive here.
+    let redirect_target = spawn_named_upstream(completion_body("redirect target answered")).await;
+
+    let hops = Arc::new(Mutex::new(0_usize));
+    let counter = hops.clone();
+    let location = format!("{}/v1/chat/completions", redirect_target.server.url());
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move || {
+            let counter = counter.clone();
+            let location = location.clone();
+            async move {
+                *counter.lock().unwrap() += 1;
+                (
+                    StatusCode::TEMPORARY_REDIRECT,
+                    [(header::LOCATION, location)],
+                )
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let redirector = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let mut config = test_config();
+    config.openai_base_url = "http://127.0.0.1:1".into();
+
+    let mut request = named_upstream_request(
+        &format!("http://{address}"),
+        Some("nrp_named_upstream"),
+        "follow me somewhere else",
+    );
+    request.headers_mut().insert(
+        "x-api-key",
+        HeaderValue::from_static("callers-own-provider-key"),
+    );
+
+    let response = router_for_launched_session(config, "nrp_named_upstream")
+        .oneshot(request)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        *hops.lock().unwrap(),
+        1,
+        "the named upstream itself should have been called exactly once"
+    );
+    assert!(
+        redirect_target.credentials.lock().unwrap().is_empty(),
+        "the redirect target must never be contacted, and must never see the caller's key"
+    );
+    assert_eq!(
+        response.status(),
+        StatusCode::TEMPORARY_REDIRECT,
+        "the redirect is surfaced to the caller rather than followed"
+    );
+
+    redirector.abort();
+}

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -5182,15 +5182,23 @@ async fn pi_tool_call_hook_omits_the_transform_when_nothing_rewrote_the_argument
 struct NamedUpstream {
     server: TestServer,
     routing_headers: Arc<Mutex<Vec<Option<String>>>>,
+    /// Every credential-bearing header the provider actually received, per request.
+    ///
+    /// Recorded so a test can assert on what a named destination is *given*, not only on where
+    /// the request went. Naming a host must not also hand it a secret this gateway holds.
+    credentials: Arc<Mutex<Vec<Vec<String>>>>,
 }
 
 async fn spawn_named_upstream(body: Value) -> NamedUpstream {
     let routing_headers = Arc::new(Mutex::new(Vec::new()));
+    let credentials = Arc::new(Mutex::new(Vec::new()));
     let recorder = routing_headers.clone();
+    let credential_recorder = credentials.clone();
     let app = Router::new().route(
         "/v1/chat/completions",
         post(move |headers: HeaderMap| {
             let recorder = recorder.clone();
+            let credential_recorder = credential_recorder.clone();
             let body = body.clone();
             async move {
                 recorder.lock().unwrap().push(
@@ -5199,6 +5207,13 @@ async fn spawn_named_upstream(body: Value) -> NamedUpstream {
                         .and_then(|value| value.to_str().ok())
                         .map(ToOwned::to_owned),
                 );
+                let seen: Vec<String> =
+                    ["authorization", "x-api-key", "api-key", "anthropic-api-key"]
+                        .into_iter()
+                        .filter(|name| headers.contains_key(*name))
+                        .map(ToOwned::to_owned)
+                        .collect();
+                credential_recorder.lock().unwrap().push(seen);
                 Json(body)
             }
         }),
@@ -5214,6 +5229,7 @@ async fn spawn_named_upstream(body: Value) -> NamedUpstream {
             handle,
         },
         routing_headers,
+        credentials,
     }
 }
 
@@ -5434,5 +5450,73 @@ async fn model_call_policy_still_applies_on_a_named_upstream() {
     assert!(
         upstream.routing_headers.lock().unwrap().is_empty(),
         "a refused call must never reach the provider"
+    );
+}
+
+/// Naming a destination must not also be a way to obtain a credential for it.
+///
+/// Environment and configured provider auth exist for the upstream this gateway was configured
+/// for, and injection fires precisely when the request carries none of its own -- so a request
+/// that both names a host and sends no credential is exactly the shape that would have carried
+/// `OPENAI_API_KEY` or the configured `Authorization` value out to an address the caller chose.
+/// The invocation credential proves who the caller is; it does not authorize exporting a secret
+/// this gateway holds.
+#[tokio::test]
+async fn a_named_upstream_never_receives_a_gateway_held_credential() {
+    let upstream = spawn_named_upstream(completion_body("named upstream answered")).await;
+    let mut config = test_config();
+    config.openai_base_url = "http://127.0.0.1:1".into();
+    // The secret this gateway would otherwise attach to an unauthenticated request.
+    config.openai_auth_header = Some("Bearer gateway-held-secret".into());
+
+    let response = router_for_launched_session(config, "nrp_named_upstream")
+        .oneshot(named_upstream_request(
+            &upstream.server.url(),
+            Some("nrp_named_upstream"),
+            "name a host while sending no credential of my own",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        *upstream.credentials.lock().unwrap(),
+        vec![Vec::<String>::new()],
+        "the named provider must receive no credential the caller did not send itself"
+    );
+}
+
+/// The other half of the same rule: a credential the caller *did* send still travels.
+///
+/// Without this the fix would read as "named upstreams are unauthenticated", which would break
+/// the feature -- pi sends the provider's own key for the provider it named, and that is the
+/// credential the request is supposed to carry.
+#[tokio::test]
+async fn a_named_upstream_still_receives_the_callers_own_credential() {
+    let upstream = spawn_named_upstream(completion_body("named upstream answered")).await;
+    let mut config = test_config();
+    config.openai_base_url = "http://127.0.0.1:1".into();
+    config.openai_auth_header = Some("Bearer gateway-held-secret".into());
+
+    let mut request = named_upstream_request(
+        &upstream.server.url(),
+        Some("nrp_named_upstream"),
+        "name a host and send my own provider key",
+    );
+    request.headers_mut().insert(
+        header::AUTHORIZATION,
+        HeaderValue::from_static("Bearer callers-own-provider-key"),
+    );
+
+    let response = router_for_launched_session(config, "nrp_named_upstream")
+        .oneshot(request)
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        *upstream.credentials.lock().unwrap(),
+        vec![vec!["authorization".to_string()]],
+        "the caller's own provider credential must still reach the provider it named"
     );
 }

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -5258,7 +5258,11 @@ fn router_for_launched_session(config: GatewayConfig, credential: &'static str) 
 fn named_upstream_request(upstream: &str, credential: Option<&str>, prompt: &str) -> Request<Body> {
     let mut builder = Request::builder()
         .method("POST")
-        .uri("/v1/chat/completions")
+        // `/chat/completions`, not `/v1/chat/completions`: Relay registers its own root as pi's
+        // base URL, and pi's OpenAI SDK appends the bare path to whatever base it was given. The
+        // named base supplies the `/v1`, which is what makes the composed destination match the
+        // endpoint pi would have called unredirected.
+        .uri("/chat/completions")
         .header(header::CONTENT_TYPE, "application/json")
         .header(
             crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
@@ -5518,5 +5522,55 @@ async fn a_named_upstream_still_receives_the_callers_own_credential() {
         *upstream.credentials.lock().unwrap(),
         vec![vec!["authorization".to_string()]],
         "the caller's own provider credential must still reach the provider it named"
+    );
+}
+
+/// A refused destination must fail the request, not quietly become a different destination.
+///
+/// This is the shape that matters: pi registered this gateway as its provider, so the prompt and
+/// the provider credential in flight were meant for the endpoint the caller named. Falling back
+/// to configured routing would hand both to whoever the gateway happens to be configured for.
+#[tokio::test]
+async fn a_refused_named_upstream_never_reaches_the_configured_provider() {
+    let configured = spawn_named_upstream(completion_body("configured upstream answered")).await;
+    let mut config = test_config();
+    config.openai_base_url = format!("{}/v1", configured.server.url());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/chat/completions")
+        .header(header::CONTENT_TYPE, "application/json")
+        // Plain http to a host that is not loopback: refused, and an on-prem provider is exactly
+        // who would be named this way.
+        .header(
+            crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
+            "http://onprem.example.com/v1",
+        )
+        .header(
+            crate::provider_auth::TRANSPARENT_PROXY_CREDENTIAL_HEADER,
+            "nrp_named_upstream",
+        )
+        .body(Body::from(
+            json!({
+                "model": "onprem/model",
+                "messages": [{ "role": "user", "content": "meant for the on-prem provider" }]
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = router_for_launched_session(config, "nrp_named_upstream")
+        .oneshot(request)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "a named destination that cannot be used must fail the request"
+    );
+    assert!(
+        configured.routing_headers.lock().unwrap().is_empty(),
+        "the configured provider must never see a prompt addressed to somewhere else"
     );
 }

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -5168,3 +5168,271 @@ async fn pi_tool_call_hook_omits_the_transform_when_nothing_rewrote_the_argument
     let body: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body, json!({}));
 }
+
+// ---------------------------------------------------------------------------
+// A launched pi session naming its own model upstream.
+//
+// The extension-side contract is asserted in `integrations/pi/test`; these cover the half
+// that only the gateway can answer -- that the named endpoint is actually forwarded to, that
+// an unauthenticated caller cannot move traffic, that the routing header does not travel to
+// the provider, and that model-call policy still applies on the named path.
+// ---------------------------------------------------------------------------
+
+/// Records what each request carried, so the assertions can be about the provider's view.
+struct NamedUpstream {
+    server: TestServer,
+    routing_headers: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+async fn spawn_named_upstream(body: Value) -> NamedUpstream {
+    let routing_headers = Arc::new(Mutex::new(Vec::new()));
+    let recorder = routing_headers.clone();
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move |headers: HeaderMap| {
+            let recorder = recorder.clone();
+            let body = body.clone();
+            async move {
+                recorder.lock().unwrap().push(
+                    headers
+                        .get(crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER)
+                        .and_then(|value| value.to_str().ok())
+                        .map(ToOwned::to_owned),
+                );
+                Json(body)
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    NamedUpstream {
+        server: TestServer {
+            url: format!("http://{address}"),
+            handle,
+        },
+        routing_headers,
+    }
+}
+
+fn completion_body(content: &str) -> Value {
+    json!({
+        "id": "chatcmpl-named",
+        "object": "chat.completion",
+        "model": "nvidia/nemotron-test",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": content },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 3, "completion_tokens": 5, "total_tokens": 8 }
+    })
+}
+
+/// A gateway that authenticates its client the way `nemo-relay run` does.
+fn router_for_launched_session(config: GatewayConfig, credential: &'static str) -> Router {
+    let mut state = AppState::new(config);
+    state.transparent_proxy_credential =
+        Some(crate::provider_auth::TransparentProxyCredential::from_static(credential));
+    router_with_state(state)
+}
+
+fn named_upstream_request(upstream: &str, credential: Option<&str>, prompt: &str) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(
+            crate::agents::pi::alignment::UPSTREAM_BASE_URL_HEADER,
+            format!("{upstream}/v1"),
+        );
+    if let Some(credential) = credential {
+        builder = builder.header(
+            crate::provider_auth::TRANSPARENT_PROXY_CREDENTIAL_HEADER,
+            credential,
+        );
+    }
+    builder
+        .body(Body::from(
+            json!({
+                "model": "nvidia/nemotron-test",
+                "messages": [{ "role": "user", "content": prompt }]
+            })
+            .to_string(),
+        ))
+        .unwrap()
+}
+
+/// The acceptance criterion: a provider the gateway does not statically front is reached, and
+/// the call is recorded as an LLM span rather than passing through unobserved.
+#[tokio::test]
+async fn a_named_upstream_is_forwarded_to_and_produces_an_llm_span() {
+    const SUBSCRIBER: &str = "pi-named-upstream-span-test";
+    let _ = deregister_subscriber(SUBSCRIBER);
+    let spans = Arc::new(Mutex::new(Vec::<String>::new()));
+    let recorder = spans.clone();
+    register_subscriber(
+        SUBSCRIBER,
+        Arc::new(move |event| {
+            if event.scope_category() == Some(ScopeCategory::End) {
+                recorder.lock().unwrap().push(event.name().to_string());
+            }
+        }),
+    )
+    .unwrap();
+
+    let upstream = spawn_named_upstream(completion_body("named upstream answered")).await;
+    let mut config = test_config();
+    // Nothing listens here. If the header were ignored, the request could not succeed, so a
+    // 200 is itself evidence that routing followed the header rather than the configuration.
+    config.openai_base_url = "http://127.0.0.1:1".into();
+
+    let response = router_for_launched_session(config, "nrp_named_upstream")
+        .oneshot(named_upstream_request(
+            &upstream.server.url(),
+            Some("nrp_named_upstream"),
+            "reach the named provider",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    assert_eq!(
+        body["choices"][0]["message"]["content"],
+        json!("named upstream answered"),
+        "the response must come from the named upstream"
+    );
+
+    // The routing header addresses the gateway, so the provider must never see it.
+    assert_eq!(
+        *upstream.routing_headers.lock().unwrap(),
+        vec![None],
+        "the routing header must be stripped before forwarding"
+    );
+
+    flush_subscribers().unwrap();
+    let names = spans.lock().unwrap().clone();
+    // The managed LLM span is named for the provider route it went through, so this is also
+    // an assertion that the call took the managed path rather than being proxied unobserved.
+    assert!(
+        names.iter().any(|name| name == "openai.chat_completions"),
+        "a named-upstream call must still be recorded as an LLM span: {names:?}"
+    );
+    deregister_subscriber(SUBSCRIBER).unwrap();
+}
+
+/// The security boundary, end to end, on the gateway anyone can reach.
+///
+/// A standalone `nemo-relay --bind` daemon mints no credential, so nothing can authenticate as
+/// its launcher and the header has to be inert: traffic goes where the operator configured it,
+/// not where the caller asked. This is the case the documentation promises stays static.
+#[tokio::test]
+async fn a_standalone_gateway_ignores_a_named_upstream() {
+    let configured = spawn_named_upstream(completion_body("configured upstream answered")).await;
+    let named = spawn_named_upstream(completion_body("named upstream answered")).await;
+    let mut config = test_config();
+    config.openai_base_url = format!("{}/v1", configured.server.url());
+
+    // `router` builds state without a transparent proxy credential, which is what a
+    // `--bind` daemon does.
+    let response = router(config)
+        .oneshot(named_upstream_request(
+            &named.server.url(),
+            None,
+            "try to move traffic without proving anything",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    assert_eq!(
+        body["choices"][0]["message"]["content"],
+        json!("configured upstream answered"),
+        "an unauthenticated header must not redirect the request"
+    );
+    assert!(
+        named.routing_headers.lock().unwrap().is_empty(),
+        "the upstream the caller named must never have been contacted"
+    );
+}
+
+/// On a launched gateway the boundary closes earlier still.
+///
+/// Holding a credential makes it mandatory, so an unauthenticated provider call is refused
+/// before routing is considered at all -- the header never gets a chance to be read. Worth
+/// pinning, because it is why the test above has to use a standalone gateway to prove the
+/// header is ignored rather than simply omitting the credential.
+#[tokio::test]
+async fn a_launched_gateway_refuses_an_unauthenticated_call_outright() {
+    let named = spawn_named_upstream(completion_body("must not be reached")).await;
+    let mut config = test_config();
+    config.openai_base_url = "http://127.0.0.1:1".into();
+
+    let response = router_for_launched_session(config, "nrp_named_upstream")
+        .oneshot(named_upstream_request(
+            &named.server.url(),
+            None,
+            "no credential at all",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        named.routing_headers.lock().unwrap().is_empty(),
+        "a refused call must never reach any provider"
+    );
+}
+
+/// Naming an upstream must not route around model-call policy: the point of redirecting is
+/// that these calls become governable, so a policy that blocks has to block here too.
+#[tokio::test]
+async fn model_call_policy_still_applies_on_a_named_upstream() {
+    const INTERCEPT: &str = "pi-named-upstream-policy-test";
+    let _ = deregister_llm_execution_intercept(INTERCEPT);
+    let _cleanup = LlmExecutionInterceptCleanup(INTERCEPT);
+    register_llm_execution_intercept(
+        INTERCEPT,
+        1,
+        Arc::new(move |_name, request, next| {
+            Box::pin(async move {
+                if request.content["messages"][0]["content"].as_str() == Some("blocked by policy") {
+                    return Err(nemo_relay::error::FlowError::GuardrailRejected(
+                        "model calls are refused by test policy".to_string(),
+                    ));
+                }
+                next(request).await
+            })
+        }),
+    )
+    .unwrap();
+
+    let upstream = spawn_named_upstream(completion_body("must not be reached")).await;
+    let mut config = test_config();
+    config.openai_base_url = "http://127.0.0.1:1".into();
+
+    let response = router_for_launched_session(config, "nrp_named_upstream")
+        .oneshot(named_upstream_request(
+            &upstream.server.url(),
+            Some("nrp_named_upstream"),
+            "blocked by policy",
+        ))
+        .await
+        .unwrap();
+
+    assert_ne!(
+        response.status(),
+        StatusCode::OK,
+        "a blocking model-call policy must refuse a named-upstream call"
+    );
+    assert!(
+        upstream.routing_headers.lock().unwrap().is_empty(),
+        "a refused call must never reach the provider"
+    );
+}

--- a/docs/nemo-relay-cli/pi.mdx
+++ b/docs/nemo-relay-cli/pi.mdx
@@ -433,6 +433,11 @@ reason, rather than falling back to the gateway's configured upstream. The
 request was addressed to the endpoint it named, and quietly sending it somewhere
 else would deliver the prompt and the provider key to a different provider.
 
+**Redirects from a named endpoint are not followed.** The checks above apply to
+the URL that was named; a redirect names a different one. A `3xx` is returned to
+pi as it is, so a provider that redirects to a canonical host has to be named at
+that host instead.
+
 A **standalone `nemo-relay --bind` daemon issues no credential**, so it ignores
 the header and keeps the static behavior below. Point it at a provider with
 `--openai-base-url` / `--anthropic-base-url`, or launch through the wrapper.

--- a/docs/nemo-relay-cli/pi.mdx
+++ b/docs/nemo-relay-cli/pi.mdx
@@ -428,6 +428,11 @@ credential travels to it, plain `http` to anything reachable from off the machin
 is refused. A local model server — `http://127.0.0.1:11434/v1` and the like — is
 allowed, since its traffic never reaches a network.
 
+**A named endpoint that cannot be used fails the request**, with `400` and a
+reason, rather than falling back to the gateway's configured upstream. The
+request was addressed to the endpoint it named, and quietly sending it somewhere
+else would deliver the prompt and the provider key to a different provider.
+
 A **standalone `nemo-relay --bind` daemon issues no credential**, so it ignores
 the header and keeps the static behavior below. Point it at a provider with
 `--openai-base-url` / `--anthropic-base-url`, or launch through the wrapper.

--- a/docs/nemo-relay-cli/pi.mdx
+++ b/docs/nemo-relay-cli/pi.mdx
@@ -426,18 +426,22 @@ the header and keeps the static behavior below. Point it at a provider with
 | Gateway forwards elsewhere | Redirected, naming the endpoint | Skipped (`upstream-mismatch`) |
 | Upstream unknown | Redirected, naming the endpoint | Skipped (`unknown-upstream`) |
 | Model's API has no gateway route | Skipped (`unserviceable-api`) | Skipped (`unserviceable-api`) |
-| The provider's models do not share one endpoint | Skipped (`provider-mixed-endpoints`) | Skipped (`provider-mixed-endpoints`) |
+| The provider's models do not share one endpoint | Redirected only if both upstreams already point at it | Redirected only if both upstreams already point at it |
 
 `registerProvider` rewrites every model of the provider, not only the selected
 one, so the check is applied to the whole provider either way. A provider that
 mixes endpoints — Fireworks serves `anthropic-messages` at `/inference` and
 `openai-completions` at `/inference/v1` — is left alone even when the selected
 model matches, because redirecting it would move its siblings to an endpoint that
-has never heard of them. Naming an endpoint does not lift that: one endpoint is
-named for the whole provider, so its models still have to share one. Pointing
-both `--openai-base-url` and `--anthropic-base-url` at that provider unblocks it
-on the static path, unless a sibling speaks an API the gateway has no route for
-at all.
+has never heard of them.
+
+**The way through is configuration, not naming.** Point `--openai-base-url` and
+`--anthropic-base-url` at that provider's respective endpoints, and every model
+then already targets the gateway's upstream for its own family, so the whole
+provider redirects. That works on a launched session and a standalone daemon
+alike. Naming cannot substitute for it: one endpoint is named per provider, so a
+provider spanning two has no single value to send. It still fails if a sibling
+speaks an API the gateway has no route for at all.
 
 Each of these outcomes is recorded as a `model_redirect` mark on the session
 scope, so a trace with no LLM spans states its own reason. The decision is

--- a/docs/nemo-relay-cli/pi.mdx
+++ b/docs/nemo-relay-cli/pi.mdx
@@ -416,6 +416,13 @@ gateway honors that header only from a request carrying this invocation's proxy
 credential, which the launcher mints per run and gives only to the process it
 starts, and strips it before forwarding.
 
+**A named endpoint receives only the credential the request already carried.**
+Naming a destination does not obtain one: the gateway never attaches its own
+configured `Authorization` value, `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` to an
+endpoint the client chose — those belong to the upstream it was configured for.
+pi sends the provider's own key for the provider it named, and that key travels;
+nothing else does.
+
 A **standalone `nemo-relay --bind` daemon issues no credential**, so it ignores
 the header and keeps the static behavior below. Point it at a provider with
 `--openai-base-url` / `--anthropic-base-url`, or launch through the wrapper.

--- a/docs/nemo-relay-cli/pi.mdx
+++ b/docs/nemo-relay-cli/pi.mdx
@@ -404,33 +404,40 @@ model's provider at the gateway directly, with
 `registerProvider(provider, { baseUrl })`. pi rewrites the URL of every existing
 model for that provider and keeps their API, headers, costs and context windows.
 
-Redirection is **conditional**. The gateway forwards to one statically
-configured upstream per API family, set by `--openai-base-url` and
-`--anthropic-base-url`, and a client cannot override that per request.
-Redirecting is therefore only correct when the gateway's upstream is the endpoint
-the selected model would otherwise have called. Pointing an NVIDIA model at a
-gateway configured for `api.openai.com` does not produce a trace without spans;
-it breaks the session.
+The gateway forwards to one statically configured upstream per API family, set by
+`--openai-base-url` and `--anthropic-base-url`. Redirecting a model whose
+endpoint is not that upstream would send the request to the wrong provider —
+which does not produce a trace without spans, it breaks the session.
 
-`nemo-relay run --agent pi` passes the gateway's upstreams to the extension, and
-the extension redirects only on a match:
+**Under `nemo-relay pi` or `nemo-relay run --agent pi`, the extension names the
+endpoint instead**, in an `x-nemo-relay-upstream-base-url` header on each
+request, so the gateway forwards to a provider it was never configured for. The
+gateway honors that header only from a request carrying this invocation's proxy
+credential, which the launcher mints per run and gives only to the process it
+starts, and strips it before forwarding.
 
-| Situation | Outcome |
-| --- | --- |
-| Gateway upstream equals the model's endpoint | Redirected; LLM spans appear under the turn |
-| Gateway forwards elsewhere | Skipped (`upstream-mismatch`) |
-| Model's API has no gateway route | Skipped (`unserviceable-api`) |
-| Upstream unknown, e.g. a standalone gateway | Skipped (`unknown-upstream`) |
-| Another model of the same provider targets an endpoint the gateway does not front | Skipped (`provider-mixed-endpoints`) |
+A **standalone `nemo-relay --bind` daemon issues no credential**, so it ignores
+the header and keeps the static behavior below. Point it at a provider with
+`--openai-base-url` / `--anthropic-base-url`, or launch through the wrapper.
+
+| Situation | Launched by `nemo-relay pi` | Standalone daemon |
+| --- | --- | --- |
+| Gateway upstream equals the model's endpoint | Redirected | Redirected |
+| Gateway forwards elsewhere | Redirected, naming the endpoint | Skipped (`upstream-mismatch`) |
+| Upstream unknown | Redirected, naming the endpoint | Skipped (`unknown-upstream`) |
+| Model's API has no gateway route | Skipped (`unserviceable-api`) | Skipped (`unserviceable-api`) |
+| The provider's models do not share one endpoint | Skipped (`provider-mixed-endpoints`) | Skipped (`provider-mixed-endpoints`) |
 
 `registerProvider` rewrites every model of the provider, not only the selected
-one, so the endpoint check is applied to the whole provider. A provider that
+one, so the check is applied to the whole provider either way. A provider that
 mixes endpoints — Fireworks serves `anthropic-messages` at `/inference` and
 `openai-completions` at `/inference/v1` — is left alone even when the selected
 model matches, because redirecting it would move its siblings to an endpoint that
-has never heard of them. Pointing both `--openai-base-url` and
-`--anthropic-base-url` at that provider unblocks it, unless a sibling speaks an
-API the gateway has no route for at all.
+has never heard of them. Naming an endpoint does not lift that: one endpoint is
+named for the whole provider, so its models still have to share one. Pointing
+both `--openai-base-url` and `--anthropic-base-url` at that provider unblocks it
+on the static path, unless a sibling speaks an API the gateway has no route for
+at all.
 
 Each of these outcomes is recorded as a `model_redirect` mark on the session
 scope, so a trace with no LLM spans states its own reason. The decision is
@@ -518,13 +525,18 @@ at the entry point directly isolates it.
 ## Troubleshoot LLM Lifecycle
 
 Look for the `model_redirect` mark on the session scope: it names the outcome and
-the reason. The common ones are `upstream-mismatch` (start the gateway with
-`--openai-base-url` or `--anthropic-base-url` pointing at the model's provider),
-`unknown-upstream` (launch through `nemo-relay run --agent pi`, or set
-`NEMO_RELAY_PI_REDIRECT=force`), `unserviceable-api` (the model's provider
-speaks an API the gateway has no route for — pick another model), and
-`provider-mixed-endpoints`, whose reason names the sibling model that blocked it
-— point both upstreams at that provider, or select a model elsewhere.
+the reason.
+
+`upstream-mismatch` and `unknown-upstream` appear only on a standalone daemon,
+which cannot be told where to forward. Launch through `nemo-relay pi` and the
+endpoint is named for you; otherwise point the gateway at the provider with
+`--openai-base-url` or `--anthropic-base-url`, or set
+`NEMO_RELAY_PI_REDIRECT=force` if you know the gateway is already correct.
+
+`unserviceable-api` means the model's provider speaks an API the gateway has no
+route for, so pick another model. `provider-mixed-endpoints` names the sibling
+model that blocked it — its provider's models do not share one endpoint, and a
+provider is redirected as a whole; select a model elsewhere.
 
 Tool and turn activity are unaffected by any of these.
 

--- a/docs/nemo-relay-cli/pi.mdx
+++ b/docs/nemo-relay-cli/pi.mdx
@@ -423,6 +423,11 @@ endpoint the client chose — those belong to the upstream it was configured for
 pi sends the provider's own key for the provider it named, and that key travels;
 nothing else does.
 
+**A named endpoint must use `https`, unless it is loopback.** Because that
+credential travels to it, plain `http` to anything reachable from off the machine
+is refused. A local model server — `http://127.0.0.1:11434/v1` and the like — is
+allowed, since its traffic never reaches a network.
+
 A **standalone `nemo-relay --bind` daemon issues no credential**, so it ignores
 the header and keeps the static behavior below. Point it at a provider with
 `--openai-base-url` / `--anthropic-base-url`, or launch through the wrapper.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -25,9 +25,11 @@ anyway, because untested is not the same as broken.
 **Model traffic is redirected conditionally.** pi has no base-URL flag and no
 generic environment override — it resolves `baseUrl` per model from a generated
 catalog — so the extension points the active model's provider at the gateway
-itself. It only does so when the gateway forwards to the endpoint that
-model would otherwise have called; see [Model Redirection](#model-redirection).
-When it does not, you get tool and turn activity but no LLM spans.
+itself. Under `nemo-relay pi` it also names the endpoint the gateway should
+forward to, so an arbitrary provider still produces LLM spans; against a
+standalone daemon it redirects only when the gateway already fronts that
+endpoint. See [Model Redirection](#model-redirection). Where it cannot redirect,
+you get tool and turn activity but no LLM spans.
 
 ## Usage
 
@@ -300,28 +302,40 @@ that provider and keeps their API, headers, costs and context windows. That is
 much cheaper than pi's own `custom-provider-*` examples, which register a
 `streamSimple` and re-implement a provider protocol.
 
-**It is conditional, and the condition is the point.** The gateway forwards to
-one statically configured upstream per API family — `--openai-base-url` and
-`--anthropic-base-url` — and a client cannot override that per request. So
-redirecting is only correct when the gateway's upstream *is* the endpoint the
-selected model would otherwise call. Pointing an NVIDIA model at a gateway
-configured for `api.openai.com` does not degrade to "no spans"; it breaks the
-session. The extension therefore redirects only on a match, and records each
-outcome that explains something as a `model_redirect` mark so a trace without LLM
-spans accounts for itself. Two transient skips are evaluated but not marked — no
-model resolved yet, and a provider already pointed at the gateway — because a
-mark per `session_start` for either is noise.
+**The gateway has to know where to forward.** It sends each API family to one
+statically configured upstream — `--openai-base-url` and `--anthropic-base-url` —
+so redirecting a model whose endpoint is not that upstream would reach the wrong
+provider. Pointing an NVIDIA model at a gateway configured for `api.openai.com`
+does not degrade to "no spans"; it breaks the session.
 
-| Situation | Outcome |
-|---|---|
-| Gateway upstream equals the model's endpoint | Redirected; LLM spans appear under the turn |
-| Gateway forwards somewhere else | Skipped, `upstream-mismatch` |
-| Model's API has no gateway route (Bedrock, Azure OpenAI Responses, Google, Google Vertex, Mistral, OpenAI Codex, Radius) | Skipped, `unserviceable-api` |
-| Launched outside `nemo-relay run --agent pi`, so the upstream is unknown | Skipped, `unknown-upstream` — set `NEMO_RELAY_PI_REDIRECT=force` to override |
-| Another model of the same provider targets an endpoint the gateway does not front | Skipped, `provider-mixed-endpoints` — the registration is provider-wide, so point both upstreams at that provider |
+There are two ways to satisfy that, and which one applies depends on how the
+gateway was started:
 
-`nemo-relay run --agent pi` sets the two upstream variables for you. Running pi
-by hand against a standalone gateway means setting them yourself, or forcing.
+- **Named per request.** Under `nemo-relay pi` or `run --agent pi`, the extension
+  sends `x-nemo-relay-upstream-base-url` on each request, so the gateway forwards
+  to a provider it was never configured for. It honors that header only from a
+  request carrying this invocation's proxy credential — minted per run and given
+  only to the process the launcher starts — and strips it before forwarding.
+- **Statically configured.** A standalone `nemo-relay --bind` daemon issues no
+  credential, so it ignores the header. Redirection there still requires the
+  gateway's own upstream to be the model's endpoint.
+
+Each outcome that explains something is recorded as a `model_redirect` mark, so a
+trace without LLM spans accounts for itself. Two transient skips are evaluated
+but not marked — no model resolved yet, and a provider already pointed at the
+gateway — because a mark per `session_start` for either is noise.
+
+| Situation | Launched by `nemo-relay pi` | Standalone daemon |
+|---|---|---|
+| Gateway upstream equals the model's endpoint | Redirected | Redirected |
+| Gateway forwards somewhere else | Redirected, naming the endpoint | Skipped, `upstream-mismatch` |
+| Upstream unknown | Redirected, naming the endpoint | Skipped, `unknown-upstream` — set `NEMO_RELAY_PI_REDIRECT=force` to override |
+| Model's API has no gateway route (Bedrock, Azure OpenAI Responses, Google, Google Vertex, Mistral, OpenAI Codex, Radius) | Skipped, `unserviceable-api` | Skipped, `unserviceable-api` |
+| The provider's models do not share one endpoint | Skipped, `provider-mixed-endpoints` | Skipped, `provider-mixed-endpoints` |
+
+The last row holds on both paths for the same reason: `registerProvider` is
+provider-wide, so one endpoint is chosen for every model of that provider, and
+they have to agree on it.
 
 The decision is re-evaluated on every `model_select`, so switching to a model the
 gateway does not front stops redirecting rather than silently misrouting.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -331,11 +331,14 @@ gateway — because a mark per `session_start` for either is noise.
 | Gateway forwards somewhere else | Redirected, naming the endpoint | Skipped, `upstream-mismatch` |
 | Upstream unknown | Redirected, naming the endpoint | Skipped, `unknown-upstream` — set `NEMO_RELAY_PI_REDIRECT=force` to override |
 | Model's API has no gateway route (Bedrock, Azure OpenAI Responses, Google, Google Vertex, Mistral, OpenAI Codex, Radius) | Skipped, `unserviceable-api` | Skipped, `unserviceable-api` |
-| The provider's models do not share one endpoint | Skipped, `provider-mixed-endpoints` | Skipped, `provider-mixed-endpoints` |
+| The provider's models do not share one endpoint | Redirected only if both upstreams already point at it | Redirected only if both upstreams already point at it |
 
-The last row holds on both paths for the same reason: `registerProvider` is
-provider-wide, so one endpoint is chosen for every model of that provider, and
-they have to agree on it.
+The last row reads the same on both paths because `registerProvider` is
+provider-wide: one endpoint is chosen for every model of that provider, so they
+have to agree on it. Pointing `--openai-base-url` and `--anthropic-base-url` at
+that provider's respective endpoints is what makes them agree — Fireworks
+redirects fine once both are set. Naming cannot substitute, because a single
+header carries a single endpoint.
 
 The decision is re-evaluated on every `model_select`, so switching to a model the
 gateway does not front stops redirecting rather than silently misrouting.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -316,6 +316,10 @@ gateway was started:
   to a provider it was never configured for. It honors that header only from a
   request carrying this invocation's proxy credential — minted per run and given
   only to the process the launcher starts — and strips it before forwarding.
+  A named endpoint receives only the credential the request already carried: the
+  gateway never attaches its own configured or environment provider key to a
+  destination the client chose, so naming a host is not a way to obtain a key
+  for it.
 - **Statically configured.** A standalone `nemo-relay --bind` daemon issues no
   credential, so it ignores the header. Redirection there still requires the
   gateway's own upstream to be the model's endpoint.

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -319,7 +319,9 @@ gateway was started:
   A named endpoint receives only the credential the request already carried: the
   gateway never attaches its own configured or environment provider key to a
   destination the client chose, so naming a host is not a way to obtain a key
-  for it.
+  for it. Because that credential does travel, a named endpoint must use `https`
+  unless it is loopback — a local model server on `127.0.0.1` is allowed, a plain
+  `http` host that is reachable from off the machine is refused.
 - **Statically configured.** A standalone `nemo-relay --bind` daemon issues no
   credential, so it ignores the header. Redirection there still requires the
   gateway's own upstream to be the model's endpoint.

--- a/integrations/pi/test/lifecycle.test.mjs
+++ b/integrations/pi/test/lifecycle.test.mjs
@@ -709,8 +709,10 @@ describe('the session join key on redirected providers', () => {
   // Same structural scope as the session id, and it matters more here: the credential
   // authenticates *this* invocation, so a provider the gateway does not front must
   // never see it. `registerProvider` runs only on a redirect, which is what enforces it.
+  // No credential, so naming the upstream is not available and a mismatch is still a
+  // refusal -- which is the state that leaves a provider un-redirected, and so the
+  // state in which nothing may be attached to it.
   it('never reaches a provider that was not redirected', async () => {
-    process.env.NEMO_RELAY_PROXY_CREDENTIAL = 'nrp_testtoken';
     process.env.NEMO_RELAY_PI_OPENAI_UPSTREAM = 'https://elsewhere.example/v1';
     try {
       const { fire, registrations } = loadRecording('sess-one');
@@ -719,6 +721,41 @@ describe('the session join key on redirected providers', () => {
     } finally {
       process.env.NEMO_RELAY_PI_OPENAI_UPSTREAM = 'https://api.openai.com/v1';
     }
+  });
+
+  // The credential turns a mismatch from a refusal into a redirect: the gateway can be
+  // told where to forward, so a provider it was never configured for still produces
+  // spans and is still subject to model-call policy.
+  it('names the endpoint when the gateway does not front it', async () => {
+    process.env.NEMO_RELAY_PROXY_CREDENTIAL = 'nrp_testtoken';
+    process.env.NEMO_RELAY_PI_OPENAI_UPSTREAM = 'https://elsewhere.example/v1';
+    try {
+      const { fire, registrations } = loadRecording('sess-one');
+      await fire('session_start', { reason: 'startup' });
+
+      assert.equal(registrations.length, 1, 'a named upstream makes the redirect safe');
+      assert.equal(
+        registrations[0].config.headers['x-nemo-relay-upstream-base-url'],
+        'https://api.openai.com/v1',
+        'the header must name the endpoint the model would otherwise have called',
+      );
+    } finally {
+      process.env.NEMO_RELAY_PI_OPENAI_UPSTREAM = 'https://api.openai.com/v1';
+    }
+  });
+
+  // Naming an upstream the gateway already forwards to would be a header that changes
+  // nothing, on every request, for the common case.
+  it('names no endpoint when the gateway already fronts the model', async () => {
+    process.env.NEMO_RELAY_PROXY_CREDENTIAL = 'nrp_testtoken';
+    const { fire, registrations } = loadRecording('sess-one');
+    await fire('session_start', { reason: 'startup' });
+
+    assert.equal(registrations.length, 1);
+    assert.ok(
+      !('x-nemo-relay-upstream-base-url' in registrations[0].config.headers),
+      'a static match must not name an upstream',
+    );
   });
 
   it('does not re-register when the session id has not moved', async () => {

--- a/integrations/pi/test/lifecycle.test.mjs
+++ b/integrations/pi/test/lifecycle.test.mjs
@@ -726,7 +726,7 @@ describe('the session join key on redirected providers', () => {
   // Asserts the extension's half of the contract only: that a mismatch now registers,
   // and that the registration carries the endpoint. Whether the gateway then forwards
   // there, opens an LLM span and applies model-call policy is asserted on the Rust
-  // side, in `pi_named_upstream_tests.rs`.
+  // side, in `crates/cli/tests/coverage/shared/server_tests.rs`.
   it('names the endpoint when the gateway does not front it', async () => {
     process.env.NEMO_RELAY_PROXY_CREDENTIAL = 'nrp_testtoken';
     process.env.NEMO_RELAY_PI_OPENAI_UPSTREAM = 'https://elsewhere.example/v1';

--- a/integrations/pi/test/lifecycle.test.mjs
+++ b/integrations/pi/test/lifecycle.test.mjs
@@ -723,9 +723,10 @@ describe('the session join key on redirected providers', () => {
     }
   });
 
-  // The credential turns a mismatch from a refusal into a redirect: the gateway can be
-  // told where to forward, so a provider it was never configured for still produces
-  // spans and is still subject to model-call policy.
+  // Asserts the extension's half of the contract only: that a mismatch now registers,
+  // and that the registration carries the endpoint. Whether the gateway then forwards
+  // there, opens an LLM span and applies model-call policy is asserted on the Rust
+  // side, in `pi_named_upstream_tests.rs`.
   it('names the endpoint when the gateway does not front it', async () => {
     process.env.NEMO_RELAY_PROXY_CREDENTIAL = 'nrp_testtoken';
     process.env.NEMO_RELAY_PI_OPENAI_UPSTREAM = 'https://elsewhere.example/v1';

--- a/integrations/pi/test/provider-redirect.test.mjs
+++ b/integrations/pi/test/provider-redirect.test.mjs
@@ -259,3 +259,109 @@ describe('a provider whose models span API families', () => {
     assert.equal(isNotable(decideRedirect(ANTHROPIC, config, new Set(), catalog)), true);
   });
 });
+
+describe('naming an upstream the gateway does not front', () => {
+  /** The launcher's credential is what the gateway requires before honouring the header. */
+  const namingConfig = (extra = {}) =>
+    matchConfig({ proxyToken: 'nrp_testtoken', ...extra });
+
+  it('redirects past a mismatch by naming the model endpoint', () => {
+    const decision = decideRedirect(
+      nvidiaModel,
+      namingConfig({ openaiUpstream: 'https://api.openai.com/v1' }),
+      none,
+      [nvidiaModel],
+    );
+
+    assert.equal(decision.kind, 'redirect');
+    assert.equal(decision.namedUpstream, nvidiaModel.baseUrl);
+  });
+
+  it('redirects when the gateway upstream is unknown', () => {
+    const decision = decideRedirect(
+      nvidiaModel,
+      { gatewayUrl: GATEWAY, mode: 'match', proxyToken: 'nrp_testtoken' },
+      none,
+      [nvidiaModel],
+    );
+
+    assert.equal(decision.kind, 'redirect');
+    assert.equal(decision.namedUpstream, nvidiaModel.baseUrl);
+  });
+
+  // Without the credential the gateway ignores the header, so redirecting would land
+  // on its configured upstream -- the wrong provider, which is the exact break the
+  // static check exists to prevent.
+  it('still refuses without the credential, because the header would be ignored', () => {
+    const decision = decideRedirect(
+      nvidiaModel,
+      matchConfig({ openaiUpstream: 'https://api.openai.com/v1' }),
+      none,
+      [nvidiaModel],
+    );
+
+    assert.equal(decision.kind, 'skip');
+    assert.equal(decision.code, 'upstream-mismatch');
+  });
+
+  it('names nothing when the gateway already fronts the endpoint', () => {
+    const decision = decideRedirect(nvidiaModel, namingConfig(), none, [nvidiaModel]);
+
+    assert.equal(decision.kind, 'redirect');
+    assert.equal(decision.namedUpstream, undefined);
+  });
+
+  // One endpoint is named for the whole provider, because `registerProvider` rewrites
+  // every model of it. A sibling elsewhere would be pointed at a host that has never
+  // heard of it -- a broken session rather than a missing span.
+  it('refuses a provider whose models do not share one endpoint', () => {
+    const sibling = {
+      id: 'nvidia/other',
+      api: 'openai-completions',
+      provider: 'nvidia',
+      baseUrl: 'https://other.nvidia.example/v1',
+    };
+    const decision = decideRedirect(
+      nvidiaModel,
+      namingConfig({ openaiUpstream: 'https://api.openai.com/v1' }),
+      none,
+      [nvidiaModel, sibling],
+    );
+
+    assert.equal(decision.kind, 'skip');
+    assert.equal(decision.code, 'provider-mixed-endpoints');
+  });
+
+  // An unserviceable sibling has no gateway route at all, so naming an endpoint for
+  // the provider would move it somewhere the gateway cannot forward it.
+  it('refuses a provider with a sibling the gateway cannot route', () => {
+    const sibling = {
+      id: 'nvidia/gemini-ish',
+      api: 'google-generative-ai',
+      provider: 'nvidia',
+      baseUrl: nvidiaModel.baseUrl,
+    };
+    const decision = decideRedirect(
+      nvidiaModel,
+      namingConfig({ openaiUpstream: 'https://api.openai.com/v1' }),
+      none,
+      [nvidiaModel, sibling],
+    );
+
+    assert.equal(decision.kind, 'skip');
+    assert.equal(decision.code, 'provider-mixed-endpoints');
+  });
+
+  // The gateway serves no route for the API at all, so there is nothing to name.
+  it('still refuses an unserviceable API', () => {
+    const decision = decideRedirect(
+      { ...nvidiaModel, api: 'google-generative-ai' },
+      namingConfig(),
+      none,
+      [],
+    );
+
+    assert.equal(decision.kind, 'skip');
+    assert.equal(decision.code, 'unserviceable-api');
+  });
+});


### PR DESCRIPTION
#### Overview

Allows a Relay-launched pi session to forward model requests to the provider’s original endpoint, even when that endpoint is not statically configured on the gateway. These calls continue to produce LLM spans and remain subject to model-call policy.

Builds on #804, which introduced the pi integration.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- The pi extension sends `x-nemo-relay-upstream-base-url` when the selected provider does not match the gateway’s configured upstream.
- The gateway accepts this header only from the launched process tree using its per-invocation proxy credential, validates the destination, and removes the header before forwarding.
- Client-named destinations receive only credentials supplied by the caller. Relay never injects configured or environment provider credentials into an endpoint selected by the client.
- Standalone gateways retain static routing because they do not issue an invocation credential.
- Provider-wide redirection still requires the provider’s models to share a compatible endpoint.
- Rust and TypeScript coverage verifies routing, authentication, header stripping, credential handling, LLM spans, and model-call policy.

Validation included `cargo nextest run -p nemo-relay-cli`, `just test-pi`, `just docs-linkcheck`, Clippy, pre-commit, and a live NVIDIA-provider run.

#### Where should the reviewer start?

1. `crates/cli/src/agents/pi/alignment.rs` — destination validation and trust boundary.
2. `crates/cli/src/gateway/request.rs` — managed-request routing and credential policy.
3. `crates/cli/src/gateway/mod.rs` — `/v1/models` routing.
4. `crates/cli/tests/coverage/shared/server_tests.rs` — end-to-end security and policy coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Authorized launched Pi sessions can route requests to selected upstream endpoints.
  - Model redirection supports compatible, previously unconfigured provider endpoints.
  - Client credentials are preserved for named upstreams, while gateway credentials are not added.
  - Named upstreams support model requests, streaming, passthrough, and model-list requests.

- **Bug Fixes**
  - Invalid or unauthorized endpoint selections are rejected instead of falling back.
  - Redirects are not followed for named upstreams, preventing unintended credential forwarding.
  - Standalone gateways continue using configured upstream matching.

- **Documentation**
  - Updated Pi guidance with endpoint naming, routing behavior, security requirements, and troubleshooting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->