### PR TITLE
fix: drain adaptive telemetry during shutdown

### DIFF
--- a/crates/adaptive/src/runtime/features.rs
+++ b/crates/adaptive/src/runtime/features.rs
@@ -526,10 +526,37 @@ impl AdaptiveRuntime {
             guard.clear();
         }
         // Remove every sender so the drain can process the queued events and
-        // finish naturally. Dropping the JoinHandle detaches that work because
-        // this synchronous API cannot await it.
+        // finish naturally. The synchronous API cannot await it, so supervise
+        // the detached drain with the same bounded timeout as shutdown.
         self.event_tx.take();
-        self.drain_handle.take();
+        if let Some(handle) = self.drain_handle.take() {
+            match tokio::runtime::Handle::try_current() {
+                Ok(runtime) => {
+                    runtime.spawn(async move {
+                        let mut handle = handle;
+                        if tokio::time::timeout(TELEMETRY_DRAIN_TIMEOUT, &mut handle)
+                            .await
+                            .is_err()
+                        {
+                            log::warn!(
+                                target: "nemo_relay.runtime",
+                                event = "adaptive_telemetry_drain_timeout";
+                                "Adaptive runtime deregistration timed out while draining telemetry; aborting remaining work"
+                            );
+                            handle.abort();
+                        }
+                    });
+                }
+                Err(_) => {
+                    log::warn!(
+                        target: "nemo_relay.runtime",
+                        event = "adaptive_telemetry_drain_aborted";
+                        "Adaptive runtime deregistration has no Tokio runtime; aborting telemetry drain"
+                    );
+                    handle.abort();
+                }
+            }
+        }
         self.registered = false;
         Ok(())
     }

--- a/crates/adaptive/src/runtime/features.rs
+++ b/crates/adaptive/src/runtime/features.rs
@@ -540,7 +540,8 @@ impl AdaptiveRuntime {
     /// A [`Result`] that is `Ok(())` when shutdown completes.
     ///
     /// # Errors
-    /// Propagates any error returned by [`Self::deregister`].
+    /// This method currently always returns `Ok(())` after deregistering
+    /// features and either draining or aborting telemetry work.
     pub async fn shutdown(mut self) -> Result<()> {
         rollback_registrations(&mut self.registrations);
         if let Ok(mut guard) = self.bound_scopes.write() {

--- a/crates/adaptive/src/runtime/features.rs
+++ b/crates/adaptive/src/runtime/features.rs
@@ -69,12 +69,16 @@ pub struct AdaptiveRuntime {
     pending_events: Arc<AtomicUsize>,
     event_tx: Option<tokio::sync::mpsc::UnboundedSender<Event>>,
     event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Event>>,
-    drain_handle: Option<tokio::task::JoinHandle<()>>,
-    drain_runtime: Option<tokio::runtime::Handle>,
+    drain_task: Option<TelemetryDrainTask>,
     registered: bool,
     runtime_id: Uuid,
     bound_scopes: Arc<RwLock<HashSet<Uuid>>>,
     registrations: Vec<ComponentRegistration>,
+}
+
+struct TelemetryDrainTask {
+    handle: tokio::task::JoinHandle<()>,
+    runtime: tokio::runtime::Handle,
 }
 
 impl fmt::Debug for AdaptiveRuntime {
@@ -162,8 +166,7 @@ impl<'a> RegistrationContext<'a> {
         handle: tokio::task::JoinHandle<()>,
         runtime: tokio::runtime::Handle,
     ) {
-        self.runtime.drain_handle = Some(handle);
-        self.runtime.drain_runtime = Some(runtime);
+        self.runtime.drain_task = Some(TelemetryDrainTask { handle, runtime });
     }
 
     fn finish(self) -> Vec<ComponentRegistration> {
@@ -228,8 +231,7 @@ impl AdaptiveRuntime {
             pending_events: Arc::new(AtomicUsize::new(0)),
             event_tx: Some(event_tx),
             event_rx: Some(event_rx),
-            drain_handle: None,
-            drain_runtime: None,
+            drain_task: None,
             registered: false,
             runtime_id: Uuid::now_v7(),
             bound_scopes: Arc::new(RwLock::new(HashSet::new())),
@@ -508,10 +510,9 @@ impl AdaptiveRuntime {
             let mut just_registered = ctx.finish();
             rollback_registrations(&mut just_registered);
             rollback_registrations(&mut self.registrations);
-            if let Some(handle) = self.drain_handle.take() {
-                handle.abort();
+            if let Some(task) = self.drain_task.take() {
+                task.handle.abort();
             }
-            self.drain_runtime.take();
             self.registered = false;
             return Err(error);
         }
@@ -528,6 +529,12 @@ impl AdaptiveRuntime {
     ///
     /// # Errors
     /// Returns any rollback error surfaced by the hosted plugin system.
+    ///
+    /// # Runtime lifecycle
+    /// This method returns before the telemetry drain finishes. Callers using a
+    /// Tokio `current_thread` runtime must keep that runtime alive and driven
+    /// until the drain completes. Call [`Self::shutdown`] when completion must
+    /// be observed before the runtime is dropped.
     pub fn deregister(&mut self) -> Result<()> {
         rollback_registrations(&mut self.registrations);
         if let Ok(mut guard) = self.bound_scopes.write() {
@@ -537,30 +544,24 @@ impl AdaptiveRuntime {
         // finish naturally. The synchronous API cannot await it, so supervise
         // the detached drain with the same bounded timeout as shutdown.
         self.event_tx.take();
-        if let Some(handle) = self.drain_handle.take() {
-            if let Some(runtime) = self.drain_runtime.take() {
-                runtime.spawn(async move {
-                    let mut handle = handle;
-                    if tokio::time::timeout(TELEMETRY_DRAIN_TIMEOUT, &mut handle)
-                        .await
-                        .is_err()
-                    {
-                        log::warn!(
-                            target: "nemo_relay.runtime",
-                            event = "adaptive_telemetry_drain_timeout";
-                            "Adaptive runtime deregistration timed out while draining telemetry; aborting remaining work"
-                        );
-                        handle.abort();
-                    }
-                });
-            } else {
-                log::warn!(
-                    target: "nemo_relay.runtime",
-                    event = "adaptive_telemetry_drain_aborted";
-                    "Adaptive runtime deregistration has no stored Tokio runtime; aborting telemetry drain"
-                );
-                handle.abort();
-            }
+        if let Some(task) = self.drain_task.take() {
+            let TelemetryDrainTask {
+                mut handle,
+                runtime,
+            } = task;
+            runtime.spawn(async move {
+                if tokio::time::timeout(TELEMETRY_DRAIN_TIMEOUT, &mut handle)
+                    .await
+                    .is_err()
+                {
+                    log::warn!(
+                        target: "nemo_relay.runtime",
+                        event = "adaptive_telemetry_drain_timeout";
+                        "Adaptive runtime deregistration timed out while draining telemetry; aborting remaining work"
+                    );
+                    handle.abort();
+                }
+            });
         }
         self.registered = false;
         Ok(())
@@ -581,9 +582,8 @@ impl AdaptiveRuntime {
         }
         self.event_tx.take();
         self.registered = false;
-        self.drain_runtime.take();
 
-        if let Some(mut handle) = self.drain_handle.take()
+        if let Some(TelemetryDrainTask { mut handle, .. }) = self.drain_task.take()
             && tokio::time::timeout(TELEMETRY_DRAIN_TIMEOUT, &mut handle)
                 .await
                 .is_err()

--- a/crates/adaptive/src/runtime/features.rs
+++ b/crates/adaptive/src/runtime/features.rs
@@ -52,6 +52,8 @@ use crate::subscriber::create_subscriber_with_counter;
 use crate::tool_parallelism_learner::ToolParallelismLearner;
 use crate::types::cache::HotCache;
 
+const TELEMETRY_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Hosted adaptive runtime that registers NeMo Relay plugin components.
 ///
 /// This type validates configuration, builds the configured storage backend,
@@ -65,7 +67,7 @@ pub struct AdaptiveRuntime {
     hot_cache: Arc<RwLock<HotCache>>,
     cache_diagnostics_tracker: Arc<RwLock<CacheDiagnosticsTracker>>,
     pending_events: Arc<AtomicUsize>,
-    event_tx: tokio::sync::mpsc::UnboundedSender<Event>,
+    event_tx: Option<tokio::sync::mpsc::UnboundedSender<Event>>,
     event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Event>>,
     drain_handle: Option<tokio::task::JoinHandle<()>>,
     registered: bool,
@@ -218,7 +220,7 @@ impl AdaptiveRuntime {
             })),
             cache_diagnostics_tracker: Arc::new(RwLock::new(CacheDiagnosticsTracker::default())),
             pending_events: Arc::new(AtomicUsize::new(0)),
-            event_tx,
+            event_tx: Some(event_tx),
             event_rx: Some(event_rx),
             drain_handle: None,
             registered: false,
@@ -523,9 +525,11 @@ impl AdaptiveRuntime {
         if let Ok(mut guard) = self.bound_scopes.write() {
             guard.clear();
         }
-        if let Some(handle) = self.drain_handle.take() {
-            handle.abort();
-        }
+        // Remove every sender so the drain can process the queued events and
+        // finish naturally. Dropping the JoinHandle detaches that work because
+        // this synchronous API cannot await it.
+        self.event_tx.take();
+        self.drain_handle.take();
         self.registered = false;
         Ok(())
     }
@@ -538,7 +542,27 @@ impl AdaptiveRuntime {
     /// # Errors
     /// Propagates any error returned by [`Self::deregister`].
     pub async fn shutdown(mut self) -> Result<()> {
-        self.deregister()
+        rollback_registrations(&mut self.registrations);
+        if let Ok(mut guard) = self.bound_scopes.write() {
+            guard.clear();
+        }
+        self.event_tx.take();
+        self.registered = false;
+
+        if let Some(mut handle) = self.drain_handle.take()
+            && tokio::time::timeout(TELEMETRY_DRAIN_TIMEOUT, &mut handle)
+                .await
+                .is_err()
+        {
+            log::warn!(
+                target: "nemo_relay.runtime",
+                event = "adaptive_telemetry_drain_timeout";
+                "Adaptive runtime shutdown timed out while draining telemetry; aborting remaining work"
+            );
+            handle.abort();
+        }
+
+        Ok(())
     }
 }
 
@@ -600,7 +624,13 @@ impl AdaptiveFeature for TelemetryFeature {
             ctx.register_subscriber(
                 &self.subscriber_name,
                 create_subscriber_with_counter(
-                    ctx.runtime.event_tx.clone(),
+                    ctx.runtime
+                        .event_tx
+                        .as_ref()
+                        .ok_or_else(|| {
+                            AdaptiveError::Internal("telemetry sender is unavailable".into())
+                        })?
+                        .clone(),
                     ctx.runtime.pending_events.clone(),
                 ),
             )

--- a/crates/adaptive/src/runtime/features.rs
+++ b/crates/adaptive/src/runtime/features.rs
@@ -70,6 +70,7 @@ pub struct AdaptiveRuntime {
     event_tx: Option<tokio::sync::mpsc::UnboundedSender<Event>>,
     event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Event>>,
     drain_handle: Option<tokio::task::JoinHandle<()>>,
+    drain_runtime: Option<tokio::runtime::Handle>,
     registered: bool,
     runtime_id: Uuid,
     bound_scopes: Arc<RwLock<HashSet<Uuid>>>,
@@ -156,8 +157,13 @@ impl<'a> RegistrationContext<'a> {
             .ok_or_else(|| AdaptiveError::Internal("telemetry already registered".into()))
     }
 
-    fn set_drain_task(&mut self, handle: tokio::task::JoinHandle<()>) {
+    fn set_drain_task(
+        &mut self,
+        handle: tokio::task::JoinHandle<()>,
+        runtime: tokio::runtime::Handle,
+    ) {
         self.runtime.drain_handle = Some(handle);
+        self.runtime.drain_runtime = Some(runtime);
     }
 
     fn finish(self) -> Vec<ComponentRegistration> {
@@ -223,6 +229,7 @@ impl AdaptiveRuntime {
             event_tx: Some(event_tx),
             event_rx: Some(event_rx),
             drain_handle: None,
+            drain_runtime: None,
             registered: false,
             runtime_id: Uuid::now_v7(),
             bound_scopes: Arc::new(RwLock::new(HashSet::new())),
@@ -504,6 +511,7 @@ impl AdaptiveRuntime {
             if let Some(handle) = self.drain_handle.take() {
                 handle.abort();
             }
+            self.drain_runtime.take();
             self.registered = false;
             return Err(error);
         }
@@ -530,31 +538,28 @@ impl AdaptiveRuntime {
         // the detached drain with the same bounded timeout as shutdown.
         self.event_tx.take();
         if let Some(handle) = self.drain_handle.take() {
-            match tokio::runtime::Handle::try_current() {
-                Ok(runtime) => {
-                    runtime.spawn(async move {
-                        let mut handle = handle;
-                        if tokio::time::timeout(TELEMETRY_DRAIN_TIMEOUT, &mut handle)
-                            .await
-                            .is_err()
-                        {
-                            log::warn!(
-                                target: "nemo_relay.runtime",
-                                event = "adaptive_telemetry_drain_timeout";
-                                "Adaptive runtime deregistration timed out while draining telemetry; aborting remaining work"
-                            );
-                            handle.abort();
-                        }
-                    });
-                }
-                Err(_) => {
-                    log::warn!(
-                        target: "nemo_relay.runtime",
-                        event = "adaptive_telemetry_drain_aborted";
-                        "Adaptive runtime deregistration has no Tokio runtime; aborting telemetry drain"
-                    );
-                    handle.abort();
-                }
+            if let Some(runtime) = self.drain_runtime.take() {
+                runtime.spawn(async move {
+                    let mut handle = handle;
+                    if tokio::time::timeout(TELEMETRY_DRAIN_TIMEOUT, &mut handle)
+                        .await
+                        .is_err()
+                    {
+                        log::warn!(
+                            target: "nemo_relay.runtime",
+                            event = "adaptive_telemetry_drain_timeout";
+                            "Adaptive runtime deregistration timed out while draining telemetry; aborting remaining work"
+                        );
+                        handle.abort();
+                    }
+                });
+            } else {
+                log::warn!(
+                    target: "nemo_relay.runtime",
+                    event = "adaptive_telemetry_drain_aborted";
+                    "Adaptive runtime deregistration has no stored Tokio runtime; aborting telemetry drain"
+                );
+                handle.abort();
             }
         }
         self.registered = false;
@@ -576,6 +581,7 @@ impl AdaptiveRuntime {
         }
         self.event_tx.take();
         self.registered = false;
+        self.drain_runtime.take();
 
         if let Some(mut handle) = self.drain_handle.take()
             && tokio::time::timeout(TELEMETRY_DRAIN_TIMEOUT, &mut handle)
@@ -638,17 +644,21 @@ impl AdaptiveFeature for TelemetryFeature {
             let agent_id = self.agent_id.clone();
             let learners = std::mem::take(&mut self.learners);
             let pending_events = ctx.runtime.pending_events.clone();
-            ctx.set_drain_task(tokio::spawn(async move {
-                crate::drain::drain_task_with_counter(
-                    rx,
-                    backend,
-                    cache,
-                    pending_events,
-                    agent_id,
-                    learners,
-                )
-                .await;
-            }));
+            let runtime = tokio::runtime::Handle::current();
+            ctx.set_drain_task(
+                runtime.spawn(async move {
+                    crate::drain::drain_task_with_counter(
+                        rx,
+                        backend,
+                        cache,
+                        pending_events,
+                        agent_id,
+                        learners,
+                    )
+                    .await;
+                }),
+                runtime,
+            );
             ctx.register_subscriber(
                 &self.subscriber_name,
                 create_subscriber_with_counter(

--- a/crates/adaptive/src/subscriber.rs
+++ b/crates/adaptive/src/subscriber.rs
@@ -29,6 +29,11 @@ pub(crate) fn create_subscriber_with_counter(
         pending_events.fetch_add(1, Ordering::SeqCst);
         if tx.send(event.clone()).is_err() {
             pending_events.fetch_sub(1, Ordering::SeqCst);
+            log::warn!(
+                target: "nemo_relay.runtime",
+                event = "adaptive_telemetry_event_dropped";
+                "Adaptive telemetry event dropped because the drain receiver is unavailable"
+            );
         }
     })
 }

--- a/crates/adaptive/tests/coverage/subscriber_tests.rs
+++ b/crates/adaptive/tests/coverage/subscriber_tests.rs
@@ -9,7 +9,10 @@ use nemo_relay::api::event::{
 };
 use nemo_relay::api::scope::ScopeType;
 use nemo_relay::codec::response::{AnnotatedLlmResponse, FinishReason};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 #[derive(Clone, Copy)]
 enum EventType {
@@ -76,6 +79,22 @@ fn test_subscriber_survives_dropped_receiver() {
 
     let event = make_test_event(EventType::Start, Some(ScopeType::Tool), Some("search"));
     subscriber(&event); // Must not panic
+}
+
+#[test]
+fn test_subscriber_restores_pending_count_when_receiver_is_dropped() {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let pending_events = Arc::new(AtomicUsize::new(0));
+    let subscriber = create_subscriber_with_counter(tx, pending_events.clone());
+    drop(rx);
+
+    subscriber(&make_test_event(
+        EventType::Start,
+        Some(ScopeType::Tool),
+        Some("search"),
+    ));
+
+    assert_eq!(pending_events.load(Ordering::SeqCst), 0);
 }
 
 // -----------------------------------------------------------------------

--- a/crates/adaptive/tests/unit/runtime_features_tests.rs
+++ b/crates/adaptive/tests/unit/runtime_features_tests.rs
@@ -18,6 +18,7 @@ use crate::trie::serialization::TrieEnvelope;
 use crate::types::metadata::{AgentHints, MetadataEnvelope, ParallelHint};
 use crate::types::plan::{ExecutionPlan, ParallelGroup};
 use crate::types::records::RunRecord;
+use nemo_relay::api::event::{BaseEvent, EventCategory, ScopeCategory, ScopeEvent};
 use nemo_relay::api::llm::{
     LlmCallExecuteParams, LlmRequest, LlmStreamCallExecuteParams, llm_call_execute,
     llm_request_intercepts, llm_stream_call_execute,
@@ -709,7 +710,7 @@ async fn adaptive_runtime_register_survives_hot_cache_seed_failures() {
         })),
         cache_diagnostics_tracker: Arc::new(RwLock::new(CacheDiagnosticsTracker::default())),
         pending_events: Arc::new(AtomicUsize::new(0)),
-        event_tx,
+        event_tx: Some(event_tx),
         event_rx: Some(event_rx),
         drain_handle: None,
         registered: false,
@@ -1345,4 +1346,51 @@ async fn adaptive_runtime_shutdown_is_a_clean_noop_after_deregister() {
         .unwrap();
     runtime.deregister().unwrap();
     runtime.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn adaptive_runtime_shutdown_drains_queued_telemetry() {
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
+    reset_global();
+
+    let agent_id = "shutdown-drain-agent";
+    let mut runtime = AdaptiveRuntime::new(AdaptiveConfig {
+        agent_id: Some(agent_id.into()),
+        state: Some(StateConfig {
+            backend: BackendSpec::in_memory(),
+        }),
+        telemetry: Some(TelemetryComponentConfig::default()),
+        ..AdaptiveConfig::default()
+    })
+    .await
+    .unwrap();
+    runtime.register().await.unwrap();
+    let backend = runtime.backend.as_ref().unwrap().clone();
+    let run_uuid = Uuid::now_v7();
+    let events = [
+        Event::Scope(ScopeEvent::new(
+            BaseEvent::builder().uuid(run_uuid).name("agent").build(),
+            ScopeCategory::Start,
+            Vec::new(),
+            EventCategory::agent(),
+            None,
+        )),
+        Event::Scope(ScopeEvent::new(
+            BaseEvent::builder().uuid(run_uuid).name("agent").build(),
+            ScopeCategory::End,
+            Vec::new(),
+            EventCategory::agent(),
+            None,
+        )),
+    ];
+    let tx = runtime.event_tx.as_ref().unwrap().clone();
+    for event in events {
+        runtime.pending_events.fetch_add(1, Ordering::SeqCst);
+        tx.send(event).unwrap();
+    }
+    drop(tx);
+
+    runtime.shutdown().await.unwrap();
+
+    assert_eq!(backend.list_runs_dyn(agent_id).await.unwrap().len(), 1);
 }

--- a/crates/adaptive/tests/unit/runtime_features_tests.rs
+++ b/crates/adaptive/tests/unit/runtime_features_tests.rs
@@ -534,15 +534,16 @@ async fn telemetry_feature_registers_subscriber_and_starts_drain_task() {
         feature.register(&mut ctx).await.unwrap();
         ctx.finish()
     };
-    assert!(runtime.drain_handle.is_some());
+    assert!(runtime.drain_task.is_some());
     assert_subscriber_registered(&name);
 
     rollback_registrations(&mut registrations);
     assert_subscriber_absent(&name);
     let handle = runtime
-        .drain_handle
+        .drain_task
         .take()
-        .expect("telemetry registration must start a drain task");
+        .expect("telemetry registration must start a drain task")
+        .handle;
     drop(runtime);
     tokio::time::timeout(Duration::from_secs(1), handle)
         .await
@@ -712,8 +713,7 @@ async fn adaptive_runtime_register_survives_hot_cache_seed_failures() {
         pending_events: Arc::new(AtomicUsize::new(0)),
         event_tx: Some(event_tx),
         event_rx: Some(event_rx),
-        drain_handle: None,
-        drain_runtime: None,
+        drain_task: None,
         registered: false,
         runtime_id: Uuid::now_v7(),
         bound_scopes: Arc::new(RwLock::new(HashSet::new())),
@@ -772,7 +772,7 @@ async fn adaptive_runtime_register_rolls_back_when_telemetry_receiver_is_missing
         matches!(err, AdaptiveError::Internal(message) if message.contains("telemetry already registered"))
     );
     assert!(!runtime.registered);
-    assert!(runtime.drain_handle.is_none());
+    assert!(runtime.drain_task.is_none());
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -1042,9 +1042,12 @@ async fn adaptive_runtime_register_feature_rolls_back_partial_registrations_and_
             .unwrap();
         runtime.registrations = ctx.finish();
     }
-    runtime.drain_handle = Some(tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(60)).await;
-    }));
+    runtime.drain_task = Some(TelemetryDrainTask {
+        handle: tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        }),
+        runtime: tokio::runtime::Handle::current(),
+    });
     runtime.registered = true;
 
     let mut feature: Box<dyn AdaptiveFeature> = Box::new(PartiallyFailingFeature);
@@ -1052,7 +1055,7 @@ async fn adaptive_runtime_register_feature_rolls_back_partial_registrations_and_
 
     assert!(matches!(err, AdaptiveError::Internal(message) if message.contains("feature boom")));
     assert!(!runtime.registered);
-    assert!(runtime.drain_handle.is_none());
+    assert!(runtime.drain_task.is_none());
     assert!(runtime.registrations.is_empty());
     assert_subscriber_absent("existing_feature");
     assert_subscriber_absent("partial_feature");
@@ -1372,6 +1375,26 @@ async fn adaptive_runtime_shutdown_drains_queued_telemetry() {
     runtime.shutdown().await.unwrap();
 
     assert_eq!(backend.list_runs_dyn(agent_id).await.unwrap().len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn adaptive_runtime_shutdown_aborts_stalled_telemetry_after_timeout() {
+    let mut runtime = AdaptiveRuntime::new(AdaptiveConfig::default())
+        .await
+        .unwrap();
+    let handle = tokio::spawn(std::future::pending::<()>());
+    let abort_handle = handle.abort_handle();
+    runtime.drain_task = Some(TelemetryDrainTask {
+        handle,
+        runtime: tokio::runtime::Handle::current(),
+    });
+    let started = tokio::time::Instant::now();
+
+    runtime.shutdown().await.unwrap();
+    tokio::task::yield_now().await;
+
+    assert!(started.elapsed() >= TELEMETRY_DRAIN_TIMEOUT);
+    assert!(abort_handle.is_finished());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/adaptive/tests/unit/runtime_features_tests.rs
+++ b/crates/adaptive/tests/unit/runtime_features_tests.rs
@@ -1366,6 +1366,45 @@ async fn adaptive_runtime_shutdown_drains_queued_telemetry() {
     .unwrap();
     runtime.register().await.unwrap();
     let backend = runtime.backend.as_ref().unwrap().clone();
+    queue_completed_agent_run(&mut runtime);
+
+    runtime.shutdown().await.unwrap();
+
+    assert_eq!(backend.list_runs_dyn(agent_id).await.unwrap().len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn adaptive_runtime_deregister_drains_queued_telemetry() {
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.lock().await;
+    reset_global();
+
+    let agent_id = "deregister-drain-agent";
+    let mut runtime = AdaptiveRuntime::new(AdaptiveConfig {
+        agent_id: Some(agent_id.into()),
+        state: Some(StateConfig {
+            backend: BackendSpec::in_memory(),
+        }),
+        telemetry: Some(TelemetryComponentConfig::default()),
+        ..AdaptiveConfig::default()
+    })
+    .await
+    .unwrap();
+    runtime.register().await.unwrap();
+    let backend = runtime.backend.as_ref().unwrap().clone();
+    queue_completed_agent_run(&mut runtime);
+
+    runtime.deregister().unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while backend.list_runs_dyn(agent_id).await.unwrap().is_empty() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("deregistered telemetry drain must finish queued runs");
+}
+
+fn queue_completed_agent_run(runtime: &mut AdaptiveRuntime) {
     let run_uuid = Uuid::now_v7();
     let events = [
         Event::Scope(ScopeEvent::new(
@@ -1389,8 +1428,4 @@ async fn adaptive_runtime_shutdown_drains_queued_telemetry() {
         tx.send(event).unwrap();
     }
     drop(tx);
-
-    runtime.shutdown().await.unwrap();
-
-    assert_eq!(backend.list_runs_dyn(agent_id).await.unwrap().len(), 1);
 }

--- a/crates/adaptive/tests/unit/runtime_features_tests.rs
+++ b/crates/adaptive/tests/unit/runtime_features_tests.rs
@@ -1402,6 +1402,8 @@ async fn adaptive_runtime_deregister_drains_queued_telemetry() {
     })
     .await
     .expect("deregistered telemetry drain must finish queued runs");
+
+    assert_eq!(backend.list_runs_dyn(agent_id).await.unwrap().len(), 1);
 }
 
 fn queue_completed_agent_run(runtime: &mut AdaptiveRuntime) {

--- a/crates/adaptive/tests/unit/runtime_features_tests.rs
+++ b/crates/adaptive/tests/unit/runtime_features_tests.rs
@@ -713,6 +713,7 @@ async fn adaptive_runtime_register_survives_hot_cache_seed_failures() {
         event_tx: Some(event_tx),
         event_rx: Some(event_rx),
         drain_handle: None,
+        drain_runtime: None,
         registered: false,
         runtime_id: Uuid::now_v7(),
         bound_scopes: Arc::new(RwLock::new(HashSet::new())),
@@ -1404,6 +1405,48 @@ async fn adaptive_runtime_deregister_drains_queued_telemetry() {
     .expect("deregistered telemetry drain must finish queued runs");
 
     assert_eq!(backend.list_runs_dyn(agent_id).await.unwrap().len(), 1);
+}
+
+#[test]
+fn adaptive_runtime_deregister_drains_telemetry_outside_block_on() {
+    let _lock = crate::TEST_GLOBAL_CONTEXT_MUTEX.blocking_lock();
+    reset_global();
+
+    let agent_id = "deregister-outside-block-on-agent";
+    let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let (mut runtime, backend) = tokio_runtime.block_on(async {
+        let mut runtime = AdaptiveRuntime::new(AdaptiveConfig {
+            agent_id: Some(agent_id.into()),
+            state: Some(StateConfig {
+                backend: BackendSpec::in_memory(),
+            }),
+            telemetry: Some(TelemetryComponentConfig::default()),
+            ..AdaptiveConfig::default()
+        })
+        .await
+        .unwrap();
+        runtime.register().await.unwrap();
+        let backend = runtime.backend.as_ref().unwrap().clone();
+        (runtime, backend)
+    });
+    queue_completed_agent_run(&mut runtime);
+
+    runtime.deregister().unwrap();
+
+    tokio_runtime.block_on(async {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while backend.list_runs_dyn(agent_id).await.unwrap().is_empty() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("deregistered telemetry drain must finish queued runs outside block_on");
+
+        assert_eq!(backend.list_runs_dyn(agent_id).await.unwrap().len(), 1);
+    });
 }
 
 fn queue_completed_agent_run(runtime: &mut AdaptiveRuntime) {


### PR DESCRIPTION
#### Overview

Preserve queued adaptive telemetry during graceful runtime shutdown with a bounded drain window.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Unregister telemetry producers and close the channel before shutdown waits for the drain task.
- Bound the graceful wait to five seconds, then log and abort only remaining work.
- Let synchronous deregistration detach a naturally closing drain instead of aborting it.
- Log receiver-loss drops and add shutdown-drain regression coverage.

#### Where should the reviewer start?

Start with `crates/adaptive/src/runtime/features.rs`, specifically `AdaptiveRuntime::shutdown()` and `deregister()`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Queued telemetry events now drain during shutdown and deregistration, improving recorded run reliability.
  - Shutdown and deregistration wait up to five seconds for telemetry processing before terminating stalled work.
  - Telemetry registrations are safely rolled back during shutdown.
  - Failed telemetry deliveries now generate a warning, making dropped events easier to identify.
  - Telemetry registration reports an error when delivery is unavailable.
  - Pending event counts are restored when telemetry delivery fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->