### PR TITLE
fix: harden PII redaction safety

### DIFF
--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -209,6 +209,27 @@ impl BuiltinMatcher {
         output.push_str(&text[cursor..]);
         output
     }
+
+    fn replace_all_expanded(&self, text: &str, replacement: &str) -> String {
+        let mut output = String::with_capacity(text.len());
+        let mut cursor = 0;
+        for captures in self.regex.captures_iter(text) {
+            let matched = captures
+                .get(0)
+                .expect("regular-expression captures always include the full match");
+            let matched_text = matched.as_str();
+            if self.detector == Some(BuiltinDetector::AwsSecretAccessKey)
+                && is_hex_git_sha(matched_text)
+            {
+                continue;
+            }
+            output.push_str(&text[cursor..matched.start()]);
+            captures.expand(replacement, &mut output);
+            cursor = matched.end();
+        }
+        output.push_str(&text[cursor..]);
+        output
+    }
 }
 
 #[derive(Clone)]
@@ -569,7 +590,7 @@ impl CompiledBuiltinBackend {
                 pattern,
                 replacement,
             } => Some(Json::String(
-                pattern.replace_all(&text, |_| replacement.as_str().to_string()),
+                pattern.replace_all_expanded(&text, replacement),
             )),
         }
     }
@@ -1276,6 +1297,45 @@ mod tests {
         assert_eq!(
             aws_result["value"],
             "sha 0123456789abcdef0123456789abcdef01234567 key [REDACTED]"
+        );
+    }
+
+    #[test]
+    fn regex_replace_expands_numbered_and_named_captures() {
+        let numbered_backend = CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                action: "regex_replace".to_string(),
+                pattern: Some("(token)-(\\d+)".to_string()),
+                replacement: Some("$1-[REDACTED]".to_string()),
+                target_paths: vec!["/value".to_string()],
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            numbered_backend.sanitize_json_preorder_dfs(serde_json::json!({
+                "value": "token-123"
+            }))["value"],
+            "token-[REDACTED]"
+        );
+
+        let named_backend = CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                action: "regex_replace".to_string(),
+                pattern: Some("(?<kind>token)-(?<value>\\d+)".to_string()),
+                replacement: Some("${kind}-[REDACTED]".to_string()),
+                target_paths: vec!["/value".to_string()],
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            named_backend.sanitize_json_preorder_dfs(serde_json::json!({
+                "value": "token-123"
+            }))["value"],
+            "token-[REDACTED]"
         );
     }
 }

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -169,20 +169,46 @@ impl TargetPathMatcher {
 enum BuiltinAction {
     Remove,
     Hash {
-        matcher: Option<Arc<Regex>>,
+        matcher: Option<Arc<BuiltinMatcher>>,
     },
     Mask {
-        matcher: Option<Arc<Regex>>,
+        matcher: Option<Arc<BuiltinMatcher>>,
         strategy: BuiltinMaskStrategy,
     },
     Redact {
-        matcher: Arc<Regex>,
+        matcher: Arc<BuiltinMatcher>,
         replacement: Arc<String>,
     },
     RegexReplace {
-        pattern: Arc<Regex>,
+        pattern: Arc<BuiltinMatcher>,
         replacement: Arc<String>,
     },
+}
+
+#[derive(Clone)]
+struct BuiltinMatcher {
+    regex: Arc<Regex>,
+    detector: Option<BuiltinDetector>,
+}
+
+impl BuiltinMatcher {
+    fn replace_all(&self, text: &str, mut replacement: impl FnMut(&str) -> String) -> String {
+        let mut output = String::with_capacity(text.len());
+        let mut cursor = 0;
+        for matched in self.regex.find_iter(text) {
+            let matched_text = matched.as_str();
+            if self.detector == Some(BuiltinDetector::AwsSecretAccessKey)
+                && is_hex_git_sha(matched_text)
+            {
+                continue;
+            }
+            output.push_str(&text[cursor..matched.start()]);
+            output.push_str(&replacement(matched_text));
+            cursor = matched.end();
+        }
+        output.push_str(&text[cursor..]);
+        output
+    }
 }
 
 #[derive(Clone)]
@@ -315,6 +341,15 @@ impl CompiledBuiltinBackend {
                     "builtin target paths must be valid RFC 6901 JSON pointers".to_string(),
                 )
             })?;
+        if trajectory.is_none()
+            && matches!(action, BuiltinAction::Remove)
+            && target_paths.is_empty()
+        {
+            return Err(PluginError::InvalidConfig(
+                "builtin.action = 'remove' requires at least one builtin.target_paths or builtin.target_path_globs selector"
+                    .to_string(),
+            ));
+        }
 
         Ok(Self {
             action,
@@ -331,8 +366,17 @@ impl CompiledBuiltinBackend {
 
     /// Sanitize optional metric text without modifying required export fields.
     fn sanitize_metric_envelope(&self, data: Json) -> Option<Json> {
-        let mut envelope = serde_json::from_value::<MetricEnvelope>(data).ok()?;
-        envelope.validate().ok()?;
+        let mut envelope = match serde_json::from_value::<MetricEnvelope>(data) {
+            Ok(envelope) => envelope,
+            Err(_) => {
+                return log_metric_envelope_omitted("metric envelope deserialization failure");
+            }
+        };
+        if envelope.validate().is_err() {
+            return log_metric_envelope_omitted(
+                "metric envelope validation failure before redaction",
+            );
+        }
         for (index, measurement) in envelope.measurements.iter_mut().enumerate() {
             measurement.description = measurement.description.take().and_then(|description| {
                 self.sanitize_metric_string_at_path(
@@ -349,8 +393,15 @@ impl CompiledBuiltinBackend {
                 .take()
                 .map(|attributes| self.sanitize_metric_attributes(attributes, index));
         }
-        envelope.validate().ok()?;
-        serde_json::to_value(envelope).ok()
+        if envelope.validate().is_err() {
+            return log_metric_envelope_omitted(
+                "metric envelope validation failure after redaction",
+            );
+        }
+        match serde_json::to_value(envelope) {
+            Ok(data) => Some(data),
+            Err(_) => log_metric_envelope_omitted("metric envelope serialization failure"),
+        }
     }
 
     /// Sanitize metric text using its payload-relative JSON Pointer.
@@ -499,47 +550,26 @@ impl CompiledBuiltinBackend {
         match &self.action {
             BuiltinAction::Remove => None,
             BuiltinAction::Hash { matcher } => Some(Json::String(match matcher {
-                Some(matcher) => matcher
-                    .replace_all(&text, |captures: &regex::Captures<'_>| {
-                        hex_sha256(
-                            captures
-                                .get(0)
-                                .map(|capture| capture.as_str())
-                                .unwrap_or(""),
-                        )
-                    })
-                    .into_owned(),
+                Some(matcher) => matcher.replace_all(&text, hex_sha256),
                 None => hex_sha256(&text),
             })),
             BuiltinAction::Mask { matcher, strategy } => Some(Json::String(match matcher {
-                Some(matcher) => matcher
-                    .replace_all(&text, |captures: &regex::Captures<'_>| {
-                        mask_with_strategy(
-                            captures
-                                .get(0)
-                                .map(|capture| capture.as_str())
-                                .unwrap_or(""),
-                            strategy,
-                        )
-                    })
-                    .into_owned(),
+                Some(matcher) => {
+                    matcher.replace_all(&text, |matched| mask_with_strategy(matched, strategy))
+                }
                 None => mask_with_strategy(&text, strategy),
             })),
             BuiltinAction::Redact {
                 matcher,
                 replacement,
             } => Some(Json::String(
-                matcher
-                    .replace_all(&text, replacement.as_str())
-                    .into_owned(),
+                matcher.replace_all(&text, |_| replacement.as_str().to_string()),
             )),
             BuiltinAction::RegexReplace {
                 pattern,
                 replacement,
             } => Some(Json::String(
-                pattern
-                    .replace_all(&text, replacement.as_str())
-                    .into_owned(),
+                pattern.replace_all(&text, |_| replacement.as_str().to_string()),
             )),
         }
     }
@@ -786,9 +816,9 @@ fn event_sanitize_callback_with_scope_categories(
                 fields.metadata = fields
                     .metadata
                     .map(|metadata| backend.sanitize_json_preorder_dfs(metadata));
-                fields.category_profile = fields.category_profile.and_then(|profile| {
-                    sanitize_serializable_with_backend::<CategoryProfile>(&backend, profile).ok()
-                });
+                fields.category_profile = fields
+                    .category_profile
+                    .and_then(|profile| sanitize_category_profile_with_backend(&backend, profile));
                 return Ok(fields);
             }
             let specialized_scope = matches!(event.as_ref(), Event::Scope(_))
@@ -813,9 +843,9 @@ fn event_sanitize_callback_with_scope_categories(
                 fields.data = fields
                     .data
                     .map(|data| backend.sanitize_json_preorder_dfs(data));
-                fields.category_profile = fields.category_profile.and_then(|profile| {
-                    sanitize_serializable_with_backend::<CategoryProfile>(&backend, profile).ok()
-                });
+                fields.category_profile = fields
+                    .category_profile
+                    .and_then(|profile| sanitize_category_profile_with_backend(&backend, profile));
             }
 
             fields.metadata = fields
@@ -957,6 +987,35 @@ fn log_llm_payload_omitted(direction: &str, codec: &LlmCodecIdentity, reason: &s
         reason;
         "PII redaction omitted an LLM {direction} payload"
     );
+}
+
+fn log_metric_envelope_omitted(reason: &str) -> Option<Json> {
+    log::warn!(
+        target: "nemo_relay.plugin",
+        event = "pii_metric_envelope_omitted",
+        reason;
+        "PII redaction omitted a metric envelope"
+    );
+    None
+}
+
+fn sanitize_category_profile_with_backend(
+    backend: &CompiledBuiltinBackend,
+    profile: CategoryProfile,
+) -> Option<CategoryProfile> {
+    match sanitize_serializable_with_backend(backend, profile) {
+        Ok(profile) => Some(profile),
+        Err(_) => {
+            log::warn!(
+                target: "nemo_relay.plugin",
+                event = "pii_llm_payload_omitted",
+                codec_kind = "annotated",
+                reason = "category profile redaction round-trip failure";
+                "PII redaction omitted an annotated LLM payload"
+            );
+            None
+        }
+    }
 }
 
 fn json_pointer_segments(pointer: &str) -> Option<Vec<String>> {
@@ -1106,7 +1165,7 @@ fn mask_with_strategy(text: &str, strategy: &BuiltinMaskStrategy) -> String {
 fn compile_builtin_matcher(
     pattern: Option<String>,
     detector: Option<BuiltinDetector>,
-) -> PluginResult<Option<Arc<Regex>>> {
+) -> PluginResult<Option<Arc<BuiltinMatcher>>> {
     let pattern_text = match (pattern, detector) {
         (Some(pattern), None) => Some(pattern),
         (None, Some(detector)) => Some(detector.regex_pattern().to_string()),
@@ -1127,7 +1186,14 @@ fn compile_builtin_matcher(
             "invalid builtin matcher regex '{pattern_text}': {err}"
         ))
     })?;
-    Ok(Some(Arc::new(pattern)))
+    Ok(Some(Arc::new(BuiltinMatcher {
+        regex: Arc::new(pattern),
+        detector,
+    })))
+}
+
+fn is_hex_git_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn sanitize_serializable_with_backend<T>(
@@ -1172,5 +1238,44 @@ mod tests {
             "0".to_string(),
             "content".to_string(),
         ]));
+    }
+
+    #[test]
+    fn detectors_ignore_embedded_api_key_prefixes_and_hex_git_shas() {
+        let api_key_backend = CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                action: "redact".to_string(),
+                detector: Some("api_key".to_string()),
+                target_paths: vec!["/value".to_string()],
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap();
+        let api_key_result = api_key_backend.sanitize_json_preorder_dfs(serde_json::json!({
+            "value": "task-management risk-assessment network-topology sk-abcdef123456"
+        }));
+        assert_eq!(
+            api_key_result["value"],
+            "task-management risk-assessment network-topology [REDACTED]"
+        );
+
+        let aws_backend = CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                action: "redact".to_string(),
+                detector: Some("aws_secret_access_key".to_string()),
+                target_paths: vec!["/value".to_string()],
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap();
+        let aws_result = aws_backend.sanitize_json_preorder_dfs(serde_json::json!({
+            "value": "sha 0123456789abcdef0123456789abcdef01234567 key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        }));
+        assert_eq!(
+            aws_result["value"],
+            "sha 0123456789abcdef0123456789abcdef01234567 key [REDACTED]"
+        );
     }
 }

--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -188,7 +188,6 @@ enum BuiltinAction {
 #[derive(Clone)]
 struct BuiltinMatcher {
     regex: Arc<Regex>,
-    detector: Option<BuiltinDetector>,
 }
 
 impl BuiltinMatcher {
@@ -197,11 +196,6 @@ impl BuiltinMatcher {
         let mut cursor = 0;
         for matched in self.regex.find_iter(text) {
             let matched_text = matched.as_str();
-            if self.detector == Some(BuiltinDetector::AwsSecretAccessKey)
-                && is_hex_git_sha(matched_text)
-            {
-                continue;
-            }
             output.push_str(&text[cursor..matched.start()]);
             output.push_str(&replacement(matched_text));
             cursor = matched.end();
@@ -217,12 +211,6 @@ impl BuiltinMatcher {
             let matched = captures
                 .get(0)
                 .expect("regular-expression captures always include the full match");
-            let matched_text = matched.as_str();
-            if self.detector == Some(BuiltinDetector::AwsSecretAccessKey)
-                && is_hex_git_sha(matched_text)
-            {
-                continue;
-            }
             output.push_str(&text[cursor..matched.start()]);
             captures.expand(replacement, &mut output);
             cursor = matched.end();
@@ -1029,10 +1017,9 @@ fn sanitize_category_profile_with_backend(
         Err(_) => {
             log::warn!(
                 target: "nemo_relay.plugin",
-                event = "pii_llm_payload_omitted",
-                codec_kind = "annotated",
+                event = "pii_category_profile_omitted",
                 reason = "category profile redaction round-trip failure";
-                "PII redaction omitted an annotated LLM payload"
+                "PII redaction omitted a category profile"
             );
             None
         }
@@ -1209,12 +1196,7 @@ fn compile_builtin_matcher(
     })?;
     Ok(Some(Arc::new(BuiltinMatcher {
         regex: Arc::new(pattern),
-        detector,
     })))
-}
-
-fn is_hex_git_sha(value: &str) -> bool {
-    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn sanitize_serializable_with_backend<T>(
@@ -1262,7 +1244,7 @@ mod tests {
     }
 
     #[test]
-    fn detectors_ignore_embedded_api_key_prefixes_and_hex_git_shas() {
+    fn detectors_ignore_embedded_api_key_prefixes_and_redact_hex_aws_secrets() {
         let api_key_backend = CompiledBuiltinBackend::new(
             BuiltinBackendConfig {
                 action: "redact".to_string(),
@@ -1294,10 +1276,7 @@ mod tests {
         let aws_result = aws_backend.sanitize_json_preorder_dfs(serde_json::json!({
             "value": "sha 0123456789abcdef0123456789abcdef01234567 key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         }));
-        assert_eq!(
-            aws_result["value"],
-            "sha 0123456789abcdef0123456789abcdef01234567 key [REDACTED]"
-        );
+        assert_eq!(aws_result["value"], "sha [REDACTED] key [REDACTED]");
     }
 
     #[test]

--- a/crates/pii-redaction/src/component.rs
+++ b/crates/pii-redaction/src/component.rs
@@ -188,7 +188,8 @@ pub struct BuiltinBackendConfig {
     #[cfg_attr(feature = "schema", schemars(schema_with = "builtin_action_schema"))]
     pub action: String,
     /// Exact RFC 6901 JSON-pointer paths to sanitize. Empty together with
-    /// [`Self::target_path_globs`] means every string leaf.
+    /// [`Self::target_path_globs`] means every string leaf, except that
+    /// `action = "remove"` requires an explicit selector.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub target_paths: Vec<String>,
     /// JSON-pointer glob paths to sanitize. A whole `*` segment matches one
@@ -962,6 +963,21 @@ fn validate_builtin_action_requirements(
     if builtin.preset.is_some() {
         validate_builtin_preset_requirements(diagnostics, policy, plugin_config, builtin);
         return;
+    }
+
+    if builtin.action == "remove"
+        && builtin.target_paths.is_empty()
+        && builtin.target_path_globs.is_empty()
+    {
+        push_policy_diag(
+            diagnostics,
+            policy.unsupported_value,
+            "pii_redaction.unsupported_value",
+            Some(PII_REDACTION_PLUGIN_KIND.to_string()),
+            Some("builtin.target_paths".to_string()),
+            "builtin.action = 'remove' requires at least one builtin.target_paths or builtin.target_path_globs selector"
+                .to_string(),
+        );
     }
 
     let custom_policy_configured = plugin_config

--- a/crates/pii-redaction/src/detectors.rs
+++ b/crates/pii-redaction/src/detectors.rs
@@ -55,7 +55,7 @@ const BUILTIN_DETECTOR_SPECS: &[BuiltinDetectorSpec] = &[
         detector: BuiltinDetector::ApiKey,
         name: "api_key",
         category: BuiltinDetectorCategory::StructuredSecret,
-        regex_pattern: r"(?:sk|rk|pk|ak)-[A-Za-z0-9_-]{8,}",
+        regex_pattern: r"\b(?:sk|rk|pk|ak)-[A-Za-z0-9_-]{8,}",
     },
     BuiltinDetectorSpec {
         detector: BuiltinDetector::IpAddress,

--- a/crates/pii-redaction/src/trajectory.rs
+++ b/crates/pii-redaction/src/trajectory.rs
@@ -77,7 +77,10 @@ impl TrajectorySanitizer {
         &self,
         request: AnnotatedLlmRequest,
     ) -> Option<AnnotatedLlmRequest> {
-        let mut value = serde_json::to_value(request).ok()?;
+        let mut value = match serde_json::to_value(request) {
+            Ok(value) => value,
+            Err(_) => return log_annotated_llm_payload_omitted("request", "serialization failure"),
+        };
         let preserved = take_root_fields(
             &value,
             &[
@@ -97,14 +100,22 @@ impl TrajectorySanitizer {
         );
         value = redact_semantic_content(value, &self.replacement, None);
         restore_root_fields(&mut value, preserved);
-        serde_json::from_value(value).ok()
+        match serde_json::from_value(value) {
+            Ok(request) => Some(request),
+            Err(_) => log_annotated_llm_payload_omitted("request", "deserialization failure"),
+        }
     }
 
     pub(super) fn sanitize_annotated_response(
         &self,
         response: AnnotatedLlmResponse,
     ) -> Option<AnnotatedLlmResponse> {
-        let mut value = serde_json::to_value(response).ok()?;
+        let mut value = match serde_json::to_value(response) {
+            Ok(value) => value,
+            Err(_) => {
+                return log_annotated_llm_payload_omitted("response", "serialization failure");
+            }
+        };
         let mut preserved = take_root_fields(
             &value,
             &[
@@ -123,7 +134,10 @@ impl TrajectorySanitizer {
         }
         value = redact_semantic_content(value, &self.replacement, None);
         restore_root_fields(&mut value, preserved);
-        serde_json::from_value(value).ok()
+        match serde_json::from_value(value) {
+            Ok(response) => Some(response),
+            Err(_) => log_annotated_llm_payload_omitted("response", "deserialization failure"),
+        }
     }
 
     pub(super) fn sanitize_event_fields(
@@ -187,8 +201,17 @@ impl TrajectorySanitizer {
 
     /// Redact optional metric text without modifying required export fields.
     fn sanitize_metric_envelope(&self, data: Json) -> Option<Json> {
-        let mut envelope = serde_json::from_value::<MetricEnvelope>(data).ok()?;
-        envelope.validate().ok()?;
+        let mut envelope = match serde_json::from_value::<MetricEnvelope>(data) {
+            Ok(envelope) => envelope,
+            Err(_) => {
+                return log_metric_envelope_omitted("metric envelope deserialization failure");
+            }
+        };
+        if envelope.validate().is_err() {
+            return log_metric_envelope_omitted(
+                "metric envelope validation failure before redaction",
+            );
+        }
         for measurement in &mut envelope.measurements {
             measurement.description = measurement
                 .description
@@ -199,9 +222,37 @@ impl TrajectorySanitizer {
                 .take()
                 .map(|attributes| redact_metric_string_attributes(attributes, &self.replacement));
         }
-        envelope.validate().ok()?;
-        serde_json::to_value(envelope).ok()
+        if envelope.validate().is_err() {
+            return log_metric_envelope_omitted(
+                "metric envelope validation failure after redaction",
+            );
+        }
+        match serde_json::to_value(envelope) {
+            Ok(data) => Some(data),
+            Err(_) => log_metric_envelope_omitted("metric envelope serialization failure"),
+        }
     }
+}
+
+fn log_annotated_llm_payload_omitted<T>(direction: &str, reason: &str) -> Option<T> {
+    log::warn!(
+        target: "nemo_relay.plugin",
+        event = "pii_llm_payload_omitted",
+        codec_kind = "annotated",
+        reason;
+        "PII redaction omitted an annotated LLM {direction} payload"
+    );
+    None
+}
+
+fn log_metric_envelope_omitted(reason: &str) -> Option<Json> {
+    log::warn!(
+        target: "nemo_relay.plugin",
+        event = "pii_metric_envelope_omitted",
+        reason;
+        "PII redaction omitted a metric envelope"
+    );
+    None
 }
 
 fn valid_mark_log_severity(event: &Event, metadata: Option<&Json>) -> Option<LogSeverity> {

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -1453,7 +1453,18 @@ async fn builtin_metric_marks_preserve_typed_measurements() {
         None,
     ));
     let callback = crate::builtin::event_sanitize_callback(
-        crate::builtin::CompiledBuiltinBackend::new(BuiltinBackendConfig::default(), None).unwrap(),
+        crate::builtin::CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                target_paths: vec!["/owner".to_string()],
+                target_path_globs: vec![
+                    "/measurements/*/description".to_string(),
+                    "/measurements/*/attributes/*".to_string(),
+                ],
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap(),
     );
     let sanitized = callback(
         Arc::new(event),
@@ -2051,7 +2062,14 @@ async fn builtin_metric_marks_drop_invalid_envelopes() {
         None,
     ));
     let callback = crate::builtin::event_sanitize_callback(
-        crate::builtin::CompiledBuiltinBackend::new(BuiltinBackendConfig::default(), None).unwrap(),
+        crate::builtin::CompiledBuiltinBackend::new(
+            BuiltinBackendConfig {
+                target_paths: vec!["/unused".to_string()],
+                ..BuiltinBackendConfig::default()
+            },
+            None,
+        )
+        .unwrap(),
     );
     let sanitized = callback(
         Arc::new(event),
@@ -2785,7 +2803,8 @@ fn validate_allows_llm_surfaces_without_codec() {
     let report = validate_plugin_config(&plugin_config(json!({
         "mode": "builtin",
         "builtin": {
-            "action": "remove"
+            "action": "remove",
+            "target_paths": ["/message"]
         },
         "input": true,
         "output": false,
@@ -3798,12 +3817,12 @@ fn builtin_remove_deletes_object_fields_and_nulls_array_or_root_targets() {
 }
 
 #[test]
-fn builtin_remove_with_empty_target_paths_only_removes_string_leaves() {
+fn builtin_remove_without_target_paths_is_rejected() {
     let _guard = crate::plugins::pii_redaction::test_mutex().lock().unwrap();
     reset_runtime();
     setup_isolated_thread();
 
-    futures::executor::block_on(initialize_plugins(plugin_config(json!({
+    let config = plugin_config(json!({
         "mode": "builtin",
         "input": false,
         "output": false,
@@ -3812,41 +3831,16 @@ fn builtin_remove_with_empty_target_paths_only_removes_string_leaves() {
         "builtin": {
             "action": "remove"
         }
-    }))))
-    .unwrap();
+    }));
+    let report = validate_plugin_config(&config);
+    assert!(report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.field.as_deref() == Some("builtin.target_paths")
+            && diagnostic.message.contains("requires at least one")
+    }));
 
-    let events = capture_events("pii-redaction-remove-empty-targets-events");
-    let _handle = tool_call(
-        ToolCallParams::builder()
-            .name("search")
-            .args(json!({
-                "secret": "abc",
-                "nested": {
-                    "keep": "yes",
-                    "count": 3
-                },
-                "items": ["a", "b", 9],
-                "public": true
-            }))
-            .build(),
-    )
-    .unwrap();
-
-    let captured_events = captured_events_snapshot(&events);
-    assert_eq!(captured_events.len(), 1);
-    assert_eq!(
-        captured_events[0].input(),
-        Some(&json!({
-            "nested": {
-                "count": 3
-            },
-            "items": [null, null, 9],
-            "public": true
-        }))
-    );
-
-    deregister_subscriber("pii-redaction-remove-empty-targets-events").unwrap();
-    clear_plugin_configuration().unwrap();
+    let activation = futures::executor::block_on(initialize_plugins(config));
+    let error = activation.expect_err("unscoped remove must fail plugin activation");
+    assert!(error.to_string().contains("requires at least one"));
 }
 
 #[test]

--- a/docs/configure-plugins/pii-redaction/configuration.mdx
+++ b/docs/configure-plugins/pii-redaction/configuration.mdx
@@ -153,6 +153,8 @@ To use `mode = "builtin"`:
 - `builtin` settings are required.
 - Set `codec` only when legacy/manual managed LLM calls need a fallback codec.
 - `builtin.action` must be `remove`, `redact`, `regex_replace`, `hash`, or `mask`.
+- `builtin.action = "remove"` requires at least one entry in `builtin.target_paths`
+  or `builtin.target_path_globs`.
 - `builtin.pattern` or `builtin.detector` is required when `builtin.action = "regex_replace"` or `builtin.action = "redact"`.
 
 ### Composed `plugins.toml` Example
@@ -233,7 +235,7 @@ The `builtin` section contains:
 | Field | Purpose |
 | --- | --- |
 | `action` | Sanitization action. Current values are `remove`, `redact`, `regex_replace`, `hash`, and `mask`. |
-| `target_paths` | Exact RFC 6901 JSON-pointer paths to sanitize. Empty together with `target_path_globs` means every matching string leaf. |
+| `target_paths` | Exact RFC 6901 JSON-pointer paths to sanitize. Empty together with `target_path_globs` means every matching string leaf, except when `action = "remove"`. |
 | `target_path_globs` | Restricted JSON-pointer glob paths. A whole `*` segment matches exactly one object key or array index. |
 | `pattern` | Regex pattern used when `action = "regex_replace"` or `action = "redact"`. |
 | `detector` | Optional built-in matcher preset. Current values are `email`, `phone`, `api_key`, `ip_address`, `ipv6`, `url`, `uuid`, `bearer_token`, `jwt`, `credit_card`, `aws_access_key_id`, `aws_secret_access_key`, `gcp_api_key`, and `azure_storage_account_key`. |
@@ -278,6 +280,10 @@ all other string leaves remain redacted.
 ### `remove`
 
 `remove` is structural.
+
+Configure at least one `target_paths` or `target_path_globs` selector when
+using `remove`. Relay rejects an unscoped `remove` policy during validation to
+prevent accidental removal of every string value in the selected surfaces.
 
 When a target matches:
 
@@ -447,8 +453,9 @@ credential family.
 
 They are deterministic regex-backed helpers, not model inference.
 
-If both target-selector lists are empty, the built-in backend sanitizes every matching
-string leaf in the selected payload boundary.
+For actions other than `remove`, if both target-selector lists are empty, the
+built-in backend sanitizes every matching string leaf in the selected payload
+boundary. The `remove` action requires at least one selector.
 
 ## Observability Semantics
 


### PR DESCRIPTION
#### Overview

Harden built-in PII redaction against false positives, unsafe default removal, and silent sanitization omissions.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Require an explicit target selector for the destructive `remove` action.
- Avoid API-key matches embedded in ordinary words without bypassing valid AWS secret shapes.
- Emit structured warnings when annotated LLM payload or metric-envelope redaction omits a value after a failed round trip.
- Add focused regression coverage for the detector and configuration behavior.

#### Where should the reviewer start?

Start with `crates/pii-redaction/src/builtin.rs`, which centralizes matcher filtering, omission diagnostics, and the unscoped-removal guard.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key detection to avoid matching keys embedded within other words.
  * Git commit SHAs are no longer incorrectly redacted as AWS secret keys.
  * Invalid or failed payload and metric processing is now logged and safely omitted.
  * Improved sanitization failure reporting.

* **Validation**
  * Removal rules now require explicit target paths or globs, preventing unintended removal of all string values.
  * Updated configuration guidance clarifies how empty selectors behave.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->