### PR TITLE
test: cover tool execution context callbacks

### DIFF
--- a/crates/core/tests/unit/native_plugin_tests.rs
+++ b/crates/core/tests/unit/native_plugin_tests.rs
@@ -4586,6 +4586,74 @@ unsafe extern "C" fn noop_tool_execution_context(
     NemoRelayStatus::Ok
 }
 
+#[cfg(unix)]
+unsafe extern "C" fn tool_execution_context_round_trip(
+    user_data: *mut c_void,
+    context_json: *const NemoRelayNativeString,
+    next_fn: NemoRelayNativeToolNextFn,
+    next_ctx: *mut c_void,
+    out_outcome_json: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    let context = match read_native_string(context_json)
+        .ok()
+        .and_then(|value| serde_json::from_str::<Json>(&value).ok())
+    {
+        Some(context) => context,
+        None => return NemoRelayStatus::InvalidArg,
+    };
+    unsafe { &*(user_data as *const Mutex<Option<Json>>) }
+        .lock()
+        .unwrap()
+        .replace(context.clone());
+
+    let args = match native_string_from_json(&context["args"]) {
+        Some(args) => args,
+        None => return NemoRelayStatus::Internal,
+    };
+    let mut result = ptr::null_mut();
+    let status = unsafe { next_fn(args, next_ctx, &mut result) };
+    unsafe { native_string_free(args) };
+    if status != NemoRelayStatus::Ok {
+        return status;
+    }
+
+    let mut outcome = match take_json_from_native_string(result, "missing tool result") {
+        Ok(outcome) => outcome,
+        Err(_) => return NemoRelayStatus::Internal,
+    };
+    outcome["pending_marks"] = json!([]);
+    let Some(outcome) = native_string_from_json(&outcome) else {
+        return NemoRelayStatus::Internal;
+    };
+    unsafe { *out_outcome_json = outcome };
+    NemoRelayStatus::Ok
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn tool_execution_context_error(
+    _user_data: *mut c_void,
+    _context_json: *const NemoRelayNativeString,
+    _next_fn: NemoRelayNativeToolNextFn,
+    _next_ctx: *mut c_void,
+    out_outcome_json: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    unsafe { *out_outcome_json = native_string(r#"{"discarded":true}"#) };
+    set_native_last_error("tool execution context failed");
+    NemoRelayStatus::InvalidArg
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn tool_execution_context_malformed_outcome(
+    _user_data: *mut c_void,
+    _context_json: *const NemoRelayNativeString,
+    _next_fn: NemoRelayNativeToolNextFn,
+    _next_ctx: *mut c_void,
+    out_outcome_json: *mut *mut NemoRelayNativeString,
+) -> NemoRelayStatus {
+    unsafe { *out_outcome_json = native_string(r#"{"pending_marks":[]}"#) };
+    NemoRelayStatus::Ok
+}
+
 unsafe extern "C" fn noop_llm_request(
     _user_data: *mut c_void,
     _request_json: *const NemoRelayNativeString,
@@ -6285,6 +6353,78 @@ async fn native_callback_wrappers_release_error_outputs_and_preserve_reasons() {
             .expect("native stream callback should fail")
             .to_string()
             .contains("LLM stream execution failed")
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn native_tool_execution_context_preserves_fields_and_callback_boundaries() {
+    let instance = Arc::new(NativePluginInstance {
+        plugin_kind: "test.native.tool-execution-context".into(),
+        relay_compat: ">=0.9,<1.0".into(),
+        allows_multiple_components: false,
+        plugin: Mutex::new(NemoRelayNativePluginV1::default()),
+        _library: libloading::os::unix::Library::this().into(),
+    });
+    let observed_context = Mutex::new(None);
+    let context = ToolExecutionContext::new("lookup", json!({"query": "private"}))
+        .with_tool_call_id(Some("call-native-1".into()));
+    let debug = format!("{context:?}");
+    assert!(debug.contains("lookup"));
+    assert!(debug.contains("call-native-1"));
+    assert!(!debug.contains("private"));
+
+    let callback = wrap_tool_execution_context_fn(
+        Arc::clone(&instance),
+        tool_execution_context_round_trip,
+        ptr::from_ref(&observed_context).cast_mut().cast(),
+        None,
+    );
+    let outcome = callback(context, tool_next(Ok(json!({"answer": 42}))))
+        .await
+        .unwrap();
+    assert_eq!(outcome.result, json!({"answer": 42}));
+    assert_eq!(
+        observed_context.lock().unwrap().as_ref(),
+        Some(&json!({
+            "tool_name": "lookup",
+            "args": {"query": "private"},
+            "tool_call_id": "call-native-1",
+        }))
+    );
+
+    let callback = wrap_tool_execution_context_fn(
+        Arc::clone(&instance),
+        tool_execution_context_error,
+        ptr::null_mut(),
+        None,
+    );
+    assert!(
+        callback(
+            ToolExecutionContext::new("lookup", json!({})),
+            tool_next(Ok(Json::Null)),
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("tool execution context failed")
+    );
+
+    let callback = wrap_tool_execution_context_fn(
+        instance,
+        tool_execution_context_malformed_outcome,
+        ptr::null_mut(),
+        None,
+    );
+    assert!(
+        callback(
+            ToolExecutionContext::new("lookup", json!({})),
+            tool_next(Ok(Json::Null)),
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("invalid native tool execution outcome")
     );
 }
 

--- a/crates/python/tests/coverage/py_types_coverage_tests.rs
+++ b/crates/python/tests/coverage/py_types_coverage_tests.rs
@@ -70,6 +70,57 @@ fn py_mark_event(event: Event) -> PyMarkEvent {
 }
 
 #[test]
+fn test_tool_execution_context_repr_excludes_arguments() {
+    let _python = crate::test_support::init_python_test();
+    Python::attach(|py| {
+        let context = nemo_relay::api::runtime::ToolExecutionContext::new(
+            "lookup",
+            json!({"secret": "private"}),
+        )
+        .with_tool_call_id(Some("call-python-1".into()));
+        let context = Py::new(
+            py,
+            PyToolExecutionContext::from_inner(py, &context).unwrap(),
+        )
+        .unwrap();
+        let context = context.bind(py);
+
+        assert_eq!(
+            context
+                .getattr("tool_name")
+                .unwrap()
+                .extract::<String>()
+                .unwrap(),
+            "lookup"
+        );
+        assert_eq!(
+            context
+                .getattr("tool_call_id")
+                .unwrap()
+                .extract::<String>()
+                .unwrap(),
+            "call-python-1"
+        );
+        assert_eq!(
+            context
+                .getattr("args")
+                .unwrap()
+                .get_item("secret")
+                .unwrap()
+                .extract::<String>()
+                .unwrap(),
+            "private"
+        );
+        let representation = context.repr().unwrap().to_str().unwrap().to_owned();
+        assert_eq!(
+            representation,
+            "ToolExecutionContext(tool_name=\"lookup\", tool_call_id=Some(\"call-python-1\"))"
+        );
+        assert!(!representation.contains("private"));
+    });
+}
+
+#[test]
 fn test_register_exposes_all_type_bindings() {
     let _python = crate::test_support::init_python_test();
     Python::attach(|py| {

--- a/crates/worker/tests/worker_sdk_tests.rs
+++ b/crates/worker/tests/worker_sdk_tests.rs
@@ -698,15 +698,18 @@ async fn worker_service_invokes_every_registration_surface() {
         "phase",
         "tool_request",
     );
-    let tool_outcome = invoke_tool_execution(
-        &mut client,
-        tool_invoke(
-            "tool-exec",
-            RegistrationSurface::ToolExecutionIntercept,
-            json!({}),
-        ),
-    )
-    .await;
+    let mut tool_execution_request = tool_invoke(
+        "tool-exec",
+        RegistrationSurface::ToolExecutionIntercept,
+        json!({}),
+    );
+    let Some(nemo_relay_worker_proto::v1::invoke_request::Payload::Tool(invocation)) =
+        tool_execution_request.payload.as_mut()
+    else {
+        panic!("tool execution request must contain a tool invocation");
+    };
+    invocation.tool_call_id = Some("call-worker-1".into());
+    let tool_outcome = invoke_tool_execution(&mut client, tool_execution_request).await;
     assert_eq!(tool_outcome.pending_marks.len(), 1);
     assert_eq!(
         tool_outcome.pending_marks[0],
@@ -717,6 +720,7 @@ async fn worker_service_invokes_every_registration_surface() {
     );
     assert_eq!(tool_outcome.annotation, Some(json!({"source": "host"})));
     let tool_exec = tool_outcome.result;
+    assert_json_field(tool_exec.clone(), "tool_call_id", "call-worker-1");
     assert_json_field(tool_exec.clone(), "next", "tool");
     assert_json_field(tool_exec, "phase", "tool_exec");
     let conditional_middleware = client
@@ -2111,6 +2115,12 @@ impl WorkerPlugin for SurfacePlugin {
         ctx.register_tool_execution_intercept("tool-exec", 1, move |context, next: ToolNext| {
             let runtime = tool_runtime.clone();
             async move {
+                if context.tool_name() != "tool" || context.args() != &json!({}) {
+                    return Err(WorkerSdkError::Callback(format!(
+                        "unexpected tool execution context: {context:?}"
+                    )));
+                }
+                let tool_call_id = context.tool_call_id().map(str::to_owned);
                 let value = context.into_args();
                 let registrations = runtime
                     .list_runtime_registrations(Some(BTreeSet::from([
@@ -2214,6 +2224,11 @@ impl WorkerPlugin for SurfacePlugin {
                 runtime.drop_scope_stack(&stack_id).await?;
                 let mut next_value = next.call(value).await?;
                 next_value.result = set_json_field(next_value.result, "phase", "tool_exec");
+                next_value
+                    .result
+                    .as_object_mut()
+                    .expect("tool execution result must be a JSON object")
+                    .insert("tool_call_id".into(), json!(tool_call_id));
                 Ok(
                     ToolExecutionInterceptOutcome::from(next_value).with_pending_mark(
                         PendingMarkSpec::builder()


### PR DESCRIPTION
#### Overview

Adds focused regression coverage for the ToolExecutionContext paths introduced by #1029. The tests exercise native callback conversion and continuation boundaries, worker context propagation, and Python-visible context properties without changing production behavior or coverage policy.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project’s license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Covers native ToolExecutionContext JSON conversion, continuation results, callback errors, malformed outcomes, and argument-redacting Debug output.
- Verifies worker callbacks receive the tool name, arguments, and provider tool-call ID.
- Verifies Python-visible properties and repr output, including argument redaction.

Validation:

- `cargo fmt --all -- --check` — passed.
- `cargo nextest run --locked -p nemo-relay native_tool_execution_context_preserves_fields_and_callback_boundaries --profile ci` — 1 passed.
- `cargo nextest run --locked -p nemo-relay-worker --test worker_sdk_tests --profile ci` — 14 passed.
- `cargo nextest run --locked -p nemo-relay-python --features __skip-implicit-config --lib test_tool_execution_context_repr_excludes_arguments --profile ci` — 1 passed.
- Commit hooks — copyright, whitespace, links, Cargo formatting, Clippy, and Cargo check passed.
- `just test-rust` — 5,086 passed; 6 unrelated existing CLI authentication/configuration and daemon tests failed. The remaining full-suite gate was explicitly waived for this test-only follow-up.

#### Where should the reviewer start?

Start with `native_tool_execution_context_preserves_fields_and_callback_boundaries` in `crates/core/tests/unit/native_plugin_tests.rs`, which covers the largest concentration of previously missed changed lines.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #1029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded tool execution coverage for preserving tool names, arguments, and call IDs across native and surface plugin callbacks.
  - Added validation for successful results, callback failures, malformed outcomes, and normalization of pending marks.
  - Added Python coverage for accessing tool execution context while keeping sensitive argument values out of representations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->