### PR TITLE
feat: report resolved plugin configuration

### DIFF
--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -1862,20 +1862,28 @@ pub(crate) fn resolve_plugin_config_documents(
     let explicit_path = explicit_path.map(Path::to_path_buf);
     let (file_value, mut sources) = merge_plugin_config_documents(documents)?
         .unwrap_or_else(|| (Json::Object(Map::new()), Vec::new()));
+    let config_paths = sources
+        .iter()
+        .map(|source| source.display().to_string())
+        .collect();
     let mut value = file_value;
     layer_config(&mut value, plugin_config_overlay_value(&config)?);
     if let Some(explicit_path) = explicit_path {
         sources.retain(|source| source != &explicit_path);
     }
     Ok(ResolvedPluginConfig {
+        resolved_config: value.clone(),
         config: serde_json::from_value(value)?,
         diagnostics: inherited_plugin_config_diagnostics(&sources),
+        config_paths,
     })
 }
 
 pub(crate) struct ResolvedPluginConfig {
     pub(crate) config: PluginConfig,
+    pub(crate) resolved_config: Json,
     pub(crate) diagnostics: Vec<ConfigDiagnostic>,
+    pub(crate) config_paths: Vec<String>,
 }
 
 /// Serializes a typed configuration as a discovery overlay.
@@ -2030,8 +2038,14 @@ fn resolve_programmatic_plugin_config(
     let mut base = discovered.value;
     layer_config(&mut base, plugin_config_overlay_value(&config)?);
     Ok(ResolvedPluginConfig {
+        resolved_config: base.clone(),
         config: serde_json::from_value(base)?,
         diagnostics,
+        config_paths: discovered
+            .sources
+            .iter()
+            .map(|source| source.display().to_string())
+            .collect(),
     })
 }
 

--- a/crates/core/src/plugin/dynamic.rs
+++ b/crates/core/src/plugin/dynamic.rs
@@ -36,12 +36,12 @@ mod trust;
 mod worker;
 
 pub use bounded::*;
-pub(crate) use configuration::resolve_plugin_host_config;
 pub use configuration::{
     DynamicPluginValidationReport, PluginHostReport, validate, validate_exact,
 };
 #[cfg(test)]
 pub(crate) use configuration::{PluginHostValidationRequest, PluginHostValidationTarget};
+pub(crate) use configuration::{resolve_plugin_host_config, sanitized_plugin_config};
 pub use host::*;
 pub use manifest::*;
 pub use native::*;

--- a/crates/core/src/plugin/dynamic/configuration.rs
+++ b/crates/core/src/plugin/dynamic/configuration.rs
@@ -44,7 +44,7 @@ pub struct DynamicPluginValidationReport {
 }
 
 /// Combined static and dynamic host report.
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct PluginHostReport {
     /// Static plugin initialization report.
@@ -52,6 +52,27 @@ pub struct PluginHostReport {
     /// Dynamic validation reports in discovery order.
     #[serde(default)]
     pub dynamic_plugins: Vec<DynamicPluginValidationReport>,
+    /// Existing `plugins.toml` files that contributed to the resolved configuration.
+    #[serde(default)]
+    pub config_paths: Vec<String>,
+    /// Fully merged plugin configuration with sensitive values redacted.
+    #[serde(default = "empty_resolved_config")]
+    pub resolved_config: Json,
+}
+
+impl Default for PluginHostReport {
+    fn default() -> Self {
+        Self {
+            config: crate::plugin::ConfigReport::default(),
+            dynamic_plugins: Vec::new(),
+            config_paths: Vec::new(),
+            resolved_config: empty_resolved_config(),
+        }
+    }
+}
+
+fn empty_resolved_config() -> Json {
+    Json::Object(Map::new())
 }
 
 /// Selects the scope of a standalone dynamic-plugin validation request.
@@ -134,6 +155,8 @@ pub(crate) struct ResolvedPluginHostConfig {
     pub(crate) dynamic_plugins: Vec<super::VerifiedDynamicPluginSpec>,
     pub(crate) dynamic_reports: Vec<DynamicPluginValidationReport>,
     pub(crate) diagnostics: Vec<crate::plugin::ConfigDiagnostic>,
+    pub(crate) config_paths: Vec<String>,
+    pub(crate) resolved_config: Json,
 }
 
 #[derive(Debug, Deserialize)]
@@ -213,6 +236,8 @@ pub fn validate_exact(config: PluginConfig) -> PluginHostReport {
     PluginHostReport {
         config: crate::plugin::validate_static_plugin_config(&config),
         dynamic_plugins: Vec::new(),
+        config_paths: Vec::new(),
+        resolved_config: sanitized_plugin_config(&config),
     }
 }
 
@@ -261,6 +286,8 @@ pub(crate) fn validate_request(request: PluginHostValidationRequest) -> Result<P
     Ok(PluginHostReport {
         config: config_report,
         dynamic_plugins,
+        config_paths: resolved.config_paths,
+        resolved_config: resolved.resolved_config,
     })
 }
 
@@ -342,12 +369,79 @@ fn resolve_plugin_host_config_inner(
         }
     }
     Ok(ResolvedPluginHostConfig {
+        config_paths: resolved.config_paths,
+        resolved_config: sanitize_resolved_config(resolved.resolved_config),
         config: resolved.config,
         policy,
         dynamic_plugins: active,
         dynamic_reports: reports,
         diagnostics: resolved.diagnostics,
     })
+}
+
+pub(crate) fn sanitized_plugin_config(config: &PluginConfig) -> Json {
+    let config = serde_json::to_value(config)
+        .expect("PluginConfig must serialize to a JSON value for diagnostics");
+    sanitize_resolved_config(config)
+}
+
+fn sanitize_resolved_config(mut config: Json) -> Json {
+    redact_config_value(&mut config, None);
+    config
+}
+
+fn redact_config_value(value: &mut Json, field_name: Option<&str>) {
+    if field_name.is_some_and(is_sensitive_field_name) {
+        *value = Json::String("[REDACTED]".to_string());
+        return;
+    }
+    if field_name.is_some_and(|name| matches!(name, "endpoint" | "url")) {
+        if let Some(endpoint) = value.as_str() {
+            *value = Json::String(diagnostic_endpoint(endpoint));
+        }
+        return;
+    }
+    match value {
+        Json::Object(values) => {
+            if field_name == Some("headers") {
+                for value in values.values_mut() {
+                    *value = Json::String("[REDACTED]".to_string());
+                }
+            } else {
+                for (name, value) in values {
+                    redact_config_value(value, Some(name));
+                }
+            }
+        }
+        Json::Array(values) => {
+            for value in values {
+                redact_config_value(value, None);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_sensitive_field_name(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "authorization" | "api_key" | "apikey" | "password" | "secret" | "token"
+    ) || name.contains("credential")
+        || name.contains("secret")
+        || name.contains("token")
+        || name.contains("password")
+}
+
+fn diagnostic_endpoint(endpoint: &str) -> String {
+    let Ok(mut endpoint) = reqwest::Url::parse(endpoint) else {
+        return endpoint.to_string();
+    };
+    let _ = endpoint.set_username("");
+    let _ = endpoint.set_password(None);
+    endpoint.set_query(None);
+    endpoint.set_fragment(None);
+    endpoint.into()
 }
 
 fn validate_declaration(

--- a/crates/core/src/plugin/dynamic/configuration.rs
+++ b/crates/core/src/plugin/dynamic/configuration.rs
@@ -392,10 +392,10 @@ fn sanitize_resolved_config(mut config: Json) -> Json {
 
 fn redact_config_value(value: &mut Json, field_name: Option<&str>) {
     if field_name.is_some_and(is_sensitive_field_name) {
-        *value = Json::String("[REDACTED]".to_string());
+        redact_sensitive_value(value);
         return;
     }
-    if field_name.is_some_and(|name| matches!(name, "endpoint" | "url")) {
+    if field_name.is_some_and(is_url_field_name) {
         if let Some(endpoint) = value.as_str() {
             *value = Json::String(diagnostic_endpoint(endpoint));
         }
@@ -405,7 +405,7 @@ fn redact_config_value(value: &mut Json, field_name: Option<&str>) {
         Json::Object(values) => {
             if field_name == Some("headers") {
                 for value in values.values_mut() {
-                    *value = Json::String("[REDACTED]".to_string());
+                    redact_sensitive_value(value);
                 }
             } else {
                 for (name, value) in values {
@@ -422,6 +422,22 @@ fn redact_config_value(value: &mut Json, field_name: Option<&str>) {
     }
 }
 
+fn redact_sensitive_value(value: &mut Json) {
+    match value {
+        Json::Object(values) => {
+            for value in values.values_mut() {
+                redact_sensitive_value(value);
+            }
+        }
+        Json::Array(values) => {
+            for value in values {
+                redact_sensitive_value(value);
+            }
+        }
+        _ => *value = Json::String("[REDACTED]".to_string()),
+    }
+}
+
 fn is_sensitive_field_name(name: &str) -> bool {
     let name = name.to_ascii_lowercase();
     matches!(
@@ -431,6 +447,18 @@ fn is_sensitive_field_name(name: &str) -> bool {
         || name.contains("secret")
         || name.contains("token")
         || name.contains("password")
+}
+
+fn is_url_field_name(name: &str) -> bool {
+    let normalized = name
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    normalized == "url"
+        || normalized == "endpoint"
+        || normalized.ends_with("url")
+        || normalized.ends_with("endpoint")
 }
 
 fn diagnostic_endpoint(endpoint: &str) -> String {

--- a/crates/core/src/plugin/dynamic/configuration.rs
+++ b/crates/core/src/plugin/dynamic/configuration.rs
@@ -387,7 +387,22 @@ pub(crate) fn sanitized_plugin_config(config: &PluginConfig) -> Json {
 
 fn sanitize_resolved_config(mut config: Json) -> Json {
     redact_config_value(&mut config, None);
+    redact_opaque_dynamic_plugin_configs(&mut config);
     config
+}
+
+fn redact_opaque_dynamic_plugin_configs(config: &mut Json) {
+    let Some(dynamic_plugins) = config
+        .pointer_mut("/plugins/dynamic")
+        .and_then(Json::as_array_mut)
+    else {
+        return;
+    };
+    for plugin in dynamic_plugins {
+        if let Some(plugin_config) = plugin.get_mut("config") {
+            redact_sensitive_value(plugin_config);
+        }
+    }
 }
 
 fn redact_config_value(value: &mut Json, field_name: Option<&str>) {

--- a/crates/core/src/plugin/dynamic/host.rs
+++ b/crates/core/src/plugin/dynamic/host.rs
@@ -42,6 +42,8 @@ pub async fn initialize(
 ) -> Result<PluginHostActivation> {
     let resolved = resolve_plugin_host_config(config, additional_plugins_toml.as_deref())?;
     let dynamic_reports = resolved.dynamic_reports;
+    let config_paths = resolved.config_paths;
+    let resolved_config = resolved.resolved_config;
     let (mut activation, config_report) = PluginHostActivation::activate_validated(
         resolved.config,
         resolved.dynamic_plugins,
@@ -51,6 +53,8 @@ pub async fn initialize(
     activation.report = PluginHostReport {
         config: config_report,
         dynamic_plugins: dynamic_reports,
+        config_paths,
+        resolved_config,
     };
     Ok(activation)
 }
@@ -97,11 +101,14 @@ impl PluginHostActivation {
     /// [`initialize`] so core owns discovery and policy resolution.
     #[doc(hidden)]
     pub async fn initialize_exact(config: PluginConfig) -> Result<Self> {
+        let resolved_config = super::sanitized_plugin_config(&config);
         let (mut activation, report) =
             Self::activate_validated(config, Vec::new(), Vec::new()).await?;
         activation.report = PluginHostReport {
             config: report,
             dynamic_plugins: Vec::new(),
+            config_paths: Vec::new(),
+            resolved_config,
         };
         Ok(activation)
     }
@@ -121,11 +128,14 @@ impl PluginHostActivation {
     {
         let dynamic_plugins = dynamic_plugins.into_iter().collect::<Vec<_>>();
         validate_dynamic_plugin_specs(&dynamic_plugins)?;
+        let resolved_config = super::sanitized_plugin_config(&config);
         let (mut activation, report) =
             Self::activate_validated(config, dynamic_plugins, Vec::new()).await?;
         activation.report = PluginHostReport {
             config: report.clone(),
             dynamic_plugins: Vec::new(),
+            config_paths: Vec::new(),
+            resolved_config,
         };
         Ok((activation, report))
     }

--- a/crates/core/tests/unit/plugin_dynamic_configuration_tests.rs
+++ b/crates/core/tests/unit/plugin_dynamic_configuration_tests.rs
@@ -108,6 +108,44 @@ fn validation_request_deserializes_every_target_and_rejects_invalid_shapes() {
 }
 
 #[test]
+fn resolved_config_redacts_secrets_without_hiding_its_structure() {
+    let sanitized = sanitize_resolved_config(json!({
+        "components": [{
+            "kind": "observability",
+            "config": {
+                "opentelemetry": {
+                    "endpoints": [{
+                        "endpoint": "https://user:secret@collector.example/v1/traces?token=secret#fragment",
+                        "headers": {"authorization": "Bearer secret"},
+                        "header_env": {"x-api-key": "OTEL_API_KEY"}
+                    }]
+                },
+                "nested": {"api_token": "secret"}
+            }
+        }]
+    }));
+
+    assert_eq!(
+        sanitized,
+        json!({
+            "components": [{
+                "kind": "observability",
+                "config": {
+                    "opentelemetry": {
+                        "endpoints": [{
+                            "endpoint": "https://collector.example/v1/traces",
+                            "headers": {"authorization": "[REDACTED]"},
+                            "header_env": {"x-api-key": "OTEL_API_KEY"}
+                        }]
+                    },
+                    "nested": {"api_token": "[REDACTED]"}
+                }
+            }]
+        })
+    );
+}
+
+#[test]
 fn lifecycle_state_selection_covers_absent_disabled_and_enabled_records() {
     let temp = tempfile::tempdir().unwrap();
     let plugins_toml = temp.path().join("plugins.toml");

--- a/crates/core/tests/unit/plugin_dynamic_configuration_tests.rs
+++ b/crates/core/tests/unit/plugin_dynamic_configuration_tests.rs
@@ -158,6 +158,73 @@ fn resolved_config_redacts_secrets_without_hiding_its_structure() {
 }
 
 #[test]
+fn plugin_host_report_redacts_opaque_dynamic_plugin_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest_path = temp.path().join("relay-plugin.toml");
+    fs::write(
+        &manifest_path,
+        r#"
+manifest_version = 1
+
+[plugin]
+id = "fixture.opaque-config"
+kind = "worker"
+
+[compat]
+relay = ">=0.8.0,<1.0"
+worker_protocol = "grpc-v1"
+
+[defaults]
+enabled = false
+
+[capabilities]
+items = ["plugin_worker"]
+
+[load]
+runtime = "command"
+entrypoint = "fixture-worker"
+"#,
+    )
+    .unwrap();
+    let config_path = temp.path().join("plugins.toml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+version = 1
+
+[[plugins.dynamic]]
+manifest = {:?}
+
+[plugins.dynamic.config]
+access_key = "access-secret"
+private_key = "private-secret"
+auth = "auth-secret"
+dsn = "https://user:password@collector.example?token=secret"
+
+[plugins.dynamic.config.nested]
+arbitrary_secret = "nested-secret"
+"#,
+            manifest_path.display().to_string()
+        ),
+    )
+    .unwrap();
+
+    let report = validate(PluginConfig::default(), Some(config_path)).unwrap();
+
+    assert_eq!(
+        report.resolved_config["plugins"]["dynamic"][0]["config"],
+        json!({
+            "access_key": "[REDACTED]",
+            "private_key": "[REDACTED]",
+            "auth": "[REDACTED]",
+            "dsn": "[REDACTED]",
+            "nested": {"arbitrary_secret": "[REDACTED]"}
+        })
+    );
+}
+
+#[test]
 fn lifecycle_state_selection_covers_absent_disabled_and_enabled_records() {
     let temp = tempfile::tempdir().unwrap();
     let plugins_toml = temp.path().join("plugins.toml");

--- a/crates/core/tests/unit/plugin_dynamic_configuration_tests.rs
+++ b/crates/core/tests/unit/plugin_dynamic_configuration_tests.rs
@@ -116,8 +116,14 @@ fn resolved_config_redacts_secrets_without_hiding_its_structure() {
                 "opentelemetry": {
                     "endpoints": [{
                         "endpoint": "https://user:secret@collector.example/v1/traces?token=secret#fragment",
+                        "Collector_URL": "https://user:secret@collector.example/v1/logs?token=secret#fragment",
                         "headers": {"authorization": "Bearer secret"},
-                        "header_env": {"x-api-key": "OTEL_API_KEY"}
+                        "header_env": {"x-api-key": "OTEL_API_KEY"},
+                        "credentials": {
+                            "username": "collector",
+                            "password": "secret",
+                            "scopes": ["traces", {"name": "logs"}]
+                        }
                     }]
                 },
                 "nested": {"api_token": "secret"}
@@ -134,8 +140,14 @@ fn resolved_config_redacts_secrets_without_hiding_its_structure() {
                     "opentelemetry": {
                         "endpoints": [{
                             "endpoint": "https://collector.example/v1/traces",
+                            "Collector_URL": "https://collector.example/v1/logs",
                             "headers": {"authorization": "[REDACTED]"},
-                            "header_env": {"x-api-key": "OTEL_API_KEY"}
+                            "header_env": {"x-api-key": "OTEL_API_KEY"},
+                            "credentials": {
+                                "username": "[REDACTED]",
+                                "password": "[REDACTED]",
+                                "scopes": ["[REDACTED]", {"name": "[REDACTED]"}]
+                            }
                         }]
                     },
                     "nested": {"api_token": "[REDACTED]"}

--- a/crates/core/tests/unit/plugin_tests.rs
+++ b/crates/core/tests/unit/plugin_tests.rs
@@ -2927,6 +2927,26 @@ fn test_programmatic_observability_destinations_concatenate_with_discovered_file
 }
 
 #[test]
+fn test_resolved_plugin_config_reports_every_contributing_file() {
+    let user = PathBuf::from("user/plugins.toml");
+    let system = PathBuf::from("system/plugins.toml");
+    let resolved = resolve_plugin_config_documents(
+        PluginConfig::default(),
+        None,
+        vec![
+            (user.clone(), json!({"version": 1})),
+            (system.clone(), json!({"version": 1})),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolved.config_paths,
+        vec![user.display().to_string(), system.display().to_string(),]
+    );
+}
+
+#[test]
 fn test_no_inherited_configuration_warning_without_discovered_files() {
     let discovered = resolve_discovered_plugin_config(Vec::new()).unwrap();
     let resolved = resolve_programmatic_plugin_config(discovered, PluginConfig::default()).unwrap();

--- a/crates/node/plugin.d.ts
+++ b/crates/node/plugin.d.ts
@@ -100,6 +100,10 @@ export interface PluginHostActivation extends AsyncDisposable {
 export interface PluginHostReport {
   config: ConfigReport;
   dynamic_plugins: DynamicPluginValidationReport[];
+  /** Existing plugins.toml files that contributed to the resolved configuration. */
+  config_paths: string[];
+  /** Fully merged plugin configuration with sensitive values redacted. */
+  resolved_config: Json;
 }
 
 export type DynamicPluginCheckState = 'unknown' | 'valid' | 'invalid';

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -5900,7 +5900,7 @@ pub struct PluginHostActivation {
 type DynamicPluginTeardownResult = std::result::Result<(), String>;
 
 enum DynamicPluginCloseStatus {
-    Active(Option<CorePluginHostActivation>),
+    Active(Box<Option<CorePluginHostActivation>>),
     Closing,
     Closed,
 }
@@ -5916,7 +5916,7 @@ impl DynamicPluginCloseState {
         let (completion, _) = tokio::sync::watch::channel(None);
         let report = activation.report();
         Self {
-            status: StdMutex::new(DynamicPluginCloseStatus::Active(Some(activation))),
+            status: StdMutex::new(DynamicPluginCloseStatus::Active(Box::new(Some(activation)))),
             report: StdMutex::new(report),
             completion,
         }
@@ -5929,10 +5929,11 @@ impl DynamicPluginCloseState {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             match &*status {
-                DynamicPluginCloseStatus::Active(Some(activation)) => Some(activation.report()),
-                DynamicPluginCloseStatus::Active(None)
-                | DynamicPluginCloseStatus::Closing
-                | DynamicPluginCloseStatus::Closed => None,
+                DynamicPluginCloseStatus::Active(activation) => activation
+                    .as_ref()
+                    .as_ref()
+                    .map(CorePluginHostActivation::report),
+                DynamicPluginCloseStatus::Closing | DynamicPluginCloseStatus::Closed => None,
             }
         };
         let mut report = self
@@ -5951,7 +5952,7 @@ impl DynamicPluginCloseState {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         match &*status {
-            DynamicPluginCloseStatus::Active(activation) => activation.is_some(),
+            DynamicPluginCloseStatus::Active(activation) => activation.as_ref().is_some(),
             DynamicPluginCloseStatus::Closing | DynamicPluginCloseStatus::Closed => false,
         }
     }
@@ -5964,13 +5965,13 @@ impl DynamicPluginCloseState {
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             match &mut *status {
                 DynamicPluginCloseStatus::Active(activation) => {
-                    if let Some(current) = activation.as_ref() {
+                    if let Some(current) = activation.as_ref().as_ref() {
                         *self
                             .report
                             .lock()
                             .unwrap_or_else(|poisoned| poisoned.into_inner()) = current.report();
                     }
-                    let activation = activation.take();
+                    let activation = activation.as_mut().take();
                     if activation.is_some() {
                         self.completion.send_replace(None);
                     }
@@ -6063,7 +6064,7 @@ impl DynamicPluginCloseState {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         *status = if retryable {
-            DynamicPluginCloseStatus::Active(activation)
+            DynamicPluginCloseStatus::Active(Box::new(activation))
         } else {
             DynamicPluginCloseStatus::Closed
         };

--- a/crates/python/src/py_plugin.rs
+++ b/crates/python/src/py_plugin.rs
@@ -838,7 +838,7 @@ impl PluginTeardownCompletion {
 }
 
 enum PluginHostCloseStatus {
-    Active(Option<PluginHostActivation>),
+    Active(Box<Option<PluginHostActivation>>),
     Closing,
     Closed,
 }
@@ -853,7 +853,7 @@ impl PluginHostCloseState {
     fn new(activation: PluginHostActivation) -> Self {
         let report = activation.report();
         Self {
-            status: Mutex::new(PluginHostCloseStatus::Active(Some(activation))),
+            status: Mutex::new(PluginHostCloseStatus::Active(Box::new(Some(activation)))),
             report: Mutex::new(report),
             completion: PluginTeardownCompletion::new(),
         }
@@ -866,10 +866,11 @@ impl PluginHostCloseState {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             match &*status {
-                PluginHostCloseStatus::Active(Some(activation)) => Some(activation.report()),
-                PluginHostCloseStatus::Active(None)
-                | PluginHostCloseStatus::Closing
-                | PluginHostCloseStatus::Closed => None,
+                PluginHostCloseStatus::Active(activation) => activation
+                    .as_ref()
+                    .as_ref()
+                    .map(PluginHostActivation::report),
+                PluginHostCloseStatus::Closing | PluginHostCloseStatus::Closed => None,
             }
         };
         let mut report = self
@@ -890,6 +891,7 @@ impl PluginHostCloseState {
         match &*status {
             PluginHostCloseStatus::Active(activation) => activation
                 .as_ref()
+                .as_ref()
                 .is_some_and(PluginHostActivation::is_active),
             PluginHostCloseStatus::Closing | PluginHostCloseStatus::Closed => false,
         }
@@ -903,13 +905,13 @@ impl PluginHostCloseState {
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             match &mut *status {
                 PluginHostCloseStatus::Active(activation) => {
-                    if let Some(current) = activation.as_ref() {
+                    if let Some(current) = activation.as_ref().as_ref() {
                         *self
                             .report
                             .lock()
                             .unwrap_or_else(|poisoned| poisoned.into_inner()) = current.report();
                     }
-                    let activation = activation.take();
+                    let activation = activation.as_mut().take();
                     *status = PluginHostCloseStatus::Closing;
                     activation
                 }
@@ -988,7 +990,7 @@ impl PluginHostCloseState {
             .status
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = if retryable {
-            PluginHostCloseStatus::Active(activation)
+            PluginHostCloseStatus::Active(Box::new(activation))
         } else {
             PluginHostCloseStatus::Closed
         };

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -142,11 +142,12 @@ When library initialization discovers `plugins.toml` files, Relay emits one
 the operational log and included in the initialization result and active plugin
 report. The report also includes `config_paths` and `resolved_config`.
 `resolved_config` is the fully merged plugin configuration. Literal secrets are
-redacted, and URL user info, query parameters, and fragments are removed. Relay
-continues with the layered destination set; validation or activation errors in
-that effective configuration still fail normally. Except for the signal-list
-clearing behavior above, changing or removing an inherited endpoint requires
-editing the layer that declares it.
+redacted, URL user info, query parameters, and fragments are removed, and every
+scalar in opaque dynamic-plugin configuration is redacted. Relay continues with
+the layered destination set; validation or activation errors in that effective
+configuration still fail normally. Except for the signal-list clearing behavior
+above, changing or removing an inherited endpoint requires editing the layer
+that declares it.
 
 For complete layering rules, refer to
 [Plugin Configuration Files](/configure-plugins/plugin-configuration-files#precedence-and-merge-behavior).

--- a/docs/configure-plugins/observability/configuration.mdx
+++ b/docs/configure-plugins/observability/configuration.mdx
@@ -140,11 +140,13 @@ semantics. List entries are not merged item by item.
 When library initialization discovers `plugins.toml` files, Relay emits one
 `plugin.configuration_inherited` warning per file. Each warning is written to
 the operational log and included in the initialization result and active plugin
-report. It names only the source path, never destination values or credentials.
-Relay continues with the layered destination set; validation or activation
-errors in that effective configuration still fail normally. Except for the
-signal-list clearing behavior above, changing or removing an inherited endpoint
-requires editing the layer that declares it.
+report. The report also includes `config_paths` and `resolved_config`.
+`resolved_config` is the fully merged plugin configuration. Literal secrets are
+redacted, and URL user info, query parameters, and fragments are removed. Relay
+continues with the layered destination set; validation or activation errors in
+that effective configuration still fail normally. Except for the signal-list
+clearing behavior above, changing or removing an inherited endpoint requires
+editing the layer that declares it.
 
 For complete layering rules, refer to
 [Plugin Configuration Files](/configure-plugins/plugin-configuration-files#precedence-and-merge-behavior).

--- a/go/nemo_relay/plugin.go
+++ b/go/nemo_relay/plugin.go
@@ -276,6 +276,8 @@ type PluginHostActivation struct {
 type PluginHostReport struct {
 	Config         ConfigReport                    `json:"config"`
 	DynamicPlugins []DynamicPluginValidationReport `json:"dynamic_plugins"`
+	ConfigPaths    []string                        `json:"config_paths"`
+	ResolvedConfig map[string]any                  `json:"resolved_config"`
 }
 
 // DynamicPluginCheckState is the result of one validation check.

--- a/integrations/openclaw/test/config.test.ts
+++ b/integrations/openclaw/test/config.test.ts
@@ -899,6 +899,8 @@ function createModules(
         return {
           config: { diagnostics: params.validateDiagnostics ?? [] },
           dynamic_plugins: [],
+          config_paths: [],
+          resolved_config: {},
         };
       },
       initialize: async (config) => {
@@ -907,6 +909,8 @@ function createModules(
           report: {
             config: { diagnostics: params.initializeDiagnostics ?? [] },
             dynamic_plugins: [],
+            config_paths: [],
+            resolved_config: {},
           },
           isActive: true,
           close: async () => {

--- a/python/nemo_relay/plugin.py
+++ b/python/nemo_relay/plugin.py
@@ -140,6 +140,8 @@ class PluginHostReport(TypedDict):
 
     config: ConfigReport
     dynamic_plugins: list[DynamicPluginValidationReport]
+    config_paths: list[str]
+    resolved_config: JsonObject
 
 
 DynamicPluginKind = Literal["rust_dynamic", "worker"]

--- a/python/nemo_relay/plugin.pyi
+++ b/python/nemo_relay/plugin.pyi
@@ -83,6 +83,8 @@ class DynamicPluginValidationReport(_DynamicPluginValidationReportRequired, tota
 class PluginHostReport(TypedDict):
     config: ConfigReport
     dynamic_plugins: list[DynamicPluginValidationReport]
+    config_paths: list[str]
+    resolved_config: JsonObject
 
 class PluginContext(Protocol):
     def register_subscriber(self, name: str, callback: Callable[[Event], None]) -> None: ...

--- a/python/tests/test_dynamic_plugin_host.py
+++ b/python/tests/test_dynamic_plugin_host.py
@@ -299,6 +299,7 @@ async def test_discovered_configuration_layers_last(
         codes = [item["code"] for item in activation.report["config"]["diagnostics"]]
         assert "plugin.configuration_inherited" in codes
         assert str(plugins_toml) in activation.report["config_paths"]
+        assert activation.report["resolved_config"]["plugins"]["policy"]["defaults"]["attestation"] == "integrity_only"
         result = await tools.execute("python-file-static-base", {"input": True}, lambda args: ToolExecutionResult(args))
         assert result.result["file_static_base"] is True
         assert result.result["native_plugin_tool_execution"] is True

--- a/python/tests/test_dynamic_plugin_host.py
+++ b/python/tests/test_dynamic_plugin_host.py
@@ -298,6 +298,7 @@ async def test_discovered_configuration_layers_last(
         activation = await plugin.initialize(plugin.PluginConfig())
         codes = [item["code"] for item in activation.report["config"]["diagnostics"]]
         assert "plugin.configuration_inherited" in codes
+        assert str(plugins_toml) in activation.report["config_paths"]
         result = await tools.execute("python-file-static-base", {"input": True}, lambda args: ToolExecutionResult(args))
         assert result.result["file_static_base"] is True
         assert result.result["native_plugin_tool_execution"] is True


### PR DESCRIPTION
#### Overview

Expose the source files and redacted effective configuration chosen during plugin initialization, so library callers can explain inherited policy without changing it.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Add `config_paths` and a redacted, fully merged `resolved_config` to plugin-host reports.
- Redact literal secrets and HTTP credential, query, and fragment data while preserving configuration structure.
- Keep layered policy behavior unchanged; do not add an `opentelemetry_destinations` summary.
- Align the Rust, Python, Node.js, and Go report contracts, documentation, and tests.

#### Where should the reviewer start?

Start with `crates/core/src/plugin/dynamic/configuration.rs`, which creates the resolved diagnostic report and applies redaction.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [RELAY-854](https://linear.app/nvidia/issue/RELAY-854/nemo-relay090-a-library-caller-inherits-opentelemetry-endpoints-from)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plugin host reports now include the configuration files contributing to the active setup.
  - Reports expose the fully merged plugin configuration across supported language integrations.
  - Resolved configuration details are sanitized by redacting secrets, authorization headers, credentials, and sensitive URL components.

- **Documentation**
  - Updated plugin observability documentation to describe configuration paths, merged settings, and sanitization behavior.

- **Tests**
  - Added coverage for configuration inheritance, source-file ordering, and sensitive-value redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->