### PR TITLE
fix: normalize Anthropic v1 upstream paths

### DIFF
--- a/crates/cli/src/gateway/routes.rs
+++ b/crates/cli/src/gateway/routes.rs
@@ -137,18 +137,12 @@ impl ProviderRoute {
         )
     }
 
-    // Like `upstream_url` but with an explicit base URL. This keeps OpenAI `/v1` normalization in
-    // one place for configured public, enterprise, or local proxy bases.
+    // Like `upstream_url` but with an explicit base URL. This keeps `/v1` normalization in one
+    // place for configured public, enterprise, or local proxy bases.
     pub(super) fn upstream_url_with_base(self, base: &str, path_and_query: &str) -> String {
         let base = base.trim_end_matches('/');
         let path_and_query = self.canonical_path_and_query(path_and_query);
-        let path_and_query = match self {
-            Self::OpenAiResponses
-            | Self::OpenAiChatCompletions
-            | Self::OpenAiImagesGenerations
-            | Self::OpenAiModels => normalize_openai_path_for_base(base, &path_and_query),
-            _ => path_and_query,
-        };
+        let path_and_query = normalize_v1_path_for_base(base, &path_and_query);
         format!("{base}{path_and_query}")
     }
 
@@ -192,7 +186,7 @@ fn configured_auth_header<'a>(
     }
 }
 
-pub(super) fn normalize_openai_path_for_base(base: &str, path_and_query: &str) -> String {
+pub(super) fn normalize_v1_path_for_base(base: &str, path_and_query: &str) -> String {
     match (base.ends_with("/v1"), path_and_query.starts_with("/v1/")) {
         (true, true) => path_and_query
             .strip_prefix("/v1")

--- a/crates/cli/tests/coverage/shared/gateway_tests.rs
+++ b/crates/cli/tests/coverage/shared/gateway_tests.rs
@@ -567,6 +567,42 @@ fn openai_upstream_url_accepts_origin_or_v1_base() {
 }
 
 #[test]
+fn anthropic_upstream_url_accepts_origin_or_v1_base() {
+    let mut config = GatewayConfig {
+        bind: "127.0.0.1:0".parse().unwrap(),
+        openai_base_url: "http://openai".into(),
+        openai_auth_header: None,
+        anthropic_base_url: "http://anthropic".into(),
+        anthropic_auth_header: None,
+        metadata: None,
+        plugin_config: None,
+        max_hook_payload_bytes: crate::configuration::DEFAULT_MAX_HOOK_PAYLOAD_BYTES,
+        max_passthrough_body_bytes: crate::configuration::DEFAULT_MAX_PASSTHROUGH_BODY_BYTES,
+    };
+
+    assert_eq!(
+        ProviderRoute::AnthropicMessages.upstream_url(&config, "/v1/messages?beta=true"),
+        "http://anthropic/v1/messages?beta=true"
+    );
+    assert_eq!(
+        ProviderRoute::AnthropicCountTokens
+            .upstream_url(&config, "/v1/messages/count_tokens?beta=true"),
+        "http://anthropic/v1/messages/count_tokens?beta=true"
+    );
+
+    config.anthropic_base_url = "http://anthropic/v1".into();
+    assert_eq!(
+        ProviderRoute::AnthropicMessages.upstream_url(&config, "/v1/messages?beta=true"),
+        "http://anthropic/v1/messages?beta=true"
+    );
+    assert_eq!(
+        ProviderRoute::AnthropicCountTokens
+            .upstream_url(&config, "/v1/messages/count_tokens?beta=true"),
+        "http://anthropic/v1/messages/count_tokens?beta=true"
+    );
+}
+
+#[test]
 fn effective_upstream_request_overlays_runtime_body_and_headers() {
     let original_body = Bytes::from_static(br#"{"model":"original"}"#);
     let mut original_headers = HeaderMap::new();


### PR DESCRIPTION
## Summary

Normalize Anthropic request paths when a configured compatible upstream base URL already includes `/v1`.

## Root cause

Claude Code sends Anthropic requests to `/v1/messages` and `/v1/messages/count_tokens`. Relay previously normalized duplicate `/v1` path segments only for OpenAI routes. Consequently, an Anthropic base such as `https://gateway.example/v1` was joined with `/v1/messages` as `https://gateway.example/v1/v1/messages`.

## Changes

- Apply the existing `/v1` base-path normalization to all configured provider routes.
- Preserve request query strings during normalization.
- Add regression coverage for Anthropic Messages and Count Tokens routes against both origin-only and `/v1`-suffixed bases.

## Validation

- `cargo fmt --check`
- `cargo test -p nemo-relay-cli anthropic_upstream_url_accepts_origin_or_v1_base -- --nocapture`

The Claude Code credential-launch behavior is intentionally excluded from this change and will be evaluated separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider routing when using base URLs with or without the `/v1` path.
  - Ensured Anthropic messages and token-counting requests preserve query parameters during URL construction.
- **Tests**
  - Added coverage for Anthropic upstream URL handling across supported base URL formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->