### PR TITLE
docs: add daemon architecture and deployment runbooks

### DIFF
--- a/docs/daemon/about.mdx
+++ b/docs/daemon/about.mdx
@@ -1,0 +1,69 @@
+---
+title: "About"
+description: "Choose a local or remote NeMo Relay daemon deployment."
+position: 1
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Use daemon mode to give coding agents a shared entry point for model requests
+and hooks. A **coding harness** is the application that runs the agent, such as
+Codex, Claude Code, or Pi. A **daemon** is a background process that stays running
+between sessions. Each user-machine identity gets its own worker and runtime state.
+
+## Start Here When
+
+Use this section to:
+
+- Run Relay at login or system startup.
+- Share one local daemon across users on a computer.
+- Connect client computers to a daemon on a Linux server.
+- Distribute the same administrator-owned settings to every user.
+- Operate workers, diagnose failed connections, and preserve streamed responses.
+
+For a personal integration managed by `nemo-relay install`, use
+[Coding Agent Installation](/nemo-relay-cli/plugin-installation). Managed daemon
+mode uses different lifecycle commands and administrator-owned configuration.
+
+## Choose a Deployment
+
+| Deployment | Daemon runs as | Available when | Guide |
+| --- | --- | --- | --- |
+| Windows user task | Signed-in user | User is logged in | [Windows](/daemon/windows) |
+| Windows system task or service | System service account | Computer is running | [Windows](/daemon/windows) |
+| macOS LaunchAgent | Signed-in user | User is logged in | [macOS](/daemon/macos) |
+| macOS LaunchDaemon | Dedicated service account | Computer is running | [macOS](/daemon/macos) |
+| Linux user service | User | User manager is running; optional lingering starts it at boot | [Linux](/daemon/linux) |
+| Linux system service | Dedicated service account | Computer is running | [Linux](/daemon/linux) |
+| Remote Linux daemon | Server service account | Server and private network are available | [Server](/daemon/remote-server), [clients](/daemon/remote-clients) |
+
+Choose one service method per daemon endpoint. The default local endpoint is
+`http://127.0.0.1:47632`. A personal Relay sidecar can already occupy that port.
+Stop the existing integration before switching, or assign a different fixed port
+and generate a separate managed bundle for that endpoint. Multiple user services
+on one computer also need separate ports; one system service can serve all users.
+
+## Before You Begin
+
+Install a Relay binary that includes `nemo-relay daemon managed-bundle` on the
+server and every client. Follow [Installation](/getting-started/installation)
+for supported binaries and [Support Matrix](/reference/support-matrix) for
+harness versions. Check `nemo-relay daemon --help` on each target before setup.
+
+An administrator must provision the system configuration, stable executable,
+and managed bundle, even for a user-level daemon. Workers ignore personal Relay
+configuration. Users need a distinct route credential for each machine-user
+identity, plus their normal model-provider authentication.
+
+Remote deployments need a trusted HTTPS certificate and a private IPv4 route
+in both directions: clients contact the daemon, and the daemon contacts client
+workers. A connection that allows only outbound traffic from clients is not enough.
+
+## Reading Order
+
+1. Read [Architecture and Startup](/daemon/architecture).
+2. Prepare [Configuration and Managed Clients](/daemon/configuration).
+3. Follow the deployment guide for your operating system.
+4. Complete [Verify Worker-Backed Operation](/daemon/operations#verify-worker-backed-operation).
+5. Keep [Reference](/daemon/reference) available for command and lifecycle details.

--- a/docs/daemon/architecture.mdx
+++ b/docs/daemon/architecture.mdx
@@ -1,0 +1,157 @@
+---
+title: "Architecture and Startup"
+description: "See how coding harnesses, MCP clients, workers, and the daemon communicate."
+position: 2
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+On narrow screens, scroll diagrams horizontally to read every label.
+
+## Process Roles
+
+The harness launches `nemo-relay daemon mcp` as a Model Context Protocol (MCP)
+process over standard input and output. This MCP connection keeps a reference
+open with the daemon. It provides no tools. The daemon's **broker** decides
+whether the user-machine route needs a new worker or can share an existing one.
+
+The MCP process starts a worker on the **client computer** only when the broker
+instructs it to. The worker loads the administrator's system configuration and
+plugins. Install the daemon as a service; do not install MCP or workers as services.
+
+<div role="region" aria-label="Process communication diagram" tabIndex={0} style={{ overflowX: "auto" }}>
+<div style={{ minWidth: "800px" }}>
+
+```mermaid
+flowchart TD
+    H["Coding harness<br/>Codex, Claude Code, or Pi"]
+    M["MCP lifecycle client"]
+    F["Short-lived hook forwarder"]
+    D["Daemon and route broker"]
+    W["Worker for one machine-user"]
+    P["Model provider"]
+    H -. "launch and MCP stdio" .-> M
+    H -. "launch with hook payload" .-> F
+    M <-->|"registration and lease renewal"| D
+    M -. "launch with protected grant" .-> W
+    W -->|"registration and heartbeat"| D
+    H -->|"model requests"| D
+    F -->|"hook requests"| D
+    D -->|"authenticated requests"| W
+    W -->|"model requests"| P
+    D -->|"model requests in pass-through"| P
+```
+
+</div>
+</div>
+
+Dotted arrows show process startup. Solid arrows show communication; responses
+return along the request path. Model streams travel back through the worker and
+daemon to the harness. Hook responses return through the hook forwarder.
+The harness and hook forwarder do not contact a worker directly.
+
+## Local Deployment
+
+<div role="region" aria-label="Local deployment diagram" tabIndex={0} style={{ overflowX: "auto" }}>
+<div style={{ minWidth: "760px" }}>
+
+```mermaid
+flowchart TD
+    subgraph PC["One computer"]
+        H["Harness and hook forwarder"]
+        M["MCP client"]
+        D["Daemon service<br/>127.0.0.1:47632"]
+        W["Per-user worker<br/>127.0.0.1:auto port"]
+        H -->|"HTTP requests"| D
+        H -. "launch" .-> M
+        M -->|"HTTP control"| D
+        M -. "launch" .-> W
+        W -->|"HTTP control"| D
+        D -->|"HTTP requests"| W
+    end
+    W -->|"HTTPS"| P["Model provider"]
+    D -->|"HTTPS in pass-through"| P
+```
+
+</div>
+</div>
+
+A system daemon has its own service identity. Each user's MCP and worker use that
+user's identity. Several harness sessions for the same identity share one worker.
+Different users do not share runtime state. The default worker port is assigned
+by the operating system; there is no worker service to enable at login.
+
+## Initialization Sequence
+
+<div role="region" aria-label="Initialization sequence diagram" tabIndex={0} style={{ overflowX: "auto" }}>
+<div style={{ minWidth: "1000px" }}>
+
+```mermaid
+sequenceDiagram
+    participant H as Harness
+    participant M as MCP client
+    participant D as Daemon
+    participant W as Worker
+    H->>M: Start with route credential in environment
+    M->>D: Request challenge and verify daemon identity
+    D-->>M: Signed challenge
+    M->>D: Signed registration and credential binding
+    alt Route needs a worker
+        D-->>M: LaunchWorker and one-time grant
+        M->>W: Launch with grant through protected stdin
+        W->>D: Prove identity and grant, register endpoint
+        D->>W: Verify readiness
+        W-->>D: Ready
+        D-->>M: Route ready
+    else Another MCP is starting or draining a worker
+        D-->>M: WaitForWorker
+        M->>D: Wait and follow broker decisions
+    else Worker is already ready
+        D-->>M: ReuseWorker
+    else Pass-through route
+        D-->>M: UsePassThrough
+    end
+    H->>M: MCP initialize
+    M-->>H: MCP initialized after route is ready
+    H->>D: Model or hook request with route credential
+    Note over M,D: MCP lease stays open for the session
+```
+
+</div>
+</div>
+
+The harness may send its MCP initialize message earlier; Relay does not serve
+the MCP protocol until it has acquired a usable route. A waiting client follows
+later broker decisions before completing startup. If worker activation fails
+after authentication, the route can become pass-through. MCP readiness alone
+does not prove that a worker is running.
+
+## Shutdown and Recovery
+
+<div role="region" aria-label="Worker lifecycle diagram" tabIndex={0} style={{ overflowX: "auto" }}>
+<div style={{ minWidth: "600px" }}>
+
+```mermaid
+stateDiagram-v2
+    [*] --> Empty
+    Empty --> Activating: First MCP reference
+    Activating --> Ready: Worker ready
+    Activating --> PassThrough: Activation fails
+    Ready --> Recovering: Worker fails
+    Recovering --> Activating: One MCP relaunches
+    Ready --> Draining: Last MCP leaves
+    PassThrough --> Empty: Last MCP leaves
+    Draining --> Empty: Worker exits
+```
+
+</div>
+</div>
+
+The diagram shows the main transitions. Explicit `--pass-through` never launches
+a worker. A draining worker cannot be revived; new MCP clients wait for it to
+exit. Accepted requests have up to two minutes to finish. Workers also stop
+accepting new requests if they lose authenticated daemon control.
+
+See [Identity and Lifecycle](/daemon/reference#understand-broker-identity-and-lifecycle)
+for heartbeat timing, restart recovery, and all broker states.

--- a/docs/daemon/configuration.mdx
+++ b/docs/daemon/configuration.mdx
@@ -17,12 +17,23 @@ starting the service runbook for your platform.
 | --- | --- | --- |
 | Runtime configuration | `/etc/nemo-relay/config.toml` | `%ProgramData%\nemo-relay\config.toml` |
 | Plugin manifest | `/etc/nemo-relay/plugins.toml` | `%ProgramData%\nemo-relay\plugins.toml` |
-| Default identity state | `$HOME/.config/nemo-relay/daemon` | `%USERPROFILE%\.config\nemo-relay\daemon` |
+| Identity state | See the resolution order below. | See the resolution order below. |
 
-`XDG_CONFIG_HOME`, when set, replaces the `.config` base for identity state on all
-platforms. It does not change the managed worker's system configuration path.
-The service runbooks set an explicit state base for the daemon. Client identities
-stay with the user and must not be shared or copied into a machine image.
+Relay resolves identity state in this order on every platform, including Windows:
+
+1. If `XDG_CONFIG_HOME` is set, use `<XDG_CONFIG_HOME>/nemo-relay/daemon`.
+2. Otherwise, if `HOME` is set, use `<HOME>/.config/nemo-relay/daemon`.
+3. Otherwise, if `USERPROFILE` is set, use `<USERPROFILE>/.config/nemo-relay/daemon`.
+
+<Note>
+On Windows, `HOME` takes precedence over `USERPROFILE`. Check the environment of
+the actual daemon or client process before backing up its keys and trust pins.
+The service runbooks set an explicit `XDG_CONFIG_HOME` for the daemon. It does
+not change the managed worker's system configuration path.
+</Note>
+
+Client identities stay with the user and must not be shared or copied into a
+machine image.
 
 For a new deployment, create `config.toml` with these contents:
 
@@ -94,7 +105,12 @@ regenerate it on every login. A token is not a model-provider key and does not
 replace the user's normal provider login.
 
 Your enterprise secret service can provision the token directly. For a small
-Unix deployment, this example creates a private local bootstrap file once, without
+deployment, choose the commands for your platform.
+
+<Tabs>
+<Tab title="Linux and macOS">
+
+This example creates a private local bootstrap file once, without
 printing the token. It requires Python 3 and fails if the file already exists:
 
 ```bash
@@ -113,7 +129,10 @@ export NEMO_RELAY_CLIENT_TOKEN="$(cat "$HOME/.config/nemo-relay-bootstrap/client
 export ANTHROPIC_CUSTOM_HEADERS="x-nemo-relay-client-token: ${NEMO_RELAY_CLIENT_TOKEN}"
 ```
 
-On Windows, create a protected bootstrap directory as the target user and generate
+</Tab>
+<Tab title="Windows PowerShell">
+
+Create a protected bootstrap directory as the target user and generate
 the token once. Do not run this block again for an existing credential:
 
 ```powershell
@@ -132,6 +151,9 @@ $RelayToken = [Convert]::ToBase64String($RelayBytes).TrimEnd('=').Replace('+','-
 $env:NEMO_RELAY_CLIENT_TOKEN = [System.IO.File]::ReadAllText($RelayTokenFile).Trim()
 $env:ANTHROPIC_CUSTOM_HEADERS = "x-nemo-relay-client-token: $env:NEMO_RELAY_CLIENT_TOKEN"
 ```
+
+</Tab>
+</Tabs>
 
 For later launches, run only the environment-loading lines, using the existing
 file. Use an administrator-provided launcher or login-environment mechanism to

--- a/docs/daemon/configuration.mdx
+++ b/docs/daemon/configuration.mdx
@@ -350,6 +350,9 @@ On Windows, create the corresponding directories in an elevated PowerShell windo
 
 ```powershell
 $RelayMarket = 'C:\ProgramData\NVIDIA\NeMoRelay\codex-marketplace-v1'
+if (Test-Path "$RelayMarket\plugins\nemo-relay-managed-v1") {
+    throw 'The plugin destination already exists; compare it with the validated bundle instead of copying again.'
+}
 New-Item -ItemType Directory -Force "$RelayMarket\.agents\plugins", "$RelayMarket\plugins" | Out-Null
 Copy-Item -Recurse -Force 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1\codex\plugin-v1' "$RelayMarket\plugins\nemo-relay-managed-v1"
 ```

--- a/docs/daemon/configuration.mdx
+++ b/docs/daemon/configuration.mdx
@@ -1,0 +1,470 @@
+---
+title: "Configuration and Managed Clients"
+description: "Prepare system configuration, credentials, and immutable coding-harness settings."
+position: 3
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+The administrator installs shared files. Each user supplies a private route
+credential through the harness's launch environment. Prepare these files before
+starting the service runbook for your platform.
+
+## System Configuration
+
+| File | Linux and macOS | Windows |
+| --- | --- | --- |
+| Runtime configuration | `/etc/nemo-relay/config.toml` | `%ProgramData%\nemo-relay\config.toml` |
+| Plugin manifest | `/etc/nemo-relay/plugins.toml` | `%ProgramData%\nemo-relay\plugins.toml` |
+| Default identity state | `$HOME/.config/nemo-relay/daemon` | `%USERPROFILE%\.config\nemo-relay\daemon` |
+
+`XDG_CONFIG_HOME`, when set, replaces the `.config` base for identity state on all
+platforms. It does not change the managed worker's system configuration path.
+The service runbooks set an explicit state base for the daemon. Client identities
+stay with the user and must not be shared or copied into a machine image.
+
+For a new deployment, create `config.toml` with these contents:
+
+```toml
+[upstream]
+openai_base_url = "https://api.openai.com/v1"
+anthropic_base_url = "https://api.anthropic.com"
+
+[logging]
+level = "info"
+stderr_enabled = true
+stderr_format = "jsonl"
+```
+
+Confirm provider URL fields against [Provider Routing](/nemo-relay-cli/basic-usage).
+Use your approved provider URLs when they differ from these defaults. Set the same
+routing on the daemon and clients for consistent pass-through behavior. Do not
+store users' provider credentials in this shared file. Info-level logs expose
+readiness events used by the runbooks; Relay's default log level is `error`.
+
+Create `plugins.toml` with the approved configuration from
+[Configure Plugins](/configure-plugins/about). A minimal file with no plugins is:
+
+```toml
+version = 1
+components = []
+```
+
+That minimal file is useful to bring up transport, but does not add observability
+or policy checks. For deployment acceptance, enable an approved exporter or
+policy and check its result. For example, use the
+[ATOF exporter](/configure-plugins/observability/atof) with a collector reachable
+by each client. Do not direct all user workers to one shared writable log file.
+
+On Unix, create `/etc/nemo-relay` as root with mode 0755 and install the two
+configuration files as root with mode 0644. On Windows, create
+`C:\ProgramData\nemo-relay` as an administrator and allow users read access only.
+If the directory is new, set its ACLs before distributing files:
+
+```powershell
+New-Item -ItemType Directory -Force 'C:\ProgramData\nemo-relay' | Out-Null
+icacls 'C:\ProgramData\nemo-relay' /inheritance:r /grant:r '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F' '*S-1-5-32-545:(OI)(CI)RX'
+```
+
+After saving the examples as local `config.toml` and `plugins.toml` files,
+install them on a new Unix deployment:
+
+```bash
+sudo install -d -m 0755 /etc/nemo-relay
+sudo install -m 0644 config.toml plugins.toml /etc/nemo-relay/
+```
+
+On Windows, copy them after setting the directory ACLs above:
+
+```powershell
+Copy-Item .\config.toml, .\plugins.toml 'C:\ProgramData\nemo-relay\'
+```
+
+For an existing installation, merge approved settings rather than replacing files
+or ACLs blindly. Managed workers ignore personal runtime configuration, plugin
+directories, and lifecycle state. Install required plugin binaries and dependencies
+in the administrator-managed locations referenced by the system manifest.
+
+## Provision Client Credentials
+
+Provision one 32-byte random, base64url-encoded token for each machine-user
+identity. Keep the same token across that identity's harness sessions. Do not
+regenerate it on every login. A token is not a model-provider key and does not
+replace the user's normal provider login.
+
+Your enterprise secret service can provision the token directly. For a small
+Unix deployment, this example creates a private local bootstrap file once, without
+printing the token. It requires Python 3 and fails if the file already exists:
+
+```bash
+python3 - <<'PYTOKEN'
+import os
+import secrets
+from pathlib import Path
+root = Path.home() / '.config' / 'nemo-relay-bootstrap'
+root.mkdir(mode=0o700, parents=True, exist_ok=True)
+root.chmod(0o700)
+fd = os.open(root / 'client-token', os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, 'w') as token_file:
+    token_file.write(secrets.token_urlsafe(32) + '\n')
+PYTOKEN
+export NEMO_RELAY_CLIENT_TOKEN="$(cat "$HOME/.config/nemo-relay-bootstrap/client-token")"
+export ANTHROPIC_CUSTOM_HEADERS="x-nemo-relay-client-token: ${NEMO_RELAY_CLIENT_TOKEN}"
+```
+
+On Windows, create a protected bootstrap directory as the target user and generate
+the token once. Do not run this block again for an existing credential:
+
+```powershell
+$RelaySecretDir = Join-Path $env:LOCALAPPDATA 'nemo-relay-bootstrap'
+$RelayUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+New-Item -ItemType Directory -Force $RelaySecretDir | Out-Null
+icacls $RelaySecretDir /inheritance:r /grant:r "${RelayUser}:(OI)(CI)F" '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F'
+$RelayTokenFile = Join-Path $RelaySecretDir 'client-token'
+if (Test-Path $RelayTokenFile) { throw 'A token already exists; reuse it.' }
+$RelayBytes = New-Object byte[] 32
+$RelayRng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+$RelayRng.GetBytes($RelayBytes)
+$RelayRng.Dispose()
+$RelayToken = [Convert]::ToBase64String($RelayBytes).TrimEnd('=').Replace('+','-').Replace('/','_')
+[System.IO.File]::WriteAllText($RelayTokenFile, $RelayToken)
+$env:NEMO_RELAY_CLIENT_TOKEN = [System.IO.File]::ReadAllText($RelayTokenFile).Trim()
+$env:ANTHROPIC_CUSTOM_HEADERS = "x-nemo-relay-client-token: $env:NEMO_RELAY_CLIENT_TOKEN"
+```
+
+For later launches, run only the environment-loading lines, using the existing
+file. Use an administrator-provided launcher or login-environment mechanism to
+repeat that loading before starting the harness. Relay does not install a login
+agent. Launch desktop applications through that prepared environment; shell
+exports do not update an app that is already running.
+
+The Claude header assignment above assumes no other custom headers are required.
+If your deployment needs other headers, preserve those and ensure there is exactly
+one `x-nemo-relay-client-token` entry with the matching token. Do not put the
+credential in the shared bundle, command-line arguments, service unit, or logs.
+
+## Choose Stable Deployment Paths
+
+| Platform | Local dispatcher executable | Installed bundle |
+| --- | --- | --- |
+| Linux and macOS | `/opt/nvidia/bin/nemo-relay` | `/opt/nvidia/share/nemo-relay-managed-v1` |
+| Windows | `C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe` | `C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1` |
+| Remote Linux client | `/opt/nvidia/bin/nemo-relay-dispatch` | `/opt/nvidia/share/nemo-relay-managed-v1` |
+
+The binary itself can be the stable dispatcher. The remote Linux example uses a
+small administrator-owned wrapper to supply worker network settings. Keep the
+chosen path fixed across binary upgrades. Dispatcher paths must contain no spaces
+or shell metacharacters, including on Windows. Bundle generation checks path shape;
+deployment tooling must enforce ownership and permissions.
+
+## Route Authentication
+
+The managed topology has the following processes:
+
+- `nemo-relay daemon` owns the public LLM and hook endpoints and the
+  authoritative route broker.
+- `nemo-relay daemon mcp` registers one MCP client reference for the current
+  machine-user identity. It advertises no MCP tools.
+- `nemo-relay daemon hook` forwards one native hook payload using the managed
+  route credential.
+- `nemo-relay daemon worker` runs the per-machine-user Relay configuration and
+  remains attached to the daemon for its useful lifetime.
+
+All LLM and hook paths remain at the daemon root. Managed settings do not use
+per-user route URLs. Requests use one Relay-specific public credential header:
+
+```text
+x-nemo-relay-client-token: <base64url-encoded-256-bit-credential>
+```
+
+Pi provider registrations also preserve Pi's runtime-selected endpoint in
+`x-nemo-relay-upstream-base-url`. The authenticated daemon consumes that
+routing header and removes it before contacting the provider. It is runtime
+model metadata, not part of the managed settings artifact.
+
+Enterprise bootstrap must provide the credential through this environment
+variable:
+
+```bash
+export NEMO_RELAY_CLIENT_TOKEN='<credential>'
+```
+
+Claude Code reads custom provider headers from its native environment variable,
+so the same bootstrap must derive exactly one header from that credential:
+
+```bash
+export ANTHROPIC_CUSTOM_HEADERS="x-nemo-relay-client-token: ${NEMO_RELAY_CLIENT_TOKEN}"
+```
+
+Do not append another `x-nemo-relay-client-token` entry to an existing custom
+header value. Managed diagnostics reject a missing, duplicate, or mismatched
+credential header.
+
+The same credential identifies MCP registration, Codex and Claude LLM
+requests, Pi provider requests, and managed hook requests. The daemon does
+not require a token file or a token environment variable. During signed MCP
+registration, it binds the credential digest to the user-machine fingerprint.
+An existing binding cannot be reassigned to another fingerprint. The daemon
+stores only credential digests, removes the public header before forwarding
+a request, and preserves the caller's provider authentication.
+
+Enrollment is open to anyone who can reach the daemon and prove possession
+of their machine identity. This proof establishes identity, not organizational
+authorization. Restrict daemon access to trusted users through your network
+or authenticated reverse proxy; do not expose open enrollment to an untrusted
+network. TLS remains required for non-loopback communication.
+
+Challenge requests are limited to 16 per transport-peer IP in a 15-second
+window, before the request body is read. MCP and worker challenges retain
+separate capacity limits. Forwarded IP headers do not override this limit:
+clients behind a reverse proxy share its peer budget. Apply additional
+per-client admission controls at the proxy for larger deployments.
+
+
+## Distribute Immutable Managed Settings
+
+A managed bundle is an administrator-owned deployment artifact, not an output
+of personal `nemo-relay install`. For each agent, platform, and deployment, its
+plugin configuration and settings must remain byte-for-byte identical across
+users and Relay binary releases.
+
+The bundle follows these rules:
+
+- Daemon and provider URLs and hook command text are fixed for the deployment.
+- Artifacts contain no user path, fingerprint, credential, generation ID, or
+  Relay binary version.
+- A stable administrator-owned dispatcher command or path survives Relay
+  upgrades.
+- Refresh validates immutable artifacts and never rewrites them.
+- An incompatible settings change uses a separately named v2 artifact rather
+  than replacing v1 bytes.
+
+Enterprise bootstrap owns credential provisioning and login-environment
+injection. Relay validates `NEMO_RELAY_CLIENT_TOKEN` but does not install an
+operating-system-specific login agent.
+
+Create a bundle once from fixed deployment values. Repeat `--agent` to select
+the artifacts that the administrator distributes:
+
+```bash
+nemo-relay daemon managed-bundle \
+  --output /opt/nvidia/share/nemo-relay-managed-v1 \
+  --daemon-address http://127.0.0.1:47632 \
+  --dispatcher-command /opt/nvidia/bin/nemo-relay \
+  --platform linux \
+  --agent codex \
+  --agent claude \
+  --agent pi
+```
+
+Run bundle generation as an administrator when writing the installed system
+path. For macOS, change `--platform linux` to `--platform macos`. For remote
+Linux, use `--daemon-address https://relay.example.com:8443` and
+`--dispatcher-command /opt/nvidia/bin/nemo-relay-dispatch`.
+
+On Windows, use an elevated PowerShell window:
+
+```powershell
+& 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe' daemon managed-bundle `
+  --output 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1' `
+  --daemon-address http://127.0.0.1:47632 `
+  --dispatcher-command 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe' `
+  --platform windows --agent codex --agent claude --agent pi
+```
+
+The installed bundle must be readable by users and writable only by administrators.
+Store the printed digest in your deployment records and provision it separately
+to clients. Do not add files to the bundle after generation, even a digest file
+or a marketplace manifest; its exact file set is validated.
+
+The destination must be new or already byte-identical. The command never
+rewrites a different v1 bundle and prints only the canonical full-bundle
+SHA-256. Provision that digest separately from the bundle; a digest stored
+inside the same artifact is not a trust root. The dispatcher path is validated
+for the target platform and must be an absolute, stable administrator path
+outside known user and temporary directories.
+
+Validate a distributed bundle and its current environment without modifying
+the bundle:
+
+```bash
+nemo-relay doctor \
+  --managed-bundle /path/to/nemo-relay-managed-v1 \
+  --managed-bundle-sha256 '<separately-provisioned-64-character-sha256>'
+```
+
+Doctor compares the exact file set and bytes with the canonical manifest and
+the separately provisioned digest, then reports missing, unexpected, or
+changed artifacts. This is a managed-only diagnostic: it does not load or fail because
+of personal configuration, plugins, or agent installations.
+
+## Load a Managed Harness
+
+Install only the managed Relay integration for this deployment. Disable or remove
+the personal Relay plugin through its harness before switching. Two Relay MCP
+entries or two sets of Relay hooks can conflict or submit events twice.
+
+The following steps load the generated bytes. They do not make a user's entire
+harness configuration immutable. For organization-wide enforcement, distribute
+these artifacts with the harness's managed policy mechanism and verify its
+effective settings. Keep unrelated settings and existing authentication intact.
+
+### Codex
+
+Codex needs both the generated plugin and the provider configuration. Create an
+administrator-owned local marketplace **beside** the validated bundle. On Linux
+and macOS, use `/opt/nvidia/share/nemo-relay-codex-marketplace-v1`; on Windows, use
+`C:\ProgramData\NVIDIA\NeMoRelay\codex-marketplace-v1`.
+
+Inside that marketplace, create `.agents/plugins/marketplace.json`:
+
+```json
+{
+  "name": "nemo-relay-managed",
+  "interface": { "displayName": "NeMo Relay Managed" },
+  "plugins": [{
+    "name": "nemo-relay-managed-v1",
+    "source": { "source": "local", "path": "./plugins/nemo-relay-managed-v1" },
+    "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+    "category": "Coding"
+  }]
+}
+```
+
+Copy the entire bundle directory `codex/plugin-v1` to the marketplace's
+`plugins/nemo-relay-managed-v1`, including hidden files. On Unix:
+
+```bash
+sudo mkdir -p /opt/nvidia/share/nemo-relay-codex-marketplace-v1/.agents/plugins
+sudo mkdir -p /opt/nvidia/share/nemo-relay-codex-marketplace-v1/plugins/nemo-relay-managed-v1
+sudo cp -R /opt/nvidia/share/nemo-relay-managed-v1/codex/plugin-v1/. \
+  /opt/nvidia/share/nemo-relay-codex-marketplace-v1/plugins/nemo-relay-managed-v1/
+```
+
+On Windows, create the corresponding directories in an elevated PowerShell window:
+
+```powershell
+$RelayMarket = 'C:\ProgramData\NVIDIA\NeMoRelay\codex-marketplace-v1'
+New-Item -ItemType Directory -Force "$RelayMarket\.agents\plugins", "$RelayMarket\plugins" | Out-Null
+Copy-Item -Recurse -Force 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1\codex\plugin-v1' "$RelayMarket\plugins\nemo-relay-managed-v1"
+```
+
+Run the copy only when creating this marketplace. Keep its files administrator-owned.
+For subsequent deployments, compare the copy with the validated bundle rather than
+merging new files into it. Save the JSON manifest at the path given above.
+
+As the target user, register and enable the plugin:
+
+```bash
+codex plugin marketplace add /opt/nvidia/share/nemo-relay-codex-marketplace-v1
+codex plugin add nemo-relay-managed-v1@nemo-relay-managed
+codex plugin list
+```
+
+On Windows, use the same commands with the quoted Windows marketplace path.
+These commands match the Codex `plugin add` interface; confirm the installed
+harness meets the repository's [minimum version](/reference/support-matrix).
+
+Load `codex/settings-v1/config.toml` from the bundle into the deployed Codex
+configuration. For a fresh user configuration, copy its contents to
+`~/.codex/config.toml` (Windows: `%USERPROFILE%\.codex\config.toml`). If a config
+already exists, back it up and merge the top-level `model_provider` setting and
+the `[model_providers.nemo-relay-managed-v1]` table once. Keep authentication and
+unrelated configuration. Do not append duplicate TOML tables. If `CODEX_HOME` is
+already configured, use that configuration location instead.
+
+Enable hooks in that effective configuration:
+
+```toml
+[features]
+hooks = true
+```
+
+Merge `hooks = true` into an existing `[features]` table when present. Restart
+Codex from the prepared token environment. Open `/mcp` and confirm the Relay MCP
+connection is ready. Review and trust the installed Relay hooks through Codex's
+hook controls; verify exactly one enabled handler for every generated hook event.
+A plugin listing alone does not prove that hooks are trusted or the provider is
+selected. See [Codex configuration](https://developers.openai.com/codex/config-basic/)
+for configuration layers and [Operations](/daemon/operations) for end-to-end checks.
+
+### Claude Code
+
+Launch Claude Code with both generated artifacts. On Linux and macOS:
+
+```bash
+claude --plugin-dir /opt/nvidia/share/nemo-relay-managed-v1/claude-code/plugin-v1 \
+  --settings /opt/nvidia/share/nemo-relay-managed-v1/claude-code/settings-v1/managed-settings.json
+```
+
+On Windows:
+
+```powershell
+claude --plugin-dir 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1\claude-code\plugin-v1' `
+  --settings 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1\claude-code\settings-v1\managed-settings.json'
+```
+
+Use these arguments in the managed launcher for every session. The filename
+`managed-settings.json` does not itself enforce policy when passed with
+`--settings`; enforced deployments must install it through Claude Code's managed
+settings mechanism. Preserve any existing organization policy when merging its
+`env.ANTHROPIC_BASE_URL` value. The plugin and its MCP/hook files remain unchanged.
+See Claude Code's [plugin loading guide](https://code.claude.com/docs/en/plugins)
+and [settings reference](https://code.claude.com/docs/en/settings).
+
+The launch environment must contain both `NEMO_RELAY_CLIENT_TOKEN` and the matching
+`ANTHROPIC_CUSTOM_HEADERS`. Check `/mcp` after startup and verify that Relay hooks
+are enabled. Keep normal Claude provider authentication in place.
+
+### Pi
+
+Use the [managed Pi extension](#deploy-the-managed-pi-extension) below on Unix.
+On Windows, the equivalent launch command is:
+
+```powershell
+pi --no-extensions -e 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1\pi\extension-v1\index.ts'
+```
+
+Always include `--no-extensions` and the exact administrator-owned extension
+path. Verify a model whose provider uses one of the supported HTTP APIs. Pi
+starts the managed MCP process itself; do not register a second Relay MCP process.
+
+### Deploy the Managed Pi Extension
+
+The Pi artifact is a fixed TypeScript extension under
+`pi/extension-v1/index.ts`. Load that exact administrator-installed file while
+disabling discovered extensions; do not copy it into a per-user extension
+directory or rewrite it during upgrades. For example:
+
+```bash
+pi --no-extensions -e /opt/nvidia/share/nemo-relay-managed-v1/pi/extension-v1/index.ts
+```
+
+`--no-extensions` is mandatory for managed launches. Pi still loads the
+explicit `-e` extension, but does not also load user, project, or discovered
+extensions that could alter provider registration, tool arguments, or shell
+policy after Relay has authorized an operation.
+
+The extension starts the fixed dispatcher as
+`daemon mcp --daemon-address <URL>`, waits for MCP initialization before
+registering managed providers, and
+keeps one process-wide broker reference across Pi reload, new, resume, and fork
+transitions. It sends Pi's session, agent, turn, compaction, tool, and custom
+shell events to `/hooks/pi`; policy responses are converted back into Pi's
+native `tool_call` and `user_bash` blocking results. Any selected Pi provider
+whose models use only OpenAI Completions, OpenAI Responses, or Anthropic
+Messages and share one endpoint is registered against the daemon, including
+custom provider names. The registration attaches `x-nemo-relay-client-token`
+and Pi's exact runtime-selected endpoint in
+`x-nemo-relay-upstream-base-url`. No per-user upstream, fingerprint,
+generation, user path, or route value is written into the managed artifact.
+
+### Codex Responses Compatibility
+
+Both the personal gateway and managed daemon accept Codex's ChatGPT-shaped
+`POST /backend-api/codex/responses` path and canonicalize it to the ordinary
+upstream Responses path. A WebSocket upgrade probe sent with `GET` to that
+path, `/responses`, or `/v1/responses` receives `426 Upgrade Required`, which
+causes clients that support the fallback to use HTTP streaming. An ordinary
+GET remains `405 Method Not Allowed`.

--- a/docs/daemon/configuration.mdx
+++ b/docs/daemon/configuration.mdx
@@ -149,7 +149,7 @@ credential in the shared bundle, command-line arguments, service unit, or logs.
 | Platform | Local dispatcher executable | Installed bundle |
 | --- | --- | --- |
 | Linux and macOS | `/opt/nvidia/bin/nemo-relay` | `/opt/nvidia/share/nemo-relay-managed-v1` |
-| Windows | `C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe` | `C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1` |
+| Windows | `C:/ProgramData/NVIDIA/NeMoRelay/nemo-relay.exe` | `C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1` |
 | Remote Linux client | `/opt/nvidia/bin/nemo-relay-dispatch` | `/opt/nvidia/share/nemo-relay-managed-v1` |
 
 The binary itself can be the stable dispatcher. The remote Linux example uses a
@@ -157,6 +157,10 @@ small administrator-owned wrapper to supply worker network settings. Keep the
 chosen path fixed across binary upgrades. Dispatcher paths must contain no spaces
 or shell metacharacters, including on Windows. Bundle generation checks path shape;
 deployment tooling must enforce ownership and permissions.
+
+On Windows, use forward slashes in `--dispatcher-command`. Generated hooks can
+run in Git Bash, which treats backslashes as escape characters. PowerShell file
+paths elsewhere in these examples can use backslashes.
 
 ## Route Authentication
 
@@ -269,7 +273,7 @@ On Windows, use an elevated PowerShell window:
 & 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe' daemon managed-bundle `
   --output 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay-managed-v1' `
   --daemon-address http://127.0.0.1:47632 `
-  --dispatcher-command 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe' `
+  --dispatcher-command 'C:/ProgramData/NVIDIA/NeMoRelay/nemo-relay.exe' `
   --platform windows --agent codex --agent claude --agent pi
 ```
 

--- a/docs/daemon/linux.mdx
+++ b/docs/daemon/linux.mdx
@@ -1,0 +1,185 @@
+---
+title: "Linux Deployment"
+description: "Run a local daemon with a user or system systemd service."
+position: 6
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Use this runbook on a Linux host with systemd. The commands use a Debian or Ubuntu
+service-account layout. Run the user steps as the intended user and the `sudo`
+steps as an administrator. For a server used by other computers, continue with
+[Remote Linux: Deploy the Daemon](/daemon/remote-server).
+
+## Prepare the Host
+
+Install a verified binary using [Installation](/getting-started/installation).
+Put it at the stable path used by the managed bundle:
+
+```bash
+sudo install -d -m 0755 /opt/nvidia/bin
+sudo install -m 0755 "$(command -v nemo-relay)" /opt/nvidia/bin/nemo-relay
+/opt/nvidia/bin/nemo-relay daemon --help
+```
+
+Complete [Configuration and Managed Clients](/daemon/configuration) on this
+computer. In these examples the bundle uses `/opt/nvidia/bin/nemo-relay` directly
+as its dispatcher and `http://127.0.0.1:47632` as its daemon address.
+Administrator-owned binaries and configuration must not be writable by users.
+
+Choose **one** of the following services. A user service stays tied to its user
+manager; a system service serves all local users independently of their logins.
+
+## User Service
+
+Create the unit directory and private identity-state directory:
+
+```bash
+mkdir -p "$HOME/.config/systemd/user" "$HOME/.config/nemo-relay/daemon"
+chmod 700 "$HOME/.config/nemo-relay/daemon"
+```
+
+Save this complete unit as `~/.config/systemd/user/nemo-relay-daemon.service`:
+
+```ini
+[Unit]
+Description=NeMo Relay local daemon
+
+[Service]
+Type=simple
+ExecStart=/opt/nvidia/bin/nemo-relay daemon --bind 127.0.0.1 --port 47632
+Environment=XDG_CONFIG_HOME=%h/.config
+WorkingDirectory=%h
+Restart=on-failure
+RestartSec=5
+UMask=0077
+TimeoutStopSec=150
+
+[Install]
+WantedBy=default.target
+```
+
+Start it now and at future user-manager starts:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now nemo-relay-daemon.service
+systemctl --user status nemo-relay-daemon.service
+journalctl --user -u nemo-relay-daemon.service -n 50 --no-pager
+```
+
+To keep this user manager running after logout and start it at boot, an
+administrator can enable [lingering](https://www.freedesktop.org/software/systemd/man/latest/loginctl.html):
+
+```bash
+sudo loginctl enable-linger "$USER"
+```
+
+Without lingering, do not promise availability before login or after logout.
+Multiple users running separate daemons must use different ports and matching
+bundles. For a shared endpoint, use the system service below.
+
+## System Service
+
+Create a dedicated account with a persistent home. The daemon stores its signing
+identity here; replacing the home can cause clients to reject its new identity.
+
+```bash
+sudo useradd --system --user-group --home-dir /var/lib/nemo-relay \
+  --create-home --shell /usr/sbin/nologin nemo-relay
+sudo chmod 700 /var/lib/nemo-relay
+sudo install -d -o nemo-relay -g nemo-relay -m 0700 /var/lib/nemo-relay/.config
+```
+
+If the account already exists, verify its home and ownership instead of creating
+it again. Save `/etc/systemd/system/nemo-relay-daemon.service`:
+
+```ini
+[Unit]
+Description=NeMo Relay shared local daemon
+After=network.target
+
+[Service]
+Type=simple
+User=nemo-relay
+Group=nemo-relay
+WorkingDirectory=/var/lib/nemo-relay
+Environment=XDG_CONFIG_HOME=/var/lib/nemo-relay/.config
+ExecStart=/opt/nvidia/bin/nemo-relay daemon --bind 127.0.0.1 --port 47632
+Restart=on-failure
+RestartSec=5
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+TimeoutStopSec=150
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable the service:
+
+```bash
+sudo chmod 644 /etc/systemd/system/nemo-relay-daemon.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now nemo-relay-daemon.service
+sudo systemctl status nemo-relay-daemon.service
+sudo journalctl -u nemo-relay-daemon.service -n 50 --no-pager
+```
+
+The service needs no `NEMO_RELAY_CLIENT_TOKEN`. Each user's harness supplies its
+own token to MCP and hook processes. The worker runs as that user, not as the
+`nemo-relay` service account.
+
+## Verify and Operate
+
+Check the listener, then launch a configured harness and complete the
+[worker-backed verification](/daemon/operations#verify-worker-backed-operation):
+
+```bash
+ss -ltn 'sport = :47632'
+```
+
+The expected listener is `127.0.0.1:47632`. A listening socket proves only that a
+process has opened the port. Use the service journal to confirm that it is Relay.
+Worker messages appear in the harness's MCP stderr log, not the daemon journal.
+
+Use the matching restart command after a unit or binary update:
+
+```bash
+systemctl --user restart nemo-relay-daemon.service
+# For the system service instead:
+sudo systemctl restart nemo-relay-daemon.service
+```
+
+Run `daemon-reload` first if you edited the unit. Follow the shared
+[upgrade procedure](/daemon/operations#upgrade-and-roll-back) to drain sessions,
+keep identity state, and validate the unchanged bundle. Test logout/login for a
+user service and a planned reboot for a system service before rollout.
+
+## Remove the Service
+
+Close harness sessions first. For a user service:
+
+```bash
+systemctl --user disable --now nemo-relay-daemon.service
+rm "$HOME/.config/systemd/user/nemo-relay-daemon.service"
+systemctl --user daemon-reload
+```
+
+If you enabled lingering only for Relay, disable it with
+`sudo loginctl disable-linger "$USER"`. Other user services may still need it.
+
+For a system service:
+
+```bash
+sudo systemctl disable --now nemo-relay-daemon.service
+sudo rm /etc/systemd/system/nemo-relay-daemon.service
+sudo systemctl daemon-reload
+```
+
+Retain identity state for rollback. Remove the service account, binary, and
+managed artifacts only after confirming that no other deployment uses them.
+See [systemd service documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html)
+for unit behavior.

--- a/docs/daemon/macos.mdx
+++ b/docs/daemon/macos.mdx
@@ -1,0 +1,193 @@
+---
+title: "macOS Deployment"
+description: "Run a local daemon with a user LaunchAgent or system LaunchDaemon."
+position: 5
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Use a LaunchAgent for a daemon that runs while one user is logged in. Use a
+LaunchDaemon for a shared daemon that starts at boot. These examples use the
+supported Apple Silicon binary and require administrator access for shared files.
+
+## Prepare the Mac
+
+Install a verified binary using [Installation](/getting-started/installation),
+then copy it to a fixed administrator-owned path:
+
+```bash
+sudo install -d -m 0755 /opt/nvidia/bin
+sudo install -m 0755 "$(command -v nemo-relay)" /opt/nvidia/bin/nemo-relay
+/opt/nvidia/bin/nemo-relay daemon --help
+```
+
+Complete [Configuration and Managed Clients](/daemon/configuration). Use
+`/opt/nvidia/bin/nemo-relay` as the dispatcher and `http://127.0.0.1:47632` as the
+bundle endpoint. Choose one of the two launchd jobs below.
+
+## User LaunchAgent
+
+Create directories as the target user:
+
+```bash
+mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs/NeMoRelay"
+mkdir -p "$HOME/.config/nemo-relay/daemon"
+chmod 700 "$HOME/.config/nemo-relay/daemon" "$HOME/Library/Logs/NeMoRelay"
+```
+
+Save the following as
+`~/Library/LaunchAgents/com.nvidia.nemo-relay.daemon.plist`.
+Replace `/Users/alex` with the user's absolute home path in all three locations.
+launchd does not expand `~` or shell variables inside a plist.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.nvidia.nemo-relay.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/nvidia/bin/nemo-relay</string><string>daemon</string>
+    <string>--bind</string><string>127.0.0.1</string>
+    <string>--port</string><string>47632</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict><key>XDG_CONFIG_HOME</key><string>/Users/alex/.config</string></dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>5</integer>
+  <key>ExitTimeOut</key><integer>150</integer>
+  <key>Umask</key><integer>63</integer>
+  <key>StandardOutPath</key><string>/Users/alex/Library/Logs/NeMoRelay/daemon.out.log</string>
+  <key>StandardErrorPath</key><string>/Users/alex/Library/Logs/NeMoRelay/daemon.err.log</string>
+</dict>
+</plist>
+```
+
+Load and inspect the job from that user's desktop login session:
+
+```bash
+chmod 644 "$HOME/Library/LaunchAgents/com.nvidia.nemo-relay.daemon.plist"
+plutil -lint "$HOME/Library/LaunchAgents/com.nvidia.nemo-relay.daemon.plist"
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.nvidia.nemo-relay.daemon.plist"
+launchctl print "gui/$(id -u)/com.nvidia.nemo-relay.daemon"
+tail -n 50 "$HOME/Library/Logs/NeMoRelay/daemon.err.log"
+```
+
+The job starts again at login. It is not a boot-time service for logged-out users.
+For multiple simultaneous user daemons, assign separate ports and bundles.
+
+## System LaunchDaemon
+
+Use a dedicated hidden service account called `_nemo-relay`. Check that the name
+is unused and select an unused numeric ID. The following example uses `499`;
+check both listings before using it and replace it if occupied:
+
+```bash
+dscl . -list /Users UniqueID
+dscl . -list /Groups PrimaryGroupID
+```
+
+As an administrator, create the account and its private home:
+
+```bash
+sudo dscl . -create /Groups/_nemo-relay
+sudo dscl . -create /Groups/_nemo-relay PrimaryGroupID 499
+sudo dscl . -create /Users/_nemo-relay
+sudo dscl . -create /Users/_nemo-relay UniqueID 499
+sudo dscl . -create /Users/_nemo-relay PrimaryGroupID 499
+sudo dscl . -create /Users/_nemo-relay UserShell /usr/bin/false
+sudo dscl . -create /Users/_nemo-relay NFSHomeDirectory /var/lib/nemo-relay
+sudo dscl . -create /Users/_nemo-relay IsHidden 1
+sudo dscl . -create /Users/_nemo-relay Password '*'
+sudo install -d -o _nemo-relay -g _nemo-relay -m 0700 /var/lib/nemo-relay
+sudo install -d -o _nemo-relay -g _nemo-relay -m 0700 /var/lib/nemo-relay/.config
+sudo install -d -o _nemo-relay -g _nemo-relay -m 0700 /Library/Logs/NeMoRelay
+```
+
+Save `/Library/LaunchDaemons/com.nvidia.nemo-relay.daemon.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.nvidia.nemo-relay.daemon</string>
+  <key>UserName</key><string>_nemo-relay</string>
+  <key>GroupName</key><string>_nemo-relay</string>
+  <key>WorkingDirectory</key><string>/var/lib/nemo-relay</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/nvidia/bin/nemo-relay</string><string>daemon</string>
+    <string>--bind</string><string>127.0.0.1</string>
+    <string>--port</string><string>47632</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict><key>XDG_CONFIG_HOME</key><string>/var/lib/nemo-relay/.config</string></dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>5</integer>
+  <key>ExitTimeOut</key><integer>150</integer>
+  <key>Umask</key><integer>63</integer>
+  <key>StandardOutPath</key><string>/Library/Logs/NeMoRelay/daemon.out.log</string>
+  <key>StandardErrorPath</key><string>/Library/Logs/NeMoRelay/daemon.err.log</string>
+</dict>
+</plist>
+```
+
+Set ownership and start it:
+
+```bash
+sudo chown root:wheel /Library/LaunchDaemons/com.nvidia.nemo-relay.daemon.plist
+sudo chmod 644 /Library/LaunchDaemons/com.nvidia.nemo-relay.daemon.plist
+plutil -lint /Library/LaunchDaemons/com.nvidia.nemo-relay.daemon.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.nvidia.nemo-relay.daemon.plist
+sudo launchctl print system/com.nvidia.nemo-relay.daemon
+sudo tail -n 50 /Library/Logs/NeMoRelay/daemon.err.log
+```
+
+The service identity lives under `/var/lib/nemo-relay/.config/nemo-relay/daemon`.
+Keep it across upgrades. User workers still load `/etc/nemo-relay`, and their
+identities remain in each user's config directory.
+
+## Verify, Restart, and Remove
+
+Check the listener and complete [worker-backed verification](/daemon/operations#verify-worker-backed-operation):
+
+```bash
+lsof -nP -iTCP:47632 -sTCP:LISTEN
+```
+
+Restart after a binary update with the command for your job:
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.nvidia.nemo-relay.daemon"
+# For the system job instead:
+sudo launchctl kickstart -k system/com.nvidia.nemo-relay.daemon
+```
+
+Close harness sessions before restarting. For plist changes, unload the job with
+`bootout`, then run its `bootstrap` command again. Test a planned logout/login
+or reboot. Configure your log rotation tool for the two log files; launchd's
+file redirection does not itself bound their size.
+
+To remove a user job:
+
+```bash
+launchctl bootout "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.nvidia.nemo-relay.daemon.plist"
+rm "$HOME/Library/LaunchAgents/com.nvidia.nemo-relay.daemon.plist"
+```
+
+To remove a system job:
+
+```bash
+sudo launchctl bootout system /Library/LaunchDaemons/com.nvidia.nemo-relay.daemon.plist
+sudo rm /Library/LaunchDaemons/com.nvidia.nemo-relay.daemon.plist
+```
+
+Retain the identity directory and service account for rollback. Follow
+[Operations](/daemon/operations) for upgrades and complete removal.
+Apple's [launchd guide](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
+explains the LaunchAgent and LaunchDaemon file layout.

--- a/docs/daemon/operations.mdx
+++ b/docs/daemon/operations.mdx
@@ -1,0 +1,158 @@
+---
+title: "Operations and Troubleshooting"
+description: "Verify worker-backed sessions, inspect logs, and recover daemon deployments."
+position: 9
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Use the service manager for daemon lifecycle operations. MCP and workers belong
+to harness sessions. `nemo-relay gateway stop` controls a personal gateway; it is
+not the stop command for a managed daemon service.
+
+## Verify Worker-Backed Operation
+
+Run these checks before rollout and after an upgrade. Use a test session and a
+non-sensitive prompt. Keep the harness open throughout the request checks.
+
+1. Run `nemo-relay doctor --managed-bundle <installed-bundle-path> --managed-bundle-sha256 <trusted-digest>`
+   in the user's prepared environment. Expect bundle and environment validation
+   to succeed. This does not prove live daemon or worker readiness.
+2. Start the managed harness. Check its MCP status and stderr logs. With
+   info-level JSONL logging enabled, expect `configuration_resolved` with
+   `mode = "managed_worker"`, followed by `worker_ready` (message: `Daemon worker
+   is ready`). Confirm the MCP handshake in the harness status view. For a reused
+   worker, find its earlier ready event and confirm the worker still exists.
+3. Confirm that the worker's endpoint is on the client computer and reachable
+   from the daemon. Use the listener and network checks in your runbook. A
+   process listing alone is insufficient.
+4. Send a model request through the harness. Confirm streaming output arrives
+   before completion and that the selected provider URL is the daemon origin.
+   Trigger a harmless tool operation to exercise a managed hook.
+5. Check an observable result from your configured worker plugin: for example,
+   new ATOF records in the approved collector for this session, or the expected
+   outcome of a test policy. Confirm both model and hook activity where supported.
+6. Open a second harness for the same user-machine identity. Confirm it reuses
+   the worker. Close both sessions, allow up to two minutes for accepted requests
+   to drain, and confirm the worker exits. If a process disappeared without
+   unregistering, allow the MCP lease-expiry interval first.
+
+A successful provider response or `daemon_mcp_ready` event **does not prove worker
+execution**. Pass-through can also produce both. Do not accept a deployment until
+the worker and expected plugin behavior have been observed.
+
+For a remote deployment, also test a planned daemon restart and a VPN reconnect.
+Verify recovery or start a fresh harness if the old one cannot restore its lease.
+Check the documented [streaming limitations](/daemon/reference#preserve-streaming-responses)
+before selecting middleware that rewrites responses.
+
+## Find Logs
+
+| Component | Log location |
+| --- | --- |
+| Linux daemon | `journalctl --user -u nemo-relay-daemon` or `sudo journalctl -u nemo-relay-daemon` |
+| macOS user daemon | `~/Library/Logs/NeMoRelay/daemon.err.log` |
+| macOS system daemon | `/Library/Logs/NeMoRelay/daemon.err.log` |
+| Windows user task | `%LOCALAPPDATA%\nemo-relay-daemon\logs\daemon.err.log` |
+| Windows system task | `C:\ProgramData\NVIDIA\NeMoRelayDaemon\logs\daemon.err.log` |
+| WinSW daemon | `NeMoRelayService.err.log` and `.out.log` in the configured log directory |
+| MCP and worker | Harness MCP stderr capture; worker stderr is inherited from MCP |
+| Plugins | Destination configured in the client system `plugins.toml` |
+
+Use `[logging] level = "info"` and `stderr_format = "jsonl"` from
+[Configuration](/daemon/configuration#system-configuration). Personal logging
+overrides can affect stderr capture; check the effective logging configuration
+if worker ready events are missing. Managed MCP and hook commands do not read
+ambient logging files. To capture their info messages, pass `NEMO_RELAY_LOG=info`
+and `NEMO_RELAY_LOG_STDERR_FORMAT=jsonl` through the harness or dispatcher to
+those processes. Otherwise, use the harness MCP status view; the optional
+`daemon_mcp_ready` log may be absent. Do not change immutable bundle bytes just
+to enable logging, and do not send debug output to MCP stdout.
+
+Record the time, daemon origin, component, event, and error kind when diagnosing
+an incident. Do not include route tokens, provider keys, private identity files,
+or activation grants in support reports.
+
+## Diagnose Common Failures
+
+| Symptom | Likely cause | Next action |
+| --- | --- | --- |
+| Service repeatedly exits | Bad path, unreadable state/configuration, or occupied port | Read service stderr; check account permissions and the listening process. |
+| TLS validation fails | Wrong name, expired chain, or untrusted CA | Check the advertised DNS name, certificate dates, and client native trust store. |
+| `401` from a public route | Missing, unknown, or unregistered credential | Load the existing token and start MCP registration before sending requests. |
+| Registered route returns `503` | No live MCP reference or route not ready | Keep the harness MCP process alive; inspect registration and worker logs. |
+| MCP is ready but no plugin result appears | Pass-through, wrong plugin setup, or wrong harness provider | Find `worker_ready`, inspect client system configuration, and check effective harness routing. |
+| `worker_launch_failed` | Worker bind, launch, activation, or registration failed | Check assigned ports, executable permissions, stderr, and daemon-to-client reachability. |
+| Remote worker advertises loopback | Wrong address override or network route | Use a concrete client IPv4 address reachable from the server. |
+| First request works but large streams stall | Buffering proxy or blocked provider path | Check the full request path and streaming requirements; compare a direct private-network deployment. |
+| Startup fails after moving service accounts | Signing identity or state directory changed | Restore the original state and ownership; verify any intended identity change out of band. |
+| Many clients fail to enroll together | Challenge admission limits | Stagger client startup; investigate shared transport-peer limits. |
+| Hooks run twice | Personal and managed integrations both loaded | Remove the duplicate Relay integration and restart the harness. |
+
+After authenticated worker activation fails, the route can stay in transient
+pass-through until **all** MCP references for that identity leave. Fixing a
+firewall while leaving every harness open does not necessarily relaunch a worker.
+Close all affected sessions, wait for cleanup, then start a fresh session and
+repeat worker verification. Failure before MCP authentication instead exits the
+MCP process with a nonzero status.
+
+## Keep Identity State
+
+The state base is `XDG_CONFIG_HOME` when set, otherwise `$HOME/.config` or
+`%USERPROFILE%\.config`. Relay stores daemon state below `nemo-relay/daemon`.
+The runbooks give system services a persistent, private base directory.
+
+`daemon-identity.pk8` is the daemon signing key. `machine-identity.pk8` identifies
+the client machine-user. Trust pins are stored under `pins` and are scoped to the
+normalized daemon origin. These keys are separate from the server's HTTPS key
+and certificate.
+
+Back up private state through an access-controlled backup system and preserve
+ownership when restoring it. Do not run two machines with a cloned client
+identity. Do not delete trust pins just to silence a mismatch: first confirm
+whether the daemon was intentionally replaced or the connection is unexpected.
+An intended signing-identity replacement needs a coordinated, verified client
+trust update. A normal TLS certificate renewal does not require replacing the
+Relay signing key.
+
+Route credential bindings are in memory. A daemon restart requires MCP
+re-registration, even when signing identity is preserved. There is no documented
+per-user credential-revocation CLI. For offboarding, remove the user's network
+access and managed launch access and end their sessions. Do not assume deleting
+a local token file revokes a binding from the running broker.
+
+## Upgrade and Roll Back
+
+1. Schedule a maintenance window. Save the approved binary version, service
+   definition, configuration, and separately trusted bundle digest.
+2. Ask users to close affected harnesses. Let accepted requests drain and wait
+   for workers to exit. A service-manager stop can interrupt active streams.
+3. Stop the daemon with the matching service manager. On clients, ensure no MCP
+   or worker process still uses the binary, especially on Windows.
+4. Install the verified replacement binary at the same administrator-owned path.
+   Keep identity state and existing immutable bundle bytes. Do not use personal
+   `nemo-relay install` or `integrations refresh` to regenerate this bundle.
+5. Start the service, validate the bundle digest, and complete worker-backed
+   verification with one client before reopening the deployment.
+
+For rollback, stop affected processes and restore the previous verified binary
+and compatible service/configuration files. Keep the same persistent identities
+and validate the same bundle. Different binary versions can share a worker only
+when their protocol ranges and capabilities are compatible; a version string
+alone is not the compatibility check.
+
+Use a separately named artifact for an incompatible managed-settings change.
+When a plugin configuration changes, restart affected harness sessions so a fresh
+worker loads the new system configuration.
+
+## Remove a Deployment
+
+Use your platform's task, launchd, or systemd removal steps. Remove the managed
+Relay plugin registration and provider settings through the deployment mechanism
+that installed them. Preserve unrelated harness settings and authentication.
+Remove firewall rules only when they no longer serve a remaining deployment.
+
+Keep identity state and the old bundle for the rollback period. Delete private
+state and bootstrap tokens only as part of the intended final retirement.
+Stopping the daemon does not remove client-side files or undo harness settings.

--- a/docs/daemon/operations.mdx
+++ b/docs/daemon/operations.mdx
@@ -16,31 +16,66 @@ not the stop command for a managed daemon service.
 Run these checks before rollout and after an upgrade. Use a test session and a
 non-sensitive prompt. Keep the harness open throughout the request checks.
 
-1. Run `nemo-relay doctor --managed-bundle <installed-bundle-path> --managed-bundle-sha256 <trusted-digest>`
-   in the user's prepared environment. Expect bundle and environment validation
-   to succeed. This does not prove live daemon or worker readiness.
-2. Start the managed harness. Check its MCP status and stderr logs. With
-   info-level JSONL logging enabled, expect `configuration_resolved` with
-   `mode = "managed_worker"`, followed by `worker_ready` (message: `Daemon worker
-   is ready`). Confirm the MCP handshake in the harness status view. For a reused
-   worker, find its earlier ready event and confirm the worker still exists.
-3. Confirm that the worker's endpoint is on the client computer and reachable
-   from the daemon. Use the listener and network checks in your runbook. A
-   process listing alone is insufficient.
-4. Send a model request through the harness. Confirm streaming output arrives
-   before completion and that the selected provider URL is the daemon origin.
-   Trigger a harmless tool operation to exercise a managed hook.
-5. Check an observable result from your configured worker plugin: for example,
-   new ATOF records in the approved collector for this session, or the expected
-   outcome of a test policy. Confirm both model and hook activity where supported.
-6. Open a second harness for the same user-machine identity. Confirm it reuses
-   the worker. Close both sessions, allow up to two minutes for accepted requests
-   to drain, and confirm the worker exits. If a process disappeared without
-   unregistering, allow the MCP lease-expiry interval first.
+<Steps>
 
+<Step title="Validate the Bundle">
+
+Run `nemo-relay doctor --managed-bundle <installed-bundle-path> --managed-bundle-sha256 <trusted-digest>`
+in the user's prepared environment. Expect bundle and environment validation
+to succeed. This does not prove live daemon or worker readiness.
+
+</Step>
+
+<Step title="Confirm Worker Readiness">
+
+Start the managed harness. Check its MCP status and stderr logs. With
+info-level JSONL logging enabled, expect `configuration_resolved` with
+`mode = "managed_worker"`, followed by `worker_ready` (message: `Daemon worker
+is ready`). Confirm the MCP handshake in the harness status view. For a reused
+worker, find its earlier ready event and confirm the worker still exists.
+
+</Step>
+
+<Step title="Check Worker Reachability">
+
+Confirm that the worker's endpoint is on the client computer and reachable
+from the daemon. Use the listener and network checks in your runbook. A
+process listing alone is insufficient.
+
+</Step>
+
+<Step title="Exercise Model Requests and Hooks">
+
+Send a model request through the harness. Confirm streaming output arrives
+before completion and that the selected provider URL is the daemon origin.
+Trigger a harmless tool operation to exercise a managed hook.
+
+</Step>
+
+<Step title="Check Plugin Results">
+
+Check an observable result from your configured worker plugin: for example,
+new ATOF records in the approved collector for this session, or the expected
+outcome of a test policy. Confirm both model and hook activity where supported.
+
+</Step>
+
+<Step title="Verify Sharing and Shutdown">
+
+Open a second harness for the same user-machine identity. Confirm it reuses
+the worker. Close both sessions, allow up to two minutes for accepted requests
+to drain, and confirm the worker exits. If a process disappeared without
+unregistering, allow the MCP lease-expiry interval first.
+
+</Step>
+
+</Steps>
+
+<Warning>
 A successful provider response or `daemon_mcp_ready` event **does not prove worker
 execution**. Pass-through can also produce both. Do not accept a deployment until
 the worker and expected plugin behavior have been observed.
+</Warning>
 
 For a remote deployment, also test a planned daemon restart and a VPN reconnect.
 Verify recovery or start a fresh harness if the old one cannot restore its lease.
@@ -99,9 +134,17 @@ MCP process with a nonzero status.
 
 ## Keep Identity State
 
-The state base is `XDG_CONFIG_HOME` when set, otherwise `$HOME/.config` or
-`%USERPROFILE%\.config`. Relay stores daemon state below `nemo-relay/daemon`.
-The runbooks give system services a persistent, private base directory.
+The state base is `XDG_CONFIG_HOME` when set. Otherwise Relay uses `HOME/.config`
+if `HOME` is set, then `USERPROFILE/.config` if `USERPROFILE` is set. This order
+also applies on Windows: `HOME` wins over `USERPROFILE`. Relay stores daemon
+state below `nemo-relay/daemon` in that base directory.
+
+<Note>
+Before backup or recovery, check these variables in the environment of the
+account and process that owns the state. An interactive shell can differ from a
+service or managed harness. The runbooks give system services an explicit,
+persistent `XDG_CONFIG_HOME`; client processes can use a different base.
+</Note>
 
 `daemon-identity.pk8` is the daemon signing key. `machine-identity.pk8` identifies
 the client machine-user. Trust pins are stored under `pins` and are scoped to the
@@ -124,17 +167,45 @@ a local token file revokes a binding from the running broker.
 
 ## Upgrade and Roll Back
 
-1. Schedule a maintenance window. Save the approved binary version, service
-   definition, configuration, and separately trusted bundle digest.
-2. Ask users to close affected harnesses. Let accepted requests drain and wait
-   for workers to exit. A service-manager stop can interrupt active streams.
-3. Stop the daemon with the matching service manager. On clients, ensure no MCP
-   or worker process still uses the binary, especially on Windows.
-4. Install the verified replacement binary at the same administrator-owned path.
-   Keep identity state and existing immutable bundle bytes. Do not use personal
-   `nemo-relay install` or `integrations refresh` to regenerate this bundle.
-5. Start the service, validate the bundle digest, and complete worker-backed
-   verification with one client before reopening the deployment.
+<Steps>
+
+<Step title="Prepare the Upgrade">
+
+Schedule a maintenance window. Save the approved binary version, service
+definition, configuration, and separately trusted bundle digest.
+
+</Step>
+
+<Step title="Drain Sessions">
+
+Ask users to close affected harnesses. Let accepted requests drain and wait
+for workers to exit. A service-manager stop can interrupt active streams.
+
+</Step>
+
+<Step title="Stop Processes">
+
+Stop the daemon with the matching service manager. On clients, ensure no MCP
+or worker process still uses the binary, especially on Windows.
+
+</Step>
+
+<Step title="Replace the Binary">
+
+Install the verified replacement binary at the same administrator-owned path.
+Keep identity state and existing immutable bundle bytes. Do not use personal
+`nemo-relay install` or `integrations refresh` to regenerate this bundle.
+
+</Step>
+
+<Step title="Verify Before Rollout">
+
+Start the service, validate the bundle digest, and complete worker-backed
+verification with one client before reopening the deployment.
+
+</Step>
+
+</Steps>
 
 For rollback, stop affected processes and restore the previous verified binary
 and compatible service/configuration files. Keep the same persistent identities

--- a/docs/daemon/reference.mdx
+++ b/docs/daemon/reference.mdx
@@ -95,7 +95,7 @@ responses:
 Every managed MCP process must name its daemon explicitly:
 
 ```bash
-nemo-relay daemon mcp --daemon-address https://relay.example.com:443
+nemo-relay daemon mcp --daemon-address https://relay.example.com:8443
 ```
 
 The address must be an HTTP or HTTPS origin with an explicit port. It cannot
@@ -125,9 +125,9 @@ Use the agent-specific subcommand in immutable managed hook settings. The
 supported command shapes are:
 
 ```bash
-nemo-relay daemon hook codex --daemon-address https://relay.example.com:443 --fail-closed
-nemo-relay daemon hook claude --daemon-address https://relay.example.com:443 --fail-open
-nemo-relay daemon hook pi --daemon-address https://relay.example.com:443 --fail-open
+nemo-relay daemon hook codex --daemon-address https://relay.example.com:8443 --fail-closed
+nemo-relay daemon hook claude --daemon-address https://relay.example.com:8443 --fail-open
+nemo-relay daemon hook pi --daemon-address https://relay.example.com:8443 --fail-open
 ```
 
 The hook process performs the following actions:

--- a/docs/daemon/reference.mdx
+++ b/docs/daemon/reference.mdx
@@ -387,7 +387,7 @@ reference baselines.
 | `NEMO_RELAY_DAEMON_OBSERVATION_CAPTURE_BYTES` | Worker observation | Positive capture limit in bytes; defaults to 4 MiB, without limiting delivered streams. |
 | `NEMO_RELAY_LOG` | Operational logger | Explicit log level, such as `info`; managed MCP and hooks skip ambient logging files. |
 | `NEMO_RELAY_LOG_STDERR_FORMAT` | Operational logger | Explicit stderr format, such as `jsonl`. |
-| `XDG_CONFIG_HOME` | Identity-state resolver | Overrides the per-account `.config` base; does not relocate managed system configuration. |
+| `XDG_CONFIG_HOME` | Identity-state resolver | First choice for identity state; otherwise Relay uses `HOME/.config`, then `USERPROFILE/.config`, on every platform. Does not relocate managed system configuration. |
 
 The MCP process removes the public route token from the worker's launch environment.
 Worker activation uses the protected inherited channel, not an environment variable.

--- a/docs/daemon/reference.mdx
+++ b/docs/daemon/reference.mdx
@@ -1,0 +1,393 @@
+---
+title: "Reference"
+description: "Commands, identity, lifecycle, and streaming contracts for managed daemon deployments."
+position: 10
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Use this page for exact command and protocol behavior. For step-by-step setup,
+start with [Daemon](/daemon/about).
+
+## Start the Daemon
+
+Start the daemon with its loopback defaults:
+
+```bash
+nemo-relay daemon
+```
+
+The default listener is `127.0.0.1:47632`. The full daemon-specific command
+shape is:
+
+```text
+nemo-relay daemon \
+  [--bind <127.0.0.1|0.0.0.0>] \
+  [--port <PORT>] \
+  [--advertise-address <URL>] \
+  [--pass-through] \
+  [--tls-cert <PEM>] \
+  [--tls-key <PKCS8-PEM>]
+```
+
+Provision `NEMO_RELAY_CLIENT_TOKEN` in client environments only. Start and
+keep an MCP connection active before sending LLM or hook requests, including
+in `--pass-through` mode. Unknown credentials return `401`; registered routes
+without a live MCP reference are unavailable and return `503`. Daemon restart
+requires MCP re-registration to restore these in-memory route bindings.
+
+The shared `/models` and `/v1/models` GET endpoints return
+`Cache-Control: no-store`, overriding provider cache policy to prevent
+cross-credential catalog reuse. LLM streaming response headers are unchanged.
+
+Worker activation still requires the broker-issued, one-time grant delivered
+through the protected inherited channel. Knowing the daemon address alone
+does not allow a worker to register or replace an existing worker.
+
+The daemon accepts only `127.0.0.1` or `0.0.0.0` for `--bind`. A daemon bound
+to `0.0.0.0` requires a concrete, reachable origin URL through
+`--advertise-address`; `0.0.0.0` itself is never an advertised or target
+address.
+
+For a non-loopback advertised origin, expose HTTPS either on the daemon
+listener or through a trusted reverse proxy. For example, native TLS has the
+following shape:
+
+```bash
+nemo-relay daemon \
+  --bind 0.0.0.0 \
+  --port 8443 \
+  --advertise-address https://relay.example.com:8443 \
+  --tls-cert /etc/nemo-relay/tls.crt \
+  --tls-key /etc/nemo-relay/tls.pk8
+```
+
+Native TLS requires an `https` advertised URL. An `https` advertised URL may
+also name a trusted reverse proxy that terminates TLS before forwarding to the
+daemon listener. Every non-loopback `--daemon-address` target must use HTTPS.
+If a trusted reverse proxy is in the data path, apply the streaming
+[streaming requirements](#configure-a-trusted-reverse-proxy).
+
+### Use Explicit Pass-Through Mode
+
+Start a daemon that never creates workers with:
+
+```bash
+nemo-relay daemon --pass-through
+```
+
+The daemon still authenticates the route credential. MCP registration can only
+receive `UsePassThrough`, and the daemon cannot issue an activation grant or
+accept worker registration. LLM requests use the same streaming transport
+directly to the configured provider. Hook requests return the existing no-op
+responses:
+
+| Agent       | Response Body        |
+| ----------- | -------------------- |
+| Codex       | `{}`                 |
+| Claude Code | `{"continue": true}` |
+| Pi          | `{}`                 |
+
+
+## Register the MCP Lifecycle Client
+
+Every managed MCP process must name its daemon explicitly:
+
+```bash
+nemo-relay daemon mcp --daemon-address https://relay.example.com:443
+```
+
+The address must be an HTTP or HTTPS origin with an explicit port. It cannot
+contain credentials, a non-root path, a query, or a fragment. Plain HTTP is
+accepted only for a loopback target.
+
+The MCP client authenticates and acquires its broker reference before it starts
+the MCP protocol. The broker, not the MCP client, chooses one directive:
+
+| Directive        | MCP Action                                                                    |
+| ---------------- | ----------------------------------------------------------------------------- |
+| `ReuseWorker`    | Use the worker already published for the fingerprint.                         |
+| `WaitForWorker`  | Wait while another MCP starts or drains the worker.                           |
+| `LaunchWorker`   | Start the current `nemo-relay` executable with the one-time activation grant. |
+| `UsePassThrough` | Keep the MCP reference while the daemon forwards the route directly.          |
+
+The MCP client never independently decides whether the route needs a worker.
+When it receives `LaunchWorker`, it starts `daemon worker` on the same machine
+and transfers the activation grant through a protected inherited standard-input
+channel. The grant is not put in command arguments, environment variables, or
+logs.
+
+
+## Forward Managed Hooks
+
+Use the agent-specific subcommand in immutable managed hook settings. The
+supported command shapes are:
+
+```bash
+nemo-relay daemon hook codex --daemon-address https://relay.example.com:443 --fail-closed
+nemo-relay daemon hook claude --daemon-address https://relay.example.com:443 --fail-open
+nemo-relay daemon hook pi --daemon-address https://relay.example.com:443 --fail-open
+```
+
+The hook process performs the following actions:
+
+1. Reads the agent's native hook payload from standard input.
+2. Reads `NEMO_RELAY_CLIENT_TOKEN` from the environment.
+3. Posts to the existing agent-specific hook path at the daemon root.
+4. Adds `x-nemo-relay-client-token` exactly once.
+5. Writes a successful, nonempty hook response to standard output without
+   changing its bytes.
+
+The hook process does not start a daemon or worker and does not perform an MCP
+handshake. Use `--fail-open` for events that must not block the agent when the
+daemon is unavailable. Use `--fail-closed` for policy events that must reject
+the operation when delivery or evaluation fails. If neither option is present,
+the existing event-specific failure policy applies.
+
+
+## Run a Daemon-Attached Worker
+
+The broker normally starts the worker. Its command shape is documented for
+managed launchers and prescribed firewall, NAT-forwarding, and test scenarios:
+
+```text
+nemo-relay daemon worker \
+  --daemon-address <URL> \
+  [--bind <127.0.0.1|0.0.0.0>] \
+  [--port <PORT>] \
+  [--advertise-address <HOST-OR-IP>]
+```
+
+Do not use the worker command as a standalone gateway. It requires the
+one-time activation grant supplied by the MCP process and must authenticate to
+the named daemon before it becomes routable.
+
+Worker network settings follow these rules:
+
+- The effective default is `127.0.0.1:0`; omitting `--port` lets the operating
+  system select an available port.
+- `--bind` accepts only `127.0.0.1` or `0.0.0.0`. Hostnames, IPv6 addresses,
+  and other IPv4 addresses are rejected.
+- An explicitly supplied port must be in `1..=65535`. Explicit `--port 0` is
+  rejected; omit the option for automatic allocation.
+- Explicit ports are for documented firewall, NAT-forwarding, and test
+  deployments.
+- A loopback worker advertises `127.0.0.1:<allocated-port>` and does not accept
+  `--advertise-address`.
+- `0.0.0.0` is bind-only. It requires a concrete daemon-reachable host or IP
+  through `--advertise-address`.
+- `--daemon-address` is mandatory. A non-loopback daemon address must use
+  HTTPS.
+
+Only the daemon can send data-plane requests to a worker. The worker validates
+the daemon-to-worker session credential from the request head before it reads
+the request body.
+
+For a broker-launched worker, set the following environment variables on the
+MCP process only when automatic network selection is insufficient:
+
+```bash
+export NEMO_RELAY_WORKER_ADVERTISE_ADDRESS='worker.example.com'
+export NEMO_RELAY_WORKER_PORT='9443'
+```
+
+`NEMO_RELAY_WORKER_ADVERTISE_ADDRESS` must be a concrete IPv4 address or
+hostname that the daemon can reach. `NEMO_RELAY_WORKER_PORT` must be in
+`1..=65535`; leave it unset for operating-system allocation. These overrides
+are intended for prescribed firewall, NAT-forwarding, and test deployments,
+and the MCP signs them into the broker registration before the daemon chooses
+the worker launch directive.
+
+
+## Understand Broker Identity and Lifecycle
+
+Each daemon component proves a signed `nemo-relay` service identity and role,
+and advertises its supported protocol range and capabilities. The binary
+version is diagnostic metadata, not a route key or a compatibility decision.
+Different compatible Relay binary versions can therefore share a worker.
+
+Each machine-user identity has an owner-private Ed25519 key. The public-key
+digest is the route fingerprint. MCP registration also binds the digest of
+`NEMO_RELAY_CLIENT_TOKEN` to that fingerprint. The daemon indexes requests by
+the credential digest but does not persist or log the raw credential. The MCP
+client trust-on-first-use pins the daemon identity to the normalized daemon
+origin.
+
+The broker accepts a worker only when it proves both the single-use activation
+grant and the same machine-user identity as the MCP client. Challenges expire,
+are single use, and are replay protected. Later control messages use scoped
+session credentials, request IDs, sequence numbers, and body hashes.
+
+One fingerprint moves through these broker states:
+
+| State         | Behavior                                                                    |
+| ------------- | --------------------------------------------------------------------------- |
+| `Empty`       | The first MCP reference receives `LaunchWorker`.                            |
+| `Activating`  | Concurrent MCP references receive `WaitForWorker`.                          |
+| `Ready`       | Requests reuse the published worker.                                        |
+| `Draining`    | New requests wait while accepted requests finish and the worker terminates. |
+| `PassThrough` | The daemon forwards authenticated requests directly to providers.           |
+| `Recovering`  | One connected MCP is nominated to replace a failed worker.                  |
+
+MCP clients renew their references every 10 seconds, and the daemon expires a
+reference after 30 seconds without renewal. Workers send a heartbeat every five
+seconds and expire after 20 seconds without one. There is no independent worker
+idle timeout.
+
+If a worker loses its authenticated control relationship, it immediately stops
+accepting new requests. Already accepted streams can finish while the worker
+reconnects or re-registers after a daemon restart. The worker exits if it cannot
+restore control within two minutes.
+
+When the last MCP reference leaves, the route enters a non-revivable drain.
+Already accepted requests have up to two minutes to finish before the worker
+terminates. A new MCP must wait for that termination, then begins a fresh
+activation. If a ready worker fails while references remain, the broker
+nominates one connected MCP to relaunch it.
+
+After MCP authentication succeeds, a worker activation, bind, registration,
+readiness, or activation-channel failure moves the whole fingerprint route to
+transient pass-through until all MCP references leave. A connection or identity
+failure before authentication instead makes the MCP process log the error and
+exit with a nonzero status.
+
+
+## Preserve Streaming Responses
+
+The daemon, worker, and pass-through paths use a pull-driven Hyper body from
+provider to client. They do not collect a successful LLM response before
+forwarding it. This transport preserves:
+
+- The response status.
+- Ordered, multivalue end-to-end headers.
+- The exact concatenated response-body byte sequence.
+- HTTP trailers.
+- SSE comments, heartbeats, `event`, `id`, `retry`, multiline `data`, and
+  `[DONE]` fields.
+- Empty and non-UTF-8 data frames that the HTTP protocol accepts.
+
+HTTP implementations can split or combine DATA frames. The guarantee is the
+same ordered body bytes and immediate availability, not matching TCP packets or
+HTTP frame boundaries.
+
+The shared connection pools support HTTP/1.1 persistence and HTTP/2
+multiplexing. Delivery remains demand driven: a slow client applies bounded
+backpressure upstream, and dropping the client cancels the corresponding
+upstream work. Relay applies separate connection and response-head deadlines;
+it does not apply a total response-lifetime deadline after streaming starts.
+
+The worker also transfers provider request bodies directly to the pooled
+Hyper client when no LLM request guardrail, request interceptor, or
+request-sanitization guardrail is registered. If one of those middleware types
+needs the complete JSON request, the worker performs one bounded decode before
+provider dispatch so the middleware can make its decision. Response bodies are
+never collected for that purpose.
+
+Caller-visible stream fidelity takes precedence over response rewriting. Do
+not use daemon-worker mode with middleware that must mutate, suppress, or
+replace successful streaming response events. Any semantic observer or cache
+must consume a bounded, nonblocking side channel. Falling behind can truncate
+that observer's capture, but it must never delay or change delivery.
+
+The worker captures at most 4 MiB per streamed response for semantic
+observation by default. Set
+`NEMO_RELAY_DAEMON_OBSERVATION_CAPTURE_BYTES` to a positive byte count before
+starting the worker to choose another bound. This setting changes only
+side-band observability; it does not cap, buffer, or truncate caller-visible
+delivery.
+
+Semantic observation has a separate 15-minute completion deadline, independent
+of the provider's 60-second response-head deadline. Exceeding the observation
+deadline marks only the captured observation as truncated; it does not stop
+caller-visible streaming.
+
+The managed worker deliberately ignores per-user Relay configuration,
+per-user plugin directories, and user lifecycle state. It loads only the
+administrator-managed system configuration and plugin manifest while still
+allowing provider secrets to arrive through their documented authentication
+environment variables. This keeps the executed plugin configuration uniform
+across users as well as keeping the coding-agent artifacts byte-identical.
+
+### Configure a Trusted Reverse Proxy
+
+A reverse proxy in front of the daemon becomes part of the streaming path.
+Configure it to:
+
+- Disable response buffering.
+- Disable compression or other response transformations.
+- Disable cache coalescing.
+- Preserve streaming over HTTP/1.1 or HTTP/2.
+- Preserve response trailers.
+
+Test these settings end to end. TLS termination alone does not guarantee raw
+stream preservation.
+
+
+## Measure Daemon Transport
+
+Run the deterministic smoke check with:
+
+```bash
+just daemon-transport-benchmark-smoke
+```
+
+The smoke check exercises OpenAI and Anthropic streaming fixtures over
+HTTP/1.1 and HTTP/2. Stream-integrity failures fail the command; its timing
+results are informational.
+
+Before a sustained comparison, build the existing size-optimized release and
+an isolated `opt-level=3` candidate:
+
+```bash
+just daemon-transport-benchmark-build-candidates
+```
+
+Start the deterministic provider with:
+
+```bash
+just daemon-transport-benchmark-provider --bind 127.0.0.1:48100
+```
+
+Start the Relay topology processes separately, then run the full load driver
+against their endpoints. For example:
+
+```bash
+export NEMO_RELAY_CLIENT_TOKEN='<credential>'
+
+just daemon-transport-benchmark \
+  --direct-url http://127.0.0.1:48100 \
+  --target daemon-pass-through=http://127.0.0.1:47632 \
+  --target daemon-worker=http://127.0.0.1:47633 \
+  --header-env daemon-pass-through:x-nemo-relay-client-token=NEMO_RELAY_CLIENT_TOKEN \
+  --header-env daemon-worker:x-nemo-relay-client-token=NEMO_RELAY_CLIENT_TOKEN
+```
+
+The full preset uses a 10-second warmup and a 60-second measured interval. It
+covers persistent HTTP/1.1 and HTTP/2 connections, 16 KiB and 1 MiB responses,
+128 streamed events, concurrency 1, 16, 64, and 256, plus a separate
+1,000-slow-stream capacity scenario. It records latency distributions,
+throughput, goodput, process resource use, pool reuse, stream integrity,
+trailers, cancellation, and reconnection data.
+
+Refer to `scripts/latency_benchmark/daemon_transport/README.md` for the complete
+topology, worker-only target, protected-header setup, process metadata, and
+report schema. Run base and candidate builds on the same otherwise-idle host.
+Timing and throughput remain non-gating until the project establishes stable
+reference baselines.
+
+## Environment Variables
+
+| Variable | Read by | Purpose |
+| --- | --- | --- |
+| `NEMO_RELAY_CLIENT_TOKEN` | Managed MCP, hook forwarder, and harness | Shared credential for one machine-user route; required in the client environment. |
+| `ANTHROPIC_CUSTOM_HEADERS` | Claude Code | Includes exactly one matching `x-nemo-relay-client-token` header. |
+| `NEMO_RELAY_WORKER_ADVERTISE_ADDRESS` | Managed MCP | Optional concrete worker hostname or IPv4 address reachable by the daemon. |
+| `NEMO_RELAY_WORKER_PORT` | Managed MCP | Optional assigned port from 1 through 65535; omit for automatic allocation. |
+| `NEMO_RELAY_DAEMON_OBSERVATION_CAPTURE_BYTES` | Worker observation | Positive capture limit in bytes; defaults to 4 MiB, without limiting delivered streams. |
+| `NEMO_RELAY_LOG` | Operational logger | Explicit log level, such as `info`; managed MCP and hooks skip ambient logging files. |
+| `NEMO_RELAY_LOG_STDERR_FORMAT` | Operational logger | Explicit stderr format, such as `jsonl`. |
+| `XDG_CONFIG_HOME` | Identity-state resolver | Overrides the per-account `.config` base; does not relocate managed system configuration. |
+
+The MCP process removes the public route token from the worker's launch environment.
+Worker activation uses the protected inherited channel, not an environment variable.

--- a/docs/daemon/remote-clients.mdx
+++ b/docs/daemon/remote-clients.mdx
@@ -74,11 +74,12 @@ the daemon, and its port is automatically allocated. For predictable firewall
 rules, write the administrator-assigned values as the target user:
 
 ```bash
-mkdir -p "$HOME/.config/nemo-relay-network"
-chmod 700 "$HOME/.config/nemo-relay-network"
-printf '%s\n' '10.30.0.21' > "$HOME/.config/nemo-relay-network/worker-address"
-printf '%s\n' '9443' > "$HOME/.config/nemo-relay-network/worker-port"
-chmod 600 "$HOME/.config/nemo-relay-network/worker-address" "$HOME/.config/nemo-relay-network/worker-port"
+relay_network_dir="${XDG_CONFIG_HOME:-$HOME/.config}/nemo-relay-network"
+mkdir -p "$relay_network_dir"
+chmod 700 "$relay_network_dir"
+printf '%s\n' '10.30.0.21' > "$relay_network_dir/worker-address"
+printf '%s\n' '9443' > "$relay_network_dir/worker-port"
+chmod 600 "$relay_network_dir/worker-address" "$relay_network_dir/worker-port"
 ```
 
 The address is a concrete hostname or IPv4 address reachable **from the daemon**,

--- a/docs/daemon/remote-clients.mdx
+++ b/docs/daemon/remote-clients.mdx
@@ -1,0 +1,161 @@
+---
+title: "Remote Linux: Deploy Clients"
+description: "Connect Linux coding harnesses and workers to a remote daemon."
+position: 8
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Use this runbook after [deploying the server](/daemon/remote-server). It targets
+Debian or Ubuntu clients on the same routed private network or VPN. Users run
+the harness, MCP, and worker locally. They do not start a local daemon service.
+
+## Install Client Files
+
+Install `/opt/nvidia/bin/nemo-relay` using the binary-copy steps in
+[Linux Deployment](/daemon/linux#prepare-the-host). Install the administrator's
+`config.toml` and `plugins.toml` in `/etc/nemo-relay` on each client. Workers do
+not download these files from the daemon and ignore personal Relay configuration.
+
+Use `/opt/nvidia/bin/nemo-relay-dispatch` as the dispatcher for this remote bundle.
+The wrapper below supplies assigned worker network settings even when a harness
+filters the environment of its MCP subprocess. Install it once as root, mode 0755:
+
+```bash
+#!/bin/sh
+set -eu
+if [ "${1-}" = daemon ] && [ "${2-}" = mcp ]; then
+    relay_network_dir="${XDG_CONFIG_HOME:-$HOME/.config}/nemo-relay-network"
+    if [ -f "$relay_network_dir/worker-address" ]; then
+        NEMO_RELAY_WORKER_ADVERTISE_ADDRESS=$(cat "$relay_network_dir/worker-address")
+        export NEMO_RELAY_WORKER_ADVERTISE_ADDRESS
+    fi
+    if [ -f "$relay_network_dir/worker-port" ]; then
+        NEMO_RELAY_WORKER_PORT=$(cat "$relay_network_dir/worker-port")
+        export NEMO_RELAY_WORKER_PORT
+    fi
+fi
+exec /opt/nvidia/bin/nemo-relay "$@"
+```
+
+The wrapper preserves arguments and does not print to stdout, which carries MCP
+messages or hook responses. It does not load executable shell code from users.
+If you use a custom `XDG_CONFIG_HOME`, make sure the harness passes it to MCP;
+otherwise use the default `$HOME/.config` consistently.
+
+Generate and distribute the remote bundle following
+[Managed Settings](/daemon/configuration#distribute-immutable-managed-settings).
+Use `https://relay.example.com:8443` and the dispatcher path above. Install the
+bundle at `/opt/nvidia/share/nemo-relay-managed-v1`, writable only by administrators.
+
+## Trust the Daemon Certificate
+
+For a private CA, obtain the approved root certificate through a trusted channel.
+On Debian or Ubuntu, install the PEM root as a `.crt` file:
+
+```bash
+sudo install -m 0644 organization-relay-root.crt /usr/local/share/ca-certificates/organization-relay-root.crt
+sudo update-ca-certificates
+getent ahostsv4 relay.example.com
+curl --silent --show-error --output /dev/null --write-out '%{http_code}\n' \
+  https://relay.example.com:8443/v1/models
+```
+
+Without a route credential, the expected HTTP status is `401`. This checks DNS,
+TLS trust, and access to the daemon; it is not worker verification. A public-CA
+certificate normally needs no additional trust-store entry. Restart running
+harnesses after changing trust. Relay uses native trust roots for daemon HTTPS.
+
+## Assign Worker Addresses and Ports
+
+The default remote worker address is selected from the client's IPv4 route to
+the daemon, and its port is automatically allocated. For predictable firewall
+rules, write the administrator-assigned values as the target user:
+
+```bash
+mkdir -p "$HOME/.config/nemo-relay-network"
+chmod 700 "$HOME/.config/nemo-relay-network"
+printf '%s\n' '10.30.0.21' > "$HOME/.config/nemo-relay-network/worker-address"
+printf '%s\n' '9443' > "$HOME/.config/nemo-relay-network/worker-port"
+chmod 600 "$HOME/.config/nemo-relay-network/worker-address" "$HOME/.config/nemo-relay-network/worker-port"
+```
+
+The address is a concrete hostname or IPv4 address reachable **from the daemon**,
+not a URL and not `0.0.0.0`. A remote worker listens on `0.0.0.0`; restrict access
+with the firewall. Assigned ports must be between 1 and 65535. Use ports above
+1023 for ordinary users and check that another process does not own the port.
+
+On a shared client, give each machine-user identity a different port, such as
+9443 and 9444. Sessions for one identity share its worker and port. Never assign
+one fixed port to every user on the same client. Multiple separate daemon
+origins may also require separate port assignments and launch environments.
+
+For an existing UFW firewall with default-deny incoming policy, an administrator
+can permit only the daemon to contact this worker:
+
+```bash
+sudo ufw allow from 10.20.0.10 to 10.30.0.21 port 9443 proto tcp
+sudo ufw status verbose
+```
+
+Add one rule per assigned port. For VPNs or NAT, verify that the advertised address
+and port actually reach this listener. Relay does not create port forwarding or
+an outbound-only tunnel. Check that broader firewall rules do not expose workers
+to unrelated hosts.
+
+## Provision Credentials and Launch a Harness
+
+Follow [Client Credentials](/daemon/configuration#provision-client-credentials)
+to provision a unique token and load it into the launch environment. Then follow
+the Codex, Claude Code, or Pi steps in
+[Load a Managed Harness](/daemon/configuration#load-a-managed-harness).
+Keep provider authentication in its normal supported environment or credential
+store. The route token does not replace the provider's API key or login.
+
+Launch from the prepared terminal or an administrator-provided desktop launcher.
+An already-running desktop app will not acquire a new shell environment. Restart
+it through the managed launch path. Do not run `daemon worker` manually; only
+MCP receives the protected activation grant needed to start it.
+
+## Verify the Return Path
+
+Keep the harness running. On the client:
+
+```bash
+ss -ltn 'sport = :9443'
+```
+
+On the daemon server, test the network path without sending any credential:
+
+```bash
+nc -vz 10.30.0.21 9443
+```
+
+A successful TCP connection proves only reachability. Complete
+[worker-backed verification](/daemon/operations#verify-worker-backed-operation),
+including the `worker_ready` log and an observable plugin result. Do not test the
+worker with a fabricated activation grant or try to extract its session token.
+
+Close all harnesses for this identity, allow the worker to drain, and confirm its
+listener closes. Open a new harness and confirm a fresh worker becomes ready.
+Repeat after a planned daemon restart and after reconnecting the VPN.
+
+## Update and Remove the Client
+
+For upgrades, close all harnesses, wait for workers to exit, replace the binary at
+the stable path, and validate the existing bundle digest. Keep the user's identity
+and daemon trust pins. Reopen the harness and verify worker behavior again.
+
+For removal, close sessions and remove the harness's managed plugin registration
+and provider settings through the same deployment mechanism that installed them.
+Do not delete unrelated harness settings or provider credentials. Remove this
+client's firewall rule when retiring its worker:
+
+```bash
+sudo ufw delete allow from 10.20.0.10 to 10.30.0.21 port 9443 proto tcp
+```
+
+Retain private identity state for rollback. Remove managed artifacts and the
+dispatcher only when no remaining user depends on them. Removing local files does
+not revoke a credential from a running daemon; see [Operations](/daemon/operations).

--- a/docs/daemon/remote-server.mdx
+++ b/docs/daemon/remote-server.mdx
@@ -1,0 +1,213 @@
+---
+title: "Remote Linux: Deploy the Daemon"
+description: "Deploy a Linux daemon with native HTTPS on a routed private network."
+position: 7
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+This runbook uses a Debian or Ubuntu server with systemd and an existing private
+LAN or VPN. The server runs the daemon. Each client runs its own harness, MCP
+process, and worker. Install system plugin configuration on **every client**;
+putting it only on the server does not configure remote workers.
+
+On narrow screens, scroll diagrams horizontally to read every label.
+
+## Plan Addresses and Connections
+
+Replace these example values consistently before generating the bundle:
+
+| Setting | Example |
+| --- | --- |
+| Daemon DNS name | `relay.example.com` |
+| Daemon private IPv4 address | `10.20.0.10` |
+| Daemon origin | `https://relay.example.com:8443` |
+| Allowed client network | `10.30.0.0/24` |
+| Example client IPv4 address | `10.30.0.21` |
+| Example worker port | `9443` |
+
+<div role="region" aria-label="Remote deployment diagram" tabIndex={0} style={{ overflowX: "auto" }}>
+<div style={{ minWidth: "760px" }}>
+
+```mermaid
+flowchart TD
+    subgraph Client["Client computer"]
+        H["Harness and hook forwarder"]
+        M["MCP lifecycle client"]
+        W["Worker<br/>10.30.0.21:9443"]
+        H -. "launch" .-> M
+        M -. "launch" .-> W
+    end
+    subgraph Server["Linux server"]
+        D["Daemon<br/>10.20.0.10:8443"]
+    end
+    H -->|"model and hook requests"| D
+    M -->|"HTTPS control"| D
+    W -->|"HTTPS control"| D
+    D -->|"HTTPS requests to worker"| W
+    W -->|"HTTPS model requests"| P["Provider"]
+    D -->|"HTTPS in pass-through"| P
+```
+
+</div>
+</div>
+
+Responses use the same connections in reverse. The daemon opens a **new inbound
+connection to the client worker**. This is not a reverse tunnel.
+
+| Initiator | Destination | Purpose |
+| --- | --- | --- |
+| Client harness, hooks, MCP, worker | Daemon TCP 8443 | HTTPS requests and control |
+| Daemon | Assigned client worker TCP port | HTTPS readiness checks and routed requests |
+| Client worker | Configured provider, normally TCP 443 | Model requests |
+| Daemon | Configured provider, normally TCP 443 | Pass-through requests |
+| Server and clients | Organization DNS and certificate services | Name resolution and trust provisioning |
+
+Allow these paths through host firewalls, VPN rules, and network access controls.
+Clients must resolve `relay.example.com` to the private server address. The daemon
+must resolve or route to each worker's advertised IPv4 address. Plain HTTP is
+not accepted for a remote daemon origin.
+
+## Install the Server
+
+Install the verified CLI as `/opt/nvidia/bin/nemo-relay` and create the
+`nemo-relay` service account and `/var/lib/nemo-relay/.config` directory using
+[Linux Deployment](/daemon/linux#system-service). Do not enable the local unit;
+use the remote unit below instead. If migrating an existing daemon, retain its
+service account and state directory.
+
+Provision `/etc/nemo-relay/config.toml` as described in
+[Configuration](/daemon/configuration#system-configuration). Keep provider
+routing consistent with the clients so pass-through reaches the intended
+providers. Do not put users' route credentials on the server.
+
+## Provision the HTTPS Certificate
+
+Obtain a server certificate for `relay.example.com` from your organization's
+certificate authority (CA), or a public CA trusted by all clients. The certificate
+must include that name in its subject alternative names. Install the full server
+certificate chain and an unencrypted PKCS#8 PEM private key. Protect the key with
+filesystem permissions; the service must be able to read it without a prompt.
+
+For an organization CA, create the key and certificate signing request on the
+server. Run this in a root shell; it does not create a self-signed certificate:
+
+```bash
+sudo -i
+install -d -o root -g nemo-relay -m 0750 /etc/nemo-relay/tls
+umask 077
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 \
+  -out /etc/nemo-relay/tls/server.pk8
+openssl req -new -key /etc/nemo-relay/tls/server.pk8 \
+  -out /etc/nemo-relay/tls/server.csr \
+  -subj '/CN=relay.example.com' \
+  -addext 'subjectAltName=DNS:relay.example.com'
+exit
+```
+
+Submit `server.csr` through your CA process. Save the returned leaf certificate
+followed by its intermediate certificates as `server-chain.pem`. Then install it
+and grant the daemon group read access:
+
+```bash
+sudo install -o root -g nemo-relay -m 0640 server-chain.pem /etc/nemo-relay/tls/server-chain.pem
+sudo chown root:nemo-relay /etc/nemo-relay/tls/server.pk8
+sudo chmod 640 /etc/nemo-relay/tls/server.pk8
+openssl x509 -in server-chain.pem -noout -subject -issuer -dates -ext subjectAltName
+```
+
+For a private CA, distribute its trusted root separately through the operating
+system's trust store on each client. See the [client runbook](/daemon/remote-clients#trust-the-daemon-certificate).
+Do not disable TLS verification. Worker TLS certificates are generated by Relay
+and their trust is carried by the authenticated broker protocol; they do not
+require a separate CA enrollment procedure.
+
+## Install the Remote Service
+
+Save `/etc/systemd/system/nemo-relay-daemon.service`:
+
+```ini
+[Unit]
+Description=NeMo Relay remote daemon
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=nemo-relay
+Group=nemo-relay
+WorkingDirectory=/var/lib/nemo-relay
+Environment=XDG_CONFIG_HOME=/var/lib/nemo-relay/.config
+ExecStart=/opt/nvidia/bin/nemo-relay daemon --bind 0.0.0.0 --port 8443 --advertise-address https://relay.example.com:8443 --tls-cert /etc/nemo-relay/tls/server-chain.pem --tls-key /etc/nemo-relay/tls/server.pk8
+Restart=on-failure
+RestartSec=5
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+TimeoutStopSec=150
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`0.0.0.0` listens on all IPv4 interfaces. It is not an address clients should use.
+The advertised origin must be reachable and include the explicit port.
+
+For a server already using UFW with a default-deny incoming policy, add the
+specific client-network rule:
+
+```bash
+sudo ufw allow from 10.30.0.0/24 to 10.20.0.10 port 8443 proto tcp
+sudo ufw status verbose
+```
+
+Check for broader existing rules that would also expose 8443. Preserve SSH and
+other required administration access when configuring the firewall. If your
+network uses a different firewall, apply the same source, destination, and port
+restriction there. Enrollment is open to reachable clients that prove an identity;
+that proof does not establish organization membership.
+
+Start and inspect the daemon:
+
+```bash
+sudo chmod 644 /etc/systemd/system/nemo-relay-daemon.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now nemo-relay-daemon.service
+sudo systemctl status nemo-relay-daemon.service
+sudo journalctl -u nemo-relay-daemon.service -n 50 --no-pager
+ss -ltn 'sport = :8443'
+```
+
+## Hand Off to Client Administrators
+
+Provide the daemon origin, allowed network, CA trust instructions, approved Relay
+binary, system configuration, and immutable managed bundle. Provision the bundle's
+SHA-256 through a separate trusted channel. Assign a worker port to each
+machine-user on shared clients. Do not share one route credential across users
+or clone machine identity files into client images.
+
+Continue with [Remote Linux: Deploy Clients](/daemon/remote-clients). Validate a
+real worker-backed session before opening access to more users. A server listener
+check alone does not prove that the return path to a worker works.
+
+## Operate and Remove
+
+Use the system-service journal for daemon logs; ask the client administrator for
+MCP and worker stderr logs. Follow [Operations](/daemon/operations) for upgrade,
+restart, pass-through detection, and identity recovery.
+
+Renew the certificate before expiry, install its chain and matching key with the
+same permissions, then restart the service during a maintenance window. Preserve
+the Relay signing identity; it is separate from the HTTPS certificate.
+
+To retire the server, close client sessions, disable the system service using
+[Linux removal steps](/daemon/linux#remove-the-service), and remove the example
+firewall rule if it is no longer needed:
+
+```bash
+sudo ufw delete allow from 10.30.0.0/24 to 10.20.0.10 port 8443 proto tcp
+```
+
+Keep identity state for rollback. Distribute a new named bundle if the daemon
+origin changes; do not rewrite an existing v1 bundle in place.

--- a/docs/daemon/windows.mdx
+++ b/docs/daemon/windows.mdx
@@ -23,8 +23,9 @@ Copy-Item (Get-Command nemo-relay.exe).Source 'C:\ProgramData\NVIDIA\NeMoRelay\n
 & 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe' daemon --help
 ```
 
-Use that executable as the dispatcher in the Windows managed bundle. Dispatcher
-paths cannot contain spaces, so do not move it under `Program Files`. The ACL
+Use `C:/ProgramData/NVIDIA/NeMoRelay/nemo-relay.exe` as the dispatcher in the Windows
+managed bundle. Forward slashes keep generated hooks compatible with Git Bash.
+Dispatcher paths cannot contain spaces, so do not move it under `Program Files`. The ACL
 above grants ordinary users read and execute access, but no write access. Complete
 [Configuration and Managed Clients](/daemon/configuration), using
 `http://127.0.0.1:47632`. System plugin configuration belongs in

--- a/docs/daemon/windows.mdx
+++ b/docs/daemon/windows.mdx
@@ -1,0 +1,214 @@
+---
+title: "Windows Deployment"
+description: "Run a daemon with Task Scheduler or a WinSW Windows service."
+position: 4
+---
+
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Use Windows PowerShell 5.1 or newer and a supported Windows Relay binary. A user
+scheduled task starts at login. A system task or Windows service starts at boot.
+Choose only one method for `127.0.0.1:47632`.
+
+## Prepare the Computer
+
+Install a verified binary using [Installation](/getting-started/installation).
+Open an administrator PowerShell window and copy it to a fixed path:
+
+```powershell
+New-Item -ItemType Directory -Force 'C:\ProgramData\NVIDIA\NeMoRelay' | Out-Null
+icacls 'C:\ProgramData\NVIDIA\NeMoRelay' /inheritance:r /grant:r '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F' '*S-1-5-32-545:(OI)(CI)RX'
+Copy-Item (Get-Command nemo-relay.exe).Source 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe'
+& 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe' daemon --help
+```
+
+Use that executable as the dispatcher in the Windows managed bundle. Dispatcher
+paths cannot contain spaces, so do not move it under `Program Files`. The ACL
+above grants ordinary users read and execute access, but no write access. Complete
+[Configuration and Managed Clients](/daemon/configuration), using
+`http://127.0.0.1:47632`. System plugin configuration belongs in
+`C:\ProgramData\nemo-relay`, including for user tasks.
+
+Keep the executable, task scripts, and system configuration writable only by
+administrators and SYSTEM. Do not give ordinary users write access to
+`C:\ProgramData\NVIDIA\NeMoRelay`. A system task must never launch code from
+a user's Downloads or AppData directory.
+
+## Create the Task Launcher
+
+Save the following administrator-owned script as
+`C:\ProgramData\NVIDIA\NeMoRelay\Start-Daemon.ps1`. It works for both task
+scopes. The parameters select separate private state and log directories.
+
+```powershell
+param(
+    [Parameter(Mandatory=$true)][string]$StateRoot,
+    [Parameter(Mandatory=$true)][string]$LogRoot
+)
+$ErrorActionPreference = 'Stop'
+New-Item -ItemType Directory -Force $StateRoot, $LogRoot | Out-Null
+$env:XDG_CONFIG_HOME = $StateRoot
+Remove-Item Env:NEMO_RELAY_CLIENT_TOKEN -ErrorAction SilentlyContinue
+foreach ($RelayLogName in @('daemon.out.log', 'daemon.err.log')) {
+    $RelayLogPath = Join-Path $LogRoot $RelayLogName
+    if ((Test-Path $RelayLogPath) -and (Get-Item $RelayLogPath).Length -gt 10MB) {
+        Move-Item $RelayLogPath "$RelayLogPath.previous" -Force
+    }
+}
+$RelayProcess = Start-Process -FilePath 'C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe' -ArgumentList @('daemon', '--bind', '127.0.0.1', '--port', '47632') -NoNewWindow -Wait -PassThru -RedirectStandardOutput (Join-Path $LogRoot 'daemon.out.log') -RedirectStandardError (Join-Path $LogRoot 'daemon.err.log')
+exit $RelayProcess.ExitCode
+```
+
+The script rotates large logs at startup only and replaces smaller logs on restart. Monitor disk usage or use the WinSW service
+below for continuous rotation. Follow your organization's script-signing policy;
+the task uses `RemoteSigned`, which does not override domain execution policy.
+
+## User Scheduled Task
+
+Run these commands in the target user's PowerShell window. The task uses that
+user's interactive token and stops being useful when that user logs out.
+
+```powershell
+$RelayUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+$RelayRoot = Join-Path $env:LOCALAPPDATA 'nemo-relay-daemon'
+New-Item -ItemType Directory -Force $RelayRoot | Out-Null
+icacls $RelayRoot /inheritance:r /grant:r "${RelayUser}:(OI)(CI)F" '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F'
+$RelayArgs = '-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File "C:\ProgramData\NVIDIA\NeMoRelay\Start-Daemon.ps1" -StateRoot "{0}\config" -LogRoot "{0}\logs"' -f $RelayRoot
+$RelayAction = New-ScheduledTaskAction -Execute "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe" -Argument $RelayArgs
+$RelayTrigger = New-ScheduledTaskTrigger -AtLogOn -User $RelayUser
+$RelayPrincipal = New-ScheduledTaskPrincipal -UserId $RelayUser -LogonType Interactive -RunLevel Limited
+$RelaySettings = New-ScheduledTaskSettingsSet -StartWhenAvailable -MultipleInstances IgnoreNew -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+Register-ScheduledTask -TaskName 'NeMoRelay-Daemon-User' -Action $RelayAction -Trigger $RelayTrigger -Principal $RelayPrincipal -Settings $RelaySettings
+Start-ScheduledTask -TaskName 'NeMoRelay-Daemon-User'
+```
+
+Use a distinct task name and port if several users install their own tasks.
+The example name is for one user deployment. For one endpoint shared by all users,
+use the system task instead.
+
+State is under `%LOCALAPPDATA%\nemo-relay-daemon\config\nemo-relay\daemon`.
+Logs are under `%LOCALAPPDATA%\nemo-relay-daemon\logs\daemon.err.log`.
+
+## System Scheduled Task
+
+Use an elevated PowerShell window. This example uses the built-in SYSTEM account
+and a separate private state directory. No account password is stored in the task.
+
+```powershell
+$RelayRoot = 'C:\ProgramData\NVIDIA\NeMoRelayDaemon'
+New-Item -ItemType Directory -Force $RelayRoot | Out-Null
+icacls $RelayRoot /inheritance:r /grant:r '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F'
+$RelayArgs = '-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File "C:\ProgramData\NVIDIA\NeMoRelay\Start-Daemon.ps1" -StateRoot "C:\ProgramData\NVIDIA\NeMoRelayDaemon\config" -LogRoot "C:\ProgramData\NVIDIA\NeMoRelayDaemon\logs"'
+$RelayAction = New-ScheduledTaskAction -Execute "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe" -Argument $RelayArgs
+$RelayTrigger = New-ScheduledTaskTrigger -AtStartup
+$RelayPrincipal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+$RelaySettings = New-ScheduledTaskSettingsSet -StartWhenAvailable -MultipleInstances IgnoreNew -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+Register-ScheduledTask -TaskName 'NeMoRelay-Daemon-System' -Action $RelayAction -Trigger $RelayTrigger -Principal $RelayPrincipal -Settings $RelaySettings
+Start-ScheduledTask -TaskName 'NeMoRelay-Daemon-System'
+```
+
+An execution limit of zero prevents Task Scheduler from applying its normal
+runtime limit. The task retries a failed process three times, one minute apart.
+After repeated failures, fix the cause and start it again. See Microsoft's
+[task settings reference](https://learn.microsoft.com/en-us/powershell/module/scheduledtasks/new-scheduledtasksettingsset)
+for these settings.
+
+## Windows Service with WinSW
+
+Relay does not implement the Windows Service Control Manager protocol directly.
+Use [WinSW](https://winsw.github.io/) as a wrapper; pointing `sc.exe create`
+directly at `nemo-relay.exe` is not a working service setup.
+
+Use the [WinSW 2.12.0 release](https://github.com/winsw/winsw/releases/tag/v2.12.0)
+for this example. Obtain the wrapper through your approved software channel and
+verify the downloaded artifact against that channel's approved digest. The
+native x64 wrapper example targets x64 Windows; an ARM64 Relay installation
+needs a separately validated compatible wrapper/runtime combination. Task
+Scheduler avoids that additional dependency.
+
+Place the wrapper at `C:\ProgramData\NVIDIA\NeMoRelay\NeMoRelayService.exe`.
+Create the private `C:\ProgramData\NVIDIA\NeMoRelayDaemon` directory and ACLs
+from the system-task steps, without registering the task. Create its `config`
+and `logs` subdirectories. Save the adjacent `NeMoRelayService.xml`:
+
+```xml
+<service>
+  <id>NeMoRelayDaemon</id>
+  <name>NeMo Relay Daemon</name>
+  <description>Shared local NeMo Relay daemon</description>
+  <executable>C:\ProgramData\NVIDIA\NeMoRelay\nemo-relay.exe</executable>
+  <arguments>daemon --bind 127.0.0.1 --port 47632</arguments>
+  <workingdirectory>C:\ProgramData\NVIDIA\NeMoRelayDaemon</workingdirectory>
+  <env name="XDG_CONFIG_HOME" value="C:\ProgramData\NVIDIA\NeMoRelayDaemon\config" />
+  <startmode>Automatic</startmode>
+  <onfailure action="restart" delay="10 sec" />
+  <stoptimeout>150 sec</stoptimeout>
+  <logpath>C:\ProgramData\NVIDIA\NeMoRelayDaemon\logs</logpath>
+  <log mode="roll-by-size">
+    <sizeThreshold>10240</sizeThreshold>
+    <keepFiles>8</keepFiles>
+  </log>
+</service>
+```
+
+WinSW defaults to LocalSystem when no service account is configured. Keep all
+wrapper and executable files administrator-owned. The XML contains no client
+token. In an elevated PowerShell window:
+
+```powershell
+New-Item -ItemType Directory -Force 'C:\ProgramData\NVIDIA\NeMoRelayDaemon\config', 'C:\ProgramData\NVIDIA\NeMoRelayDaemon\logs' | Out-Null
+& 'C:\ProgramData\NVIDIA\NeMoRelay\NeMoRelayService.exe' install
+& 'C:\ProgramData\NVIDIA\NeMoRelay\NeMoRelayService.exe' start
+& 'C:\ProgramData\NVIDIA\NeMoRelay\NeMoRelayService.exe' status
+Get-Service NeMoRelayDaemon
+```
+
+Inspect `NeMoRelayService.out.log` and `NeMoRelayService.err.log` under the log
+directory. Startup failures can also appear in the Windows Application event log.
+
+## Verify and Maintain
+
+For tasks, inspect the matching task and its log:
+
+```powershell
+Get-ScheduledTask -TaskName 'NeMoRelay-Daemon-User'
+Get-ScheduledTaskInfo -TaskName 'NeMoRelay-Daemon-User'
+Get-Content "$env:LOCALAPPDATA\nemo-relay-daemon\logs\daemon.err.log" -Tail 50
+Get-NetTCPConnection -LocalPort 47632 -State Listen
+```
+
+For the system task, substitute `NeMoRelay-Daemon-System` and
+`C:\ProgramData\NVIDIA\NeMoRelayDaemon\logs\daemon.err.log`.
+A running task's last result may be `0x41301`, meaning it is still running.
+Check the listening process and then perform
+[worker-backed verification](/daemon/operations#verify-worker-backed-operation).
+Test a planned sign-out/sign-in or reboot before rollout.
+
+Close harness sessions before stopping a task or service. Task termination and
+service-wrapper shutdown can interrupt streams; do not treat the timeout as a
+guarantee of graceful draining. For a task restart, use `Stop-ScheduledTask`,
+confirm the listener has closed, then `Start-ScheduledTask`. If a child process
+remains, identify its executable and owner before stopping that specific process.
+For WinSW, use its `stop` and `start` commands. Follow
+[Upgrade and Roll Back](/daemon/operations#upgrade-and-roll-back) when replacing
+the binary, which Windows can keep locked while it is running.
+
+## Remove the Task or Service
+
+For the selected task:
+
+```powershell
+Stop-ScheduledTask -TaskName 'NeMoRelay-Daemon-User'
+Unregister-ScheduledTask -TaskName 'NeMoRelay-Daemon-User' -Confirm:$false
+```
+
+Substitute the system task name when applicable. For WinSW:
+
+```powershell
+& 'C:\ProgramData\NVIDIA\NeMoRelay\NeMoRelayService.exe' stop
+& 'C:\ProgramData\NVIDIA\NeMoRelay\NeMoRelayService.exe' uninstall
+```
+
+Confirm the port is closed. Preserve the identity directory for rollback and
+remove shared binaries and managed artifacts only when no other client uses them.

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -83,7 +83,9 @@ nemo-relay install codex
 ```
 
 Refer to [Coding Agent Installation](/nemo-relay-cli/plugin-installation) for
-the persistent integration workflow.
+the persistent integration workflow. For an administrator-managed
+background service, use [Daemon](/daemon/about); install the binary here, then
+follow its managed configuration and platform runbook.
 
 <Note>
 The installers download the published SHA-256 checksum for the selected release

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -14,6 +14,10 @@ navigation:
     title: "NVIDIA NeMo Relay CLI"
     slug: nemo-relay-cli
     title-source: frontmatter
+  - folder: ./daemon
+    title: "Daemon"
+    slug: daemon
+    title-source: frontmatter
   - folder: ./supported-integrations
     title: "Supported Integrations"
     slug: supported-integrations

--- a/docs/nemo-relay-cli/about.mdx
+++ b/docs/nemo-relay-cli/about.mdx
@@ -69,7 +69,7 @@ Use these guide links to move from CLI setup into agent-specific instructions.
 
 - [Basic Usage](/nemo-relay-cli/basic-usage) explains gateway routes, transparent runs,
   shared configuration, hook forwarding, and runtime mapping.
-- [Managed Daemon](/nemo-relay-cli/daemon) covers the brokered multi-user
+- [Daemon](/daemon/about) covers the brokered multi-user
   daemon, managed hook and MCP commands, worker networking, immutable settings,
   and lossless streaming transport.
 - [Coding Agent Installation](/nemo-relay-cli/plugin-installation) covers

--- a/docs/nemo-relay-cli/daemon.mdx
+++ b/docs/nemo-relay-cli/daemon.mdx
@@ -1,537 +1,63 @@
 ---
-title: 'Managed Daemon'
-description: 'Deploy the brokered NeMo Relay daemon, MCP lifecycle client, managed hook forwarder, and worker.'
+title: "Managed Daemon"
+description: "Find daemon architecture, deployment runbooks, configuration, and reference documentation."
 position: 7
 ---
 
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-Use the managed daemon when an administrator must give multiple users the same
-coding-agent configuration while preserving per-user NeMo Relay runtime state.
-The daemon is the only public endpoint. It authenticates a machine-user route,
-then either sends traffic through that route's worker or forwards it directly
-to the configured provider in pass-through mode.
-
-This deployment model is separate from a personal installation. The existing
-top-level `nemo-relay mcp` command and the hidden `nemo-relay hook-forward`
-command remain available for personal integrations.
+The managed daemon guide now has its own [Daemon section](/daemon/about).
+Choose a topic below, or start with the [deployment comparison](/daemon/about#choose-a-deployment).
 
 ## Process Topology
 
-The managed topology has the following processes:
-
-- `nemo-relay daemon` owns the public LLM and hook endpoints and the
-  authoritative route broker.
-- `nemo-relay daemon mcp` registers one MCP client reference for the current
-  machine-user identity. It advertises no MCP tools.
-- `nemo-relay daemon hook` forwards one native hook payload using the managed
-  route credential.
-- `nemo-relay daemon worker` runs the per-machine-user Relay configuration and
-  remains attached to the daemon for its useful lifetime.
-
-All LLM and hook paths remain at the daemon root. Managed settings do not use
-per-user route URLs. Requests use one Relay-specific public credential header:
-
-```text
-x-nemo-relay-client-token: <base64url-encoded-256-bit-credential>
-```
-
-Pi provider registrations also preserve Pi's runtime-selected endpoint in
-`x-nemo-relay-upstream-base-url`. The authenticated daemon consumes that
-routing header and removes it before contacting the provider. It is runtime
-model metadata, not part of the managed settings artifact.
-
-Enterprise bootstrap must provide the credential through this environment
-variable:
-
-```bash
-export NEMO_RELAY_CLIENT_TOKEN='<credential>'
-```
-
-Claude Code reads custom provider headers from its native environment variable,
-so the same bootstrap must derive exactly one header from that credential:
-
-```bash
-export ANTHROPIC_CUSTOM_HEADERS="x-nemo-relay-client-token: ${NEMO_RELAY_CLIENT_TOKEN}"
-```
-
-Do not append another `x-nemo-relay-client-token` entry to an existing custom
-header value. Managed diagnostics reject a missing, duplicate, or mismatched
-credential header.
-
-The same credential identifies MCP registration, Codex and Claude LLM
-requests, Pi provider requests, and managed hook requests. The daemon does
-not require a token file or a token environment variable. During signed MCP
-registration, it binds the credential digest to the user-machine fingerprint.
-An existing binding cannot be reassigned to another fingerprint. The daemon
-stores only credential digests, removes the public header before forwarding
-a request, and preserves the caller's provider authentication.
-
-Enrollment is open to anyone who can reach the daemon and prove possession
-of their machine identity. This proof establishes identity, not organizational
-authorization. Restrict daemon access to trusted users through your network
-or authenticated reverse proxy; do not expose open enrollment to an untrusted
-network. TLS remains required for non-loopback communication.
-
-Challenge requests are limited to 16 per transport-peer IP in a 15-second
-window, before the request body is read. MCP and worker challenges retain
-separate capacity limits. Forwarded IP headers do not override this limit:
-clients behind a reverse proxy share its peer budget. Apply additional
-per-client admission controls at the proxy for larger deployments.
+See [Process Topology](/daemon/architecture#process-roles).
 
 ## Start the Daemon
 
-Start the daemon with its loopback defaults:
-
-```bash
-nemo-relay daemon
-```
-
-The default listener is `127.0.0.1:47632`. The full daemon-specific command
-shape is:
-
-```text
-nemo-relay daemon \
-  [--bind <127.0.0.1|0.0.0.0>] \
-  [--port <PORT>] \
-  [--advertise-address <URL>] \
-  [--pass-through] \
-  [--tls-cert <PEM>] \
-  [--tls-key <PKCS8-PEM>]
-```
-
-Provision `NEMO_RELAY_CLIENT_TOKEN` in client environments only. Start and
-keep an MCP connection active before sending LLM or hook requests, including
-in `--pass-through` mode. Unknown credentials return `401`; registered routes
-without a live MCP reference are unavailable and return `503`. Daemon restart
-requires MCP re-registration to restore these in-memory route bindings.
-
-The shared `/models` and `/v1/models` GET endpoints return
-`Cache-Control: no-store`, overriding provider cache policy to prevent
-cross-credential catalog reuse. LLM streaming response headers are unchanged.
-
-Worker activation still requires the broker-issued, one-time grant delivered
-through the protected inherited channel. Knowing the daemon address alone
-does not allow a worker to register or replace an existing worker.
-
-The daemon accepts only `127.0.0.1` or `0.0.0.0` for `--bind`. A daemon bound
-to `0.0.0.0` requires a concrete, reachable origin URL through
-`--advertise-address`; `0.0.0.0` itself is never an advertised or target
-address.
-
-For a non-loopback advertised origin, expose HTTPS either on the daemon
-listener or through a trusted reverse proxy. For example, native TLS has the
-following shape:
-
-```bash
-nemo-relay daemon \
-  --bind 0.0.0.0 \
-  --port 8443 \
-  --advertise-address https://relay.example.com:8443 \
-  --tls-cert /etc/nemo-relay/tls.crt \
-  --tls-key /etc/nemo-relay/tls.pk8
-```
-
-Native TLS requires an `https` advertised URL. An `https` advertised URL may
-also name a trusted reverse proxy that terminates TLS before forwarding to the
-daemon listener. Every non-loopback `--daemon-address` target must use HTTPS.
-If a trusted reverse proxy is in the data path, apply the streaming
-requirements later on this page.
+See [Start the Daemon](/daemon/reference#start-the-daemon).
 
 ### Use Explicit Pass-Through Mode
 
-Start a daemon that never creates workers with:
-
-```bash
-nemo-relay daemon --pass-through
-```
-
-The daemon still authenticates the route credential. MCP registration can only
-receive `UsePassThrough`, and the daemon cannot issue an activation grant or
-accept worker registration. LLM requests use the same streaming transport
-directly to the configured provider. Hook requests return the existing no-op
-responses:
-
-| Agent       | Response Body        |
-| ----------- | -------------------- |
-| Codex       | `{}`                 |
-| Claude Code | `{"continue": true}` |
-| Pi          | `{}`                 |
+See [Use Explicit Pass-Through Mode](/daemon/reference#use-explicit-pass-through-mode).
 
 ## Register the MCP Lifecycle Client
 
-Every managed MCP process must name its daemon explicitly:
-
-```bash
-nemo-relay daemon mcp --daemon-address https://relay.example.com:443
-```
-
-The address must be an HTTP or HTTPS origin with an explicit port. It cannot
-contain credentials, a non-root path, a query, or a fragment. Plain HTTP is
-accepted only for a loopback target.
-
-The MCP client authenticates and acquires its broker reference before it starts
-the MCP protocol. The broker, not the MCP client, chooses one directive:
-
-| Directive        | MCP Action                                                                    |
-| ---------------- | ----------------------------------------------------------------------------- |
-| `ReuseWorker`    | Use the worker already published for the fingerprint.                         |
-| `WaitForWorker`  | Wait while another MCP starts or drains the worker.                           |
-| `LaunchWorker`   | Start the current `nemo-relay` executable with the one-time activation grant. |
-| `UsePassThrough` | Keep the MCP reference while the daemon forwards the route directly.          |
-
-The MCP client never independently decides whether the route needs a worker.
-When it receives `LaunchWorker`, it starts `daemon worker` on the same machine
-and transfers the activation grant through a protected inherited standard-input
-channel. The grant is not put in command arguments, environment variables, or
-logs.
+See [Register the MCP Lifecycle Client](/daemon/reference#register-the-mcp-lifecycle-client).
 
 ## Forward Managed Hooks
 
-Use the agent-specific subcommand in immutable managed hook settings. The
-supported command shapes are:
-
-```bash
-nemo-relay daemon hook codex --daemon-address https://relay.example.com:443 --fail-closed
-nemo-relay daemon hook claude --daemon-address https://relay.example.com:443 --fail-open
-nemo-relay daemon hook pi --daemon-address https://relay.example.com:443 --fail-open
-```
-
-The hook process performs the following actions:
-
-1. Reads the agent's native hook payload from standard input.
-2. Reads `NEMO_RELAY_CLIENT_TOKEN` from the environment.
-3. Posts to the existing agent-specific hook path at the daemon root.
-4. Adds `x-nemo-relay-client-token` exactly once.
-5. Writes a successful, nonempty hook response to standard output without
-   changing its bytes.
-
-The hook process does not start a daemon or worker and does not perform an MCP
-handshake. Use `--fail-open` for events that must not block the agent when the
-daemon is unavailable. Use `--fail-closed` for policy events that must reject
-the operation when delivery or evaluation fails. If neither option is present,
-the existing event-specific failure policy applies.
+See [Forward Managed Hooks](/daemon/reference#forward-managed-hooks).
 
 ## Run a Daemon-Attached Worker
 
-The broker normally starts the worker. Its command shape is documented for
-managed launchers and prescribed firewall, NAT-forwarding, and test scenarios:
-
-```text
-nemo-relay daemon worker \
-  --daemon-address <URL> \
-  [--bind <127.0.0.1|0.0.0.0>] \
-  [--port <PORT>] \
-  [--advertise-address <HOST-OR-IP>]
-```
-
-Do not use the worker command as a standalone gateway. It requires the
-one-time activation grant supplied by the MCP process and must authenticate to
-the named daemon before it becomes routable.
-
-Worker network settings follow these rules:
-
-- The effective default is `127.0.0.1:0`; omitting `--port` lets the operating
-  system select an available port.
-- `--bind` accepts only `127.0.0.1` or `0.0.0.0`. Hostnames, IPv6 addresses,
-  and other IPv4 addresses are rejected.
-- An explicitly supplied port must be in `1..=65535`. Explicit `--port 0` is
-  rejected; omit the option for automatic allocation.
-- Explicit ports are for documented firewall, NAT-forwarding, and test
-  deployments.
-- A loopback worker advertises `127.0.0.1:<allocated-port>` and does not accept
-  `--advertise-address`.
-- `0.0.0.0` is bind-only. It requires a concrete daemon-reachable host or IP
-  through `--advertise-address`.
-- `--daemon-address` is mandatory. A non-loopback daemon address must use
-  HTTPS.
-
-Only the daemon can send data-plane requests to a worker. The worker validates
-the daemon-to-worker session credential from the request head before it reads
-the request body.
-
-For a broker-launched worker, set the following environment variables on the
-MCP process only when automatic network selection is insufficient:
-
-```bash
-export NEMO_RELAY_WORKER_ADVERTISE_ADDRESS='worker.example.com'
-export NEMO_RELAY_WORKER_PORT='9443'
-```
-
-`NEMO_RELAY_WORKER_ADVERTISE_ADDRESS` must be a concrete IPv4 address or
-hostname that the daemon can reach. `NEMO_RELAY_WORKER_PORT` must be in
-`1..=65535`; leave it unset for operating-system allocation. These overrides
-are intended for prescribed firewall, NAT-forwarding, and test deployments,
-and the MCP signs them into the broker registration before the daemon chooses
-the worker launch directive.
+See [Run a Daemon-Attached Worker](/daemon/reference#run-a-daemon-attached-worker).
 
 ## Understand Broker Identity and Lifecycle
 
-Each daemon component proves a signed `nemo-relay` service identity and role,
-and advertises its supported protocol range and capabilities. The binary
-version is diagnostic metadata, not a route key or a compatibility decision.
-Different compatible Relay binary versions can therefore share a worker.
-
-Each machine-user identity has an owner-private Ed25519 key. The public-key
-digest is the route fingerprint. MCP registration also binds the digest of
-`NEMO_RELAY_CLIENT_TOKEN` to that fingerprint. The daemon indexes requests by
-the credential digest but does not persist or log the raw credential. The MCP
-client trust-on-first-use pins the daemon identity to the normalized daemon
-origin.
-
-The broker accepts a worker only when it proves both the single-use activation
-grant and the same machine-user identity as the MCP client. Challenges expire,
-are single use, and are replay protected. Later control messages use scoped
-session credentials, request IDs, sequence numbers, and body hashes.
-
-One fingerprint moves through these broker states:
-
-| State         | Behavior                                                                    |
-| ------------- | --------------------------------------------------------------------------- |
-| `Empty`       | The first MCP reference receives `LaunchWorker`.                            |
-| `Activating`  | Concurrent MCP references receive `WaitForWorker`.                          |
-| `Ready`       | Requests reuse the published worker.                                        |
-| `Draining`    | New requests wait while accepted requests finish and the worker terminates. |
-| `PassThrough` | The daemon forwards authenticated requests directly to providers.           |
-| `Recovering`  | One connected MCP is nominated to replace a failed worker.                  |
-
-MCP clients renew their references every 10 seconds, and the daemon expires a
-reference after 30 seconds without renewal. Workers send a heartbeat every five
-seconds and expire after 20 seconds without one. There is no independent worker
-idle timeout.
-
-If a worker loses its authenticated control relationship, it immediately stops
-accepting new requests. Already accepted streams can finish while the worker
-reconnects or re-registers after a daemon restart. The worker exits if it cannot
-restore control within two minutes.
-
-When the last MCP reference leaves, the route enters a non-revivable drain.
-Already accepted requests have up to two minutes to finish before the worker
-terminates. A new MCP must wait for that termination, then begins a fresh
-activation. If a ready worker fails while references remain, the broker
-nominates one connected MCP to relaunch it.
-
-After MCP authentication succeeds, a worker activation, bind, registration,
-readiness, or activation-channel failure moves the whole fingerprint route to
-transient pass-through until all MCP references leave. A connection or identity
-failure before authentication instead makes the MCP process log the error and
-exit with a nonzero status.
+See [Understand Broker Identity and Lifecycle](/daemon/reference#understand-broker-identity-and-lifecycle).
 
 ## Preserve Streaming Responses
 
-The daemon, worker, and pass-through paths use a pull-driven Hyper body from
-provider to client. They do not collect a successful LLM response before
-forwarding it. This transport preserves:
-
-- The response status.
-- Ordered, multivalue end-to-end headers.
-- The exact concatenated response-body byte sequence.
-- HTTP trailers.
-- SSE comments, heartbeats, `event`, `id`, `retry`, multiline `data`, and
-  `[DONE]` fields.
-- Empty and non-UTF-8 data frames that the HTTP protocol accepts.
-
-HTTP implementations can split or combine DATA frames. The guarantee is the
-same ordered body bytes and immediate availability, not matching TCP packets or
-HTTP frame boundaries.
-
-The shared connection pools support HTTP/1.1 persistence and HTTP/2
-multiplexing. Delivery remains demand driven: a slow client applies bounded
-backpressure upstream, and dropping the client cancels the corresponding
-upstream work. Relay applies separate connection and response-head deadlines;
-it does not apply a total response-lifetime deadline after streaming starts.
-
-The worker also transfers provider request bodies directly to the pooled
-Hyper client when no LLM request guardrail, request interceptor, or
-request-sanitization guardrail is registered. If one of those middleware types
-needs the complete JSON request, the worker performs one bounded decode before
-provider dispatch so the middleware can make its decision. Response bodies are
-never collected for that purpose.
-
-Caller-visible stream fidelity takes precedence over response rewriting. Do
-not use daemon-worker mode with middleware that must mutate, suppress, or
-replace successful streaming response events. Any semantic observer or cache
-must consume a bounded, nonblocking side channel. Falling behind can truncate
-that observer's capture, but it must never delay or change delivery.
-
-The worker captures at most 4 MiB per streamed response for semantic
-observation by default. Set
-`NEMO_RELAY_DAEMON_OBSERVATION_CAPTURE_BYTES` to a positive byte count before
-starting the worker to choose another bound. This setting changes only
-side-band observability; it does not cap, buffer, or truncate caller-visible
-delivery.
-
-Semantic observation has a separate 15-minute completion deadline, independent
-of the provider's 60-second response-head deadline. Exceeding the observation
-deadline marks only the captured observation as truncated; it does not stop
-caller-visible streaming.
-
-The managed worker deliberately ignores per-user Relay configuration,
-per-user plugin directories, and user lifecycle state. It loads only the
-administrator-managed system configuration and plugin manifest while still
-allowing provider secrets to arrive through their documented authentication
-environment variables. This keeps the executed plugin configuration uniform
-across users as well as keeping the coding-agent artifacts byte-identical.
+See [Preserve Streaming Responses](/daemon/reference#preserve-streaming-responses).
 
 ### Configure a Trusted Reverse Proxy
 
-A reverse proxy in front of the daemon becomes part of the streaming path.
-Configure it to:
-
-- Disable response buffering.
-- Disable compression or other response transformations.
-- Disable cache coalescing.
-- Preserve streaming over HTTP/1.1 or HTTP/2.
-- Preserve response trailers.
-
-Test these settings end to end. TLS termination alone does not guarantee raw
-stream preservation.
+See [Configure a Trusted Reverse Proxy](/daemon/reference#configure-a-trusted-reverse-proxy).
 
 ## Distribute Immutable Managed Settings
 
-A managed bundle is an administrator-owned deployment artifact, not an output
-of personal `nemo-relay install`. For each agent, platform, and deployment, its
-plugin configuration and settings must remain byte-for-byte identical across
-users and Relay binary releases.
-
-The bundle follows these rules:
-
-- Daemon and provider URLs and hook command text are fixed for the deployment.
-- Artifacts contain no user path, fingerprint, credential, generation ID, or
-  Relay binary version.
-- A stable administrator-owned dispatcher command or path survives Relay
-  upgrades.
-- Refresh validates immutable artifacts and never rewrites them.
-- An incompatible settings change uses a separately named v2 artifact rather
-  than replacing v1 bytes.
-
-Enterprise bootstrap owns credential provisioning and login-environment
-injection. Relay validates `NEMO_RELAY_CLIENT_TOKEN` but does not install an
-operating-system-specific login agent.
-
-Create a bundle once from fixed deployment values. Repeat `--agent` to select
-the artifacts that the administrator distributes:
-
-```bash
-nemo-relay daemon managed-bundle \
-  --output /srv/nemo-relay/nemo-relay-managed-v1 \
-  --daemon-address https://relay.example.com:443 \
-  --dispatcher-command /opt/nvidia/bin/nemo-relay-dispatch \
-  --platform linux \
-  --agent codex \
-  --agent claude \
-  --agent pi
-```
-
-The destination must be new or already byte-identical. The command never
-rewrites a different v1 bundle and prints only the canonical full-bundle
-SHA-256. Provision that digest separately from the bundle; a digest stored
-inside the same artifact is not a trust root. The dispatcher path is validated
-for the target platform and must be an absolute, stable administrator path
-outside known user and temporary directories.
-
-Validate a distributed bundle and its current environment without modifying
-the bundle:
-
-```bash
-nemo-relay doctor \
-  --managed-bundle /path/to/nemo-relay-managed-v1 \
-  --managed-bundle-sha256 '<separately-provisioned-64-character-sha256>'
-```
-
-Doctor compares the exact file set and bytes with the canonical manifest and
-the separately provisioned digest, then reports missing, unexpected, or
-changed artifacts. This is a managed-only diagnostic: it does not load or fail because
-of personal configuration, plugins, or agent installations.
+See [Distribute Immutable Managed Settings](/daemon/configuration#distribute-immutable-managed-settings).
 
 ### Deploy the Managed Pi Extension
 
-The Pi artifact is a fixed TypeScript extension under
-`pi/extension-v1/index.ts`. Load that exact administrator-installed file while
-disabling discovered extensions; do not copy it into a per-user extension
-directory or rewrite it during upgrades. For example:
-
-```bash
-pi --no-extensions -e /srv/nemo-relay/nemo-relay-managed-v1/pi/extension-v1/index.ts
-```
-
-`--no-extensions` is mandatory for managed launches. Pi still loads the
-explicit `-e` extension, but does not also load user, project, or discovered
-extensions that could alter provider registration, tool arguments, or shell
-policy after Relay has authorized an operation.
-
-The extension starts the fixed dispatcher as
-`daemon mcp --daemon-address <URL>`, waits for MCP initialization before
-registering managed providers, and
-keeps one process-wide broker reference across Pi reload, new, resume, and fork
-transitions. It sends Pi's session, agent, turn, compaction, tool, and custom
-shell events to `/hooks/pi`; policy responses are converted back into Pi's
-native `tool_call` and `user_bash` blocking results. Any selected Pi provider
-whose models use only OpenAI Completions, OpenAI Responses, or Anthropic
-Messages and share one endpoint is registered against the daemon, including
-custom provider names. The registration attaches `x-nemo-relay-client-token`
-and Pi's exact runtime-selected endpoint in
-`x-nemo-relay-upstream-base-url`. No per-user upstream, fingerprint,
-generation, user path, or route value is written into the managed artifact.
+See [Deploy the Managed Pi Extension](/daemon/configuration#deploy-the-managed-pi-extension).
 
 ### Codex Responses Compatibility
 
-Both the personal gateway and managed daemon accept Codex's ChatGPT-shaped
-`POST /backend-api/codex/responses` path and canonicalize it to the ordinary
-upstream Responses path. A WebSocket upgrade probe sent with `GET` to that
-path, `/responses`, or `/v1/responses` receives `426 Upgrade Required`, which
-causes clients that support the fallback to use HTTP streaming. An ordinary
-GET remains `405 Method Not Allowed`.
+See [Codex Responses Compatibility](/daemon/configuration#codex-responses-compatibility).
 
 ## Measure Daemon Transport
 
-Run the deterministic smoke check with:
-
-```bash
-just daemon-transport-benchmark-smoke
-```
-
-The smoke check exercises OpenAI and Anthropic streaming fixtures over
-HTTP/1.1 and HTTP/2. Stream-integrity failures fail the command; its timing
-results are informational.
-
-Before a sustained comparison, build the existing size-optimized release and
-an isolated `opt-level=3` candidate:
-
-```bash
-just daemon-transport-benchmark-build-candidates
-```
-
-Start the deterministic provider with:
-
-```bash
-just daemon-transport-benchmark-provider --bind 127.0.0.1:48100
-```
-
-Start the Relay topology processes separately, then run the full load driver
-against their endpoints. For example:
-
-```bash
-export NEMO_RELAY_CLIENT_TOKEN='<credential>'
-
-just daemon-transport-benchmark \
-  --direct-url http://127.0.0.1:48100 \
-  --target daemon-pass-through=http://127.0.0.1:47632 \
-  --target daemon-worker=http://127.0.0.1:47633 \
-  --header-env daemon-pass-through:x-nemo-relay-client-token=NEMO_RELAY_CLIENT_TOKEN \
-  --header-env daemon-worker:x-nemo-relay-client-token=NEMO_RELAY_CLIENT_TOKEN
-```
-
-The full preset uses a 10-second warmup and a 60-second measured interval. It
-covers persistent HTTP/1.1 and HTTP/2 connections, 16 KiB and 1 MiB responses,
-128 streamed events, concurrency 1, 16, 64, and 256, plus a separate
-1,000-slow-stream capacity scenario. It records latency distributions,
-throughput, goodput, process resource use, pool reuse, stream integrity,
-trailers, cancellation, and reconnection data.
-
-Refer to `scripts/latency_benchmark/daemon_transport/README.md` for the complete
-topology, worker-only target, protected-header setup, process metadata, and
-report schema. Run base and candidate builds on the same otherwise-idle host.
-Timing and throughput remain non-gating until the project establishes stable
-reference baselines.
+See [Measure Daemon Transport](/daemon/reference#measure-daemon-transport).


### PR DESCRIPTION
#### Overview

Daemon deployment guidance was concentrated in one reference page and lacked platform runbooks and diagrams. Add a dedicated Daemon section covering architecture, managed clients, local services, and remote Linux deployment.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add ten pages, with Windows user/system scheduled tasks and a WinSW service, macOS user/system launchd jobs, Linux user/system systemd units, and separate remote Linux server/client runbooks.
- Add five Mermaid diagrams for process communication, initialization, local and remote topology, and worker lifecycle. Keep diagrams readable with horizontal scrolling on narrow screens.
- Document managed harness setup, credentials, persistent identities, worker networking, verification, upgrades, and troubleshooting. Use a space-free Windows dispatcher path accepted by bundle validation.
- Move the existing daemon contracts into focused pages, update navigation and entry points, and preserve all 13 legacy heading anchors.

Validation: `just docs` passed, including link checks; Fern's comparison with previously published redirects was skipped because FDR returned HTTP 403. Rendered and inspected diagrams at desktop and narrow widths. Checked shell, TOML, JSON, XML, and launchd plist syntax. Generated three-agent bundles and passed managed `doctor` validation for Linux, macOS, and Windows. Built the CLI and exercised local daemon authentication, MCP initialization, and worker sharing between two clients. Staged repository hooks passed.

OS service installations and live provider/plugin behavior were not exercised. No unrelated language test suites were run. No runtime/API breaking changes; this PR changes documentation only.

#### Where should the reviewer start?

Start with `docs/daemon/about.mdx` for the reading path, then `docs/daemon/architecture.mdx` for the process model. Review the platform runbooks and `docs/daemon/operations.mdx` for deployment acceptance checks that distinguish worker execution from pass-through.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to: none. Documents the daemon architecture introduced in #1000.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive daemon documentation covering architecture, configuration, operations, troubleshooting, authentication, networking, lifecycle management, and reference topics.
  * Added deployment runbooks for Linux, macOS, Windows, remote clients, and remote servers.
  * Added guidance for managed-client integrations, credentials, TLS, service setup, upgrades, recovery, and safe removal.
  * Added daemon navigation and reorganized the previous daemon guide into a concise documentation index.
  * Updated installation guidance and links to direct readers to the new daemon documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->