### PR TITLE
fix(cli): tolerate dangling Codex marketplace registration

### DIFF
--- a/crates/cli/src/agents/mod.rs
+++ b/crates/cli/src/agents/mod.rs
@@ -812,6 +812,7 @@ fn failed_integration_readiness(
         relay: None,
         host_plugin_registered: None,
         host_marketplace_registered: None,
+        host_marketplace_unloadable: false,
         plugin_setup: None,
     };
     readiness.push("Host readiness", Err(details.to_string()));

--- a/crates/cli/src/installation/marketplace/host.rs
+++ b/crates/cli/src/installation/marketplace/host.rs
@@ -96,22 +96,35 @@ pub(super) fn run_host_marketplace_removal(
 
 #[derive(Debug, Clone)]
 pub(crate) struct HostRegistrationReport {
-    pub(crate) host_plugin_registered: bool,
+    /// `None` means the host CLI could not determine whether the plugin is registered.
+    pub(crate) host_plugin_registered: Option<bool>,
     pub(crate) host_marketplace_registered: bool,
+    /// The registered Relay marketplace was identified but its snapshot could not be loaded.
+    pub(crate) host_marketplace_unloadable: bool,
 }
 
 impl HostRegistrationReport {
     pub(super) fn ok(&self) -> bool {
-        self.host_plugin_registered && self.host_marketplace_registered
+        self.host_plugin_registered == Some(true)
+            && self.host_marketplace_registered
+            && !self.host_marketplace_unloadable
+    }
+
+    pub(super) fn host_plugin_may_be_registered(&self) -> bool {
+        self.host_plugin_registered != Some(false)
     }
 
     #[cfg(test)]
     pub(super) fn to_json(&self) -> Value {
-        json!({
+        let mut report = json!({
             "ok": self.ok(),
             "host_plugin_registered": self.host_plugin_registered,
             "host_marketplace_registered": self.host_marketplace_registered
-        })
+        });
+        if self.host_marketplace_unloadable {
+            report["host_marketplace_unloadable"] = Value::Bool(true);
+        }
+        report
     }
 }
 
@@ -126,8 +139,12 @@ pub(super) fn validate_host_registration(
         Ok(report)
     } else {
         let mut missing = Vec::new();
-        if !report.host_plugin_registered {
-            missing.push(format!("{PLUGIN_NAME}@{MARKETPLACE_NAME} host plugin"));
+        match report.host_plugin_registered {
+            Some(false) => missing.push(format!("{PLUGIN_NAME}@{MARKETPLACE_NAME} host plugin")),
+            None => missing.push(format!(
+                "{PLUGIN_NAME}@{MARKETPLACE_NAME} host plugin registration could not be determined"
+            )),
+            Some(true) => {}
         }
         if !report.host_marketplace_registered {
             missing.push(format!("{MARKETPLACE_NAME} host marketplace"));
@@ -147,8 +164,9 @@ pub(super) fn host_registration_report(
 ) -> Result<HostRegistrationReport, String> {
     if options.dry_run {
         return Ok(HostRegistrationReport {
-            host_plugin_registered: true,
+            host_plugin_registered: Some(true),
             host_marketplace_registered: true,
+            host_marketplace_unloadable: false,
         });
     }
     require_host_cli(host, options, runner)?;
@@ -160,8 +178,9 @@ pub(crate) fn claude_registration_report(
     runner: &dyn CommandRunner,
 ) -> Result<HostRegistrationReport, String> {
     Ok(HostRegistrationReport {
-        host_plugin_registered: claude_plugin_registered(options, runner)?,
+        host_plugin_registered: Some(claude_plugin_registered(options, runner)?),
         host_marketplace_registered: claude_marketplace_registered(options, runner)?,
+        host_marketplace_unloadable: false,
     })
 }
 
@@ -169,9 +188,22 @@ pub(crate) fn codex_registration_report(
     options: &PluginInstallOptions,
     runner: &dyn CommandRunner,
 ) -> Result<HostRegistrationReport, String> {
+    let host_plugin_registered = match codex_plugin_registered(options, runner) {
+        Ok(registered) => registered,
+        Err(error) if is_dangling_codex_marketplace_error(&error) => {
+            return Ok(HostRegistrationReport {
+                host_plugin_registered: None,
+                host_marketplace_registered: true,
+                host_marketplace_unloadable: true,
+            });
+        }
+        Err(error) => return Err(error),
+    };
+
     Ok(HostRegistrationReport {
-        host_plugin_registered: codex_plugin_registered(options, runner)?,
+        host_plugin_registered: Some(host_plugin_registered),
         host_marketplace_registered: codex_marketplace_registered(options, runner)?,
+        host_marketplace_unloadable: false,
     })
 }
 
@@ -250,6 +282,16 @@ fn codex_marketplace_registered(
         .lines()
         .filter_map(|line| line.split_whitespace().next())
         .any(|name| name == MARKETPLACE_NAME))
+}
+
+fn is_dangling_codex_marketplace_error(error: &str) -> bool {
+    let plugin_list_snapshot_error = "failed to load configured marketplace snapshot(s):";
+    let marketplace = format!("`{MARKETPLACE_NAME}`");
+    let invalid_manifest = "marketplace root does not contain a supported manifest";
+    error.contains(plugin_list_snapshot_error)
+        && error
+            .lines()
+            .any(|line| line.contains(&marketplace) && line.contains(invalid_manifest))
 }
 
 fn plugin_entry_matches(entry: &Value) -> bool {

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -93,6 +93,8 @@ pub(crate) struct HostPluginReadiness {
     #[serde(skip_serializing)]
     pub(crate) host_marketplace_registered: Option<bool>,
     #[serde(skip_serializing)]
+    pub(crate) host_marketplace_unloadable: bool,
+    #[serde(skip_serializing)]
     pub(crate) plugin_setup: Option<Value>,
 }
 
@@ -511,7 +513,7 @@ fn force_cleanup_target_exists_with_runner(
         skip_doctor: true,
     };
     host_registration_report(host, &options, runner).is_ok_and(|registration| {
-        registration.host_plugin_registered || registration.host_marketplace_registered
+        registration.host_plugin_may_be_registered() || registration.host_marketplace_registered
     })
 }
 
@@ -997,7 +999,12 @@ fn recover_failed_install_registration<H: MarketplaceHost>(
                 "{error}; refusing destructive rollback because the host registration state could not be verified after a registration command failed: {report_error}"
             )
         })?;
-        registration.host_plugin_added |= observed.host_plugin_registered;
+        let observed_plugin_registered = observed.host_plugin_registered.ok_or_else(|| {
+            format!(
+                "{error}; refusing destructive rollback because the host plugin registration state could not be determined after a registration command failed"
+            )
+        })?;
+        registration.host_plugin_added |= observed_plugin_registered;
         registration.host_marketplace_added |= observed.host_marketplace_registered;
     }
     retire_live_replacement_before_rollback(host, layout, options, setup_runner, transaction, &registration)
@@ -1251,8 +1258,8 @@ fn retire_installed_generation(
     let mut existing_install = local_install_exists;
     if !generation_fence.exists() {
         let registration = host_registration_report(host, options, runner)?;
-        existing_install |=
-            registration.host_plugin_registered || registration.host_marketplace_registered;
+        existing_install |= registration.host_plugin_may_be_registered()
+            || registration.host_marketplace_registered;
         if existing_install && !legacy_plugin_without_mcp(host, plugin_root)? {
             return Err(missing_generation_fence_error(host, &generation_fence));
         }
@@ -1262,8 +1269,8 @@ fn retire_installed_generation(
             .map_err(|cause| invalid_generation_fence_error(host, &generation_fence, &cause))?;
     if retirement.is_none() && !existing_install {
         let registration = host_registration_report(host, options, runner)?;
-        existing_install =
-            registration.host_plugin_registered || registration.host_marketplace_registered;
+        existing_install = registration.host_plugin_may_be_registered()
+            || registration.host_marketplace_registered;
     }
     if retirement.is_none() && existing_install && !legacy_plugin_without_mcp(host, plugin_root)? {
         return Err(missing_generation_fence_error(host, &generation_fence));
@@ -1464,7 +1471,16 @@ fn doctor_host_json_value(
 ) -> Result<Value, String> {
     let readiness = collect_host_plugin_readiness(host, options, runner, setup_runner);
     let host_registration_ok = readiness.host_plugin_registered == Some(true)
-        && readiness.host_marketplace_registered == Some(true);
+        && readiness.host_marketplace_registered == Some(true)
+        && !readiness.host_marketplace_unloadable;
+    let mut host_registration = json!({
+        "ok": host_registration_ok,
+        "host_plugin_registered": readiness.host_plugin_registered,
+        "host_marketplace_registered": readiness.host_marketplace_registered
+    });
+    if readiness.host_marketplace_unloadable {
+        host_registration["host_marketplace_unloadable"] = json!(true);
+    }
     Ok(json!({
         "ok": readiness.ok(),
         "host": readiness.host,
@@ -1472,11 +1488,7 @@ fn doctor_host_json_value(
         "nemo_relay": readiness.relay,
         "marketplace": readiness.marketplace,
         "plugin": readiness.plugin,
-        "host_registration": {
-            "ok": host_registration_ok,
-            "host_plugin_registered": readiness.host_plugin_registered,
-            "host_marketplace_registered": readiness.host_marketplace_registered
-        },
+        "host_registration": host_registration,
         "checks": readiness.plugin_setup,
         "state_path": readiness.state_path,
         "readiness_checks": readiness.checks
@@ -1514,6 +1526,7 @@ fn collect_host_plugin_readiness(
         relay: None,
         host_plugin_registered: None,
         host_marketplace_registered: None,
+        host_marketplace_unloadable: false,
         plugin_setup: None,
     };
 
@@ -1618,8 +1631,9 @@ fn collect_host_plugin_readiness(
         );
         match host_registration_report(host, options, runner) {
             Ok(report) => {
-                readiness.host_plugin_registered = Some(report.host_plugin_registered);
+                readiness.host_plugin_registered = report.host_plugin_registered;
                 readiness.host_marketplace_registered = Some(report.host_marketplace_registered);
+                readiness.host_marketplace_unloadable = report.host_marketplace_unloadable;
                 readiness.push(
                     "Host registration",
                     report
@@ -1629,10 +1643,13 @@ fn collect_host_plugin_readiness(
                 );
                 readiness.push(
                     "Host plugin registration",
-                    report
-                        .host_plugin_registered
-                        .then_some("registered".into())
-                        .ok_or_else(|| "nemo-relay host plugin is not registered".into()),
+                    match report.host_plugin_registered {
+                        Some(true) => Ok("registered".into()),
+                        Some(false) => Err("nemo-relay host plugin is not registered".into()),
+                        None => Err(
+                            "nemo-relay host plugin registration could not be determined".into(),
+                        ),
+                    },
                 );
                 readiness.push(
                     "Host marketplace registration",
@@ -1980,7 +1997,8 @@ fn prepare_plugin_install(
         layout.validate_persisted_state(state)?;
     }
     let registration = host_registration_report(host, options, runner)?;
-    let plugin_registered = registration.host_plugin_registered;
+    let plugin_registration = registration.host_plugin_registered;
+    let plugin_may_be_registered = registration.host_plugin_may_be_registered();
     let marketplace_registered = registration.host_marketplace_registered;
     let state_bytes = match fs::read(&layout.state_path) {
         Ok(bytes) => Some(bytes),
@@ -1992,10 +2010,9 @@ fn prepare_plugin_install(
             ));
         }
     };
-    let previous_setup_installed = persisted
+    let persisted_setup_installed = persisted
         .as_ref()
-        .is_some_and(|state| state.plugin_setup_installed)
-        || plugin_registered;
+        .is_some_and(|state| state.plugin_setup_installed);
     let previous_marketplace_root = persisted
         .as_ref()
         .map(|state| state.marketplace_root.clone())
@@ -2019,29 +2036,34 @@ fn prepare_plugin_install(
     // failure. `validate_persisted_state` above already guarantees the state names this layout's
     // roots, so `local_install_exists` covers everything the state file could point at.
     let previous_install_exists =
-        local_install_exists || plugin_registered || marketplace_registered;
-    let generation_retirement = if previous_install_exists {
-        if !previous_generation_fence.exists() {
-            if legacy_plugin_without_mcp(host, &previous_plugin_root)? {
-                None
-            } else {
-                return Err(missing_generation_fence_error(
-                    host,
-                    &previous_generation_fence,
-                ));
-            }
-        } else {
-            Some(
-                GenerationRetirement::acquire_for_plugin(
-                    &previous_generation_fence,
-                    &layout.generation_lock,
-                )
-                .map_err(|cause| {
-                    invalid_generation_fence_error(host, &previous_generation_fence, &cause)
-                })?
-                .ok_or_else(|| missing_generation_fence_error(host, &previous_generation_fence))?,
+        local_install_exists || plugin_may_be_registered || marketplace_registered;
+    if previous_install_exists
+        && !previous_generation_fence.exists()
+        && !legacy_plugin_without_mcp(host, &previous_plugin_root)?
+    {
+        return Err(missing_generation_fence_error(
+            host,
+            &previous_generation_fence,
+        ));
+    }
+    let plugin_registered = plugin_registration.ok_or_else(|| {
+        format!(
+            "refusing to modify the {} plugin because its host plugin registration state could not be determined",
+            host.label()
+        )
+    })?;
+    let previous_setup_installed = persisted_setup_installed || plugin_registered;
+    let generation_retirement = if previous_install_exists && previous_generation_fence.exists() {
+        Some(
+            GenerationRetirement::acquire_for_plugin(
+                &previous_generation_fence,
+                &layout.generation_lock,
             )
-        }
+            .map_err(|cause| {
+                invalid_generation_fence_error(host, &previous_generation_fence, &cause)
+            })?
+            .ok_or_else(|| missing_generation_fence_error(host, &previous_generation_fence))?,
+        )
     } else {
         None
     };
@@ -2400,7 +2422,7 @@ fn remove_promoted_replacement(
     }
     match host_registration_report(host, options, runner) {
         Ok(report) => {
-            if report.host_plugin_registered
+            if report.host_plugin_may_be_registered()
                 && let Err(error) = run_host_plugin_removal(host, options, runner)
             {
                 errors.push(error);
@@ -2460,7 +2482,14 @@ fn reconcile_restored_registration(
             return;
         }
     };
-    if report.host_plugin_registered
+    let Some(host_plugin_registered) = report.host_plugin_registered else {
+        errors.push(
+            "host plugin registration state could not be determined while restoring the previous install"
+                .into(),
+        );
+        return;
+    };
+    if host_plugin_registered
         && !snapshot.plugin_registered
         && let Err(error) = run_host_plugin_removal(host, options, runner)
     {
@@ -2484,7 +2513,7 @@ fn reconcile_restored_registration(
         errors.push(error);
     }
     if snapshot.plugin_registered
-        && !report.host_plugin_registered
+        && !host_plugin_registered
         && let Err(error) = run_host_plugin_registration(host, options, runner)
     {
         errors.push(error);

--- a/crates/cli/src/installation/marketplace/mod.rs
+++ b/crates/cli/src/installation/marketplace/mod.rs
@@ -2483,6 +2483,21 @@ fn reconcile_restored_registration(
         }
     };
     let Some(host_plugin_registered) = report.host_plugin_registered else {
+        if snapshot.marketplace_registered
+            && let Err(error) = run_host_marketplace_registration(
+                host,
+                &snapshot.original_marketplace_root,
+                options,
+                runner,
+            )
+        {
+            errors.push(error);
+        }
+        if snapshot.plugin_registered
+            && let Err(error) = run_host_plugin_registration(host, options, runner)
+        {
+            errors.push(error);
+        }
         errors.push(
             "host plugin registration state could not be determined while restoring the previous install"
                 .into(),

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -32,6 +32,7 @@ fn host_plugin_readiness_aggregates_success_and_failure_checks() {
         relay: None,
         host_plugin_registered: None,
         host_marketplace_registered: None,
+        host_marketplace_unloadable: false,
         plugin_setup: None,
     };
     readiness.push("Host CLI", Ok("available".into()));
@@ -50,6 +51,7 @@ const GENERATION_LOCK_HELPER_PATH_ENV: &str = "NEMO_RELAY_TEST_GENERATION_LOCK_P
 const LOCK_HELPER_READY_ENV: &str = "NEMO_RELAY_TEST_LOCK_READY";
 const LOCK_HELPER_RELEASE_ENV: &str = "NEMO_RELAY_TEST_LOCK_RELEASE";
 const TEST_GENERATION_TOKEN: &str = "test-generation";
+const DANGLING_CODEX_MARKETPLACE_ERROR: &str = "Error: failed to load configured marketplace snapshot(s):\n\n- `nemo-relay-local` at /tmp/plugins/codex-marketplace: marketplace root does not contain a supported manifest\n";
 
 fn force_snapshot_with_backups(
     backup_marketplace_root: PathBuf,
@@ -1943,8 +1945,9 @@ fn host_command_helpers_cover_dry_run_missing_failure_and_reporting() {
     assert_eq!(report.to_json()["ok"], json!(true));
     assert_eq!(
         HostRegistrationReport {
-            host_plugin_registered: false,
+            host_plugin_registered: Some(false),
             host_marketplace_registered: true,
+            host_marketplace_unloadable: false,
         }
         .to_json()["host_plugin_registered"],
         json!(false)
@@ -2069,8 +2072,9 @@ fn host_registration_report_accepts_claude_and_codex_shape_variants() {
             );
         let report = host_registration_report(CodingAgent::ClaudeCode, &normal, &runner).unwrap();
         assert!(report.ok());
-        assert!(report.host_plugin_registered);
+        assert_eq!(report.host_plugin_registered, Some(true));
         assert!(report.host_marketplace_registered);
+        assert!(!report.host_marketplace_unloadable);
     }
 
     let runner = MockRunner::default()
@@ -2097,8 +2101,9 @@ fn host_registration_report_accepts_claude_and_codex_shape_variants() {
             format!("{MARKETPLACE_NAME} /tmp/nemo-relay-local\n"),
         );
     let report = host_registration_report(CodingAgent::Codex, &normal, &runner).unwrap();
-    assert!(!report.host_plugin_registered);
+    assert_eq!(report.host_plugin_registered, Some(false));
     assert!(report.host_marketplace_registered);
+    assert!(!report.host_marketplace_unloadable);
 
     let runner = MockRunner::default()
         .with_executable("codex", "/bin/codex")
@@ -2109,8 +2114,9 @@ fn host_registration_report_accepts_claude_and_codex_shape_variants() {
         .with_capture_output("/bin/codex plugin marketplace list", "other /tmp/other\n");
     let report = host_registration_report(CodingAgent::Codex, &normal, &runner).unwrap();
     assert!(!report.ok());
-    assert!(!report.host_plugin_registered);
+    assert_eq!(report.host_plugin_registered, Some(false));
     assert!(!report.host_marketplace_registered);
+    assert!(!report.host_marketplace_unloadable);
 }
 
 #[test]
@@ -2153,6 +2159,47 @@ fn host_registration_report_surfaces_capture_status_and_stderr_variants() {
     let error = host_registration_report(CodingAgent::ClaudeCode, &normal, &runner).unwrap_err();
     assert!(error.contains("exit code 5"));
     assert!(!error.contains("exit code 5:"));
+}
+
+#[test]
+fn codex_registration_report_identifies_a_dangling_relay_marketplace() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("codex", "/bin/codex")
+        .with_capture_status(
+            "/bin/codex plugin list",
+            1,
+            "",
+            DANGLING_CODEX_MARKETPLACE_ERROR,
+        );
+
+    let report = host_registration_report(CodingAgent::Codex, &options(dir.path()), &runner)
+        .expect("the recognized dangling marketplace should produce a partial report");
+
+    assert_eq!(report.host_plugin_registered, None);
+    assert!(report.host_marketplace_registered);
+    assert!(report.host_marketplace_unloadable);
+    assert!(!report.ok());
+    assert_eq!(runner.capture_commands(), vec!["/bin/codex plugin list"]);
+}
+
+#[test]
+fn codex_registration_report_preserves_other_marketplace_snapshot_failures() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("codex", "/bin/codex")
+        .with_capture_status(
+            "/bin/codex plugin list",
+            1,
+            "",
+            "Error: failed to load configured marketplace snapshot(s):\n\n- `team-broken` at /tmp/team-broken: marketplace root does not contain a supported manifest\n",
+        );
+
+    let error = host_registration_report(CodingAgent::Codex, &options(dir.path()), &runner)
+        .expect_err("an unrelated marketplace failure must remain an error");
+
+    assert!(error.contains("failed to load configured marketplace snapshot(s):"));
+    assert!(error.contains("`team-broken`"));
 }
 
 #[test]
@@ -3060,6 +3107,113 @@ fn force_install_rejects_registered_legacy_plugin_without_generation_fence() {
     );
     assert!(error.contains("close all Codex clients"), "{error}");
     assert!(error.contains("codex plugin remove"), "{error}");
+    assert!(runner.commands().is_empty());
+    assert!(setup_runner.calls().is_empty());
+    assert_no_install_stage(dir.path());
+}
+
+#[test]
+fn force_install_reports_a_dangling_codex_marketplace_as_an_unsafe_generation() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_capture_status(
+            "/bin/codex plugin list",
+            1,
+            "",
+            DANGLING_CODEX_MARKETPLACE_ERROR,
+        );
+    let setup_runner = MockSetupRunner::default();
+    let options = PluginInstallOptions {
+        force: true,
+        ..options(dir.path())
+    };
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+
+    let error = install_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap_err();
+
+    assert_actionable_generation_error(&error, "MCP generation marker is missing");
+    assert!(!layout.marketplace_root.exists());
+    assert!(!layout.generation_lock.exists());
+    assert!(runner.commands().is_empty());
+    assert!(setup_runner.calls().is_empty());
+    assert_no_install_stage(dir.path());
+}
+
+#[test]
+fn force_install_preserves_orphaned_state_for_a_dangling_codex_marketplace() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_capture_status(
+            "/bin/codex plugin list",
+            1,
+            "",
+            DANGLING_CODEX_MARKETPLACE_ERROR,
+        );
+    let setup_runner = MockSetupRunner::default();
+    let options = PluginInstallOptions {
+        force: true,
+        ..options(dir.path())
+    };
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    let original_state = std::fs::read(&layout.state_path).unwrap();
+    std::fs::remove_dir_all(&layout.marketplace_root).unwrap();
+    assert!(layout.generation_lock.exists());
+
+    let error = install_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap_err();
+
+    assert_actionable_generation_error(&error, "MCP generation marker is missing");
+    assert!(!layout.marketplace_root.exists());
+    assert_eq!(std::fs::read(&layout.state_path).unwrap(), original_state);
+    assert!(layout.generation_lock.exists());
+    assert!(runner.commands().is_empty());
+    assert!(setup_runner.calls().is_empty());
+    assert_no_install_stage(dir.path());
+}
+
+#[test]
+fn force_install_preserves_a_generation_when_plugin_registration_is_unknown() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_capture_status(
+            "/bin/codex plugin list",
+            1,
+            "",
+            DANGLING_CODEX_MARKETPLACE_ERROR,
+        );
+    let setup_runner = MockSetupRunner::default();
+    let options = PluginInstallOptions {
+        force: true,
+        ..options(dir.path())
+    };
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    std::fs::remove_file(&layout.marketplace_manifest).unwrap();
+    let generation_token = InstallGeneration::capture(layout.generation_fence.clone())
+        .unwrap()
+        .token()
+        .to_owned();
+
+    let error = install_host(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap_err();
+
+    assert!(
+        error.contains("registration state could not be determined"),
+        "{error}"
+    );
+    assert!(layout.marketplace_root.exists());
+    assert!(layout.state_path.exists());
+    assert_eq!(
+        InstallGeneration::capture(layout.generation_fence)
+            .unwrap()
+            .token(),
+        generation_token
+    );
     assert!(runner.commands().is_empty());
     assert!(setup_runner.calls().is_empty());
     assert_no_install_stage(dir.path());
@@ -4405,7 +4559,55 @@ fn failed_plugin_registration_rolls_back_observed_plugin_side_effects() {
 }
 
 #[test]
-fn unverifiable_registration_failure_preserves_the_install_tree() {
+fn unknown_plugin_registration_preserves_the_install_tree() {
+    let dir = tempdir().unwrap();
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    let mut runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex");
+    runner.failing_suffix = Some(layout.marketplace_root.display().to_string());
+    runner.capture_output_sequences.get_mut().insert(
+        "/bin/codex plugin list".into(),
+        VecDeque::from([
+            CommandOutput::success(String::new()),
+            CommandOutput {
+                status: 1,
+                stdout: String::new(),
+                stderr: DANGLING_CODEX_MARKETPLACE_ERROR.into(),
+            },
+        ]),
+    );
+    runner.capture_output_sequences.get_mut().insert(
+        "/bin/codex plugin marketplace list".into(),
+        VecDeque::from([CommandOutput::success(String::new())]),
+    );
+    let setup_runner = MockSetupRunner::default();
+
+    let error = install_host(
+        CodingAgent::Codex,
+        &options(dir.path()),
+        &runner,
+        &setup_runner,
+    )
+    .unwrap_err();
+
+    assert!(error.contains("refusing destructive rollback"), "{error}");
+    assert!(error.contains("could not be determined"), "{error}");
+    assert!(layout.marketplace_root.exists());
+    assert!(layout.state_path.exists());
+    assert!(layout.generation_lock.exists());
+    InstallGeneration::capture(layout.generation_fence).unwrap();
+    assert!(
+        runner
+            .commands()
+            .iter()
+            .all(|command| !command.contains("plugin marketplace remove")
+                && !command.contains("plugin remove"))
+    );
+}
+
+#[test]
+fn unverifiable_registration_report_preserves_the_install_tree() {
     let dir = tempdir().unwrap();
     let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
     let mut runner = MockRunner::default()
@@ -4447,7 +4649,8 @@ fn unverifiable_registration_failure_preserves_the_install_tree() {
         runner
             .commands()
             .iter()
-            .all(|command| !command.contains("plugin marketplace remove"))
+            .all(|command| !command.contains("plugin marketplace remove")
+                && !command.contains("plugin remove"))
     );
 }
 
@@ -4631,6 +4834,41 @@ fn uninstall_rejects_registered_legacy_plugin_without_generation_fence() {
     assert!(error.contains("close all Codex clients"), "{error}");
     assert!(layout.marketplace_root.exists());
     assert!(layout.state_path.exists());
+    assert!(runner.commands().is_empty());
+    assert!(setup_runner.calls().is_empty());
+}
+
+#[test]
+fn uninstall_preserves_orphaned_state_for_a_dangling_codex_marketplace() {
+    let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_capture_status(
+            "/bin/codex plugin list",
+            1,
+            "",
+            DANGLING_CODEX_MARKETPLACE_ERROR,
+        );
+    let setup_runner = MockSetupRunner::default();
+    write_installed_state(CodingAgent::Codex, dir.path());
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    let original_state = std::fs::read(&layout.state_path).unwrap();
+    std::fs::remove_dir_all(&layout.marketplace_root).unwrap();
+    assert!(layout.generation_lock.exists());
+
+    let error = uninstall_host(
+        CodingAgent::Codex,
+        &options(dir.path()),
+        &runner,
+        &setup_runner,
+    )
+    .unwrap_err();
+
+    assert_actionable_generation_error(&error, "MCP generation marker is missing");
+    assert!(!layout.marketplace_root.exists());
+    assert_eq!(std::fs::read(&layout.state_path).unwrap(), original_state);
+    assert!(layout.generation_lock.exists());
     assert!(runner.commands().is_empty());
     assert!(setup_runner.calls().is_empty());
 }
@@ -4868,6 +5106,11 @@ fn doctor_json_uses_quiet_plugin_report() {
     assert_eq!(report["host"], json!("codex"));
     assert_eq!(report["ok"], json!(true));
     assert_eq!(report["host_registration"]["ok"], json!(true));
+    assert!(
+        report["host_registration"]
+            .get("host_marketplace_unloadable")
+            .is_none()
+    );
     assert_eq!(
         runner.capture_commands(),
         vec![
@@ -5433,23 +5676,34 @@ fn readiness_report_accepts_generated_plugin_manifest_from_an_older_version() {
 }
 
 #[test]
-fn doctor_json_preserves_unknown_host_registration_state() {
+fn doctor_json_reports_a_dangling_marketplace_without_guessing_plugin_registration() {
     let dir = tempdir().unwrap();
+    let runner = MockRunner::default()
+        .with_executable("nemo-relay", "/bin/nemo-relay")
+        .with_executable("codex", "/bin/codex")
+        .with_capture_status(
+            "/bin/codex plugin list",
+            1,
+            "",
+            DANGLING_CODEX_MARKETPLACE_ERROR,
+        );
     let setup_runner = MockSetupRunner::default();
     let options = options(dir.path());
     write_installed_state(CodingAgent::Codex, dir.path());
 
-    let report = doctor_host_json_value(
-        CodingAgent::Codex,
-        &options,
-        &MockRunner::default(),
-        &setup_runner,
-    )
-    .unwrap();
+    let report =
+        doctor_host_json_value(CodingAgent::Codex, &options, &runner, &setup_runner).unwrap();
 
     assert_eq!(report["host_registration"]["ok"], json!(false));
     assert!(report["host_registration"]["host_plugin_registered"].is_null());
-    assert!(report["host_registration"]["host_marketplace_registered"].is_null());
+    assert_eq!(
+        report["host_registration"]["host_marketplace_registered"],
+        json!(true)
+    );
+    assert_eq!(
+        report["host_registration"]["host_marketplace_unloadable"],
+        json!(true)
+    );
 }
 
 #[test]
@@ -5489,6 +5743,7 @@ fn stopped_lazy_sidecar_does_not_fail_host_readiness() {
         relay: None,
         host_plugin_registered: None,
         host_marketplace_registered: None,
+        host_marketplace_unloadable: false,
         plugin_setup: None,
     };
 

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -4597,6 +4597,7 @@ fn unknown_plugin_registration_preserves_the_install_tree() {
     assert!(layout.state_path.exists());
     assert!(layout.generation_lock.exists());
     InstallGeneration::capture(layout.generation_fence).unwrap();
+    assert_no_install_stage(dir.path());
     assert!(
         runner
             .commands()

--- a/crates/cli/tests/coverage/agents/plugin_install_tests.rs
+++ b/crates/cli/tests/coverage/agents/plugin_install_tests.rs
@@ -4002,6 +4002,60 @@ fn force_replacement_restoration_reports_failed_host_reregistration() {
 }
 
 #[test]
+fn force_replacement_restoration_reregisters_snapshot_when_plugin_state_is_unknown() {
+    let dir = tempdir().unwrap();
+    let layout = PluginLayout::new(CodingAgent::Codex, dir.path());
+    let original_marketplace_root = dir.path().join("original-marketplace");
+    let mut snapshot = ForceInstallSnapshot {
+        state_bytes: None,
+        setup_snapshot: None,
+        original_marketplace_root: original_marketplace_root.clone(),
+        original_plugin_root: original_marketplace_root.join("plugins/nemo-relay-plugin"),
+        original_generation_fence: original_marketplace_root.join(GENERATION_FILE_NAME),
+        plugin_registered: true,
+        marketplace_registered: true,
+        backup_marketplace_root: dir.path().join("unused-marketplace-backup"),
+        backup_plugin_root: None,
+        marketplace_moved: false,
+        plugin_moved: false,
+        replacement_promoted: false,
+        generation_retirement: None,
+    };
+    let runner = MockRunner::default()
+        .with_executable("codex", "/bin/codex")
+        .with_capture_status(
+            "/bin/codex plugin list",
+            1,
+            "",
+            DANGLING_CODEX_MARKETPLACE_ERROR,
+        );
+
+    let error = restore_force_replacement(
+        CodingAgent::Codex,
+        &layout,
+        &mut snapshot,
+        &options(dir.path()),
+        &runner,
+        &MockSetupRunner::default(),
+    )
+    .unwrap_err();
+
+    assert!(error.contains("could not be determined"), "{error}");
+    assert!(runner.commands().iter().any(|command| {
+        command.ends_with(&format!(
+            "plugin marketplace add {}",
+            original_marketplace_root.display()
+        ))
+    }));
+    assert!(
+        runner
+            .commands()
+            .iter()
+            .any(|command| { command.ends_with("plugin add nemo-relay-plugin@nemo-relay-local") })
+    );
+}
+
+#[test]
 fn force_replacement_moves_and_restores_a_separate_plugin_tree() {
     let dir = tempdir().unwrap();
     let previous_marketplace_root = dir.path().join("previous-marketplace");

--- a/crates/cli/tests/coverage/shared/doctor_tests.rs
+++ b/crates/cli/tests/coverage/shared/doctor_tests.rs
@@ -220,6 +220,7 @@ fn exit_code_fails_when_an_installed_host_plugin_is_unready() {
             relay: None,
             host_plugin_registered: None,
             host_marketplace_registered: None,
+            host_marketplace_unloadable: false,
             plugin_setup: None,
         });
 

--- a/docs/nemo-relay-cli/plugin-installation.mdx
+++ b/docs/nemo-relay-cli/plugin-installation.mdx
@@ -328,6 +328,12 @@ the required plugin MCP starts it before the captured turn. Doctor also reports
 newly required forwarded environment names and recommends
 `nemo-relay install codex --force`.
 
+In `nemo-relay doctor --json` output, a configured but unloadable Codex
+marketplace is reported with `host_marketplace_unloadable: true` under the
+integration's `host_registration` object. In that state,
+`host_plugin_registered` is `null` because Codex could not determine whether
+the plugin is registered.
+
 For Claude Code, doctor also validates version 2.1.121 or newer, the generated
 `alwaysLoad` MCP server, and its generation marker. A stopped sidecar remains
 informational because the next MCP process starts it. Persistent hooks wait for


### PR DESCRIPTION
#### Overview

Recognize a dangling `nemo-relay-local` Codex marketplace as a partial registration state instead of propagating the raw `codex plugin list` failure.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Detect the specific Codex failure where `nemo-relay-local` remains registered but its marketplace snapshot cannot be loaded.
- Report the marketplace as registered and unloadable while preserving the plugin registration as unknown.
- Treat unknown plugin registration conservatively in install, uninstall, cleanup, and rollback paths.
- Surface Relay's actionable generation-fence remediation instead of the raw Codex host error.
- Report `host_plugin_registered: null` and `host_marketplace_unloadable: true` in doctor JSON for the dangling state, while omitting the new field for normal states.
- Preserve existing behavior for unrelated marketplace and host CLI failures.
- Add regression coverage for probe recognition, force install, ordinary uninstall, rollback safety, and doctor serialization.

This implements the first, tolerant-probe layer described in the issue. Automatic `--force` recovery remains follow-up work because it must account for potentially live MCP clients through the external generation lock.

#### Where should the reviewer start?

Start with `crates/cli/src/installation/marketplace/host.rs`, where the dangling Codex error is converted into a partial `HostRegistrationReport`.

Then review `crates/cli/src/installation/marketplace/mod.rs`, where unknown plugin registration is handled conservatively by mutation and rollback paths.

#### Testing

- `uv run pre-commit run --all-files`
- `just build-rust`
- `just test-rust`
  - 4,619 workspace tests passed
  - 43 Rust example tests passed

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace readiness reporting when a marketplace snapshot cannot be unloaded.
  * Installation status now distinguishes unregistered plugins from unknown registration states.
  * Prevented cleanup, rollback, uninstall, and force-install actions when registration is uncertain.
  * Codex installation failures involving dangling marketplace snapshots now preserve relevant state and provide actionable diagnostics.
  * Marketplace restoration now attempts to re-register the previous marketplace and plugin.
  * Doctor readiness JSON now reports marketplace unloadability and unknown plugin registration status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->