### PR TITLE
docs: clarify ATIF metadata path sanitization

### DIFF
--- a/docs/configure-plugins/observability/atif.mdx
+++ b/docs/configure-plugins/observability/atif.mdx
@@ -104,7 +104,7 @@ filename_template = "{metadata.atif_prefix:-unassigned}/trajectory-{session_id}.
 ```
 
 With scope metadata `{"atif_prefix":"tenant-a/session-123"}`, Relay writes
-`logs/tenant-a/session-123/trajectory-<scope-uuid>.json`. The template must
+`logs/tenant-a-session-123/trajectory-<scope-uuid>.json`. The template must
 still contain `{session_id}`.
 
 Use `:-` to provide a literal fallback when metadata can be absent, for example
@@ -112,16 +112,26 @@ Use `:-` to provide a literal fallback when metadata can be absent, for example
 metadata field is absent or `null`. A present non-string value is rejected
 instead of being routed through the fallback.
 
-Each metadata placeholder must resolve to a string containing a non-empty,
-relative path fragment. Slash-separated segments can contain ASCII letters,
-digits, `-`, `_`, `.`, and `~`. Relay rejects empty segments, `.` and `..`
-segments, absolute paths, backslashes, spaces, and other characters. If a
-placeholder is missing without a fallback, is present but non-string, or
-resolves to an unsafe value, Relay skips that trajectory. It records a runtime
-diagnostic and causes `activation.close()` to fail. Literal
-template text must also be a relative, traversal-free path. The rendered
-filename applies to local, S3, and HTTP storage in the same way as a static
-filename.
+Relay sanitizes a present string metadata value into one filename fragment
+before rendering it. ASCII letters, digits, `-`, `_`, `.`, and `~` are kept;
+every consecutive group of other characters, including `/`, is replaced with
+one `-`. Metadata placeholders therefore do not create directory levels. For
+example, `tenant-a/session-123` becomes `tenant-a-session-123`, and
+`../tenant` becomes `-tenant`.
+
+Use a prevalidated identifier when distinct metadata values must produce
+distinct paths: sanitization is lossy, so different input values can produce
+the same fragment. A literal `:-` fallback is not sanitized and must itself be
+a non-empty, safe relative path fragment; it can contain slash-separated
+segments with ASCII letters, digits, `-`, `_`, `.`, and `~`. Relay rejects
+empty segments, `.` and `..` segments, absolute paths, backslashes, spaces,
+and other characters in a fallback.
+
+If a placeholder is missing without a fallback, is present but non-string, or
+sanitizes to an empty value, Relay skips that trajectory. It records a runtime
+diagnostic and causes `activation.close()` to fail. Literal template text must
+also be a relative, traversal-free path. The rendered filename applies to
+local, S3, and HTTP storage in the same way as a static filename.
 
 The CLI gateway parses `x-nemo-relay-session-metadata` as JSON and merges it
 into the top-level scope metadata:


### PR DESCRIPTION
#### Overview

Clarify the documented ATIF metadata-routing behavior after the path-safety hardening change: metadata values are sanitized into filename fragments rather than rejected or interpreted as directory paths.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update the metadata-routing example to show slash replacement in the generated filename.
- Document the allowed characters, lossy sanitization, possible collisions, and the distinction between sanitized metadata and validated literal fallbacks.
- Preserve the documented failure behavior for missing, non-string, and empty-after-sanitization metadata values.

#### Where should the reviewer start?

Review `docs/configure-plugins/observability/atif.mdx`, especially the Metadata-Based Paths section, which now matches the security-hardened runtime behavior.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: RELAY-852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Metadata-based filenames now sanitize unsafe characters into hyphens, preventing unintended directory segments.
  - Literal fallback paths retain safe nested segments while enforcing stricter path validation.
  - Invalid, missing, or empty metadata no longer produces a trajectory; closing the activation reports the failure.
  - Consistent filename handling is now applied across local, S3, and HTTP storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->