### PR TITLE
fix: force Codex Responses fallback to HTTP

### DIFF
--- a/crates/cli/src/gateway/routes.rs
+++ b/crates/cli/src/gateway/routes.rs
@@ -53,6 +53,7 @@ impl ProviderRoute {
         match path {
             "/responses" => Some(Self::OpenAiResponses),
             "/v1/responses" => Some(Self::OpenAiResponses),
+            "/backend-api/codex/responses" => Some(Self::OpenAiResponses),
             "/chat/completions" => Some(Self::OpenAiChatCompletions),
             "/v1/chat/completions" => Some(Self::OpenAiChatCompletions),
             "/v1/images/generations" => Some(Self::OpenAiImagesGenerations),
@@ -140,14 +141,24 @@ impl ProviderRoute {
     // one place for configured public, enterprise, or local proxy bases.
     pub(super) fn upstream_url_with_base(self, base: &str, path_and_query: &str) -> String {
         let base = base.trim_end_matches('/');
+        let path_and_query = self.canonical_path_and_query(path_and_query);
         let path_and_query = match self {
             Self::OpenAiResponses
             | Self::OpenAiChatCompletions
             | Self::OpenAiImagesGenerations
-            | Self::OpenAiModels => normalize_openai_path_for_base(base, path_and_query),
-            _ => path_and_query.to_string(),
+            | Self::OpenAiModels => normalize_openai_path_for_base(base, &path_and_query),
+            _ => path_and_query,
         };
         format!("{base}{path_and_query}")
+    }
+
+    fn canonical_path_and_query(self, path_and_query: &str) -> String {
+        if self == Self::OpenAiResponses
+            && let Some(suffix) = path_and_query.strip_prefix("/backend-api/codex/responses")
+        {
+            return format!("/responses{suffix}");
+        }
+        path_and_query.to_string()
     }
 
     // Narrows gateway routing to the smaller taxonomy used by trace alignment. Keeping this
@@ -220,10 +231,11 @@ pub(super) fn gateway_upstream_url_override_with_openai_key_state(
     path_and_query: &str,
     has_openai_replacement_key: bool,
 ) -> Option<String> {
+    let path_and_query = route.canonical_path_and_query(path_and_query);
     alignment::gateway_upstream_url_override(
         headers,
         route.alignment_route(),
-        path_and_query,
+        &path_and_query,
         has_openai_replacement_key,
     )
 }

--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -16,6 +16,7 @@ use axum::body::Body;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::{HeaderMap, HeaderValue, Request, StatusCode, header};
+use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -641,13 +642,33 @@ fn router_with_state(state: AppState) -> Router {
         .route("/chat/completions", post(gateway::passthrough))
         .route("/models", get(gateway::models))
         .route("/v1/responses", post(gateway::passthrough))
+        .route("/backend-api/codex/responses", post(gateway::passthrough))
         .route("/v1/chat/completions", post(gateway::passthrough))
         .route("/v1/images/generations", post(gateway::images_generations))
         .route("/v1/messages", post(gateway::passthrough))
         .route("/v1/messages/count_tokens", post(gateway::passthrough))
         .route("/v1/models", get(gateway::models))
+        .layer(middleware::from_fn(responses_websocket_fallback))
         .layer(DefaultBodyLimit::max(max_hook_payload_bytes))
         .with_state(state)
+}
+
+// Codex treats 426 from its Responses WebSocket probe as a signal to use HTTP/SSE. Keep ordinary
+// GETs at 405 so this compatibility response does not broaden the public Responses API surface.
+async fn responses_websocket_fallback(request: Request<Body>, next: Next) -> Response {
+    let is_responses_path = matches!(
+        request.uri().path(),
+        "/responses" | "/v1/responses" | "/backend-api/codex/responses"
+    );
+    let is_websocket_upgrade = request
+        .headers()
+        .get(header::UPGRADE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("websocket"));
+    if request.method() == http::Method::GET && is_responses_path && is_websocket_upgrade {
+        return StatusCode::UPGRADE_REQUIRED.into_response();
+    }
+    next.run(request).await
 }
 
 async fn bootstrap_tls_tunnel(

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -497,6 +497,10 @@ fn provider_routes_preserve_path_query_and_choose_upstream() {
         "http://openai/v1/responses?x=1"
     );
     assert_eq!(
+        ProviderRoute::OpenAiResponses.upstream_url(&config, "/backend-api/codex/responses?x=1"),
+        "http://openai/v1/responses?x=1"
+    );
+    assert_eq!(
         ProviderRoute::OpenAiModels.upstream_url(&config, "/models"),
         "http://openai/v1/models"
     );
@@ -508,6 +512,14 @@ fn provider_routes_preserve_path_query_and_choose_upstream() {
     assert_eq!(
         ProviderRoute::AnthropicMessages.upstream_url(&config, "/v1/messages"),
         "http://anthropic/v1/messages"
+    );
+}
+
+#[test]
+fn chatgpt_shaped_responses_path_is_a_responses_route() {
+    assert_eq!(
+        ProviderRoute::from_path("/backend-api/codex/responses"),
+        Some(ProviderRoute::OpenAiResponses)
     );
 }
 
@@ -1951,6 +1963,16 @@ fn chatgpt_backend_url_omits_v1_prefix() {
             ProviderRoute::OpenAiResponses,
             &headers,
             "/v1/responses",
+            false,
+        )
+        .as_deref(),
+        Some("https://chatgpt.com/backend-api/codex/responses")
+    );
+    assert_eq!(
+        gateway_upstream_url_override_with_openai_key_state(
+            ProviderRoute::OpenAiResponses,
+            &headers,
+            "/backend-api/codex/responses",
             false,
         )
         .as_deref(),

--- a/crates/cli/tests/coverage/shared/server_tests.rs
+++ b/crates/cli/tests/coverage/shared/server_tests.rs
@@ -248,6 +248,50 @@ fn test_config() -> GatewayConfig {
     }
 }
 
+#[tokio::test]
+async fn responses_websocket_upgrades_request_http_fallback() {
+    let app = router_with_state(AppState::new(test_config()));
+
+    for path in [
+        "/responses",
+        "/v1/responses",
+        "/backend-api/codex/responses",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(path)
+                    .header(header::CONNECTION, "upgrade")
+                    .header(header::UPGRADE, "websocket")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UPGRADE_REQUIRED, "{path}");
+    }
+}
+
+#[tokio::test]
+async fn responses_plain_get_remains_method_not_allowed() {
+    let app = router_with_state(AppState::new(test_config()));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/responses")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
 #[test]
 fn startup_status_reports_bound_gateway_and_exporters() {
     let config = GatewayConfig {


### PR DESCRIPTION
#### Overview

Return HTTP 426 for Codex Responses WebSocket probes so Codex falls back to the supported HTTP/SSE transport when Relay is configured through `openai_base_url`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Handle WebSocket upgrade probes on `/responses`, `/v1/responses`, and `/backend-api/codex/responses` with HTTP 426.
- Preserve HTTP 405 for ordinary GET requests.
- Route POST requests from the ChatGPT-shaped Codex path through the existing Responses gateway and normalize it to the canonical upstream path.
- Add regression coverage for routing, upstream URL construction, WebSocket fallback, and ordinary GET behavior.
- Attach the fallback through additive router middleware so the patch also applies cleanly to `main`.

Validation:
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run pre-commit run --all-files`
- `just test-rust`: 4,463 tests passed; the existing timing-sensitive `unhealthy_owned_gateway_is_force_killed_after_the_grace_period` test failed in the suite and passed when rerun in isolation.
- Applied the exact patch to current `main` and passed `responses_websocket_upgrades_request_http_fallback`.
- Ran an isolated live E2E with Codex CLI 0.151.0, ChatGPT authentication, `OPENAI_API_KEY` unset, user configuration ignored, and the built-in `openai` provider pointed at the Relay gateway:
  - `GET /responses` with `Upgrade: websocket` returned 426.
  - `GET /models?client_version=0.151.0` returned 200.
  - The HTTP/SSE fallback `POST /responses` returned 200.
  - Codex returned `pong` and exited 0.
  - The capture contained exactly one sampling POST, so there was no sampling retry or duplicate model invocation. The only added work was one loopback WebSocket probe; Codex logged the HTTP fallback about 80 microseconds after recording the 426.

#### Where should the reviewer start?

Start with `responses_websocket_fallback` in `crates/cli/src/server/mod.rs`, then review the ChatGPT-shaped path normalization in `crates/cli/src/gateway/routes.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenAI Responses requests through the `/backend-api/codex/responses` route.
  - Requests are correctly forwarded to the standard OpenAI Responses endpoint, including supported backend overrides.

- **Bug Fixes**
  - WebSocket upgrade probes to Responses endpoints now return `426 Upgrade Required` instead of being handled as ordinary requests.
  - Regular GET requests continue to follow normal method handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
