### PR TITLE
fix: clarify dynamic-plugin attestation defaults

### DIFF
--- a/crates/core/src/plugin/dynamic/trust.rs
+++ b/crates/core/src/plugin/dynamic/trust.rs
@@ -95,7 +95,9 @@ impl DynamicPluginTrustFailure {
                 path.display()
             ),
             Self::MissingSignature => format!(
-                "dynamic plugin '{plugin_id}' requires integrity.signature under host policy"
+                "dynamic plugin '{plugin_id}' requires integrity.signature under host policy; \
+                 sign the artifact and configure trusted_public_keys, or set attestation to \
+                 'integrity_only' or 'signature_if_present' under [plugins.policy.defaults]"
             ),
             Self::MissingTrustedKeys => format!(
                 "dynamic plugin '{plugin_id}' requires signature verification, but no trusted_public_keys are configured in host policy"

--- a/crates/core/tests/unit/plugin_dynamic_trust_tests.rs
+++ b/crates/core/tests/unit/plugin_dynamic_trust_tests.rs
@@ -137,6 +137,8 @@ fn trust_failures_have_stable_codes_messages_and_structured_errors() {
     let missing_signature = DynamicPluginTrustFailure::MissingSignature.display("fixture.trust");
     assert!(missing_signature.contains("configure trusted_public_keys"));
     assert!(missing_signature.contains("[plugins.policy.defaults]"));
+    assert!(missing_signature.contains("integrity_only"));
+    assert!(missing_signature.contains("signature_if_present"));
 
     let without_parse_errors = DynamicPluginTrustFailure::SignatureVerification {
         path: PathBuf::from("artifact.sig"),

--- a/crates/core/tests/unit/plugin_dynamic_trust_tests.rs
+++ b/crates/core/tests/unit/plugin_dynamic_trust_tests.rs
@@ -134,6 +134,10 @@ fn trust_failures_have_stable_codes_messages_and_structured_errors() {
         assert!(error.message.contains("fixture.trust"));
     }
 
+    let missing_signature = DynamicPluginTrustFailure::MissingSignature.display("fixture.trust");
+    assert!(missing_signature.contains("configure trusted_public_keys"));
+    assert!(missing_signature.contains("[plugins.policy.defaults]"));
+
     let without_parse_errors = DynamicPluginTrustFailure::SignatureVerification {
         path: PathBuf::from("artifact.sig"),
         parse_errors: Vec::new(),

--- a/docs/about-nemo-relay/release-notes/index.mdx
+++ b/docs/about-nemo-relay/release-notes/index.mdx
@@ -30,6 +30,17 @@ Relay](/about-nemo-relay/overview).
 NeMo Relay 0.9 is under development. This page will track its user-visible
 changes, compatibility updates, and fixed known issues.
 
+<Warning title="Breaking change: dynamic-plugin attestation">
+
+Dynamic-plugin attestation now runs in the core host for every embedding API.
+If `[plugins.policy.defaults]` omits its policy fields, Relay requires startup
+success and a trusted artifact signature. An unsigned plugin that activated on
+0.8 can be refused on 0.9. Sign the artifact and configure
+`trusted_public_keys`, or explicitly configure a less restrictive `attestation`
+mode. See the [0.9 migration guidance](/reference/migration-guides).
+
+</Warning>
+
 ## Known Issues in 0.9
 
 - OTLP collectors can return a successful response while rejecting individual

--- a/docs/configure-plugins/discoverable-plugins.mdx
+++ b/docs/configure-plugins/discoverable-plugins.mdx
@@ -84,11 +84,15 @@ trusted_public_keys = ["ed25519:<base64-public-key>"]
 ```
 
 `startup = "required"` makes lifecycle preflight failures for an enabled plugin
-fatal. The default is `optional`, which skips that preflight. A later native or
-worker load or activation failure still stops gateway startup; correct or
-disable the plugin to start without it. `attestation` accepts `integrity_only`,
-`signature_if_present`, or `signature_required`; integrity verification always
-checks the declared artifact digest.
+fatal. When a policy field is omitted, the host defaults to `startup =
+"required"` and `attestation = "signature_required"`. An unsigned dynamic
+plugin is therefore refused unless you sign its artifact and configure a
+trusted public key, or explicitly select `integrity_only` or
+`signature_if_present`. A later native or worker load or activation failure
+still stops gateway startup; correct or disable the plugin to start without it.
+`attestation` accepts `integrity_only`, `signature_if_present`, or
+`signature_required`; integrity verification always checks the declared
+artifact digest.
 
 Use `startup = "required"` when failed integrity or signature verification must
 prevent worker startup. An optional trust failure records failed lifecycle

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -11,7 +11,19 @@ upgrade actions as they are identified during the 0.9 development cycle.
 
 ## Upgrade to NeMo Relay 0.9
 
-No migration actions have been recorded for NeMo Relay 0.9 yet.
+### Dynamic-plugin attestation is enforced by the core host
+
+NeMo Relay 0.9 evaluates dynamic-plugin attestation in the core host for every
+embedding API, not only through CLI lifecycle commands. When
+`[plugins.policy.defaults]` omits these fields, the effective policy is
+`startup = "required"` and `attestation = "signature_required"`.
+
+An unsigned plugin that activated on 0.8 can therefore be refused during 0.9
+startup. Sign its artifact and configure `trusted_public_keys`, or explicitly
+set `attestation = "integrity_only"` or `"signature_if_present"` under
+`[plugins.policy.defaults]` when that trust posture is appropriate. Validate
+the resolved policy and artifact evidence before deployment with
+`nemo-relay plugins validate <plugin-id>`.
 
 ## Related Release Information
 

--- a/docs/reference/migration-guides.mdx
+++ b/docs/reference/migration-guides.mdx
@@ -25,6 +25,9 @@ set `attestation = "integrity_only"` or `"signature_if_present"` under
 the resolved policy and artifact evidence before deployment with
 `nemo-relay plugins validate <plugin-id>`.
 
+`integrity_only` skips signature verification only. It still requires a valid
+`source.artifact` and matching `integrity.sha256` digest.
+
 ## Related Release Information
 
 For release highlights, compatibility updates, and current known issues, refer


### PR DESCRIPTION
#### Overview

Document the 0.9 dynamic-plugin attestation migration and make a missing-signature refusal actionable.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Correct the documented policy defaults to fail-closed startup and signature-required attestation.
- Add 0.9 migration and release-note callouts with the explicit signing and policy-relaxation paths.
- Tell operators how to resolve a missing signature, and cover that diagnostic in the core trust test.

#### Where should the reviewer start?

Start with `docs/configure-plugins/discoverable-plugins.mdx` for the corrected operator contract, then review the missing-signature diagnostic in `crates/core/src/plugin/dynamic/trust.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes RELAY-850


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Dynamic plugin attestation now runs in the core host for every embedding API.
  - By default, plugins must start successfully and have trusted signatures; unsigned plugins may prevent startup.

- **Documentation**
  - Added guidance for signing artifacts, configuring trusted keys, selecting less restrictive attestation modes, and validating plugins with the CLI.
  - Clarified default plugin policy settings and migration steps for version 0.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->