### PR TITLE
fix(cli): preserve Pi tool-result text

### DIFF
--- a/crates/cli/assets/pi-extension/index.ts
+++ b/crates/cli/assets/pi-extension/index.ts
@@ -729,15 +729,40 @@ function summarize(result: unknown, isError: boolean): unknown {
   if (typeof result === 'object') {
     const record = result as Record<string, unknown>;
     const content = record.content ?? record.output ?? record.text;
+    const text = toolResultText(content);
     return {
-      content:
-        typeof content === 'string'
-          ? truncate(content)
-          : `Tool ${isError ? 'failed' : 'completed'}.`,
+      content: text === null ? `Tool ${isError ? 'failed' : 'completed'}.` : text,
       result_keys: Object.keys(record).slice(0, 20),
     };
   }
   return { content: truncate(String(result)) };
+}
+
+/** Extract and bound Pi's ordered text blocks without forwarding image or unknown parts. */
+function toolResultText(content: unknown): string | null {
+  if (typeof content === 'string') return truncate(content);
+  if (!Array.isArray(content)) return null;
+
+  let text = '';
+  let omittedChars = 0;
+  let foundText = false;
+
+  const append = (value: string): void => {
+    const kept = value.slice(0, Math.max(0, MAX_CONTENT_CHARS - text.length));
+    text += kept;
+    omittedChars += value.length - kept.length;
+  };
+
+  for (const part of content) {
+    if (typeof part !== 'object' || part === null || Array.isArray(part)) continue;
+    const block = part as Record<string, unknown>;
+    if (block.type !== 'text' || typeof block.text !== 'string') continue;
+    if (foundText) append('\n');
+    append(block.text);
+    foundText = true;
+  }
+  if (!foundText) return null;
+  return omittedChars === 0 ? text : `${text}... [truncated ${omittedChars} chars]`;
 }
 
 function truncate(value: string): string {

--- a/crates/cli/assets/pi-extension/index.ts
+++ b/crates/cli/assets/pi-extension/index.ts
@@ -748,7 +748,10 @@ function toolResultText(content: unknown): string | null {
   let foundText = false;
 
   const append = (value: string): void => {
-    const kept = value.slice(0, Math.max(0, MAX_CONTENT_CHARS - text.length));
+    const kept = sliceAtCodePointBoundary(
+      value,
+      Math.max(0, MAX_CONTENT_CHARS - text.length),
+    );
     text += kept;
     omittedChars += value.length - kept.length;
   };
@@ -765,8 +768,24 @@ function toolResultText(content: unknown): string | null {
   return omittedChars === 0 ? text : `${text}... [truncated ${omittedChars} chars]`;
 }
 
+/** Return at most limit UTF-16 units without splitting a surrogate pair. */
+function sliceAtCodePointBoundary(value: string, limit: number): string {
+  let end = Math.min(value.length, limit);
+  if (
+    end > 0 &&
+    end < value.length &&
+    value.charCodeAt(end - 1) >= 0xd800 &&
+    value.charCodeAt(end - 1) <= 0xdbff &&
+    value.charCodeAt(end) >= 0xdc00 &&
+    value.charCodeAt(end) <= 0xdfff
+  ) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
 function truncate(value: string): string {
-  return value.length <= MAX_CONTENT_CHARS
-    ? value
-    : `${value.slice(0, MAX_CONTENT_CHARS)}... [truncated ${value.length - MAX_CONTENT_CHARS} chars]`;
+  if (value.length <= MAX_CONTENT_CHARS) return value;
+  const kept = sliceAtCodePointBoundary(value, MAX_CONTENT_CHARS);
+  return `${kept}... [truncated ${value.length - kept.length} chars]`;
 }

--- a/docs/nemo-relay-cli/pi.mdx
+++ b/docs/nemo-relay-cli/pi.mdx
@@ -263,10 +263,12 @@ recorded on the session scope rather than opening an empty turn to hold it.
 | `user_bash` | Tool span start named `user_bash`, and the inline shell gate |
 | *(after the `user_bash` verdict)* | `user_bash_end`, a tool span end. Synthesized by the extension the moment the gate decides, **before the command runs** — pi reports no completion for inline shell, so this span measures the policy decision and not the shell command's duration |
 
-**Tool results are truncated at 2000 characters** before the extension forwards
-them, with the overflow replaced by a `... [truncated N chars]` suffix. A
-guardrail or subscriber that reads a tool result sees the truncated form, so do
-not write policy that depends on the tail of a long result.
+For pi's structured tool results, the extension joins text parts in order and
+omits image and other non-text parts. **Tool-result text is truncated at 2000
+characters** before the extension forwards it. The overflow is replaced by a
+`... [truncated N chars]` suffix. A guardrail or subscriber that reads a tool
+result sees this bounded text projection, so do not write policy that depends on
+the tail of a long result or on non-text content.
 
 pi's `tool_execution_start` is deliberately not forwarded: it fires before
 argument validation and also for calls that never execute. `tool_result` is not

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -422,11 +422,12 @@ the first event of the turn.
 
 ## What Is Not Represented
 
-**Tool results are truncated at 2000 characters** before they are forwarded, with
-the overflow replaced by a `... [truncated N chars]` suffix. The gateway
-therefore records what a tool returned, not necessarily all of it — a large file
-read or a long command output is cut. Raise `MAX_CONTENT_CHARS` in `index.ts` if
-a policy needs to see more.
+For pi's structured tool results, the extension joins text parts in order and
+omits image and other non-text parts. **Tool-result text is truncated at 2000
+characters** before it is forwarded. The overflow is replaced by a
+`... [truncated N chars]` suffix. The gateway therefore records a bounded text
+projection, not the complete result — a large file read or a long command output
+is cut. Raise `MAX_CONTENT_CHARS` in `index.ts` if a policy needs to see more.
 
 **Tool arguments are not truncated, and must not be.** The `tool_call` post is
 the gated one: a guardrail decides on exactly those arguments, and a request

--- a/integrations/pi/test/tool-result.test.mjs
+++ b/integrations/pi/test/tool-result.test.mjs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Verifies how Pi's structured tool results are projected into Relay hooks. */
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, it } from 'node:test';
+
+import { listen, load as loadExtension, named, stubGateway } from './harness.mjs';
+
+const extension = (await import('../index.ts')).default;
+const load = () => loadExtension(extension, { ctx: { mode: 'print', hasUI: false } });
+
+describe('tool result projection', () => {
+  let ctx;
+
+  before(async () => {
+    ctx = stubGateway();
+    process.env.NEMO_RELAY_PI_GATEWAY_URL = await listen(ctx.server);
+  });
+
+  after(() => {
+    ctx.server.close();
+    delete process.env.NEMO_RELAY_PI_GATEWAY_URL;
+  });
+
+  beforeEach(() => {
+    ctx.posts.length = 0;
+  });
+
+  async function project(result, isError = false) {
+    const fire = load();
+    await fire('tool_execution_end', {
+      toolCallId: 'result-under-test',
+      toolName: 'test-tool',
+      result,
+      isError,
+    });
+    await fire('session_shutdown', { reason: 'quit' });
+    return named(ctx.posts, 'tool_execution_end')[0];
+  }
+
+  it('preserves text from a Pi Read result', async () => {
+    const post = await project({
+      content: [{ type: 'text', text: 'line one\nline two\n' }],
+      details: { truncation: null },
+    });
+
+    assert.equal(post.result.content, 'line one\nline two\n');
+    assert.deepEqual(post.result.result_keys, ['content', 'details']);
+    assert.equal(post.status, 'ok');
+  });
+
+  it('preserves the diagnostic from a failed Pi Bash result', async () => {
+    const post = await project(
+      {
+        content: [{ type: 'text', text: '(no output)\n\nCommand exited with code 42' }],
+        details: {},
+      },
+      true,
+    );
+
+    assert.equal(post.result.content, '(no output)\n\nCommand exited with code 42');
+    assert.equal(post.status, 'error');
+  });
+
+  it('joins text in order, omits images, and bounds the aggregate', async () => {
+    const prefix = 'a'.repeat(1998);
+    const post = await project({
+      content: [
+        { type: 'text', text: prefix },
+        { type: 'image', data: 'binary-image-data', mimeType: 'image/png' },
+        { type: 'text', text: 'BC' },
+      ],
+      details: {},
+    });
+
+    assert.equal(post.result.content, `${prefix}\nB... [truncated 1 chars]`);
+    assert.doesNotMatch(post.result.content, /binary-image-data/);
+  });
+});

--- a/integrations/pi/test/tool-result.test.mjs
+++ b/integrations/pi/test/tool-result.test.mjs
@@ -77,4 +77,15 @@ describe('tool result projection', () => {
     assert.equal(post.result.content, `${prefix}\nB... [truncated 1 chars]`);
     assert.doesNotMatch(post.result.content, /binary-image-data/);
   });
+
+  it('does not split Unicode surrogate pairs at the truncation boundary', async () => {
+    const prefix = 'a'.repeat(1999);
+    const value = `${prefix}😀tail`;
+
+    for (const result of [value, { content: [{ type: 'text', text: value }] }]) {
+      ctx.posts.length = 0;
+      const post = await project(result);
+      assert.equal(post.result.content, `${prefix}... [truncated 6 chars]`);
+    }
+  });
 });


### PR DESCRIPTION
#### Overview

Pi returns normal tool output as an ordered `content` array. The Relay extension only kept scalar strings, so Read and Bash spans were recorded as `Tool completed.` or `Tool failed.` instead of the text Pi produced.

This change keeps the text from those results while preserving the existing 2,000-character bound.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Join Pi text parts in order before applying the existing result limit.
- Omit image and unknown parts instead of serializing them into observability events.
- Keep the existing scalar-result and fallback behavior.
- Add Pi-shaped Read and Bash success/error tests, plus mixed-content and truncation coverage.
- Clarify the result projection in the Pi README and user guide.

There is no Rust, gateway, binding, event-schema, or public API change.

PR #986 refactors the same helper but does not add array handling. This branch is based directly on `main`, not on #986. It is staying in draft while that overlap is resolved; if #986 lands first, this branch will take the small conflict resolution before review.

Validation:

- `just test-pi` — 113 passed.
- `cargo build -p nemo-relay-cli` — passed.
- Changed-file pre-commit checks — passed.
- Real Pi 0.84.4 through the rebuilt Relay CLI and a deterministic local OpenAI-compatible endpoint — passed. Pi executed Read, and the ATOF tool-end event contained the exact canary text instead of `Tool completed.`

```json
{"name":"read","status":"ok","content":"CANARY-PI-TOOL-RESULT: Ada Lovelace has an account at ada.lovelace@example.test.\nThis line exists to verify the real Pi AgentToolResult shape reaches Relay rather than a generic completion marker.\n"}
```

#### Where should the reviewer start?

Start with `toolResultText()` and `summarize()` in `crates/cli/assets/pi-extension/index.ts`, then the real result shapes in `integrations/pi/test/tool-result.test.mjs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Structured tool results now preserve text blocks in order while omitting images and other non-text content.
  * Large results are truncated to 2,000 characters with an indication of omitted content.
  * Truncation preserves Unicode characters correctly.
  * Results without text use a completion-status fallback, including clearer failed-command diagnostics.

* **Documentation**
  * Updated guidance to explain structured-result formatting, omitted content, and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->