### PR TITLE
fix: preserve Codex automation tool outputs

### DIFF
--- a/crates/core/src/codec/openai_responses.rs
+++ b/crates/core/src/codec/openai_responses.rs
@@ -396,7 +396,7 @@ fn decode_responses_content_part(value: &Json) -> Result<ContentPart> {
     }
 }
 
-fn decode_responses_input_item(value: &Json) -> Result<Message> {
+fn decode_responses_input_item(value: &Json, codex_dialect: bool) -> Result<Message> {
     let obj = value.as_object().ok_or_else(|| {
         FlowError::InvalidArgument("OpenAI Responses input item must be an object".into())
     })?;
@@ -483,6 +483,27 @@ fn decode_responses_input_item(value: &Json) -> Result<Message> {
             })
         }
         "function_call_output" => {
+            // Codex persists namespaced app-tool results in conversation history without the
+            // public Responses API's call_id. Keep that Codex-only extension opaque so Relay can
+            // forward it losslessly without treating it as a portable, correlated tool result.
+            if codex_dialect
+                && matches!(obj.get("call_id"), None | Some(Json::Null))
+                && obj
+                    .get("name")
+                    .and_then(Json::as_str)
+                    .is_some_and(|name| !name.is_empty())
+                && obj
+                    .get("namespace")
+                    .and_then(Json::as_str)
+                    .is_some_and(|namespace| !namespace.is_empty())
+                && obj.contains_key("output")
+            {
+                return Ok(Message::ProviderNative {
+                    provider: "openai_responses".into(),
+                    kind: kind.into(),
+                    value: value.clone(),
+                });
+            }
             let call_id = obj.get("call_id").and_then(Json::as_str).ok_or_else(|| {
                 FlowError::InvalidArgument(
                     "OpenAI Responses function_call_output is missing call_id".into(),
@@ -1292,6 +1313,12 @@ impl LlmCodec for OpenAIResponsesCodec {
         let input = obj.get("input").ok_or_else(|| {
             FlowError::InvalidArgument("OpenAI Responses request is missing input".into())
         })?;
+        let codex_dialect = obj
+            .get("client_metadata")
+            .and_then(Json::as_object)
+            .and_then(|metadata| metadata.get("x-codex-installation-id"))
+            .and_then(Json::as_str)
+            .is_some_and(|installation_id| !installation_id.is_empty());
         let messages = if let Some(input) = input.as_str() {
             vec![Message::User {
                 content: MessageContent::Text(input.to_string()),
@@ -1306,7 +1333,7 @@ impl LlmCodec for OpenAIResponsesCodec {
                     )
                 })?
                 .iter()
-                .map(decode_responses_input_item)
+                .map(|item| decode_responses_input_item(item, codex_dialect))
                 .collect::<Result<Vec<_>>>()?
         };
         let instructions = match obj.get("instructions") {

--- a/crates/core/tests/unit/codec/openai_responses_tests.rs
+++ b/crates/core/tests/unit/codec/openai_responses_tests.rs
@@ -778,6 +778,157 @@ fn request_schema_fixture_round_trips_ordered_native_items_and_surgical_edits() 
 }
 
 #[test]
+fn codex_namespaced_function_output_without_call_id_round_trips_losslessly() {
+    let codec = OpenAIResponsesCodec;
+    let native_output = json!({
+        "type": "function_call_output",
+        "namespace": "codex_app",
+        "name": "automation_update",
+        "output": {"status": "created"},
+        "future": {"preserve": true}
+    });
+    let original = make_request(json!({
+        "model": "gpt-5",
+        "client_metadata": {"x-codex-installation-id": "installation-1"},
+        "input": [
+            {"type": "message", "role": "user", "content": "Create an automation."},
+            native_output.clone()
+        ]
+    }));
+
+    let mut annotated = codec.decode(&original).unwrap();
+    assert!(matches!(
+        &annotated.messages[1],
+        Message::ProviderNative { provider, kind, value }
+            if provider == "openai_responses"
+                && kind == "function_call_output"
+                && value == &native_output
+    ));
+    assert_eq!(codec.encode(&annotated, &original).unwrap(), original);
+
+    let mut explicit_null = original.clone();
+    explicit_null.content["input"][1]["call_id"] = Json::Null;
+    let explicit_null_annotated = codec.decode(&explicit_null).unwrap();
+    assert!(matches!(
+        &explicit_null_annotated.messages[1],
+        Message::ProviderNative { value, .. } if value.get("call_id") == Some(&Json::Null)
+    ));
+    assert_eq!(
+        codec
+            .encode(&explicit_null_annotated, &explicit_null)
+            .unwrap(),
+        explicit_null
+    );
+
+    let Message::User {
+        content: MessageContent::Text(text),
+        ..
+    } = &mut annotated.messages[0]
+    else {
+        panic!("expected portable Responses user message");
+    };
+    *text = "Create a daily automation.".into();
+    let encoded = codec.encode(&annotated, &original).unwrap();
+    assert_eq!(encoded.content["input"][1], native_output);
+    assert_eq!(
+        encoded.content["input"][0]["content"],
+        json!("Create a daily automation.")
+    );
+}
+
+#[test]
+fn unpaired_function_outputs_remain_strict_outside_codex_namespaced_items() {
+    let codec = OpenAIResponsesCodec;
+    let codex_metadata = json!({"x-codex-installation-id": "installation-1"});
+    let invalid_items = [
+        (
+            None,
+            json!({
+                "type": "function_call_output",
+                "namespace": "codex_app",
+                "name": "automation_update",
+                "output": "ok"
+            }),
+        ),
+        (
+            Some(json!({"x-codex-installation-id": ""})),
+            json!({
+                "type": "function_call_output",
+                "namespace": "codex_app",
+                "name": "automation_update",
+                "output": "ok"
+            }),
+        ),
+        (
+            Some(codex_metadata.clone()),
+            json!({"type": "function_call_output", "output": "ok"}),
+        ),
+        (
+            Some(codex_metadata.clone()),
+            json!({
+                "type": "function_call_output",
+                "namespace": "codex_app",
+                "name": "",
+                "output": "ok"
+            }),
+        ),
+        (
+            Some(codex_metadata.clone()),
+            json!({
+                "type": "function_call_output",
+                "namespace": "",
+                "name": "automation_update",
+                "output": "ok"
+            }),
+        ),
+        (
+            Some(codex_metadata.clone()),
+            json!({
+                "type": "function_call_output",
+                "namespace": 7,
+                "name": "automation_update",
+                "output": "ok"
+            }),
+        ),
+        (
+            Some(codex_metadata.clone()),
+            json!({
+                "type": "function_call_output",
+                "namespace": "codex_app",
+                "name": false,
+                "output": "ok"
+            }),
+        ),
+        (
+            Some(codex_metadata.clone()),
+            json!({
+                "type": "function_call_output",
+                "namespace": "codex_app",
+                "name": "automation_update",
+                "call_id": 7,
+                "output": "ok"
+            }),
+        ),
+        (
+            Some(codex_metadata),
+            json!({
+                "type": "function_call_output",
+                "namespace": "codex_app",
+                "name": "automation_update"
+            }),
+        ),
+    ];
+
+    for (client_metadata, item) in invalid_items {
+        let mut content = json!({"model": "gpt-5", "input": [item]});
+        if let Some(client_metadata) = client_metadata {
+            content["client_metadata"] = client_metadata;
+        }
+        assert!(codec.decode(&make_request(content)).is_err());
+    }
+}
+
+#[test]
 fn responses_tool_edits_preserve_unknown_fields_and_explicit_nulls() {
     let codec = OpenAIResponsesCodec;
     let original = make_request(json!({
@@ -1189,7 +1340,7 @@ fn assert_responses_decode_component_branches() {
         json!({"type": "function_call_output", "call_id": "call"}),
         json!({"type": "function_call_output", "id": 7, "call_id": "call", "output": "ok"}),
     ] {
-        assert!(decode_responses_input_item(&invalid).is_err());
+        assert!(decode_responses_input_item(&invalid, false).is_err());
     }
     for portable in [
         json!({"type": "message", "role": "user", "content": "u"}),
@@ -1200,7 +1351,7 @@ fn assert_responses_decode_component_branches() {
         json!({"type": "function_call_output", "id": null, "call_id": "call", "output": "ok"}),
     ] {
         assert!(!matches!(
-            decode_responses_input_item(&portable).unwrap(),
+            decode_responses_input_item(&portable, false).unwrap(),
             Message::ProviderNative { .. }
         ));
     }
@@ -1210,7 +1361,7 @@ fn assert_responses_decode_component_branches() {
         json!({"type": "reasoning", "summary": []}),
     ] {
         assert!(matches!(
-            decode_responses_input_item(&native).unwrap(),
+            decode_responses_input_item(&native, false).unwrap(),
             Message::ProviderNative { .. }
         ));
     }


### PR DESCRIPTION
#### Overview

Allow Codex scheduled and automation tasks to pass through Relay when Codex persists a namespaced app-tool result without the public Responses API call ID. The compatibility path is restricted to requests carrying Codex installation metadata and preserves the native item losslessly.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Detect the Codex Responses dialect from non-empty `client_metadata.x-codex-installation-id`.
- Preserve namespaced `function_call_output` items as provider-native only when `call_id` is absent or null and valid `name`, `namespace`, and `output` fields are present.
- Keep strict validation for standard Responses requests and malformed Codex items.
- Add regression coverage for absent and null call IDs, exact round trips, surgical edits, and strict negative cases.

Validation:

- `cargo fmt --all -- --check`
- `cargo test -p nemo-relay openai_responses --lib` (57 passed)
- `cargo test -p nemo-relay --lib` (1,599 passed)
- Commit hooks passed except workspace-wide `cargo clippy` and `cargo check`, which are blocked by existing unresolved `initialize_plugins` and `clear_plugin_configuration` references in `nemo-relay-pii-redaction` tests.
- `just test-rust` is blocked by the same unrelated `nemo-relay-pii-redaction` compilation errors.

Breaking changes: none.

#### Where should the reviewer start?

Start with `decode_responses_input_item` in `crates/core/src/codec/openai_responses.rs`, then review `codex_namespaced_function_output_without_call_id_round_trips_losslessly` in the corresponding codec tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes [RELAY-840](https://linear.app/nvidia/issue/RELAY-840/codex-scheduled-tasks-failing-with-nemo-relay)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Codex-formatted OpenAI Responses.
  - Preserves valid Codex function-call output messages even when standard call identifiers are absent.
  - Maintains unknown fields and explicit null values during request processing.
  - Continues rejecting malformed or incomplete metadata and invalid tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->