### PR TITLE
docs: clarify epoch timestamp precision

### DIFF
--- a/docs/reference/atof-event-format.mdx
+++ b/docs/reference/atof-event-format.mdx
@@ -362,7 +362,7 @@ Unknown `category_profile` keys MUST be preserved verbatim by consumers. Adding 
 
 Emitters choose per event. A single stream MAY contain events in both forms.
 
-**Why microseconds and not nanoseconds.** JSON numbers are IEEE 754 doubles with 53 bits of integer precision (~9 × 10¹⁵). Nanoseconds since epoch for 2026 is ~1.76 × 10¹⁸ — exceeds safe integer range. Microseconds fits safely and remains precise enough for agent-scope event correlation.
+**Why microseconds and not nanoseconds.** JSON numbers are IEEE 754 doubles with 53 bits of integer precision (~9 × 10¹⁵). A nanosecond epoch timestamp in 2026 (~1.76 × 10¹⁸) exceeds that safe-integer range. A microsecond timestamp fits and remains precise enough for agent-scope event correlation.
 
 <Warning title="Normalize Timestamps Before Sorting">
   Events are emitted in wall-clock order. Delivery from subscriber callbacks MAY arrive out-of-order for concurrent operations. Consumers MUST sort by `timestamp` before processing. When sorting a mixed-format stream, consumers MUST normalize both forms to a common representation (typically integer microseconds) before comparison — lexicographic string vs integer comparison is undefined.


### PR DESCRIPTION
#### Overview

Rephrases explanation of timestamp precision for clarity.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Documentation-only change to the timestamp precision explanation.

#### Where should the reviewer start?

See `docs/reference/atof-event-format.mdx`

#### Validation
- `just docs` passed

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- No related issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified why ATOF uses integer epoch microseconds rather than nanoseconds.
  * Corrected the example value and improved grammar in the event format reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->