### PR TITLE
ci: pin PyPI publishing action to release commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -487,7 +487,7 @@ jobs:
           fi
 
       - name: Publish to PyPI with trusted publishing
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true
 


### PR DESCRIPTION
#### Overview

Correct the PyPI publishing action pin so its GHCR trampoline image resolves during release publication.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Replace the v1.14.2 annotated tag-object pin with the release commit SHA required by the action's container-image lookup.

#### Where should the reviewer start?

- `.github/workflows/ci.yaml`, in the `Publish to PyPI with trusted publishing` step.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PyPI publishing workflow dependency reference.
  * Publishing behavior and configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->