### PR TITLE
fix: preserve LangChain message boundaries

### DIFF
--- a/python/nemo_relay/integrations/langchain/_serialization.py
+++ b/python/nemo_relay/integrations/langchain/_serialization.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
 LANGCHAIN_MODEL_RESPONSE_KEY = "__nemo_relay_integrations_langchain_model_response"
 _LANGCHAIN_MODELED_REQUEST_KEYS = {"messages", "model", "tool_choice", "tools"}
+_LANGCHAIN_PROVIDER = "langchain"
 _LC_TO_RELAY_MESSAGE_ROLE = {
     "human": "user",
     "ai": "assistant",
@@ -132,41 +133,79 @@ class LangChainCodec(LlmCodec):
         ]
 
     @classmethod
-    def _langchain_message_to_annotated(cls, message: BaseMessage) -> list[dict[str, Any]]:
-        content = message.content
+    def _langchain_content_to_annotated(cls, content: Any) -> str | list[dict[str, Any]]:
+        """Preserve one LangChain message while exposing its portable text blocks."""
         if content is None:
-            content = []
-        elif isinstance(content, str):
-            content = [content]
+            return ""
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            raise ValueError(f"Unsupported LangChain message content type: {type(content)}")
 
+        content_parts = []
+        for content_part in content:
+            if isinstance(content_part, str):
+                content_parts.append({"type": "text", "text": content_part})
+            elif (
+                isinstance(content_part, dict)
+                and content_part.get("type") == "text"
+                and isinstance(content_part.get("text"), str)
+            ):
+                content_parts.append(dict(content_part))
+            elif isinstance(content_part, dict):
+                content_parts.append(
+                    {
+                        "type": "provider_native",
+                        "provider": _LANGCHAIN_PROVIDER,
+                        "kind": str(content_part.get("type") or "content_block"),
+                        "value": dict(content_part),
+                    }
+                )
+            else:
+                raise ValueError(f"Unsupported LangChain message content part type: {type(content_part)}")
+        return content_parts
+
+    @staticmethod
+    def _annotated_content_to_langchain(content: Any) -> Any:
+        """Restore LangChain-native blocks after annotated request interception."""
+        if not isinstance(content, list):
+            return content
+
+        content_parts = []
+        for content_part in content:
+            if (
+                isinstance(content_part, dict)
+                and content_part.get("type") == "provider_native"
+                and content_part.get("provider") == _LANGCHAIN_PROVIDER
+            ):
+                value = content_part.get("value")
+                if not isinstance(value, str | dict):
+                    raise ValueError("LangChain provider-native content must contain a string or object value")
+                content_parts.append(value)
+            else:
+                content_parts.append(content_part)
+        return content_parts
+
+    @classmethod
+    def _langchain_message_to_annotated(cls, message: BaseMessage) -> dict[str, Any]:
+        content = message.content
         name = message.name
         role = _LC_TO_RELAY_MESSAGE_ROLE.get(message.type, message.type)
 
-        messages = []
-        for content_index, msg in enumerate(content):
-            relay_message: dict[str, Any] = {"role": role}
-            if isinstance(msg, str):
-                relay_message["content"] = msg
-            elif isinstance(msg, dict):
-                relay_message.update(msg)
-                if "content" not in relay_message:
-                    relay_message["content"] = relay_message.pop("text", "")
-            else:
-                raise ValueError(f"Unsupported LangChain message content type: {type(content)}")
+        relay_message: dict[str, Any] = {
+            "role": role,
+            "content": cls._langchain_content_to_annotated(content),
+        }
+        if name is not None:
+            relay_message["name"] = name
 
-            if name is not None:
-                relay_message["name"] = name
+        # Using getattr as we are inferring subclasses of BaseMessage based upon the role
+        if role == "assistant":
+            relay_message["tool_calls"] = cls._langchain_tool_calls_to_annotated(getattr(message, "tool_calls", []))
+        elif role == "tool":
+            relay_message["tool_call_id"] = getattr(message, "tool_call_id", "")
 
-            # Using getattr as we are inferring subclasses of BaseMessage based upon the role
-            if role == "assistant":
-                tool_calls = getattr(message, "tool_calls", []) if content_index == 0 else []
-                relay_message["tool_calls"] = cls._langchain_tool_calls_to_annotated(tool_calls)
-            elif role == "tool":
-                relay_message["tool_call_id"] = getattr(message, "tool_call_id", "")
-
-            messages.append(relay_message)
-
-        return messages
+        return relay_message
 
     @classmethod
     def _annotated_message_to_langchain(
@@ -175,7 +214,7 @@ class LangChainCodec(LlmCodec):
         provider_tool_calls: list[dict[str, Any]] | None = None,
     ) -> BaseMessage:
         role = message.get("role")
-        content = message.get("content", "")
+        content = cls._annotated_content_to_langchain(message.get("content", ""))
         name = message.get("name")
 
         if role == "system":
@@ -207,9 +246,8 @@ class LangChainCodec(LlmCodec):
                 if isinstance(candidate, list):
                     raw_tool_calls = candidate
             if raw_tool_calls is not None:
-                annotated_messages = cls._langchain_message_to_annotated(message)
-                if annotated_messages:
-                    provider_tool_calls.append((annotated_messages[0], raw_tool_calls))
+                annotated_message = cls._langchain_message_to_annotated(message)
+                provider_tool_calls.append((annotated_message, raw_tool_calls))
         return provider_tool_calls
 
     def _provider_tool_calls_for_message(
@@ -243,7 +281,7 @@ class LangChainCodec(LlmCodec):
         messages: list[dict[str, Any]] = []
         if isinstance(raw_messages, list):
             for message in messages_from_dict(raw_messages):
-                messages.extend(self._langchain_message_to_annotated(message))
+                messages.append(self._langchain_message_to_annotated(message))
 
         model = payload.get("model")
         tools = payload.get("tools")

--- a/python/nemo_relay/integrations/langchain/_serialization.py
+++ b/python/nemo_relay/integrations/langchain/_serialization.py
@@ -212,9 +212,14 @@ class LangChainCodec(LlmCodec):
         cls,
         message: dict[str, Any],
         provider_tool_calls: list[dict[str, Any]] | None = None,
+        original_message: BaseMessage | None = None,
     ) -> BaseMessage:
         role = message.get("role")
-        content = cls._annotated_content_to_langchain(message.get("content", ""))
+        content = (
+            original_message.content
+            if original_message is not None
+            else cls._annotated_content_to_langchain(message.get("content", ""))
+        )
         name = message.get("name")
 
         if role == "system":
@@ -230,6 +235,62 @@ class LangChainCodec(LlmCodec):
         if role == "tool":
             return ToolMessage(content=content, name=name, tool_call_id=str(message.get("tool_call_id") or ""))
         raise ValueError(f"Unsupported annotated LangChain message role: {role!r}")
+
+    @classmethod
+    def _original_messages(cls, original: LLMRequest) -> list[tuple[dict[str, Any], BaseMessage]]:
+        """Return original LangChain messages with their annotated representations."""
+        raw_messages = original.content.get("messages")
+        if not isinstance(raw_messages, list):
+            return []
+
+        return [(cls._langchain_message_to_annotated(message), message) for message in messages_from_dict(raw_messages)]
+
+    @staticmethod
+    def _message_content_matches(message: dict[str, Any], original_message: dict[str, Any]) -> bool:
+        """Return whether two messages have the same role, content, and tool result identity."""
+        return all(message.get(key) == original_message.get(key) for key in ("role", "content", "tool_call_id"))
+
+    @classmethod
+    def _original_messages_for_annotated(
+        cls,
+        messages: list[dict[str, Any]],
+        original_messages: list[tuple[dict[str, Any], BaseMessage]],
+    ) -> list[BaseMessage | None]:
+        """Match unchanged message content to its original LangChain representation."""
+        matches: list[BaseMessage | None] = [None] * len(messages)
+        matched_original_indexes: set[int] = set()
+
+        if len(messages) == len(original_messages):
+            for index, message in enumerate(messages):
+                original_annotated_message, original_langchain_message = original_messages[index]
+                if cls._message_content_matches(message, original_annotated_message):
+                    matches[index] = original_langchain_message
+                    matched_original_indexes.add(index)
+
+        for message_index, message in enumerate(messages):
+            if matches[message_index] is not None:
+                continue
+            candidate_indexes = [
+                original_index
+                for original_index, (original_annotated_message, _) in enumerate(original_messages)
+                if original_index not in matched_original_indexes
+                and cls._message_content_matches(message, original_annotated_message)
+            ]
+            if len(candidate_indexes) != 1:
+                continue
+            original_index = candidate_indexes[0]
+            matching_message_count = sum(
+                1
+                for candidate_index, candidate_message in enumerate(messages)
+                if matches[candidate_index] is None
+                and cls._message_content_matches(candidate_message, original_messages[original_index][0])
+            )
+            if matching_message_count != 1:
+                continue
+            matches[message_index] = original_messages[original_index][1]
+            matched_original_indexes.add(original_index)
+
+        return matches
 
     @classmethod
     def _original_provider_tool_calls(cls, original: LLMRequest) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
@@ -300,16 +361,22 @@ class LangChainCodec(LlmCodec):
         """Encode annotated request edits back into a LangChain-shaped payload."""
         payload = dict(original.content)
         payload.update(annotated.extra)
+        messages = annotated.messages
+        original_messages = self._original_messages(original)
+        original_messages_by_annotated_index = self._original_messages_for_annotated(messages, original_messages)
         original_provider_tool_calls = self._original_provider_tool_calls(original)
         matched_original_messages: set[int] = set()
         encoded_messages = []
-        for message in annotated.messages:
+        for index, message in enumerate(messages):
+            original_message = original_messages_by_annotated_index[index]
             provider_tool_calls = None
             if message.get("role") == "assistant":
                 provider_tool_calls = self._provider_tool_calls_for_message(
                     message, original_provider_tool_calls, matched_original_messages
                 )
-            encoded_messages.append(self._annotated_message_to_langchain(message, provider_tool_calls))
+            encoded_messages.append(
+                self._annotated_message_to_langchain(message, provider_tool_calls, original_message)
+            )
         payload["messages"] = messages_to_dict(encoded_messages)
         if annotated.model is not None:
             payload["model"] = annotated.model

--- a/python/tests/integrations/deepagents_tests/test_deepagents_integration.py
+++ b/python/tests/integrations/deepagents_tests/test_deepagents_integration.py
@@ -277,6 +277,49 @@ def test_model_call_routes_through_langchain_execution_middleware(
 
 
 @pytest.mark.parametrize("use_async", [False, True])
+def test_model_call_preserves_multi_block_system_message(
+    use_async: bool,
+    deepagents_integration_module: types.ModuleType,
+):
+    from langchain.agents.middleware import ModelRequest, ModelResponse
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+    content_blocks = [
+        {"type": "text", "text": "first"},
+        {"type": "text", "text": "second"},
+        {"type": "text", "text": "third"},
+        {"type": "text", "text": "fourth"},
+    ]
+    request = ModelRequest(
+        model=_mock_deepagents_chat_model([AIMessage(content="unused")]),
+        system_message=SystemMessage(content_blocks=content_blocks),
+        messages=[HumanMessage(content="hello")],
+    )
+    seen_request: dict[str, ModelRequest[Any]] = {}
+
+    def handler(next_request: ModelRequest[Any]) -> ModelResponse[Any]:
+        seen_request["request"] = next_request
+        return ModelResponse(result=[AIMessage(content="done")])
+
+    async def async_handler(next_request: ModelRequest[Any]) -> ModelResponse[Any]:
+        return handler(next_request)
+
+    middleware = deepagents_integration_module.NemoRelayDeepAgentsMiddleware()
+    if use_async:
+        response = asyncio.run(middleware.awrap_model_call(request, async_handler))
+    else:
+        response = middleware.wrap_model_call(request, handler)
+
+    assert response.result[0].content == "done"
+    assert seen_request["request"].system_message is not None
+    assert seen_request["request"].system_message.content == content_blocks
+    assert len(seen_request["request"].messages) == 1
+    assert seen_request["request"].messages[0].content == "hello"
+    assert request.system_message is not None
+    assert request.system_message.content == content_blocks
+
+
+@pytest.mark.parametrize("use_async", [False, True])
 def test_tool_call_routes_through_langchain_execution_middleware(
     use_async: bool,
     monkeypatch: pytest.MonkeyPatch,

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -554,6 +554,117 @@ def test_langchain_request_codec_preserves_multi_block_assistant_message():
     }
 
 
+def test_langchain_request_codec_preserves_unchanged_bare_string_content_parts():
+    from langchain_core.messages import HumanMessage, messages_from_dict, messages_to_dict
+
+    from nemo_relay.integrations.langchain._serialization import LangChainCodec
+
+    original_content = ["first", {"type": "text", "text": "second"}]
+    request = nemo_relay.LLMRequest({}, {"messages": messages_to_dict([HumanMessage(content=original_content)])})
+
+    codec = LangChainCodec()
+    rebuilt = messages_from_dict(
+        cast(list[dict[str, Any]], codec.encode(codec.decode(request), request).content["messages"])
+    )
+
+    assert rebuilt[0].content == original_content
+
+
+def test_langchain_request_codec_uses_canonical_blocks_after_bare_string_content_edit():
+    from langchain_core.messages import HumanMessage, messages_from_dict, messages_to_dict
+
+    from nemo_relay.integrations.langchain._serialization import LangChainCodec
+
+    request = nemo_relay.LLMRequest(
+        {},
+        {"messages": messages_to_dict([HumanMessage(content=["first", {"type": "text", "text": "second"}])])},
+    )
+
+    codec = LangChainCodec()
+    annotated = codec.decode(request)
+    message = dict(annotated.messages[0])
+    content = [dict(part) for part in cast(list[dict[str, Any]], message["content"])]
+    content[0]["text"] = "first from intercept"
+    message["content"] = content
+    annotated.messages = [message]
+    rebuilt = messages_from_dict(cast(list[dict[str, Any]], codec.encode(annotated, request).content["messages"]))
+
+    assert rebuilt[0].content == [
+        {"type": "text", "text": "first from intercept"},
+        {"type": "text", "text": "second"},
+    ]
+
+
+@pytest.mark.parametrize("message_list_edit", ["prepend", "append", "delete"])
+def test_langchain_request_codec_preserves_bare_strings_across_message_list_edits(message_list_edit: str):
+    from langchain_core.messages import AIMessage, HumanMessage, messages_from_dict, messages_to_dict
+
+    from nemo_relay.integrations.langchain._serialization import LangChainCodec
+
+    request = nemo_relay.LLMRequest(
+        {},
+        {"messages": messages_to_dict([HumanMessage(content=["first"]), AIMessage(content=["second"])])},
+    )
+
+    codec = LangChainCodec()
+    annotated = codec.decode(request)
+    if message_list_edit == "prepend":
+        annotated.messages = [{"role": "system", "content": "new"}, *annotated.messages]
+    elif message_list_edit == "append":
+        annotated.messages = [*annotated.messages, {"role": "assistant", "content": "new", "tool_calls": []}]
+    else:
+        annotated.messages = annotated.messages[:1]
+    rebuilt = messages_from_dict(cast(list[dict[str, Any]], codec.encode(annotated, request).content["messages"]))
+
+    preserved_messages = [message for message in rebuilt if message.content != "new"]
+    assert preserved_messages[0].content == ["first"]
+    if message_list_edit != "delete":
+        assert preserved_messages[1].content == ["second"]
+
+
+def test_langchain_request_codec_preserves_bare_strings_after_name_edit():
+    from langchain_core.messages import HumanMessage, messages_from_dict, messages_to_dict
+
+    from nemo_relay.integrations.langchain._serialization import LangChainCodec
+
+    request = nemo_relay.LLMRequest({}, {"messages": messages_to_dict([HumanMessage(content=["first"])])})
+
+    codec = LangChainCodec()
+    annotated = codec.decode(request)
+    message = dict(annotated.messages[0])
+    message["name"] = "renamed"
+    annotated.messages = [message]
+    rebuilt = messages_from_dict(cast(list[dict[str, Any]], codec.encode(annotated, request).content["messages"]))
+
+    assert rebuilt[0].name == "renamed"
+    assert rebuilt[0].content == ["first"]
+
+
+def test_langchain_request_codec_does_not_guess_bare_string_shape_for_ambiguous_messages():
+    from langchain_core.messages import HumanMessage, messages_from_dict, messages_to_dict
+
+    from nemo_relay.integrations.langchain._serialization import LangChainCodec
+
+    request = nemo_relay.LLMRequest(
+        {},
+        {
+            "messages": messages_to_dict(
+                [
+                    HumanMessage(content=["same"]),
+                    HumanMessage(content=[{"type": "text", "text": "same"}]),
+                ]
+            )
+        },
+    )
+
+    codec = LangChainCodec()
+    annotated = codec.decode(request)
+    annotated.messages = annotated.messages[1:]
+    rebuilt = messages_from_dict(cast(list[dict[str, Any]], codec.encode(annotated, request).content["messages"]))
+
+    assert rebuilt[0].content == [{"type": "text", "text": "same"}]
+
+
 def test_langchain_request_codec_preserves_distinct_system_messages_and_native_blocks():
     from langchain_core.messages import HumanMessage, SystemMessage, messages_from_dict, messages_to_dict
 

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -493,7 +493,7 @@ def test_langchain_request_codec_builds_provider_tool_calls_for_new_assistant():
     ]
 
 
-def test_langchain_request_codec_keeps_multi_block_tool_calls_on_first_assistant_fragment():
+def test_langchain_request_codec_preserves_multi_block_assistant_message():
     from langchain_core.messages import AIMessage, messages_from_dict, messages_to_dict
 
     from nemo_relay.integrations.langchain._serialization import LangChainCodec
@@ -532,25 +532,101 @@ def test_langchain_request_codec_keeps_multi_block_tool_calls_on_first_assistant
     rebuilt = messages_from_dict(
         cast(list[dict[str, Any]], codec.encode(codec.decode(request), request).content["messages"])
     )
-    assert all(isinstance(message, AIMessage) for message in rebuilt)
-    rebuilt_assistants = cast(list[AIMessage], rebuilt)
+    assert len(rebuilt) == 1
+    rebuilt_assistant = rebuilt[0]
+    assert isinstance(rebuilt_assistant, AIMessage)
 
-    assert [message.tool_calls for message in rebuilt_assistants] == [
-        [{"id": "call-weather", "name": "get_weather", "args": {"city": "SF"}, "type": "tool_call"}],
-        [],
+    assert rebuilt_assistant.content == [
+        {"type": "text", "text": "first"},
+        {"type": "text", "text": "second"},
     ]
-    assert [message.additional_kwargs for message in rebuilt_assistants] == [
-        {
-            "tool_calls": [
-                {
-                    "id": "call-weather",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"city":"SF"}'},
-                }
-            ]
-        },
-        {},
+    assert rebuilt_assistant.tool_calls == [
+        {"id": "call-weather", "name": "get_weather", "args": {"city": "SF"}, "type": "tool_call"}
     ]
+    assert rebuilt_assistant.additional_kwargs == {
+        "tool_calls": [
+            {
+                "id": "call-weather",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "SF"}'},
+            }
+        ]
+    }
+
+
+def test_langchain_request_codec_preserves_distinct_system_messages_and_native_blocks():
+    from langchain_core.messages import HumanMessage, SystemMessage, messages_from_dict, messages_to_dict
+
+    from nemo_relay.integrations.langchain._serialization import LangChainCodec
+
+    original_messages = [
+        SystemMessage(content="first system message"),
+        SystemMessage(content="second system message"),
+        HumanMessage(content=[{"type": "image", "url": "https://example.com/image.png"}]),
+    ]
+    request = nemo_relay.LLMRequest({}, {"messages": messages_to_dict(original_messages)})
+
+    codec = LangChainCodec()
+    annotated = codec.decode(request)
+    rebuilt = messages_from_dict(cast(list[dict[str, Any]], codec.encode(annotated, request).content["messages"]))
+
+    assert [message.type for message in rebuilt] == ["system", "system", "human"]
+    assert [message.content for message in rebuilt] == [message.content for message in original_messages]
+
+
+def test_model_call_applies_edit_to_one_system_content_block(
+    nemo_relay_middleware: NemoRelayMiddleware,
+):
+    from langchain.agents.middleware import ModelRequest, ModelResponse
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+    content_blocks = [
+        {"type": "text", "text": "first"},
+        {"type": "text", "text": "second"},
+        {"type": "text", "text": "third"},
+        {"type": "text", "text": "fourth"},
+    ]
+    request = ModelRequest(
+        model=_mk_mock_model(),
+        system_message=SystemMessage(content_blocks=content_blocks),
+        messages=[HumanMessage(content="hello")],
+    )
+    seen_request: dict[str, ModelRequest[Any]] = {}
+
+    def edit_system_block(
+        _name: str,
+        llm_request: nemo_relay.LLMRequest,
+        annotated: nemo_relay.AnnotatedLLMRequest | None,
+    ) -> nemo_relay.LLMRequestInterceptOutcome:
+        assert annotated is not None
+        messages = annotated.messages
+        system_message = dict(messages[0])
+        system_content = [dict(part) for part in cast(list[dict[str, Any]], system_message["content"])]
+        system_content[1]["text"] = "second from intercept"
+        system_message["content"] = system_content
+        annotated.messages = [system_message, *messages[1:]]
+        return nemo_relay.LLMRequestInterceptOutcome(llm_request, annotated)
+
+    def handler(next_request: ModelRequest[Any]) -> ModelResponse[Any]:
+        seen_request["request"] = next_request
+        return ModelResponse(result=[AIMessage(content="done")])
+
+    nemo_relay.intercepts.register_llm_request("edit_system_content_block", 1, False, edit_system_block)
+    try:
+        response = nemo_relay_middleware.wrap_model_call(request, handler)
+    finally:
+        nemo_relay.intercepts.deregister_llm_request("edit_system_content_block")
+
+    assert response.result[0].content == "done"
+    assert seen_request["request"].system_message is not None
+    assert seen_request["request"].system_message.content == [
+        content_blocks[0],
+        {"type": "text", "text": "second from intercept"},
+        content_blocks[2],
+        content_blocks[3],
+    ]
+    assert request.system_message is not None
+    assert request.system_message.content == content_blocks
 
 
 def test_model_call_intercept_rebuilds_provider_tool_calls(


### PR DESCRIPTION
#### Overview

Preserve LangChain message boundaries when LLM requests pass through Relay. A multi-block LangChain message now remains one logical message instead of being expanded into multiple provider-facing messages.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Previously, `LangChainCodec` flattened each content block into a separate annotated message. For Deep Agents, one four-block system message therefore reached the provider as four system messages, which could change how the composed system prompt was interpreted.

This change:

- Preserves one annotated message for each original LangChain message.
- Keeps ordered text and provider-native content blocks inside that message.
- Preserves message-level tool-call information.
- Allows middleware to modify individual blocks without mutating the original request.
- Adds synchronous and asynchronous LangChain and Deep Agents regression coverage.

Validation:

- `just test-python-langchain`: 103 tests passed.
- Real Deep Agents, Relay, and NVIDIA provider smoke: passed.
  - The provider received one four-block system message and one human message.
  - The managed tool emitted Relay start and end events.
  - The tool ran once and returned the expected result.
- `uv run pre-commit run --all-files`: passed.
- `just test-python`: 79 of 80 native tests passed. The remaining environment-sensitive Guardrails coverage test failed with `Invalid config path ./rails`; it does not exercise the changed LangChain serialization path.

This change does not alter public APIs or non-Python bindings.

#### Where should the reviewer start?

Start with `python/nemo_relay/integrations/langchain/_serialization.py`, particularly the conversion between LangChain messages and Relay's annotated request representation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LangChain message handling to preserve multi-block text, native content, system messages, and tool-call details.
  - Prevented edits to one system-message block from unintentionally affecting other messages or the original request.
  - Improved compatibility with Deep Agents middleware when processing messages with multiple content blocks.

- **Tests**
  - Added coverage for synchronous and asynchronous middleware flows, content preservation, tool calls, native image blocks, and targeted message edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->