### PR TITLE
test: align managed Pi docs contract

### DIFF
--- a/crates/cli/tests/coverage/daemon/managed_tests.rs
+++ b/crates/cli/tests/coverage/daemon/managed_tests.rs
@@ -154,10 +154,8 @@ fn assert_pi_bundle_artifacts(bundle: &RenderedBundle) {
 
 #[test]
 fn managed_pi_launch_disables_discovered_extensions() {
-    const ISOLATED_LAUNCH: &str =
-        "pi --no-extensions -e /srv/nemo-relay/nemo-relay-managed-v1/pi/extension-v1/index.ts";
-    const NON_ISOLATED_LAUNCH: &str =
-        "pi -e /srv/nemo-relay/nemo-relay-managed-v1/pi/extension-v1/index.ts";
+    const ISOLATED_LAUNCH: &str = "pi --no-extensions -e ";
+    const NON_ISOLATED_LAUNCH: &str = "pi -e ";
 
     let rendered = render_bundle(&spec([ManagedAgent::Pi])).unwrap();
     let readme = rendered
@@ -166,7 +164,7 @@ fn managed_pi_launch_disables_discovered_extensions() {
         .find(|artifact| artifact.path == "pi/extension-v1/README.md")
         .unwrap();
     let readme = std::str::from_utf8(&readme.bytes).unwrap();
-    let daemon_docs = include_str!("../../../../../docs/nemo-relay-cli/daemon.mdx");
+    let daemon_docs = include_str!("../../../../../docs/daemon/configuration.mdx");
 
     for (source_name, source) in [
         ("rendered managed Pi README", readme),


### PR DESCRIPTION
#### Overview

Keep the managed Pi launch documentation contract aligned with the daemon runbook split.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Read the managed Pi deployment command from `docs/daemon/configuration.mdx`, its authoritative location.
- Assert the isolation flags rather than a particular administrator install root.

#### Where should the reviewer start?

- `crates/cli/tests/coverage/daemon/managed_tests.rs`: the managed Pi documentation contract.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated managed Pi launch coverage tests to use command prefixes instead of hard-coded extension paths.
  * Updated the test documentation reference to the daemon configuration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->