### PR TITLE
fix: preserve OTLP root spans for local scopes

### DIFF
--- a/crates/core/src/api/runtime/scope_stack.rs
+++ b/crates/core/src/api/runtime/scope_stack.rs
@@ -250,6 +250,11 @@ impl ScopeStack {
             .or_else(|| (!self.is_rootless_propagation).then(|| self.root_uuid()))
     }
 
+    /// Return the synthetic parent imported from a rooted propagation context.
+    pub(crate) fn event_propagation_parent_uuid(&self) -> Option<Uuid> {
+        self.propagated_parent_uuid
+    }
+
     /// Whether `uuid` is the synthetic parent imported from propagation.
     pub fn is_propagated_parent(&self, uuid: Uuid) -> bool {
         self.propagated_parent_uuid == Some(uuid)

--- a/crates/core/src/api/runtime/subscriber_dispatcher.rs
+++ b/crates/core/src/api/runtime/subscriber_dispatcher.rs
@@ -522,6 +522,12 @@ mod native {
                 .ok()
                 .and_then(|stack| stack.event_propagation_root_uuid()),
         );
+        event.set_propagation_parent_uuid(
+            scope_stack
+                .read()
+                .ok()
+                .and_then(|stack| stack.event_propagation_parent_uuid()),
+        );
         let message = DispatcherMessage::Deliver {
             event: Box::new(event),
             transform: None,
@@ -553,6 +559,12 @@ mod native {
                 .read()
                 .ok()
                 .and_then(|stack| stack.event_propagation_root_uuid()),
+        );
+        event.set_propagation_parent_uuid(
+            scope_stack
+                .read()
+                .ok()
+                .and_then(|stack| stack.event_propagation_parent_uuid()),
         );
         let injectors = snapshot_event_metadata_injectors(&scope_stack);
         let message = DispatcherMessage::Deliver {
@@ -588,6 +600,12 @@ mod native {
                 .read()
                 .ok()
                 .and_then(|stack| stack.event_propagation_root_uuid()),
+        );
+        event.set_propagation_parent_uuid(
+            scope_stack
+                .read()
+                .ok()
+                .and_then(|stack| stack.event_propagation_parent_uuid()),
         );
         let injectors = snapshot_event_metadata_injectors(&scope_stack);
         let (completion_tx, completion) = tokio::sync::oneshot::channel();
@@ -628,6 +646,12 @@ mod native {
                 .ok()
                 .and_then(|stack| stack.event_propagation_root_uuid()),
         );
+        event.set_propagation_parent_uuid(
+            scope_stack
+                .read()
+                .ok()
+                .and_then(|stack| stack.event_propagation_parent_uuid()),
+        );
         let injectors = snapshot_event_metadata_injectors(&scope_stack);
         let message = DispatcherMessage::Deliver {
             event: Box::new(event),
@@ -658,6 +682,12 @@ mod native {
                 .read()
                 .ok()
                 .and_then(|stack| stack.event_propagation_root_uuid()),
+        );
+        event.set_propagation_parent_uuid(
+            scope_stack
+                .read()
+                .ok()
+                .and_then(|stack| stack.event_propagation_parent_uuid()),
         );
         let injectors = snapshot_event_metadata_injectors(&scope_stack);
         let message = DispatcherMessage::Deliver {
@@ -1156,6 +1186,7 @@ mod native {
     ) -> (Option<Event>, Vec<DispatcherMessage>) {
         let state = process_state();
         let propagation_root_uuid = event.propagation_root_uuid();
+        let propagation_parent_uuid = event.propagation_parent_uuid();
         let (mut transformed, mut nested_publications) = match transform {
             Some(transform) => {
                 let runtime = match build_sanitizer_invocation_runtime() {
@@ -1200,6 +1231,7 @@ mod native {
             None => (event, Vec::new()),
         };
         transformed.set_propagation_root_uuid(propagation_root_uuid);
+        transformed.set_propagation_parent_uuid(propagation_parent_uuid);
         let (injected, injector_publications) =
             inject_event_metadata_snapshot(transformed, injectors, publication_context.clone());
         nested_publications.extend(injector_publications);

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -2129,6 +2129,9 @@ impl OtelEventProcessor {
         let Some(parent_uuid) = event.parent_uuid() else {
             return Context::new();
         };
+        if event.propagation_parent_uuid() != Some(parent_uuid) {
+            return Context::new();
+        }
         let Some(root_uuid) = event.propagation_root_uuid() else {
             return Context::new();
         };

--- a/crates/core/src/observability/otel_logs.rs
+++ b/crates/core/src/observability/otel_logs.rs
@@ -628,6 +628,9 @@ impl ScopeLineage {
         if let Some(context) = self.completed.get(&parent_uuid) {
             return Some(context.span_context.clone());
         }
+        if event.propagation_parent_uuid() != Some(parent_uuid) {
+            return None;
+        }
         event.propagation_root_uuid().map(|root_uuid| {
             SpanContext::new(
                 relay_trace_id(root_uuid),

--- a/crates/core/tests/unit/observability/otel_logs_tests.rs
+++ b/crates/core/tests/unit/observability/otel_logs_tests.rs
@@ -108,6 +108,34 @@ fn scope_lineage_retains_active_contexts_and_preserves_root_trace_id() {
 }
 
 #[test]
+fn scope_lineage_synthesizes_remote_context_only_for_imported_parents() {
+    let lineage = ScopeLineage::new();
+    let root_uuid = Uuid::now_v7();
+    let imported_parent_uuid = Uuid::now_v7();
+    let mut imported = scope_with_parent(
+        Uuid::now_v7(),
+        Some(imported_parent_uuid),
+        ScopeCategory::Start,
+    );
+    imported.set_propagation_root_uuid(Some(root_uuid));
+    imported.set_propagation_parent_uuid(Some(imported_parent_uuid));
+
+    let remote_context = lineage
+        .parent_context(&imported)
+        .expect("imported parent context");
+    assert!(remote_context.is_remote());
+    assert_eq!(remote_context.trace_id(), relay_trace_id(root_uuid));
+    assert_eq!(
+        remote_context.span_id(),
+        relay_span_id(imported_parent_uuid)
+    );
+
+    let mut local = scope_with_parent(Uuid::now_v7(), Some(Uuid::now_v7()), ScopeCategory::Start);
+    local.set_propagation_root_uuid(Some(Uuid::now_v7()));
+    assert!(lineage.parent_context(&local).is_none());
+}
+
+#[test]
 fn scope_lineage_reuses_completed_parent_within_ttl_and_expires_after_boundary() {
     let mut lineage = ScopeLineage::new();
     let parent = Uuid::now_v7();

--- a/crates/core/tests/unit/observability/otel_tests.rs
+++ b/crates/core/tests/unit/observability/otel_tests.rs
@@ -660,12 +660,66 @@ fn propagated_root_parent_projects_as_a_remote_otel_parent() {
         None,
     );
     event.set_propagation_root_uuid(Some(root_uuid));
+    event.set_propagation_parent_uuid(Some(parent_uuid));
     let parent_context = processor.parent_context(&event);
     let parent_span = parent_context.span();
     let span_context = parent_span.span_context();
     assert!(span_context.is_remote());
     assert_eq!(span_context.trace_id(), relay_trace_id(root_uuid));
     assert_eq!(span_context.span_id(), relay_span_id(parent_uuid));
+}
+
+#[test]
+fn local_unexported_parent_starts_a_root_trace() {
+    let parent_uuid = Uuid::now_v7();
+    let agent_uuid = Uuid::now_v7();
+    let (provider, exporter) = make_provider();
+    let mut processor = OtelEventProcessor::new(provider, "test".into());
+    let mut start = make_start_event(
+        agent_uuid,
+        Some(parent_uuid),
+        "receiver-agent",
+        ScopeType::Agent,
+        None,
+    );
+    start.set_propagation_root_uuid(Some(agent_uuid));
+
+    processor.process(&start);
+    processor.process(&make_end_event(
+        agent_uuid,
+        Some(parent_uuid),
+        "receiver-agent",
+        ScopeType::Agent,
+        None,
+    ));
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.span_context.trace_id(), relay_trace_id(agent_uuid));
+    assert_eq!(span.parent_span_id, SpanId::INVALID);
+    assert!(!span.parent_span_is_remote);
+}
+
+#[test]
+fn orphan_mark_with_a_local_unexported_parent_starts_a_new_trace() {
+    let parent_uuid = Uuid::now_v7();
+    let (provider, exporter) = make_provider();
+    let mut processor = OtelEventProcessor::new(provider, "test".into());
+    let mut mark = make_mark_event(Some(parent_uuid), "detached", None);
+    let mark_uuid = mark.uuid();
+    mark.set_propagation_root_uuid(Some(Uuid::now_v7()));
+
+    processor.process(&mark);
+    processor.force_flush().unwrap();
+
+    let spans = exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.span_context.trace_id(), relay_trace_id(mark_uuid));
+    assert_eq!(span.parent_span_id, SpanId::INVALID);
+    assert!(!span.parent_span_is_remote);
 }
 
 #[test]

--- a/crates/core/tests/unit/subscriber_dispatcher_tests.rs
+++ b/crates/core/tests/unit/subscriber_dispatcher_tests.rs
@@ -922,10 +922,12 @@ fn synchronous_transform_panics_drop_only_the_current_event() {
 #[test]
 fn transforms_preserve_the_captured_propagation_root() {
     let root_uuid = Uuid::now_v7();
+    let parent_uuid = Uuid::now_v7();
     let event = Event::Mark(MarkEvent::new(
         BaseEvent::builder()
             .name("transformed-propagation-root")
             .propagation_root_uuid(root_uuid)
+            .propagation_parent_uuid(parent_uuid)
             .build(),
         None,
         None,
@@ -943,7 +945,9 @@ fn transforms_preserve_the_captured_propagation_root() {
     let (published, nested) =
         sanitize_event_snapshot(event, Some(transform), Vec::new(), Vec::new(), None);
 
-    assert_eq!(published.unwrap().propagation_root_uuid(), Some(root_uuid));
+    let published = published.unwrap();
+    assert_eq!(published.propagation_root_uuid(), Some(root_uuid));
+    assert_eq!(published.propagation_parent_uuid(), Some(parent_uuid));
     assert!(nested.is_empty());
 }
 

--- a/crates/types/src/api/event.rs
+++ b/crates/types/src/api/event.rs
@@ -983,6 +983,14 @@ pub struct BaseEvent {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub propagation_root_uuid: Option<Uuid>,
+    /// Synthetic parent imported with the propagation context.
+    ///
+    /// This is runtime-only delivery state. It distinguishes an imported
+    /// parent from ordinary Relay scope parentage without extending the ATOF
+    /// wire format.
+    #[builder(default)]
+    #[serde(skip)]
+    pub propagation_parent_uuid: Option<Uuid>,
     /// Unique identifier for the event or span.
     #[builder(default = Uuid::now_v7())]
     pub uuid: Uuid,
@@ -1250,6 +1258,16 @@ impl Event {
     /// Attach the causal root captured at event emission.
     pub fn set_propagation_root_uuid(&mut self, root_uuid: Option<Uuid>) {
         self.base_mut().propagation_root_uuid = root_uuid;
+    }
+
+    /// Return the synthetic parent imported with the propagation context.
+    pub fn propagation_parent_uuid(&self) -> Option<Uuid> {
+        self.base().propagation_parent_uuid
+    }
+
+    /// Attach the synthetic parent captured at event emission.
+    pub fn set_propagation_parent_uuid(&mut self, parent_uuid: Option<Uuid>) {
+        self.base_mut().propagation_parent_uuid = parent_uuid;
     }
 
     /// Return the unique event or span UUID.


### PR DESCRIPTION
#### Overview

Fix OpenTelemetry lineage for local Relay scopes. The trace exporter now creates a remote parent only for a parent explicitly imported through a rooted propagation context.

- [x] I confirm this contribution is my own work, or I have the right to submit it under the project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Carry the imported propagation parent as runtime-only event-delivery state, preserving it through event transforms without changing the ATOF wire format.
- Prevent local unexported Relay parents from becoming synthetic remote OTLP parents in trace and log projections.
- Add coverage for local roots, orphan marks, rooted imports, rootless propagation, transformed events, and log lineage.

Validation:

- `cargo fmt --check`
- `uv run pre-commit run`
- `cargo test -p nemo-relay --lib observability::otel::tests`
- `cargo test -p nemo-relay --lib observability::otel_logs::tests`
- `cargo test -p nemo-relay --lib api::runtime::subscriber_dispatcher::tests`
- `just test-rust`

#### Where should the reviewer start?

`crates/core/src/observability/otel.rs`, where remote-parent synthesis is now restricted to the event's imported propagation parent.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenTelemetry trace lineage by preserving event parent context through asynchronous processing and transformations.
  * Prevented unrelated or local parent scopes from being incorrectly attached to remote trace contexts.
  * Ensured orphaned or locally unexported scopes correctly begin new root traces without invalid remote parent links.

* **Tests**
  * Expanded coverage for imported parents, local scopes, orphan marks, and propagation through transformed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->