### PR TITLE
chore: Fix proposed branch name in `prepare-code-freeze` Skill

### DIFF
--- a/.agents/skills/prepare-code-freeze/SKILL.md
+++ b/.agents/skills/prepare-code-freeze/SKILL.md
@@ -29,7 +29,7 @@ This workflow assumes `upstream` is the NVIDIA repository remote
    If the remote release branch already exists, verify it points where expected
    before continuing.
 4. Create a PR branch from latest `upstream/main`, for example
-   `docs/code-freeze-<major>.<minor>`.
+   `chore/version-bump-<major>.<minor>`.
 5. Update `.github/nightly-alpha-branches.yaml` to include the new release
    branch.
 6. Run `just set-version <next-version>` to update all project-owned


### PR DESCRIPTION
#### Overview

* I think it should be `chore/version-bump-<major>.<minor>` as it isn't a documentation change.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

Update maintenance skill 

#### Where should the reviewer start?

* `.agents/skills/prepare-code-freeze/SKILL.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the code-freeze workflow’s branch naming example to use the version-bump format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->