### PR TITLE
test: update PII redaction plugin host calls

### DIFF
--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -946,7 +946,7 @@ async fn trajectory_managed_llm_events_fail_closed_for_runtime_and_opaque_codecs
         ),
         ("opaque", LlmCodecIdentity::Opaque),
     ] {
-        initialize_plugins(plugin_config(json!({
+        test_initialize_plugin_host_exact(plugin_config(json!({
             "codec": "openai_responses",
             "mode": "builtin",
             "builtin": {"preset": "trajectory_context"}
@@ -1004,7 +1004,7 @@ async fn trajectory_managed_llm_events_fail_closed_for_runtime_and_opaque_codecs
         assert!(!serde_json::to_string(&captured).unwrap().contains("SECRET"));
 
         deregister_subscriber(&subscriber_name).unwrap();
-        clear_plugin_configuration().unwrap();
+        test_close_plugin_host().unwrap();
     }
 }
 
@@ -1014,7 +1014,7 @@ async fn trajectory_managed_llm_events_trust_the_active_builtin_codec_over_raw_s
     reset_runtime();
     setup_isolated_thread();
 
-    initialize_plugins(plugin_config(json!({
+    test_initialize_plugin_host_exact(plugin_config(json!({
         "codec": "openai_responses",
         "mode": "builtin",
         "builtin": {"preset": "trajectory_context"}
@@ -1074,7 +1074,7 @@ async fn trajectory_managed_llm_events_trust_the_active_builtin_codec_over_raw_s
     assert!(!serde_json::to_string(&captured).unwrap().contains("SECRET"));
 
     deregister_subscriber("pii-trajectory-active-codec-surface").unwrap();
-    clear_plugin_configuration().unwrap();
+    test_close_plugin_host().unwrap();
 }
 
 #[tokio::test]
@@ -2643,7 +2643,7 @@ fn trajectory_component_preserves_normalized_cost_source_and_optimization_summar
     reset_runtime();
     setup_isolated_thread();
 
-    futures::executor::block_on(initialize_plugins(plugin_config(json!({
+    futures::executor::block_on(test_initialize_plugin_host_exact(plugin_config(json!({
         "codec": "openai_chat",
         "mode": "builtin",
         "builtin": {"preset": "trajectory_context"}
@@ -2739,7 +2739,7 @@ fn trajectory_component_preserves_normalized_cost_source_and_optimization_summar
     assert_eq!(summary.estimated_cost_saved, Some(0.25));
 
     assert!(deregister_subscriber("trajectory-normalized-accounting").unwrap());
-    clear_plugin_configuration().unwrap();
+    test_close_plugin_host().unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Overview

Update stale PII-redaction unit-test calls so the Rust test target compiles against the owned plugin-host lifecycle API.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace three removed `initialize_plugins` calls with `test_initialize_plugin_host_exact`.
- Replace their three removed `clear_plugin_configuration` calls with `test_close_plugin_host`.
- Preserve each test's existing initialization and cleanup behavior.

Validation:
- `cargo test -p nemo-relay-pii-redaction --no-run --locked`
- Main `just test-rust` workspace phase: 5,054 tests passed (one passed on retry); the later isolated gRPC worker plugin-example phase could not complete because the local disk filled.
- Staged pre-commit hooks, including `cargo fmt`, `cargo clippy`, and `cargo check`

#### Where should the reviewer start?

`crates/pii-redaction/tests/unit/component_tests.rs`, where the six stale lifecycle calls are aligned with the test-host API already used throughout the file.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated PII redaction tests to use the standard plugin host setup and cleanup helpers.
  * Preserved existing test coverage and behavior while aligning test execution with current host lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->