### PR TITLE
feat: add Hermes Agent integration adapter

### DIFF
--- a/python/nemo_relay/integrations/__init__.py
+++ b/python/nemo_relay/integrations/__init__.py
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Optional integrations for NeMo Relay."""
+
+# Available integrations: langchain, langgraph, deepagents, hermes

--- a/python/nemo_relay/integrations/hermes/__init__.py
+++ b/python/nemo_relay/integrations/hermes/__init__.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NeMo Relay integration for Hermes Agent."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from nemo_relay.integrations.hermes.callbacks import NemoRelayHermesCallbackHandler
+from nemo_relay.integrations.hermes.middleware import NemoRelayHermesMiddleware
+
+
+def add_nemo_relay_integration(
+    kwargs: Mapping[str, Any] | None = None,
+    *,
+    instrument_subagents: bool = True,
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Attach NeMo Relay observability to a Hermes Agent configuration.
+
+    Use this helper when constructing a Hermes agent to inject Relay
+    middleware for tool-call sanitisation, LLM payload guards, and
+    lifecycle scope tracking.
+
+    Args:
+        kwargs: Existing keyword arguments for the Hermes agent.
+        instrument_subagents: Whether to add Relay middleware to
+            delegated sub-agents that do not already carry it.
+        **overrides: Keyword arguments that override values from *kwargs*.
+
+    Returns:
+        dict[str, Any]: Arguments ready to pass to the Hermes agent.
+    """
+    observed = dict(kwargs or {})
+    observed.update(overrides)
+
+    agent_name = observed.get("agent_name", "hermes-agent")
+    blocked_tools = list(observed.get("blocked_tools", ()))
+    max_tool_args_size = int(observed.get("max_tool_args_size", 65536))
+
+    middleware = list(observed.get("middleware", ()))
+    if not any(isinstance(m, NemoRelayHermesMiddleware) for m in middleware):
+        middleware.append(
+            NemoRelayHermesMiddleware(
+                agent_name=agent_name,
+                blocked_tools=blocked_tools,
+                max_tool_args_size=max_tool_args_size,
+            )
+        )
+    observed["middleware"] = middleware
+
+    callbacks = list(observed.get("callbacks", ()))
+    if not any(isinstance(c, NemoRelayHermesCallbackHandler) for c in callbacks):
+        callbacks.append(NemoRelayHermesCallbackHandler(agent_name=agent_name))
+    observed["callbacks"] = callbacks
+
+    if instrument_subagents:
+        subagents = list(observed.get("subagents", ()))
+        instrumented = []
+        for sub in subagents:
+            if isinstance(sub, dict) and not any(
+                isinstance(m, NemoRelayHermesMiddleware)
+                for m in sub.get("middleware", ())
+            ):
+                sub = dict(sub)
+                sub_mw = list(sub.get("middleware", ()))
+                sub_mw.append(
+                    NemoRelayHermesMiddleware(
+                        agent_name=sub.get("name", "subagent"),
+                        blocked_tools=blocked_tools,
+                        max_tool_args_size=max_tool_args_size,
+                    )
+                )
+                sub["middleware"] = sub_mw
+            instrumented.append(sub)
+        observed["subagents"] = instrumented
+
+    return observed
+
+
+__all__ = [
+    "NemoRelayHermesCallbackHandler",
+    "NemoRelayHermesMiddleware",
+    "add_nemo_relay_integration",
+]

--- a/python/nemo_relay/integrations/hermes/callbacks.py
+++ b/python/nemo_relay/integrations/hermes/callbacks.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hermes Agent callback handler that maps lifecycle events to NeMo Relay scopes."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import threading
+import typing
+
+import nemo_relay
+
+if typing.TYPE_CHECKING:
+    pass
+
+_logger = logging.getLogger(__name__)
+
+
+class _CompletedScope(typing.NamedTuple):
+    """A scope that has ended but cannot yet be popped (LIFO ordering)."""
+    handle: nemo_relay.ScopeHandle
+    output: nemo_relay.Json | None
+    metadata: nemo_relay.Json | None
+    ended_at: datetime.datetime
+
+
+def _current_scope_handle() -> nemo_relay.ScopeHandle | None:
+    try:
+        if not nemo_relay.scope_stack_active():
+            return None
+        return nemo_relay.scope.get_handle()
+    except Exception:
+        _logger.debug("NeMo Relay: reading current scope failed", exc_info=True)
+        return None
+
+
+class NemoRelayHermesCallbackHandler:
+    """Bridge Hermes Agent lifecycle events to NeMo Relay scopes.
+
+    Maps the Hermes event hierarchy to NeMo Relay scope types:
+
+    * **Session**  -> ScopeType.Run
+    * **Turn**     -> ScopeType.Turn
+    * **Tool**     -> ScopeType.Function
+    * **LLM**      -> ScopeType.LLM
+    * **Subagent** -> ScopeType.Agent
+    * **Task**     -> ScopeType.Task
+    """
+
+    def __init__(self, agent_name: str = "hermes-agent") -> None:
+        self._agent_name = agent_name
+        self._lock = threading.Lock()
+        self._active_scopes: dict[str, nemo_relay.ScopeHandle] = {}
+        self._pending_completions: dict[str, _CompletedScope] = {}
+
+    # -- public event methods --------------------------------------------------
+
+    def on_session_start(
+        self,
+        session_id: str,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        """Open a Run scope for the session."""
+        try:
+            handle = nemo_relay.scope.push(
+                f"session:{session_id}",
+                nemo_relay.ScopeType.Run,
+                data={"agent_name": self._agent_name, "session_id": session_id},
+            )
+            with self._lock:
+                self._active_scopes[session_id] = handle
+        except Exception:
+            _logger.debug("on_session_start failed", exc_info=True)
+
+    def on_session_end(self, session_id: str, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """Close the Run scope for the session."""
+        self._close_scope(session_id)
+
+    def on_turn_start(
+        self,
+        turn_id: str,
+        session_id: str,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        """Open a Turn scope as a child of the current top scope."""
+        try:
+            parent = self._active_scopes.get(session_id)
+            handle = nemo_relay.scope.push(
+                f"turn:{turn_id}",
+                nemo_relay.ScopeType.Turn,
+                handle=parent,
+                data={"turn_id": turn_id},
+            )
+            with self._lock:
+                self._active_scopes[turn_id] = handle
+        except Exception:
+            _logger.debug("on_turn_start failed", exc_info=True)
+
+    def on_turn_end(self, turn_id: str, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self._close_scope(turn_id)
+
+    def on_tool_call_start(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        args: dict[str, typing.Any] | None = None,
+        *posargs: typing.Any,
+        **kw: typing.Any,
+    ) -> None:
+        """Open a Function scope for a tool invocation."""
+        try:
+            handle = nemo_relay.scope.push(
+                tool_name,
+                nemo_relay.ScopeType.Function,
+                data={"tool_call_id": tool_call_id, "tool_name": tool_name},
+                input=args,
+            )
+            with self._lock:
+                self._active_scopes[tool_call_id] = handle
+        except Exception:
+            _logger.debug("on_tool_call_start failed", exc_info=True)
+
+    def on_tool_call_end(
+        self,
+        tool_call_id: str,
+        result: typing.Any = None,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        self._close_scope(tool_call_id, output={"result": str(result)[:2048]} if result is not None else None)
+
+    def on_llm_call_start(
+        self,
+        llm_call_id: str,
+        model: str,
+        request_data: dict[str, typing.Any] | None = None,
+        *posargs: typing.Any,
+        **kw: typing.Any,
+    ) -> None:
+        """Open an LLM scope for a model call."""
+        try:
+            handle = nemo_relay.scope.push(
+                f"llm:{model}",
+                nemo_relay.ScopeType.LLM,
+                data={"llm_call_id": llm_call_id, "model": model},
+                input=request_data,
+            )
+            with self._lock:
+                self._active_scopes[llm_call_id] = handle
+        except Exception:
+            _logger.debug("on_llm_call_start failed", exc_info=True)
+
+    def on_llm_call_end(
+        self,
+        llm_call_id: str,
+        response_data: typing.Any = None,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        self._close_scope(llm_call_id, output=response_data if isinstance(response_data, dict) else None)
+
+    def on_subagent_start(
+        self,
+        subagent_id: str,
+        agent_name: str,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        """Open an Agent scope for a delegated sub-agent."""
+        try:
+            handle = nemo_relay.scope.push(
+                f"subagent:{agent_name}",
+                nemo_relay.ScopeType.Agent,
+                data={"subagent_id": subagent_id, "agent_name": agent_name},
+            )
+            with self._lock:
+                self._active_scopes[subagent_id] = handle
+        except Exception:
+            _logger.debug("on_subagent_start failed", exc_info=True)
+
+    def on_subagent_end(self, subagent_id: str, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self._close_scope(subagent_id)
+
+    def on_task_start(
+        self,
+        task_id: str,
+        task_name: str,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        """Open a Task scope for a cron/scheduled task."""
+        try:
+            handle = nemo_relay.scope.push(
+                f"task:{task_name}",
+                nemo_relay.ScopeType.Task,
+                data={"task_id": task_id, "task_name": task_name},
+            )
+            with self._lock:
+                self._active_scopes[task_id] = handle
+        except Exception:
+            _logger.debug("on_task_start failed", exc_info=True)
+
+    def on_task_end(self, task_id: str, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self._close_scope(task_id)
+
+    # -- internal ---------------------------------------------------------------
+
+    def _close_scope(
+        self,
+        event_id: str,
+        output: nemo_relay.Json | None = None,
+        metadata: nemo_relay.Json | None = None,
+    ) -> None:
+        """Close the scope for *event_id*, respecting LIFO ordering."""
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with self._lock:
+            handle = self._active_scopes.pop(event_id, None)
+            if handle is None:
+                return
+
+            top = _current_scope_handle()
+            if top is not None and top == handle:
+                nemo_relay.scope.pop(handle, output=output, metadata=metadata)
+                self._drain_pending()
+            else:
+                self._pending_completions[event_id] = _CompletedScope(
+                    handle=handle, output=output, metadata=metadata, ended_at=now,
+                )
+
+    def _drain_pending(self) -> None:
+        """Pop completed scopes that are now at the top of the stack."""
+        drained = True
+        while drained:
+            drained = False
+            top = _current_scope_handle()
+            if top is None:
+                break
+            for eid, pending in list(self._pending_completions.items()):
+                if pending.handle == top:
+                    nemo_relay.scope.pop(
+                        pending.handle,
+                        output=pending.output,
+                        metadata=pending.metadata,
+                    )
+                    del self._pending_completions[eid]
+                    drained = True
+                    break

--- a/python/nemo_relay/integrations/hermes/middleware.py
+++ b/python/nemo_relay/integrations/hermes/middleware.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pre-execution validation middleware for Hermes Agent tool and LLM calls."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import nemo_relay
+
+_logger = logging.getLogger(__name__)
+
+_SECRET_KEYS = frozenset({"api_key", "token", "secret", "password", "authorization", "bearer"})
+_REDACTED = "***REDACTED***"
+
+
+def _redact_secrets(args: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of *args* with secret-looking values redacted."""
+    redacted: dict[str, Any] = {}
+    for key, value in args.items():
+        if key.lower() in _SECRET_KEYS:
+            redacted[key] = _REDACTED
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def _payload_size(payload: Mapping[str, Any] | None) -> int:
+    """Rough byte-size estimate of a JSON-serialisable mapping."""
+    if payload is None:
+        return 0
+    import json
+    try:
+        return len(json.dumps(payload, default=str).encode())
+    except Exception:
+        return 0
+
+
+class NemoRelayHermesMiddleware:
+    """Middleware that guards Hermes Agent tool and LLM calls.
+
+    Features:
+    * **Secret redaction** -- sanitises tool arguments before they reach
+      the observability pipeline.
+    * **Tool blocking** -- denies invocations of tools in a configurable
+      block-list.
+    * **Payload size guard** -- rejects LLM requests whose payload
+      exceeds a configurable byte threshold.
+    """
+
+    def __init__(
+        self,
+        agent_name: str = "hermes-agent",
+        blocked_tools: Sequence[str] | None = None,
+        max_tool_args_size: int = 65536,
+    ) -> None:
+        self._agent_name = agent_name
+        self._blocked_tools = frozenset(blocked_tools or ())
+        self._max_tool_args_size = max_tool_args_size
+        self._registered = False
+
+    # -- registration ----------------------------------------------------------
+
+    def register(self) -> None:
+        """Register all guardrails and intercepts with the NeMo Relay runtime."""
+        if self._registered:
+            return
+        self._registered = True
+
+        # Tool argument sanitisation
+        try:
+            nemo_relay.guardrails.register_tool_sanitize_request(
+                f"{self._agent_name}-redact",
+                10,
+                self._sanitize_tool_args,
+            )
+        except Exception:
+            _logger.debug("Failed to register tool sanitiser", exc_info=True)
+
+        # Tool blocking
+        if self._blocked_tools:
+            try:
+                nemo_relay.guardrails.register_tool_sanitize_request(
+                    f"{self._agent_name}-block",
+                    5,
+                    self._block_denied_tools,
+                )
+            except Exception:
+                _logger.debug("Failed to register tool blocker", exc_info=True)
+
+        # LLM payload size guard
+        try:
+            nemo_relay.intercepts.register_llm_request(
+                f"{self._agent_name}-size-guard",
+                10,
+                False,
+                self._guard_llm_payload_size,
+            )
+        except Exception:
+            _logger.debug("Failed to register LLM size guard", exc_info=True)
+
+    # -- guard callbacks -------------------------------------------------------
+
+    def _sanitize_tool_args(
+        self, tool_name: str, args: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        return _redact_secrets(args)
+
+    def _block_denied_tools(
+        self, tool_name: str, args: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        if tool_name in self._blocked_tools:
+            raise ValueError(f"Tool {tool_name!r} is blocked by Hermes middleware policy")
+        return dict(args)
+
+    def _guard_llm_payload_size(
+        self,
+        name: str,
+        request: nemo_relay.LLMRequest,
+        annotated: nemo_relay.AnnotatedLLMRequest | None,
+    ) -> nemo_relay.LLMRequestInterceptOutcome:
+        size = _payload_size(request.content)
+        if size > self._max_tool_args_size:
+            raise ValueError(
+                f"LLM payload ({size} bytes) exceeds configured limit"
+                f" ({self._max_tool_args_size} bytes)"
+            )
+        return nemo_relay.LLMRequestInterceptOutcome(request, annotated)
+
+    # -- properties ------------------------------------------------------------
+
+    @property
+    def agent_name(self) -> str:
+        return self._agent_name
+
+    @property
+    def blocked_tools(self) -> frozenset[str]:
+        return self._blocked_tools
+
+    @property
+    def max_tool_args_size(self) -> int:
+        return self._max_tool_args_size

--- a/python/nemo_relay/integrations/hermes/subscriber.py
+++ b/python/nemo_relay/integrations/hermes/subscriber.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Subscriber that bridges NeMo Relay ATOF lifecycle events to Hermes-compatible log entries."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+
+class HermesATOFSubscriber:
+    """Format NeMo Relay lifecycle events as Hermes-compatible structured log dicts.
+
+    Each event is converted to a dict with keys:
+    event_type, scope_name, scope_type, timestamp, data.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[dict[str, Any]] = []
+
+    def __call__(self, event: Mapping[str, Any]) -> None:
+        """Process a single lifecycle event."""
+        try:
+            formatted = self._format_event(event)
+            self._events.append(formatted)
+            _logger.debug("Hermes ATOF: %s %s", formatted["event_type"], formatted["scope_name"])
+        except Exception:
+            _logger.debug("Failed to format event", exc_info=True)
+
+    def _format_event(self, event: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "event_type": event.get("event_type", event.get("type", "unknown")),
+            "scope_name": event.get("scope_name", event.get("name", "")),
+            "scope_type": event.get("scope_type", ""),
+            "timestamp": event.get("timestamp", datetime.datetime.now(datetime.timezone.utc).isoformat()),
+            "data": event.get("data", {}),
+        }
+
+    @property
+    def events(self) -> list[dict[str, Any]]:
+        """Return accumulated events (read-only snapshot)."""
+        return list(self._events)
+
+    def clear(self) -> None:
+        """Flush accumulated events."""
+        self._events.clear()

--- a/python/tests/test_hermes_integration.py
+++ b/python/tests/test_hermes_integration.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Hermes Agent integration."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+
+# We mock the nemo_relay native layer since we cannot build the Rust core
+# in a pure-Python test environment.
+
+MOCK_HANDLE = MagicMock(name="ScopeHandle")
+
+
+@pytest.fixture(autouse=True)
+def _mock_relay_native():
+    """Patch nemo_relay native calls so the tests run without the Rust runtime."""
+    mock_native = MagicMock()
+    mock_native.push_scope.return_value = MOCK_HANDLE
+    mock_stack_active = MagicMock(return_value=True)
+
+    with patch.dict("sys.modules", {
+        "nemo_relay": MagicMock(),
+        "nemo_relay._native": mock_native,
+        "nemo_relay._context": MagicMock(),
+    }):
+        # Re-import after patching so references resolve to mocks
+        import nemo_relay as nr
+        nr.ScopeType = MagicMock()
+        nr.ScopeType.Run = "Run"
+        nr.ScopeType.Turn = "Turn"
+        nr.ScopeType.Function = "Function"
+        nr.ScopeType.LLM = "LLM"
+        nr.ScopeType.Agent = "Agent"
+        nr.ScopeType.Task = "Task"
+        nr.scope = MagicMock()
+        nr.scope.push.return_value = MOCK_HANDLE
+        nr.scope.get_handle.return_value = MOCK_HANDLE
+        nr.scope_stack_active = MagicMock(return_value=True)
+        nr.guardrails = MagicMock()
+        nr.intercepts = MagicMock()
+        nr.LLMRequest = MagicMock
+        nr.AnnotatedLLMRequest = MagicMock
+        nr.LLMRequestInterceptOutcome = MagicMock
+        nr.ScopeHandle = MagicMock
+        nr.Json = dict
+
+        yield nr
+
+
+# ---- Callback handler tests -------------------------------------------------
+
+class TestHermesCallbackHandler:
+    def _make_handler(self):
+        from nemo_relay.integrations.hermes.callbacks import NemoRelayHermesCallbackHandler
+        return NemoRelayHermesCallbackHandler(agent_name="test-agent")
+
+    def test_session_scope_hierarchy(self, _mock_relay_native):
+        handler = self._make_handler()
+        nr = _mock_relay_native
+
+        handler.on_session_start("sess-1")
+        nr.scope.push.assert_called()
+        assert nr.scope.push.call_args[0][1] == nr.ScopeType.Run
+
+        handler.on_session_end("sess-1")
+        nr.scope.pop.assert_called()
+
+    def test_tool_call_scope(self, _mock_relay_native):
+        handler = self._make_handler()
+        nr = _mock_relay_native
+
+        handler.on_tool_call_start("tc-1", "web_search", {"query": "hello"})
+        nr.scope.push.assert_called()
+        call_args = nr.scope.push.call_args
+        assert call_args[0][1] == nr.ScopeType.Function
+        assert call_args[0][0] == "web_search"
+
+        handler.on_tool_call_end("tc-1", result="found 5 results")
+        nr.scope.pop.assert_called()
+
+    def test_subagent_scope(self, _mock_relay_native):
+        handler = self._make_handler()
+        nr = _mock_relay_native
+
+        handler.on_subagent_start("sub-1", "worker")
+        nr.scope.push.assert_called()
+        assert nr.scope.push.call_args[0][1] == nr.ScopeType.Agent
+
+        handler.on_subagent_end("sub-1")
+        nr.scope.pop.assert_called()
+
+    def test_llm_scope(self, _mock_relay_native):
+        handler = self._make_handler()
+        nr = _mock_relay_native
+
+        handler.on_llm_call_start("llm-1", "gpt-4o", {"messages": []})
+        nr.scope.push.assert_called()
+        assert nr.scope.push.call_args[0][1] == nr.ScopeType.LLM
+
+        handler.on_llm_call_end("llm-1")
+        nr.scope.pop.assert_called()
+
+    def test_task_scope(self, _mock_relay_native):
+        handler = self._make_handler()
+        nr = _mock_relay_native
+
+        handler.on_task_start("task-1", "daily-healthcheck")
+        nr.scope.push.assert_called()
+        assert nr.scope.push.call_args[0][1] == nr.ScopeType.Task
+
+        handler.on_task_end("task-1")
+        nr.scope.pop.assert_called()
+
+    def test_unknown_event_does_not_crash(self, _mock_relay_native):
+        handler = self._make_handler()
+        # Closing a scope that was never opened should be a no-op
+        handler.on_session_end("nonexistent")
+
+
+# ---- Middleware tests --------------------------------------------------------
+
+class TestHermesMiddleware:
+    def test_redacts_secrets(self):
+        from nemo_relay.integrations.hermes.middleware import _redact_secrets
+        args = {"query": "hello", "api_key": "sk-secret", "password": "hunter2"}
+        result = _redact_secrets(args)
+        assert result["query"] == "hello"
+        assert result["api_key"] == "***REDACTED***"
+        assert result["password"] == "***REDACTED***"
+
+    def test_blocks_denied_tools(self):
+        from nemo_relay.integrations.hermes.middleware import NemoRelayHermesMiddleware
+        mw = NemoRelayHermesMiddleware(blocked_tools=["dangerous_tool"])
+        with pytest.raises(ValueError, match="blocked"):
+            mw._block_denied_tools("dangerous_tool", {})
+
+    def test_allows_permitted_tools(self):
+        from nemo_relay.integrations.hermes.middleware import NemoRelayHermesMiddleware
+        mw = NemoRelayHermesMiddleware(blocked_tools=["dangerous_tool"])
+        result = mw._block_denied_tools("safe_tool", {"x": 1})
+        assert result == {"x": 1}
+
+    def test_payload_size_guard_rejects_oversized(self, _mock_relay_native):
+        from nemo_relay.integrations.hermes.middleware import NemoRelayHermesMiddleware
+        nr = _mock_relay_native
+        mw = NemoRelayHermesMiddleware(max_tool_args_size=10)
+        big_request = MagicMock()
+        big_request.content = {"messages": ["a" * 1000]}
+        with pytest.raises(ValueError, match="exceeds configured limit"):
+            mw._guard_llm_payload_size("test", big_request, None)
+
+    def test_register_idempotent(self, _mock_relay_native):
+        from nemo_relay.integrations.hermes.middleware import NemoRelayHermesMiddleware
+        nr = _mock_relay_native
+        mw = NemoRelayHermesMiddleware()
+        mw.register()
+        mw.register()  # second call should be no-op
+        assert nr.guardrails.register_tool_sanitize_request.call_count == 1
+
+
+# ---- add_nemo_relay_integration tests ---------------------------------------
+
+class TestAddIntegration:
+    def test_injects_middleware(self):
+        from nemo_relay.integrations.hermes import add_nemo_relay_integration
+        result = add_nemo_relay_integration({"agent_name": "my-agent"})
+        assert "middleware" in result
+        assert "callbacks" in result
+        assert len(result["middleware"]) == 1
+        assert len(result["callbacks"]) == 1
+
+    def test_no_duplicate_middleware(self):
+        from nemo_relay.integrations.hermes import add_nemo_relay_integration
+        from nemo_relay.integrations.hermes.middleware import NemoRelayHermesMiddleware
+        existing = NemoRelayHermesMiddleware()
+        result = add_nemo_relay_integration({"middleware": [existing]})
+        assert len(result["middleware"]) == 1
+
+    def test_instruments_subagents(self):
+        from nemo_relay.integrations.hermes import add_nemo_relay_integration
+        subs = [{"name": "worker", "middleware": []}]
+        result = add_nemo_relay_integration({"subagents": subs})
+        assert len(result["subagents"][0]["middleware"]) == 1
+
+
+# ---- Subscriber tests -------------------------------------------------------
+
+class TestHermesSubscriber:
+    def test_formats_events(self):
+        from nemo_relay.integrations.hermes.subscriber import HermesATOFSubscriber
+        sub = HermesATOFSubscriber()
+        event = {
+            "event_type": "scope_start",
+            "scope_name": "test",
+            "scope_type": "Agent",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "data": {"key": "value"},
+        }
+        sub(event)
+        assert len(sub.events) == 1
+        assert sub.events[0]["event_type"] == "scope_start"
+        assert sub.events[0]["scope_name"] == "test"
+
+    def test_clear(self):
+        from nemo_relay.integrations.hermes.subscriber import HermesATOFSubscriber
+        sub = HermesATOFSubscriber()
+        sub({"event_type": "x", "scope_name": "y"})
+        sub.clear()
+        assert len(sub.events) == 0
+
+    def test_unknown_event_defaults(self):
+        from nemo_relay.integrations.hermes.subscriber import HermesATOFSubscriber
+        sub = HermesATOFSubscriber()
+        sub({})
+        assert sub.events[0]["event_type"] == "unknown"


### PR DESCRIPTION
## What
Adds a NeMo Relay integration adapter for [Hermes Agent](https://github.com/NousResearch/hermes-agent), a multi-agent orchestrator supporting Discord, Telegram, Feishu, and CLI platforms.

## Why
Hermes Agent manages complex multi-agent workflows with sub-agent delegation, tool orchestration, cron scheduling, and multi-platform delivery. Without a NeMo Relay integration, Hermes users lack structured observability into scope hierarchies, tool-call lifecycles, and LLM request boundaries. This integration fills that gap alongside the existing LangChain and Deep Agents adapters.

## How
- **callbacks.py**: Maps Hermes lifecycle events (session, turn, tool call, LLM call, sub-agent delegation, cron task) to NeMo Relay scopes using the ScopeType hierarchy. Implements LIFO completion tracking for concurrent scope ordering, following the same pattern as the LangChain integration.
- **middleware.py**: Pre-execution validation middleware that sanitises tool arguments (redacts secrets), blocks denied tools, and guards against oversized LLM payloads.
- **subscriber.py**: Bridges NeMo Relay ATOF lifecycle events to Hermes-compatible structured log entries.
- **add_nemo_relay_integration()**: One-call helper that injects Relay middleware and callbacks into Hermes agent configuration, with optional sub-agent instrumentation.

## Testing
- Unit tests in test_hermes_integration.py with mocked native bindings
- Tests cover: scope hierarchy ordering, secret redaction, tool blocking, size guards, idempotent registration, middleware injection, subscriber event formatting

## Breaking changes
None. The integration is opt-in via add_nemo_relay_integration().
