### PR TITLE
fix: preserve requests with overlapping PII paths

### DIFF
--- a/crates/pii-redaction/src/builtin.rs
+++ b/crates/pii-redaction/src/builtin.rs
@@ -666,6 +666,10 @@ impl CompiledBuiltinBackend {
                 .matching_json_pointer_paths(&sanitized),
         );
 
+        let mut target_paths = target_paths.into_iter().collect::<Vec<_>>();
+        target_paths
+            .sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+
         for target_segments in target_paths {
             let current_annotated = codec.decode(&sanitized_request).ok()?;
             let mut current = serde_json::to_value(&current_annotated).ok()?;

--- a/crates/pii-redaction/tests/unit/component_tests.rs
+++ b/crates/pii-redaction/tests/unit/component_tests.rs
@@ -1434,6 +1434,57 @@ async fn normalized_llm_paths_use_configured_anthropic_codec_without_a_system_me
 }
 
 #[tokio::test]
+async fn normalized_anthropic_overlapping_paths_redact_multiple_text_blocks() {
+    let backend = crate::builtin::CompiledBuiltinBackend::new(
+        BuiltinBackendConfig {
+            action: "redact".to_string(),
+            detector: Some("email".to_string()),
+            target_path_globs: vec![
+                "/messages/*/content".to_string(),
+                "/messages/*/content/*/text".to_string(),
+            ],
+            ..BuiltinBackendConfig::default()
+        },
+        None,
+    )
+    .unwrap();
+    let sanitize_request = crate::builtin::llm_sanitize_request_callback(backend);
+
+    let sanitized = sanitize_request(
+        LlmRequest {
+            headers: serde_json::Map::new(),
+            content: json!({
+                "model": "claude-opus-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "first@example.com"},
+                        {"type": "text", "text": "second@example.com"}
+                    ]
+                }],
+                "stream": true
+            }),
+        },
+        LlmSanitizeRequestContext::for_request_codec(Some(Arc::new(
+            crate::codec::anthropic::AnthropicMessagesCodec,
+        ))),
+    )
+    .await
+    .expect("the sanitizer callback must succeed")
+    .expect("overlapping normalized paths must retain the request payload");
+
+    assert_eq!(
+        sanitized.content["messages"][0]["content"][0]["text"],
+        json!("[REDACTED]")
+    );
+    assert_eq!(
+        sanitized.content["messages"][0]["content"][1]["text"],
+        json!("[REDACTED]")
+    );
+    assert_eq!(sanitized.content["stream"], json!(true));
+}
+
+#[tokio::test]
 async fn trajectory_preset_redacts_known_marks_and_nested_scope_content() {
     let callback = crate::builtin::event_sanitize_callback(trajectory_backend(None, "preserve"));
     let chunk = Event::Mark(MarkEvent::new(


### PR DESCRIPTION
#### Overview

Fix PII redaction of normalized LLM requests when configured target path globs match both a parent container and nested leaf fields. Previously, this configuration could cause the sanitizer to omit the request payload entirely, which in turn prevented downstream observability exporters from emitting request-derived attributes such as `gen_ai.input.messages`.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

The normalized-request sanitizer first attempts to encode all sanitized annotations in one operation. When provider-native arrays contain multiple edited items without stable identities, the codec intentionally rejects that aggregate encode to avoid associating edits with the wrong provider fields.

The incremental fallback collected matching JSON-pointer paths in a `BTreeSet`, which made traversal lexicographic. For overlapping selectors such as `/messages/*/content` and `/messages/*/content/*/text`, that ordering processes the parent content array first. If the array contains multiple redacted text blocks, encoding that parent-level edit hits the same ambiguity and the fallback returns `None`, dropping the sanitized request payload.

This change:

- sorts incremental target paths by descending segment depth, with lexical ordering as a deterministic tie-breaker;
- applies leaf text edits before parent container matches, allowing each provider-native block to be updated safely;
- adds an Anthropic regression test using both overlapping selectors and two email-bearing text blocks;
- verifies that both emails are redacted and unrelated provider fields such as `stream` are preserved.

There are no public API changes or breaking changes.

Validation performed:

- `cargo test -p nemo-relay-pii-redaction normalized_anthropic_overlapping_paths_redact_multiple_text_blocks -- --nocapture`
- `just test-rust` — 5,063 workspace tests passed; all isolated Rust plugin example suites passed. One existing timeout-sensitive diagnostic test passed on its automatic retry.
- `uv run pre-commit run --from-ref origin/main --to-ref HEAD`

#### Where should the reviewer start?

Start with `CompiledBuiltinBackend::sanitize_request_target_paths_incrementally` in `crates/pii-redaction/src/builtin.rs`, specifically the leaf-first ordering before the incremental encode loop. The regression is `normalized_anthropic_overlapping_paths_redact_multiple_text_blocks` in `crates/pii-redaction/tests/unit/component_tests.rs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sensitive-data redaction for requests with overlapping nested paths.
  - Ensured multiple text blocks in Anthropic messages are consistently redacted.
  - Preserved unrelated request fields, such as streaming settings, during sanitization.

- **Tests**
  - Added regression coverage for nested message content and overlapping redaction paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->