### PR TITLE
fix: keep Relay headers out of LangChain models that reject extra_headers

### DIFF
--- a/docs/supported-integrations/langchain.mdx
+++ b/docs/supported-integrations/langchain.mdx
@@ -90,7 +90,13 @@ print(f"Final response: {final_message.content}")
 
 When the agent uses `ChatNVIDIA`, NeMo Relay forwards request headers, including
 Dynamo session lineage, as HTTP headers. They are not added to the NIM request
-body.
+body. For chat models built on the OpenAI or Anthropic Python SDKs, such as
+`langchain-openai` and `langchain-anthropic`, the headers travel in the
+per-request `extra_headers` model setting, which those SDKs send as HTTP headers.
+NeMo Relay also uses `extra_headers` when your `model_settings` already configure
+it. Other providers, such as `ChatOCIGenAI` from `langchain-oci`, receive no Relay
+headers because their SDKs reject unknown request fields; the model call proceeds
+without them.
 
 ## Verify the Integration
 

--- a/python/nemo_relay/integrations/langchain/_serialization.py
+++ b/python/nemo_relay/integrations/langchain/_serialization.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import functools
+import importlib
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -439,6 +441,38 @@ def _chat_nvidia_with_relay_headers(model: Any, headers: dict[str, Any]) -> Any 
     return model.model_copy(update={"default_headers": {**default_headers, **relay_headers}})
 
 
+_EXTRA_HEADERS_MODEL_CLASSES: tuple[tuple[str, str], ...] = (
+    # OpenAI and Anthropic Python SDKs accept ``extra_headers`` as a per-request option.
+    ("langchain_openai.chat_models.base", "BaseChatOpenAI"),
+    ("langchain_anthropic.chat_models", "ChatAnthropic"),
+)
+
+
+@functools.cache
+def _optional_class(module_name: str, class_name: str) -> type | None:
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        return None
+    return getattr(module, class_name, None)
+
+
+def _model_accepts_extra_headers(model: Any, model_settings: dict[str, Any]) -> bool:
+    """Return whether ``model`` sends the ``extra_headers`` model setting as HTTP headers.
+
+    ``extra_headers`` is an OpenAI and Anthropic SDK request option. Other provider SDKs
+    treat unknown model settings as request-body fields and reject them, so Relay
+    headers only travel this way when the SDK is known to accept the option or the
+    caller already configures ``extra_headers`` for the model.
+    """
+    if isinstance(model_settings.get("extra_headers"), dict):
+        return True
+    return any(
+        (model_class := _optional_class(module_name, class_name)) is not None and isinstance(model, model_class)
+        for module_name, class_name in _EXTRA_HEADERS_MODEL_CLASSES
+    )
+
+
 def payload_to_model_request(
     original: ModelRequest[Any],
     llm_request: LLMRequest,
@@ -460,8 +494,7 @@ def payload_to_model_request(
         # Using dict() to ensure we have a copy
         model_settings_copy = dict(model_settings)
         extra_headers = model_settings_copy.get("extra_headers")
-        if not isinstance(extra_headers, dict):
-            extra_headers = {}
+        extra_headers = dict(extra_headers) if isinstance(extra_headers, dict) else {}
         overrides["model_settings"] = model_settings_copy
     else:
         overrides["model_settings"] = {}
@@ -471,9 +504,11 @@ def payload_to_model_request(
         model_with_headers = _chat_nvidia_with_relay_headers(original.model, llm_request.headers)
         if model_with_headers is not None:
             overrides["model"] = model_with_headers
-        else:
+        elif _model_accepts_extra_headers(original.model, overrides["model_settings"]):
             extra_headers.update(llm_request.headers)
             overrides["model_settings"]["extra_headers"] = extra_headers
+        # Other providers get no Relay headers: their SDKs reject unknown request fields,
+        # and failing the model call is worse than dropping observability headers.
 
     if "tool_choice" in llm_request.content:
         overrides["tool_choice"] = llm_request.content["tool_choice"]

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -862,7 +862,7 @@ def test_payload_to_model_request_leaves_chat_nvidia_model_unchanged_without_rel
     assert converted.model_settings == {"temperature": 1.0}
 
 
-def test_payload_to_model_request_keeps_generic_model_headers_in_model_settings(model_request: ModelRequest[Any]):
+def test_payload_to_model_request_does_not_inject_relay_headers_for_generic_models(model_request: ModelRequest[Any]):
     from nemo_relay.integrations.langchain._serialization import (
         model_request_to_payload,
         payload_to_model_request,
@@ -876,10 +876,93 @@ def test_payload_to_model_request_keeps_generic_model_headers_in_model_settings(
     converted = payload_to_model_request(model_request, relay_request)
 
     assert converted.model is model_request.model
+    assert converted.model_settings == {"temperature": 1.0}
+
+
+def test_payload_to_model_request_forwards_relay_headers_as_extra_headers_for_anthropic(
+    model_request: ModelRequest[Any],
+):
+    from nemo_relay.integrations.langchain._serialization import (
+        model_request_to_payload,
+        payload_to_model_request,
+    )
+
+    ChatAnthropic = pytest.importorskip("langchain_anthropic").ChatAnthropic
+    original = model_request.override(model=ChatAnthropic.model_construct(model="claude-test"))
+    relay_request = nemo_relay.LLMRequest(
+        {"x-relay-header": "value"},
+        model_request_to_payload("mock-model", original),
+    )
+
+    converted = payload_to_model_request(original, relay_request)
+
+    assert converted.model is original.model
     assert converted.model_settings == {
         "temperature": 1.0,
         "extra_headers": {"x-relay-header": "value"},
     }
+
+
+def test_payload_to_model_request_merges_relay_headers_into_configured_extra_headers(
+    model_request: ModelRequest[Any],
+):
+    from nemo_relay.integrations.langchain._serialization import (
+        model_request_to_payload,
+        payload_to_model_request,
+    )
+
+    configured_headers = {"x-team": "platform"}
+    original = model_request.override(model_settings={"temperature": 1.0, "extra_headers": configured_headers})
+    relay_request = nemo_relay.LLMRequest(
+        {"x-relay-header": "value"},
+        model_request_to_payload("mock-model", original),
+    )
+
+    converted = payload_to_model_request(original, relay_request)
+
+    assert converted.model_settings == {
+        "temperature": 1.0,
+        "extra_headers": {"x-team": "platform", "x-relay-header": "value"},
+    }
+    assert configured_headers == {"x-team": "platform"}
+
+
+def test_wrap_model_call_does_not_inject_extra_headers_for_models_that_reject_them(
+    nemo_relay_middleware: NemoRelayMiddleware,
+):
+    from langchain.agents.middleware import ModelRequest, ModelResponse
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import AIMessage, HumanMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+
+    class StrictKwargsChatModel(BaseChatModel):
+        """Provider whose SDK rejects unknown request fields, like langchain-oci."""
+
+        model: str = "strict-model"
+
+        def _generate(self, messages: Any, stop: Any = None, run_manager: Any = None, **kwargs: Any) -> ChatResult:
+            unexpected = sorted(set(kwargs) - {"temperature"})
+            if unexpected:
+                raise TypeError(f"Unrecognized keyword arguments: {', '.join(unexpected)}")
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="strict-ok"))])
+
+        @property
+        def _llm_type(self) -> str:
+            return "strict-kwargs"
+
+    request = ModelRequest(
+        model=StrictKwargsChatModel(),
+        messages=[HumanMessage(content="hello")],
+        model_settings={"temperature": 0.0},
+    )
+
+    def handler(model_request: ModelRequest[Any]) -> ModelResponse[Any]:
+        result = model_request.model.invoke(model_request.messages, **model_request.model_settings)
+        return ModelResponse(result=[result])
+
+    response = nemo_relay_middleware.wrap_model_call(request, handler)
+
+    assert response.result[0].content == "strict-ok"
 
 
 def test_langchain_model_response_codec_decodes_text_and_tool_calls():

--- a/python/tests/integrations/langchain_tests/test_middleware.py
+++ b/python/tests/integrations/langchain_tests/test_middleware.py
@@ -955,14 +955,29 @@ def test_wrap_model_call_does_not_inject_extra_headers_for_models_that_reject_th
         messages=[HumanMessage(content="hello")],
         model_settings={"temperature": 0.0},
     )
+    seen_request: dict[str, ModelRequest[Any]] = {}
+
+    def add_relay_header(
+        _name: str,
+        llm_request: nemo_relay.LLMRequest,
+        annotated: nemo_relay.AnnotatedLLMRequest | None,
+    ) -> nemo_relay.LLMRequestInterceptOutcome:
+        llm_request.headers["x-relay-header"] = "value"
+        return nemo_relay.LLMRequestInterceptOutcome(llm_request, annotated)
 
     def handler(model_request: ModelRequest[Any]) -> ModelResponse[Any]:
+        seen_request["request"] = model_request
         result = model_request.model.invoke(model_request.messages, **model_request.model_settings)
         return ModelResponse(result=[result])
 
-    response = nemo_relay_middleware.wrap_model_call(request, handler)
+    nemo_relay.intercepts.register_llm_request("test_strict_model_relay_header", 1, False, add_relay_header)
+    try:
+        response = nemo_relay_middleware.wrap_model_call(request, handler)
+    finally:
+        nemo_relay.intercepts.deregister_llm_request("test_strict_model_relay_header")
 
     assert response.result[0].content == "strict-ok"
+    assert seen_request["request"].model_settings == {"temperature": 0.0}
 
 
 def test_langchain_model_response_codec_decodes_text_and_tool_calls():


### PR DESCRIPTION
#### Overview

`NemoRelayMiddleware` fails every model call on LangChain chat models whose SDK rejects unknown request fields, because Relay request headers are injected as `model_settings["extra_headers"]` for any model that is not `ChatNVIDIA`. With `langchain-oci`, `create_agent(..., middleware=[NemoRelayMiddleware()])` on `ChatOCIGenAI` raises `TypeError: Unrecognized keyword arguments: extra_headers` on the first turn. This change routes headers through `extra_headers` only where that option is an HTTP-header mechanism, and leaves the request untouched elsewhere.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- What failed: the runtime injects `x-dynamo-session-id` lineage headers on every managed LLM call, so `payload_to_model_request` always added `extra_headers` to `model_settings` for non-`ChatNVIDIA` models. LangChain passes `model_settings` as invocation kwargs; the OpenAI and Anthropic SDKs accept `extra_headers`, but `langchain-oci` forwards kwargs into the OCI `ChatDetails` request model, which rejects the field. Reproduced against nemo-relay 0.8.4 with langchain-oci 0.3.2 on a live OCI Generative AI tenancy.
- `_serialization.py`: add `_model_accepts_extra_headers`, which is true for `langchain_openai` `BaseChatOpenAI` subclasses, `langchain_anthropic` `ChatAnthropic`, or when the caller already configures `extra_headers` in `model_settings`. Optional imports are cached with `functools.cache`. `ChatNVIDIA` keeps its existing transport path. Any caller-provided `extra_headers` dict is copied before Relay headers are merged, so the original `model_settings` is no longer mutated.
- Tests: replace the generic-model expectation with the new behavior; add coverage for the Anthropic path and the configured-`extra_headers` path; add a regression test that runs a strict-kwargs `BaseChatModel` through the real `NemoRelayMiddleware.wrap_model_call` pipeline. The regression test fails on `main` with the exact production error and passes with this change.
- Docs: `docs/supported-integrations/langchain.mdx` now describes all three header paths.
- Validation: `uv run pytest python/tests/integrations/langchain_tests/test_middleware.py` (30 passed, 3 skipped), `just test-python` (686 passed), and `uv run pre-commit run --files <changed files>` (all hooks passed, including ruff, ty, and the docs linkcheck).
- Breaking changes: none. Models built on other SDKs stop receiving Relay headers in `model_settings`; previously those calls failed, or the provider ignored the field.

#### Where should the reviewer start?

`_model_accepts_extra_headers` and the `elif` branch in `payload_to_model_request` in `python/nemo_relay/integrations/langchain/_serialization.py`, then `test_wrap_model_call_does_not_inject_extra_headers_for_models_that_reject_them` in `python/tests/integrations/langchain_tests/test_middleware.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none (follow-up to #464, which introduced the `ChatNVIDIA` transport path and kept other models on `extra_headers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved LangChain integration handling for Relay headers across supported providers.
  - OpenAI- and Anthropic-based models now receive Relay headers through supported header settings while preserving existing configuration.
  - NVIDIA models keep headers separate from the request body.
  - Unsupported providers continue without Relay headers to avoid invalid requests.

- **Documentation**
  - Expanded LangChain integration guidance with provider-specific header behavior and configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->