### PR TITLE
refactor(cli): resolve Sonar findings

### DIFF
--- a/crates/cli/assets/pi-extension/index.ts
+++ b/crates/cli/assets/pi-extension/index.ts
@@ -730,8 +730,9 @@ function summarize(result: unknown, isError: boolean): unknown {
     const record = result as Record<string, unknown>;
     const content = record.content ?? record.output ?? record.text;
     const text = toolResultText(content);
+    const outcome = isError ? 'failed' : 'completed';
     return {
-      content: text === null ? `Tool ${isError ? 'failed' : 'completed'}.` : text,
+      content: text ?? `Tool ${outcome}.`,
       result_keys: Object.keys(record).slice(0, 20),
     };
   }
@@ -783,13 +784,17 @@ function toolResultText(content: unknown): string | null {
 /** Return at most limit UTF-16 units without splitting a surrogate pair. */
 function sliceAtCodePointBoundary(value: string, limit: number): string {
   let end = Math.min(value.length, limit);
+  const previousCodeUnit = value.slice(end - 1, end).codePointAt(0);
+  const nextCodeUnit = value.slice(end, end + 1).codePointAt(0);
   if (
     end > 0 &&
     end < value.length &&
-    value.charCodeAt(end - 1) >= 0xd800 &&
-    value.charCodeAt(end - 1) <= 0xdbff &&
-    value.charCodeAt(end) >= 0xdc00 &&
-    value.charCodeAt(end) <= 0xdfff
+    previousCodeUnit !== undefined &&
+    previousCodeUnit >= 0xd800 &&
+    previousCodeUnit <= 0xdbff &&
+    nextCodeUnit !== undefined &&
+    nextCodeUnit >= 0xdc00 &&
+    nextCodeUnit <= 0xdfff
   ) {
     end -= 1;
   }

--- a/crates/cli/src/daemon/managed/pi_extension/index.ts
+++ b/crates/cli/src/daemon/managed/pi_extension/index.ts
@@ -190,6 +190,18 @@ export default function managedNemoRelayPi(pi: ExtensionAPI): void {
     };
   }
 
+  function payload(
+    context: ExtensionContext,
+    hookEventName: string,
+    fields: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      session_id: sessionId(context),
+      hook_event_name: hookEventName,
+      ...fields,
+    };
+  }
+
   async function sendObservation(body: Record<string, unknown>): Promise<void> {
     try {
       const active = await runtime();
@@ -640,7 +652,7 @@ function createSharedLease(config: DeploymentConfig, credential: string, removeF
     credential,
     ensureReady(): Promise<void> {
       if (released) return Promise.reject(new Error('managed Pi MCP lease was released'));
-      if (initialized && child?.exitCode === null && child.signalCode === null) {
+      if (initialized && child && child.exitCode === null && child.signalCode === null) {
         return Promise.resolve();
       }
       if (starting) return starting;
@@ -970,47 +982,6 @@ function jsonType(value: unknown): string {
   return typeof value;
 }
 
-function payload(
-  context: ExtensionContext,
-  hookEventName: string,
-  fields: Record<string, unknown> = {},
-): Record<string, unknown> {
-  return {
-    session_id: sessionId(context),
-    hook_event_name: hookEventName,
-    ...fields,
-  };
-}
-
-function objectShapeViolation(current: unknown, next: unknown, path: string): string | null {
-  const currentRecord = current as Record<string, unknown>;
-  const nextRecord = next as Record<string, unknown>;
-  const currentKeys = Object.keys(currentRecord).sort((left, right) => left.localeCompare(right));
-  const nextKeys = Object.keys(nextRecord).sort((left, right) => left.localeCompare(right));
-  const added = nextKeys.filter((key) => !currentKeys.includes(key));
-  const removed = currentKeys.filter((key) => !nextKeys.includes(key));
-  if (added.length > 0) return `${path} added ${added.join(', ')}`;
-  if (removed.length > 0) return `${path} removed ${removed.join(', ')}`;
-  for (const key of currentKeys) {
-    const violation = shapeViolation(currentRecord[key], nextRecord[key], `${path}.${key}`);
-    if (violation) return violation;
-  }
-  return null;
-}
-
-function arrayShapeViolation(current: unknown, next: unknown, path: string): string | null {
-  const currentItems = current as unknown[];
-  const nextItems = next as unknown[];
-  if (currentItems.length !== nextItems.length) {
-    return `${path} changed length from ${currentItems.length} to ${nextItems.length}`;
-  }
-  for (const [index, item] of currentItems.entries()) {
-    const violation = shapeViolation(item, nextItems[index], `${path}[${index}]`);
-    if (violation) return violation;
-  }
-  return null;
-}
-
 function shapeViolation(current: unknown, next: unknown, path = 'input'): string | null {
   const currentType = jsonType(current);
   const nextType = jsonType(next);
@@ -1018,10 +989,29 @@ function shapeViolation(current: unknown, next: unknown, path = 'input'): string
     return `${path} changed type from ${currentType} to ${nextType}`;
   }
   if (currentType === 'object') {
-    return objectShapeViolation(current, next, path);
+    const currentRecord = current as Record<string, unknown>;
+    const nextRecord = next as Record<string, unknown>;
+    const currentKeys = Object.keys(currentRecord).sort((left, right) => left.localeCompare(right));
+    const nextKeys = Object.keys(nextRecord).sort((left, right) => left.localeCompare(right));
+    const added = nextKeys.filter((key) => !currentKeys.includes(key));
+    const removed = currentKeys.filter((key) => !nextKeys.includes(key));
+    if (added.length > 0) return `${path} added ${added.join(', ')}`;
+    if (removed.length > 0) return `${path} removed ${removed.join(', ')}`;
+    for (const key of currentKeys) {
+      const violation = shapeViolation(currentRecord[key], nextRecord[key], `${path}.${key}`);
+      if (violation) return violation;
+    }
   }
   if (currentType === 'array') {
-    return arrayShapeViolation(current, next, path);
+    const currentItems = current as unknown[];
+    const nextItems = next as unknown[];
+    if (currentItems.length !== nextItems.length) {
+      return `${path} changed length from ${currentItems.length} to ${nextItems.length}`;
+    }
+    for (const [index, item] of currentItems.entries()) {
+      const violation = shapeViolation(item, nextItems[index], `${path}[${index}]`);
+      if (violation) return violation;
+    }
   }
   return null;
 }
@@ -1062,9 +1052,8 @@ export function summarizeManagedToolResult(result: unknown, isError: boolean): R
   if (isRecord(result)) {
     const content = result.content ?? result.output ?? result.text;
     const text = toolResultText(content);
-    const outcome = isError ? 'failed' : 'completed';
     return {
-      content: text ?? `Tool ${outcome}.`,
+      content: text === null ? `Tool ${isError ? 'failed' : 'completed'}.` : text,
       result_keys: Object.keys(result).slice(0, 20),
     };
   }
@@ -1107,17 +1096,13 @@ function toolResultText(content: unknown): string | null {
 
 function sliceAtCodePointBoundary(value: string, limit: number): string {
   let end = Math.min(value.length, limit);
-  const previousCodeUnit = value.slice(end - 1, end).codePointAt(0);
-  const nextCodeUnit = value.slice(end, end + 1).codePointAt(0);
   if (
     end > 0 &&
     end < value.length &&
-    previousCodeUnit !== undefined &&
-    previousCodeUnit >= 0xd800 &&
-    previousCodeUnit <= 0xdbff &&
-    nextCodeUnit !== undefined &&
-    nextCodeUnit >= 0xdc00 &&
-    nextCodeUnit <= 0xdfff
+    value.charCodeAt(end - 1) >= 0xd800 &&
+    value.charCodeAt(end - 1) <= 0xdbff &&
+    value.charCodeAt(end) >= 0xdc00 &&
+    value.charCodeAt(end) <= 0xdfff
   ) {
     end -= 1;
   }

--- a/crates/cli/src/daemon/managed/pi_extension/index.ts
+++ b/crates/cli/src/daemon/managed/pi_extension/index.ts
@@ -190,18 +190,6 @@ export default function managedNemoRelayPi(pi: ExtensionAPI): void {
     };
   }
 
-  function payload(
-    context: ExtensionContext,
-    hookEventName: string,
-    fields: Record<string, unknown> = {},
-  ): Record<string, unknown> {
-    return {
-      session_id: sessionId(context),
-      hook_event_name: hookEventName,
-      ...fields,
-    };
-  }
-
   async function sendObservation(body: Record<string, unknown>): Promise<void> {
     try {
       const active = await runtime();
@@ -652,7 +640,7 @@ function createSharedLease(config: DeploymentConfig, credential: string, removeF
     credential,
     ensureReady(): Promise<void> {
       if (released) return Promise.reject(new Error('managed Pi MCP lease was released'));
-      if (initialized && child && child.exitCode === null && child.signalCode === null) {
+      if (initialized && child?.exitCode === null && child.signalCode === null) {
         return Promise.resolve();
       }
       if (starting) return starting;
@@ -982,6 +970,47 @@ function jsonType(value: unknown): string {
   return typeof value;
 }
 
+function payload(
+  context: ExtensionContext,
+  hookEventName: string,
+  fields: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    session_id: sessionId(context),
+    hook_event_name: hookEventName,
+    ...fields,
+  };
+}
+
+function objectShapeViolation(current: unknown, next: unknown, path: string): string | null {
+  const currentRecord = current as Record<string, unknown>;
+  const nextRecord = next as Record<string, unknown>;
+  const currentKeys = Object.keys(currentRecord).sort((left, right) => left.localeCompare(right));
+  const nextKeys = Object.keys(nextRecord).sort((left, right) => left.localeCompare(right));
+  const added = nextKeys.filter((key) => !currentKeys.includes(key));
+  const removed = currentKeys.filter((key) => !nextKeys.includes(key));
+  if (added.length > 0) return `${path} added ${added.join(', ')}`;
+  if (removed.length > 0) return `${path} removed ${removed.join(', ')}`;
+  for (const key of currentKeys) {
+    const violation = shapeViolation(currentRecord[key], nextRecord[key], `${path}.${key}`);
+    if (violation) return violation;
+  }
+  return null;
+}
+
+function arrayShapeViolation(current: unknown, next: unknown, path: string): string | null {
+  const currentItems = current as unknown[];
+  const nextItems = next as unknown[];
+  if (currentItems.length !== nextItems.length) {
+    return `${path} changed length from ${currentItems.length} to ${nextItems.length}`;
+  }
+  for (const [index, item] of currentItems.entries()) {
+    const violation = shapeViolation(item, nextItems[index], `${path}[${index}]`);
+    if (violation) return violation;
+  }
+  return null;
+}
+
 function shapeViolation(current: unknown, next: unknown, path = 'input'): string | null {
   const currentType = jsonType(current);
   const nextType = jsonType(next);
@@ -989,29 +1018,10 @@ function shapeViolation(current: unknown, next: unknown, path = 'input'): string
     return `${path} changed type from ${currentType} to ${nextType}`;
   }
   if (currentType === 'object') {
-    const currentRecord = current as Record<string, unknown>;
-    const nextRecord = next as Record<string, unknown>;
-    const currentKeys = Object.keys(currentRecord).sort((left, right) => left.localeCompare(right));
-    const nextKeys = Object.keys(nextRecord).sort((left, right) => left.localeCompare(right));
-    const added = nextKeys.filter((key) => !currentKeys.includes(key));
-    const removed = currentKeys.filter((key) => !nextKeys.includes(key));
-    if (added.length > 0) return `${path} added ${added.join(', ')}`;
-    if (removed.length > 0) return `${path} removed ${removed.join(', ')}`;
-    for (const key of currentKeys) {
-      const violation = shapeViolation(currentRecord[key], nextRecord[key], `${path}.${key}`);
-      if (violation) return violation;
-    }
+    return objectShapeViolation(current, next, path);
   }
   if (currentType === 'array') {
-    const currentItems = current as unknown[];
-    const nextItems = next as unknown[];
-    if (currentItems.length !== nextItems.length) {
-      return `${path} changed length from ${currentItems.length} to ${nextItems.length}`;
-    }
-    for (const [index, item] of currentItems.entries()) {
-      const violation = shapeViolation(item, nextItems[index], `${path}[${index}]`);
-      if (violation) return violation;
-    }
+    return arrayShapeViolation(current, next, path);
   }
   return null;
 }
@@ -1052,8 +1062,9 @@ export function summarizeManagedToolResult(result: unknown, isError: boolean): R
   if (isRecord(result)) {
     const content = result.content ?? result.output ?? result.text;
     const text = toolResultText(content);
+    const outcome = isError ? 'failed' : 'completed';
     return {
-      content: text === null ? `Tool ${isError ? 'failed' : 'completed'}.` : text,
+      content: text ?? `Tool ${outcome}.`,
       result_keys: Object.keys(result).slice(0, 20),
     };
   }
@@ -1096,13 +1107,17 @@ function toolResultText(content: unknown): string | null {
 
 function sliceAtCodePointBoundary(value: string, limit: number): string {
   let end = Math.min(value.length, limit);
+  const previousCodeUnit = value.slice(end - 1, end).codePointAt(0);
+  const nextCodeUnit = value.slice(end, end + 1).codePointAt(0);
   if (
     end > 0 &&
     end < value.length &&
-    value.charCodeAt(end - 1) >= 0xd800 &&
-    value.charCodeAt(end - 1) <= 0xdbff &&
-    value.charCodeAt(end) >= 0xdc00 &&
-    value.charCodeAt(end) <= 0xdfff
+    previousCodeUnit !== undefined &&
+    previousCodeUnit >= 0xd800 &&
+    previousCodeUnit <= 0xdbff &&
+    nextCodeUnit !== undefined &&
+    nextCodeUnit >= 0xdc00 &&
+    nextCodeUnit <= 0xdfff
   ) {
     end -= 1;
   }

--- a/crates/cli/src/daemon/mcp/mod.rs
+++ b/crates/cli/src/daemon/mcp/mod.rs
@@ -314,6 +314,14 @@ impl Drop for ActivationChild {
 
 type PendingLaunch = Option<(String, ActivationChild, tokio::time::Instant)>;
 
+fn route_activation_timed_out(started: tokio::time::Instant, directive: &BrokerDirective) -> bool {
+    started.elapsed() > ACTIVATION_POLL_MAX
+        && !matches!(
+            directive,
+            BrokerDirective::ReuseWorker { .. } | BrokerDirective::UsePassThrough
+        )
+}
+
 async fn stop_pending_launch(launched: &mut PendingLaunch) -> Result<(), CliError> {
     if let Some((_, mut child, _)) = launched.take() {
         child.child.kill().await.map_err(CliError::Io)?;
@@ -329,12 +337,7 @@ async fn make_route_ready(
     let mut launched: PendingLaunch = None;
     let result = async {
         loop {
-            if started.elapsed() > ACTIVATION_POLL_MAX
-                && !matches!(
-                    directive,
-                    BrokerDirective::ReuseWorker { .. } | BrokerDirective::UsePassThrough
-                )
-            {
+            if route_activation_timed_out(started, &directive) {
                 return Err(CliError::Launch(
                     "timed out waiting for the broker route to become ready".into(),
                 ));

--- a/crates/cli/tests/managed_pi_extension_tests.mjs
+++ b/crates/cli/tests/managed_pi_extension_tests.mjs
@@ -50,18 +50,18 @@ test('managed Pi MCP lease becomes ready, restarts, and releases without another
   const dispatcher = join(directory, 'dispatcher.mjs');
   await writeFile(
     dispatcher,
-    `#!/usr/bin/env node
+    String.raw`#!/usr/bin/env node
 import { appendFileSync, readFileSync } from 'node:fs';
 import { createInterface } from 'node:readline';
-appendFileSync(${JSON.stringify(launches)}, 'launch\\n');
-const launchCount = readFileSync(${JSON.stringify(launches)}, 'utf8').trim().split('\\n').length;
+appendFileSync(${JSON.stringify(launches)}, 'launch\n');
+const launchCount = readFileSync(${JSON.stringify(launches)}, 'utf8').trim().split('\n').length;
 const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
 lines.on('line', (line) => {
   const request = JSON.parse(line);
   if (request.method === 'initialize') {
     process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: {
       protocolVersion: '2025-11-25', capabilities: {}, serverInfo: { name: 'nemo-relay', version: 'test' }
-    } }) + '\\n');
+    } }) + '\n');
   } else if (request.method === 'notifications/initialized' && launchCount === 1) {
     setTimeout(() => process.exit(0), 10);
   }


### PR DESCRIPTION
#### Overview

Resolve all 17 open SonarQube findings reported for the current `main` branch across the managed Pi extension and MCP daemon.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Move the managed hook payload helper out of the extension installer.
- simplify lease readiness checks and tool-result summaries with optional chaining and nullish coalescing.
- Split recursive shape validation into focused object and array helpers.
- Preserve UTF-16 surrogate-pair truncation behavior while using `codePointAt()`.
- Extract the MCP route activation timeout predicate to reduce cognitive complexity.
- Use `String.raw` for the managed Pi dispatcher test fixture.

Validation:

- `just test-pi` (passed: TypeScript checks, 114 Pi tests, and 5 managed Pi tests)
- `cargo test -p nemo-relay-cli daemon::mcp --features __test-cli-port-override,__skip-implicit-config --locked` (passed: 23 MCP tests)
- `cargo fmt --all -- --check` (passed)
- `git diff --check` (passed)
- Local Sonar analysis confirmed the originally reported TypeScript and JavaScript rules are cleared.
- `just test-rust`, workspace Cargo Check, and workspace Clippy are blocked by six unrelated existing compile errors in `crates/pii-redaction` tests, where `initialize_plugins` and `clear_plugin_configuration` are unavailable.

#### Where should the reviewer start?

Start with `shapeViolation` and its extracted helpers in `crates/cli/src/daemon/managed/pi_extension/index.ts`, then review `route_activation_timed_out` in `crates/cli/src/daemon/mcp/mod.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of tool results when operations fail or complete without expected output.
  - Improved string truncation for characters represented by surrogate pairs.
  - More accurately identifies healthy managed processes during readiness checks.
  - Preserved existing route activation timeout behavior while improving its handling internally.
- **Tests**
  - Updated managed extension test fixtures while preserving launch, initialization, and restart coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->