### PR TITLE
docs: document Python plugin-host exceptions

### DIFF
--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -41,6 +41,15 @@ mode. See the [0.9 migration guidance](/reference/migration-guides).
 
 </Warning>
 
+### Compatibility changes
+
+- Python plugin-host activation now raises `ValueError` for invalid static
+  configuration and `FileNotFoundError` for unavailable plugin configuration
+  or resources. Code that caught `RuntimeError` from
+  `nemo_relay.plugin.initialize()` or `nemo_relay.plugin.activate()` must
+  update its exception handlers. Use the [0.9 migration guide](/reference/migration-guides)
+  for the recommended validation workflow.
+
 ## Known Issues in 0.9
 
 - OTLP collectors can return a successful response while rejecting individual

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -28,6 +28,16 @@ the resolved policy and artifact evidence before deployment with
 `integrity_only` skips signature verification only. It still requires a valid
 `source.artifact` and matching `integrity.sha256` digest.
 
+### Update Python plugin-host exception handlers
+
+`nemo_relay.plugin.initialize()` and `nemo_relay.plugin.activate()` now raise
+`ValueError` when static plugin configuration is invalid, and
+`FileNotFoundError` when a referenced plugin configuration or resource is
+unavailable. Earlier releases surfaced these failures as `RuntimeError`.
+Update exception handlers accordingly. Use `nemo_relay.plugin.validate()` or
+`nemo_relay.plugin.validate_exact()` to inspect static configuration diagnostics
+without activating plugins.
+
 ## Related Release Information
 
 For release highlights, compatibility updates, and current known issues, refer

--- a/python/nemo_relay/plugin.py
+++ b/python/nemo_relay/plugin.py
@@ -458,6 +458,14 @@ async def initialize(
 
     Returns:
         An owned activation whose report includes static and dynamic results.
+
+    Raises:
+        ValueError: If the supplied configuration is malformed or fails plugin
+            validation.
+        FileNotFoundError: If a referenced plugin configuration or resource is
+            unavailable.
+        RuntimeError: If activation cannot acquire the host or a plugin cannot
+            be registered.
     """
     path = os.fspath(additional_plugins_toml) if additional_plugins_toml is not None else None
     return PluginHostActivation(await _initialize(_normalize_object(config), path))
@@ -479,6 +487,14 @@ async def activate(
 
     Returns:
         An async context manager that yields the owned activation.
+
+    Raises:
+        ValueError: If the supplied configuration is malformed or fails plugin
+            validation.
+        FileNotFoundError: If a referenced plugin configuration or resource is
+            unavailable.
+        RuntimeError: If activation cannot acquire the host or a plugin cannot
+            be registered.
     """
     activation = await initialize(config, additional_plugins_toml)
     try:
@@ -502,6 +518,18 @@ def validate(
 
     Returns:
         A static configuration report and selected dynamic validation reports.
+
+    Raises:
+        ValueError: If the supplied configuration or a resolved configuration
+            layer is malformed.
+        FileNotFoundError: If a referenced plugin configuration or resource is
+            unavailable.
+        RuntimeError: If validation encounters an internal host failure.
+
+    Notes:
+        Static plugin validation errors are returned in the report rather than
+        raised. Use :func:`validate_exact` when only the supplied static
+        configuration should be checked.
     """
     path = os.fspath(additional_plugins_toml) if additional_plugins_toml is not None else None
     return cast(PluginHostReport, _validate(_normalize_object(config), path))

--- a/python/tests/test_pii_redaction_plugin.py
+++ b/python/tests/test_pii_redaction_plugin.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from plugin_host_test_helper import validate_plugin_config
 
 from nemo_relay import plugin
@@ -84,6 +85,34 @@ class TestPiiRedactionConfigHelpers:
             )
         )
         assert report["diagnostics"] == []
+
+    async def test_initialize_and_activate_reject_no_enabled_surfaces_with_value_error(self):
+        config = plugin.PluginConfig(
+            components=[
+                ComponentSpec(
+                    PiiRedactionConfig(
+                        input=False,
+                        output=False,
+                        mark=False,
+                        tool_input=False,
+                        tool_output=False,
+                    )
+                )
+            ]
+        )
+
+        report = validate_plugin_config(config)
+        assert any(
+            diagnostic["message"] == "at least one redaction surface must be enabled"
+            for diagnostic in report["diagnostics"]
+        )
+
+        with pytest.raises(ValueError, match="at least one redaction surface must be enabled"):
+            await plugin.initialize(config)
+
+        with pytest.raises(ValueError, match="at least one redaction surface must be enabled"):
+            async with plugin.activate(config):
+                pass
 
     def test_list_kinds_includes_builtin_pii_redaction(self):
         assert PII_REDACTION_PLUGIN_KIND in plugin.list_kinds()


### PR DESCRIPTION
#### Overview

Document the Python plugin-host exception contract and the 0.9 migration action for RELAY-851. Add regression coverage for invalid static PII redaction configuration.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Document `ValueError`, `FileNotFoundError`, and `RuntimeError` behavior for `plugin.initialize()`, `plugin.activate()`, and `plugin.validate()`.
- Clarify that static validation failures are returned as diagnostics before activation.
- Add the 0.9 migration-guide and release-note entries for callers that previously caught `RuntimeError`.
- Add a PII regression test covering `initialize()` and `activate()` for invalid redaction surfaces.

Validation:

- `uv run ruff check python/nemo_relay/plugin.py python/tests/test_pii_redaction_plugin.py`
- `uv run pytest python/tests/test_pii_redaction_plugin.py`
- `just docs` (passed; redirect check skipped because FDR returned 403)
- `just test-python` (77 Rust binding, 687 Python, and 24 Python plugin-example tests passed)
- `uv run pre-commit run` (staged changes)

#### Where should the reviewer start?

Start with `python/nemo_relay/plugin.py` for the public exception contract, then `python/tests/test_pii_redaction_plugin.py` for the invalid-static-configuration behavior it documents.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-851


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configurations with all PII redaction surfaces disabled now produce a validation diagnostic and are rejected during plugin initialization and activation.

* **Documentation**
  * Clarified validation and plugin lifecycle error behavior.
  * Documented that invalid static configuration raises `ValueError`, while unavailable plugin configuration or resources raise `FileNotFoundError`.
  * Added migration guidance for callers currently handling `RuntimeError` during plugin initialization or activation.
  * Documented how to inspect validation diagnostics without activating a plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->