### PR TITLE
fix(codec): accumulate Anthropic compaction deltas

### DIFF
--- a/crates/core/src/codec/anthropic.rs
+++ b/crates/core/src/codec/anthropic.rs
@@ -1302,6 +1302,15 @@ impl AnthropicMessagesStreamingState {
                     block.has_citations = true;
                 }
             }
+            "compaction_delta"
+                if block.skeleton.get("type").and_then(Json::as_str) == Some("compaction") =>
+            {
+                for field in ["content", "encrypted_content"] {
+                    if let Some(value) = delta.get(field) {
+                        block.skeleton.insert(field.to_string(), value.clone());
+                    }
+                }
+            }
             // thinking_delta, signature_delta, and any future delta types fall through; the block
             // skeleton retains whatever shape was set at content_block_start.
             _ => {}

--- a/crates/core/tests/unit/codec/anthropic_tests.rs
+++ b/crates/core/tests/unit/codec/anthropic_tests.rs
@@ -1474,6 +1474,65 @@ fn anthropic_streaming_codec_preserves_usage_across_partial_updates() {
 }
 
 #[test]
+fn anthropic_streaming_codec_accumulates_live_compaction_shape() {
+    for (delta, expected) in [
+        // A live Anthropic response omitted encrypted_content entirely.
+        (
+            json!({"type": "compaction_delta", "content": "<summary>state</summary>"}),
+            json!({"type": "compaction", "content": "<summary>state</summary>"}),
+        ),
+        (
+            json!({
+                "type": "compaction_delta", "content": "<summary>state</summary>",
+                "encrypted_content": "opaque"
+            }),
+            json!({
+                "type": "compaction", "content": "<summary>state</summary>",
+                "encrypted_content": "opaque"
+            }),
+        ),
+        (
+            json!({
+                "type": "compaction_delta", "content": "<summary>state</summary>",
+                "encrypted_content": null
+            }),
+            json!({
+                "type": "compaction", "content": "<summary>state</summary>",
+                "encrypted_content": null
+            }),
+        ),
+    ] {
+        let codec = AnthropicMessagesStreamingCodec::new();
+        let mut collector = codec.collector();
+        let finalizer = codec.finalizer();
+        for event in [
+            json!({
+                "type": "message_start", "message": {
+                    "id": "msg_compact", "type": "message", "role": "assistant",
+                    "model": "claude-sonnet-4-6", "content": [],
+                    "usage": {"input_tokens": 0, "output_tokens": 0}
+                }
+            }),
+            json!({
+                "type": "content_block_start", "index": 0,
+                "content_block": {"type": "compaction", "content": null}
+            }),
+            json!({"type": "content_block_delta", "index": 0, "delta": delta}),
+            json!({"type": "content_block_stop", "index": 0}),
+            json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": "compaction", "stop_sequence": null},
+                "usage": {"input_tokens": 0, "output_tokens": 0}
+            }),
+            json!({"type": "message_stop"}),
+        ] {
+            collector(event).unwrap();
+        }
+        assert_eq!(finalizer()["content"][0], expected);
+    }
+}
+
+#[test]
 fn anthropic_streaming_codec_assembles_tool_use_input_from_partial_json() {
     let codec = AnthropicMessagesStreamingCodec::new();
     let mut collector = codec.collector();


### PR DESCRIPTION
## Summary

Related to #1034.

Anthropic streams a compaction block as a null start skeleton followed by one complete `compaction_delta`. Relay's collector handled text, tool-input JSON, and citation deltas but ignored compaction deltas, leaving the finalized aggregate with `content: null`.

This adds one guarded match arm that copies the known `content` and `encrypted_content` fields into the existing compaction skeleton when they are present.

Before:

```json
{"type":"compaction","content":null}
```

After:

```json
{"type":"compaction","content":"<summary>…</summary>"}
```

The implementation preserves missing, explicit-null, and string `encrypted_content` states distinctly.

## Evidence

- A paid above-threshold Anthropic call produced the sparse start/delta sequence used by the regression test.
- The regression failed against the prior collector and passed with this change.
- [Anthropic's compaction streaming documentation](https://platform.claude.com/docs/en/build-with-claude/compaction#streaming) specifies one complete `compaction_delta` per block.

## Scope

- Nine production lines and one focused regression test.
- No public API, configuration, dependency, runtime, or concurrency changes.
- Raw SSE forwarding remains unchanged.
- This does **not** make response-cache replay safe or enable compaction caching. The conservative bypass must remain until the related cache-safety issue is resolved.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p nemo-relay anthropic` — 70 unit tests and 1 integration test passed
- `cargo clippy -p nemo-relay --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Anthropic streaming responses containing compaction blocks.
  * Compaction content and encrypted content now accumulate correctly, including omitted, populated, and explicitly empty values.

* **Tests**
  * Added coverage for compaction block streaming and encrypted content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
