### PR TITLE
fix: normalize Windows marketplace paths for host CLIs

### DIFF
--- a/crates/cli/src/installation/marketplace/host.rs
+++ b/crates/cli/src/installation/marketplace/host.rs
@@ -26,11 +26,27 @@ pub(super) fn run_host_marketplace_registration(
             "plugin".into(),
             "marketplace".into(),
             "add".into(),
-            marketplace_root.display().to_string(),
+            marketplace_path_argument_for_platform(marketplace_root, cfg!(windows)),
         ],
         options,
         runner,
     )
+}
+
+pub(crate) fn marketplace_path_argument_for_platform(
+    marketplace_root: &Path,
+    windows: bool,
+) -> String {
+    let path = marketplace_root.display().to_string();
+    if !windows {
+        return path;
+    }
+
+    if let Some(unc) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{unc}")
+    } else {
+        path.strip_prefix(r"\\?\").unwrap_or(&path).to_owned()
+    }
 }
 
 pub(super) fn run_host_plugin_registration(

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -96,6 +96,28 @@ fn windows_verbatim_relay_paths_are_normalized_for_mcp_config() {
 }
 
 #[test]
+fn windows_verbatim_marketplace_paths_are_normalized_for_host_cli() {
+    use crate::installation::marketplace::host::marketplace_path_argument_for_platform;
+
+    assert_eq!(
+        marketplace_path_argument_for_platform(
+            Path::new(
+                r"\\?\C:\Users\sumahalingam\AppData\Local\nemo-relay\plugins\claude-code-marketplace"
+            ),
+            true,
+        ),
+        r"C:\Users\sumahalingam\AppData\Local\nemo-relay\plugins\claude-code-marketplace"
+    );
+    assert_eq!(
+        marketplace_path_argument_for_platform(
+            Path::new(r"\\?\UNC\server\share\nemo-relay\claude-code-marketplace"),
+            true,
+        ),
+        r"\\server\share\nemo-relay\claude-code-marketplace"
+    );
+}
+
+#[test]
 fn readiness_worker_returns_a_report_and_handles_channel_disconnects() {
     let dir = tempdir().unwrap();
     let readiness = collect_marketplace_readiness(


### PR DESCRIPTION
#### Overview

Normalize Windows marketplace directory paths before sending them to coding-agent CLIs, so Claude Code accepts the local marketplace created by `nemo-relay install all --force`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Strip the Windows extended-length `\\?\\` prefix from marketplace paths passed to host CLI registration commands.
- Preserve UNC paths by converting `\\?\\UNC\\server\\share` to `\\server\\share`.
- Add regression coverage for local and UNC marketplace paths.

#### Where should the reviewer start?

Start with `crates/cli/src/installation/marketplace/host.rs`, where host marketplace registration now normalizes the command argument. The adjacent regression test covers the reported Windows path format.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes AEP-120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved marketplace registration on Windows by normalizing extended-length paths before they are passed to the host CLI.
  - Standardized both drive-letter paths and extended UNC paths while preserving existing behavior on other platforms.

- **Tests**
  - Added Windows-specific coverage for marketplace paths using drive-letter and UNC formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->