### PR TITLE
feat: export OTLP traces to a local file

### DIFF
--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -8097,6 +8097,87 @@ SOFTWARE.
 
 ```
 
+## const-hex - 1.19.1
+
+**Repository URL**: https://github.com/danipopes/const-hex
+**License Type(s)**: Apache-2.0
+### License: https://spdx.org/licenses/Apache-2.0.html
+```
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
 ## const-oid - 0.10.2
 
 **Repository URL**: https://github.com/RustCrypto/formats
@@ -32754,6 +32835,245 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
+## proptest - 1.11.0
+
+**Repository URL**: https://github.com/proptest-rs/proptest
+**License Type(s)**: MIT OR Apache-2.0
+### License: https://spdx.org/licenses/
+### License File: LICENSE-APACHE
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+### License File: LICENSE-MIT
+```
+Copyright (c) 2016 FullContact, Inc
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
 ## prost - 0.14.3
 
 **Repository URL**: https://github.com/tokio-rs/prost
@@ -36259,6 +36579,221 @@ APPENDIX: How to apply the Apache License to your work.
    file or class name and description of purpose be included on the
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
+```
+
+## rand_xorshift - 0.4.0
+
+**Repository URL**: https://github.com/rust-random/rngs
+**License Type(s)**: MIT OR Apache-2.0
+### License: https://spdx.org/licenses/
+### License File: LICENSE-APACHE
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+```
+
+### License File: LICENSE-MIT
+```
+Copyright 2018 Developers of the Rand project
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 ```
 
 ## rcgen - 0.13.2
@@ -50775,6 +51310,241 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
+
+## unarray - 0.1.4
+
+**Repository URL**: https://github.com/cameron1024/unarray
+**License Type(s)**: MIT OR Apache-2.0
+### License: https://spdx.org/licenses/
+### License File: LICENSE-APACHE
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```
+
+### License File: LICENSE-MIT
+```
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ## unicase - 2.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ dependencies = [
  "pythonize",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,9 +2224,12 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
+ "base64",
+ "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
+ "serde",
  "tonic",
  "tonic-prost",
 ]
@@ -2393,6 +2408,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.3",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
 ]
 
 [[package]]
@@ -2745,6 +2775,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rcgen"
@@ -4079,6 +4118,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -79,6 +79,8 @@ base64 = "0.22"
 ring = ">=0.17.13, <0.18"
 jsonschema = { version = "0.46.6", default-features = false }
 percent-encoding = "2"
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "trace", "with-serde"] }
+prost = "0.14"
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "logs", "metrics", "http-proto", "reqwest-blocking-client", "reqwest-rustls", "grpc-tonic", "tls-ring", "tls-roots"] }
 reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "rustls-tls-native-roots", "stream"] }
 # Match the HTTP client version used by opentelemetry-otlp.
@@ -104,7 +106,6 @@ tokio = { version = "1", features = ["rt", "macros", "sync", "test-util", "rt-mu
 futures = "0.3"
 opentelemetry_sdk = { workspace = true, features = ["trace", "logs", "metrics", "testing"] }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic", "logs", "metrics"] }
-prost = "0.14"
 tonic = { version = "0.14.1", features = ["transport"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 serde_json = "1"

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -44,6 +44,7 @@ mod confined_fs;
 pub(crate) mod manual;
 pub(crate) mod openinference;
 pub mod otel;
+pub mod otel_file;
 mod otel_genai;
 pub mod otel_logs;
 pub mod otel_metrics;

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -18,12 +18,14 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use super::otel_file::{OtlpFileFormat, OtlpFileSpanExporter};
 use super::otel_signal::{
     MetricMarkClassification, SignalRuntimeDiagnostics, classify_metric_mark, resolve_header_env,
     should_relog_runtime_diagnostic,
@@ -181,6 +183,23 @@ pub enum OtlpTransport {
     Grpc,
 }
 
+/// A local file destination for exported spans.
+///
+/// A file sink is a different kind of destination rather than another
+/// transport: it has no endpoint, no headers, and no timeout, so it is modelled
+/// separately instead of as an [`OtlpTransport`] variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OtlpFileSinkSettings {
+    /// Directory the output is confined to.
+    pub output_directory: PathBuf,
+    /// Full path of the output file, which must live under `output_directory`.
+    pub path: PathBuf,
+    /// On-disk encoding.
+    pub format: OtlpFileFormat,
+    /// Whether an existing file is appended to rather than truncated.
+    pub append: bool,
+}
+
 /// Completes a bare OTLP/HTTP base URL with the standard trace signal path.
 #[doc(hidden)]
 pub fn resolve_http_trace_endpoint(endpoint: &str) -> Cow<'_, str> {
@@ -275,6 +294,7 @@ pub struct OpenTelemetryConfig {
     max_export_batch_size: Option<usize>,
     scheduled_delay: Option<Duration>,
     completed_span_context_ttl: Duration,
+    file_sink: Option<OtlpFileSinkSettings>,
 }
 
 impl OpenTelemetryConfig {
@@ -300,6 +320,7 @@ impl OpenTelemetryConfig {
             max_export_batch_size: None,
             scheduled_delay: None,
             completed_span_context_ttl: DEFAULT_COMPLETED_SPAN_CONTEXT_TTL,
+            file_sink: None,
         }
     }
 
@@ -309,6 +330,33 @@ impl OpenTelemetryConfig {
             otel_type,
             endpoint: endpoint.into(),
             ..Self::default_values()
+        }
+    }
+
+    /// Creates a typed OpenTelemetry exporter writing OTLP to a local file.
+    ///
+    /// Unlike [`OpenTelemetryConfig::new`] this carries no endpoint: the spans
+    /// never cross a network, so endpoint validation does not apply to it.
+    pub fn new_file_sink(otel_type: OpenTelemetryType, file_sink: OtlpFileSinkSettings) -> Self {
+        Self {
+            otel_type,
+            file_sink: Some(file_sink),
+            ..Self::default_values()
+        }
+    }
+
+    /// Returns the file sink this config writes to, if it has one.
+    pub fn file_sink(&self) -> Option<&OtlpFileSinkSettings> {
+        self.file_sink.as_ref()
+    }
+
+    /// Returns the destination identity used in diagnostics and delivery errors.
+    ///
+    /// Never a URL's credentials or query: see [`trace_endpoint_log_identity`].
+    fn destination_label(&self) -> String {
+        match &self.file_sink {
+            Some(file_sink) => file_sink.path.display().to_string(),
+            None => self.endpoint.clone(),
         }
     }
 
@@ -586,16 +634,33 @@ impl OpenTelemetrySubscriber {
         )
     }
 
+    /// Creates a plugin-managed subscriber for a configured file sink.
+    pub(crate) fn new_for_plugin_file_sink(
+        config: OpenTelemetryConfig,
+        file_sink_index: usize,
+    ) -> Result<Self> {
+        Self::new_with_runtime_diagnostics(
+            config,
+            Some(format!(
+                "opentelemetry.file_sinks[{file_sink_index}].output_directory"
+            )),
+        )
+    }
+
     fn new_with_runtime_diagnostics(
         mut config: OpenTelemetryConfig,
         diagnostic_field: Option<String>,
     ) -> Result<Self> {
-        if config.endpoint.trim().is_empty() {
-            return Err(OpenTelemetryError::ExporterBuild(
-                "endpoint must be a nonblank string".to_string(),
-            ));
+        // A file sink has no endpoint to validate; everything below this point
+        // is destination-independent.
+        if config.file_sink.is_none() {
+            if config.endpoint.trim().is_empty() {
+                return Err(OpenTelemetryError::ExporterBuild(
+                    "endpoint must be a nonblank string".to_string(),
+                ));
+            }
+            validate_trace_endpoint(&config.endpoint)?;
         }
-        validate_trace_endpoint(&config.endpoint)?;
         if config.completed_span_context_ttl.is_zero() {
             return Err(OpenTelemetryError::ExporterBuild(
                 "completed_span_context_ttl must be greater than 0".to_string(),
@@ -1028,49 +1093,62 @@ fn build_tracer_provider_with_resource(
     runtime_diagnostics: SignalRuntimeDiagnostics,
     resource_attributes: Vec<KeyValue>,
 ) -> Result<SdkTracerProvider> {
-    let exporter = match config.transport {
-        OtlpTransport::HttpBinary => {
-            // Construct the blocking client outside any caller-owned async runtime,
-            // matching the OTLP exporter's default client construction behavior.
-            let timeout = config.timeout;
-            let client = thread::spawn(move || {
-                reqwest_otel::blocking::Client::builder()
-                    .timeout(timeout)
-                    .redirect(reqwest_otel::redirect::Policy::none())
+    let exporter = match &config.file_sink {
+        Some(file_sink) => TraceExporter::File(
+            OtlpFileSpanExporter::new(
+                &file_sink.output_directory,
+                &file_sink.path,
+                file_sink.format,
+                file_sink.append,
+            )
+            .map_err(|error| OpenTelemetryError::ExporterBuild(error.to_string()))?,
+        ),
+        None => TraceExporter::Otlp(match config.transport {
+            OtlpTransport::HttpBinary => {
+                // Construct the blocking client outside any caller-owned async runtime,
+                // matching the OTLP exporter's default client construction behavior.
+                let timeout = config.timeout;
+                let client = thread::spawn(move || {
+                    reqwest_otel::blocking::Client::builder()
+                        .timeout(timeout)
+                        .redirect(reqwest_otel::redirect::Policy::none())
+                        .build()
+                })
+                .join()
+                .map_err(|_| {
+                    OpenTelemetryError::ExporterBuild(
+                        "OTLP HTTP client construction panicked".into(),
+                    )
+                })?
+                .map_err(|error| OpenTelemetryError::ExporterBuild(error.to_string()))?;
+                let mut builder = OtlpSpanExporter::builder()
+                    .with_http()
+                    .with_http_client(client)
+                    .with_protocol(Protocol::HttpBinary)
+                    .with_timeout(config.timeout);
+                builder = builder
+                    .with_endpoint(resolve_http_trace_endpoint(&config.endpoint).into_owned());
+                if !config.headers.is_empty() {
+                    builder = builder.with_headers(config.headers.clone());
+                }
+                builder
                     .build()
-            })
-            .join()
-            .map_err(|_| {
-                OpenTelemetryError::ExporterBuild("OTLP HTTP client construction panicked".into())
-            })?
-            .map_err(|error| OpenTelemetryError::ExporterBuild(error.to_string()))?;
-            let mut builder = OtlpSpanExporter::builder()
-                .with_http()
-                .with_http_client(client)
-                .with_protocol(Protocol::HttpBinary)
-                .with_timeout(config.timeout);
-            builder =
-                builder.with_endpoint(resolve_http_trace_endpoint(&config.endpoint).into_owned());
-            if !config.headers.is_empty() {
-                builder = builder.with_headers(config.headers.clone());
+                    .map_err(|e| OpenTelemetryError::ExporterBuild(e.to_string()))?
             }
-            builder
-                .build()
-                .map_err(|e| OpenTelemetryError::ExporterBuild(e.to_string()))?
-        }
-        OtlpTransport::Grpc => {
-            let mut builder = OtlpSpanExporter::builder()
-                .with_tonic()
-                .with_protocol(Protocol::Grpc)
-                .with_timeout(config.timeout);
-            builder = builder.with_endpoint(config.endpoint.clone());
-            if !config.headers.is_empty() {
-                builder = builder.with_metadata(build_grpc_metadata(&config.headers)?);
+            OtlpTransport::Grpc => {
+                let mut builder = OtlpSpanExporter::builder()
+                    .with_tonic()
+                    .with_protocol(Protocol::Grpc)
+                    .with_timeout(config.timeout);
+                builder = builder.with_endpoint(config.endpoint.clone());
+                if !config.headers.is_empty() {
+                    builder = builder.with_metadata(build_grpc_metadata(&config.headers)?);
+                }
+                builder
+                    .build()
+                    .map_err(|e| OpenTelemetryError::ExporterBuild(e.to_string()))?
             }
-            builder
-                .build()
-                .map_err(|e| OpenTelemetryError::ExporterBuild(e.to_string()))?
-        }
+        }),
     };
 
     // Disable per-span attribute caps. Consumers may emit large attribute
@@ -1098,7 +1176,7 @@ fn build_tracer_provider_with_resource(
     }
     let processor = DiagnosticBatchSpanProcessor::new_with_batch_config(
         exporter,
-        config.endpoint.clone(),
+        config.destination_label(),
         runtime_diagnostics,
         batch_config.build(),
     );
@@ -1129,6 +1207,48 @@ fn canonical_resource_key(attributes: &[KeyValue]) -> String {
         .collect::<Vec<_>>();
     entries.sort();
     entries.join("\u{1f}")
+}
+
+/// Trace destinations this module can build.
+///
+/// `SpanExporter::export` returns `impl Future`, so the trait is not
+/// dyn-compatible and the destinations cannot be boxed behind it. A concrete
+/// enum keeps one exporter type flowing into `CountingSpanExporter` and the
+/// batch processor below it.
+#[derive(Debug)]
+enum TraceExporter {
+    Otlp(OtlpSpanExporter),
+    File(OtlpFileSpanExporter),
+}
+
+impl SpanExporter for TraceExporter {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        match self {
+            Self::Otlp(exporter) => exporter.export(batch).await,
+            Self::File(exporter) => exporter.export(batch).await,
+        }
+    }
+
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        match self {
+            Self::Otlp(exporter) => exporter.shutdown_with_timeout(timeout),
+            Self::File(exporter) => exporter.shutdown_with_timeout(timeout),
+        }
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        match self {
+            Self::Otlp(exporter) => exporter.force_flush(),
+            Self::File(exporter) => exporter.force_flush(),
+        }
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        match self {
+            Self::Otlp(exporter) => exporter.set_resource(resource),
+            Self::File(exporter) => exporter.set_resource(resource),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/core/src/observability/otel_file.rs
+++ b/crates/core/src/observability/otel_file.rs
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! OTLP file export for NeMo Relay Core.
+//!
+//! [`OtlpFileSpanExporter`] is a [`SpanExporter`] that writes the same
+//! `ExportTraceServiceRequest` the OTLP network exporters put on the wire to a
+//! local file instead. It exists for consumers that treat a trajectory as an
+//! artifact rather than as telemetry -- evaluation harnesses, offline replay,
+//! and any environment with no collector to export to.
+//!
+//! The default [`OtlpFileFormat::JsonLines`] follows the OpenTelemetry Protocol
+//! File Exporter specification: one OTLP/JSON-encoded request per line.
+//! [`OtlpFileFormat::Proto`] writes each request length-delimited, matching the
+//! OpenTelemetry Collector file exporter's `format: proto` layout, for
+//! consumers that would rather not pay JSON's size and parse cost.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema;
+use opentelemetry_proto::transform::trace::tonic::group_spans_by_resource_and_scope;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+use opentelemetry_sdk::trace::{SpanData, SpanExporter};
+use prost::Message;
+use serde::{Deserialize, Serialize};
+
+use super::private_file::{create_private_dir_all, open_private};
+
+/// Result type for the OTLP file exporter.
+pub type Result<T> = std::result::Result<T, OtlpFileExporterError>;
+
+/// Errors produced while configuring or operating the OTLP file exporter.
+#[derive(Debug, thiserror::Error)]
+pub enum OtlpFileExporterError {
+    /// Failed to create the directory containing the output file.
+    #[error("failed to create OTLP output directory {path:?}: {source}")]
+    CreateDirectory {
+        /// Directory that could not be created.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// Failed to open the output file.
+    #[error("failed to open OTLP output file {path:?}: {source}")]
+    OpenFile {
+        /// Output path that failed to open.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+}
+
+/// On-disk encoding used by [`OtlpFileSpanExporter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OtlpFileFormat {
+    /// One OTLP/JSON-encoded `ExportTraceServiceRequest` per line.
+    ///
+    /// This is the serialization described by the OpenTelemetry Protocol File
+    /// Exporter specification, and the default for that reason.
+    #[default]
+    JsonLines,
+    /// Length-delimited OTLP protobuf: a big-endian `u32` byte count followed
+    /// by that many bytes of encoded `ExportTraceServiceRequest`.
+    Proto,
+}
+
+impl OtlpFileFormat {
+    /// Returns the conventional file extension for the format.
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::JsonLines => "jsonl",
+            Self::Proto => "otlp.pb",
+        }
+    }
+}
+
+/// Writes exported spans to a local file as OTLP.
+///
+/// The exporter owns its writer and closes it on shutdown. Every export is
+/// flushed before it returns: a batch that the SDK reports as delivered is
+/// durable on disk, so a run that dies between batches still leaves a readable
+/// prefix rather than an empty file.
+#[derive(Debug)]
+pub struct OtlpFileSpanExporter {
+    path: PathBuf,
+    format: OtlpFileFormat,
+    writer: Mutex<Option<BufWriter<File>>>,
+    resource: ResourceAttributesWithSchema,
+}
+
+impl OtlpFileSpanExporter {
+    /// Creates an exporter writing `path` in `format`.
+    ///
+    /// `root` confines the output the same way the ATOF and ATIF file sinks are
+    /// confined, and the file is created with owner-only permissions because a
+    /// trajectory carries prompt and response content.
+    pub fn new(root: &Path, path: &Path, format: OtlpFileFormat, append: bool) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            create_private_dir_all(parent).map_err(|source| {
+                OtlpFileExporterError::CreateDirectory {
+                    path: parent.to_path_buf(),
+                    source,
+                }
+            })?;
+        }
+        let file =
+            open_private(root, path, append).map_err(|source| OtlpFileExporterError::OpenFile {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            format,
+            writer: Mutex::new(Some(BufWriter::new(file))),
+            resource: ResourceAttributesWithSchema::default(),
+        })
+    }
+
+    /// Returns the path this exporter writes to.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Encodes one export request in the configured format.
+    ///
+    /// Kept separate from the write so the framing is testable without a file,
+    /// and so a serialization failure never leaves a partial record behind: the
+    /// record is fully encoded before any of it reaches the writer.
+    fn encode(&self, request: &ExportTraceServiceRequest) -> std::result::Result<Vec<u8>, String> {
+        match self.format {
+            OtlpFileFormat::JsonLines => {
+                // Compact, never pretty: the specification's file layout is one
+                // record per line, so an embedded newline would split a record.
+                let mut line = serde_json::to_vec(request)
+                    .map_err(|error| format!("failed to serialize OTLP/JSON: {error}"))?;
+                line.push(b'\n');
+                Ok(line)
+            }
+            OtlpFileFormat::Proto => {
+                let payload = request.encode_to_vec();
+                let length = u32::try_from(payload.len()).map_err(|_| {
+                    format!(
+                        "OTLP export of {} bytes exceeds the length-delimited frame maximum",
+                        payload.len()
+                    )
+                })?;
+                let mut frame = Vec::with_capacity(payload.len() + 4);
+                frame.extend_from_slice(&length.to_be_bytes());
+                frame.extend_from_slice(&payload);
+                Ok(frame)
+            }
+        }
+    }
+}
+
+impl SpanExporter for OtlpFileSpanExporter {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        // An empty batch would otherwise encode to a record with no spans,
+        // which a reader cannot distinguish from a lost one.
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let resource_spans = group_spans_by_resource_and_scope(batch, &self.resource);
+        let record = self
+            .encode(&ExportTraceServiceRequest { resource_spans })
+            .map_err(OTelSdkError::InternalFailure)?;
+
+        let mut guard = self
+            .writer
+            .lock()
+            .map_err(|_| OTelSdkError::InternalFailure(lock_poisoned(&self.path)))?;
+        let writer = guard.as_mut().ok_or(OTelSdkError::AlreadyShutdown)?;
+        writer
+            .write_all(&record)
+            .and_then(|()| writer.flush())
+            .map_err(|error| {
+                OTelSdkError::InternalFailure(format!(
+                    "failed to write OTLP export to {:?}: {error}",
+                    self.path
+                ))
+            })
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+        let mut guard = self
+            .writer
+            .lock()
+            .map_err(|_| OTelSdkError::InternalFailure(lock_poisoned(&self.path)))?;
+        let Some(mut writer) = guard.take() else {
+            return Err(OTelSdkError::AlreadyShutdown);
+        };
+        writer.flush().map_err(|error| {
+            OTelSdkError::InternalFailure(format!(
+                "failed to flush OTLP output file {:?}: {error}",
+                self.path
+            ))
+        })
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        let mut guard = self
+            .writer
+            .lock()
+            .map_err(|_| OTelSdkError::InternalFailure(lock_poisoned(&self.path)))?;
+        // A flush after shutdown is not an error: every record the exporter
+        // accepted is already durable, so there is nothing left to fail on.
+        let Some(writer) = guard.as_mut() else {
+            return Ok(());
+        };
+        writer.flush().map_err(|error| {
+            OTelSdkError::InternalFailure(format!(
+                "failed to flush OTLP output file {:?}: {error}",
+                self.path
+            ))
+        })
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        self.resource = resource.into();
+    }
+}
+
+fn lock_poisoned(path: &Path) -> String {
+    format!("the OTLP file exporter state lock for {path:?} was poisoned")
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[path = "../../tests/unit/observability/otel_file_tests.rs"]
+mod tests;

--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -731,6 +731,7 @@ crate::editor_config! {
     impl OpenTelemetrySectionConfig {
         enabled => { label: "enabled", kind: Boolean },
         endpoints => { label: "traces", kind: List, name: "traces", list: &OPENTELEMETRY_ENDPOINT_LIST },
+        file_sinks => { label: "file_sinks", kind: List, list: &OPENTELEMETRY_FILE_SINK_LIST },
         logs => {
             label: "logs",
             kind: Section,
@@ -900,6 +901,84 @@ impl EditorConfig for OpenTelemetryEndpointConfig {
     }
 }
 
+impl EditorConfig for OpenTelemetryFileSinkConfig {
+    fn editor_schema() -> &'static EditorSchema {
+        static SCHEMA: EditorSchema = EditorSchema {
+            fields: &[
+                otel_editor_field(
+                    "type",
+                    EditorFieldKind::Enum,
+                    &["full", "gen_ai", "openinference"],
+                    false,
+                ),
+                otel_editor_field("output_directory", EditorFieldKind::String, &[], false),
+                otel_editor_field("filename", EditorFieldKind::String, &[], true),
+                otel_editor_field(
+                    "format",
+                    EditorFieldKind::Enum,
+                    &["json_lines", "proto"],
+                    false,
+                ),
+                otel_editor_field(
+                    "mode",
+                    EditorFieldKind::Enum,
+                    &["append", "overwrite"],
+                    false,
+                ),
+                otel_editor_field(
+                    "mark_projection",
+                    EditorFieldKind::Enum,
+                    &["inherit", "event", "tool"],
+                    false,
+                ),
+                otel_list_editor_field(
+                    "mark_exclude_names",
+                    false,
+                    &crate::config_editor::STRING_LIST_ITEM,
+                ),
+                otel_editor_field("attribute_mappings", EditorFieldKind::List, &[], false),
+                otel_editor_field(
+                    "promote_metadata_prefixes",
+                    EditorFieldKind::List,
+                    &[],
+                    true,
+                ),
+                otel_editor_field(
+                    "promote_resource_metadata_prefixes",
+                    EditorFieldKind::List,
+                    &[],
+                    true,
+                ),
+                otel_editor_field("service_name", EditorFieldKind::String, &[], false),
+                otel_editor_field("service_namespace", EditorFieldKind::String, &[], true),
+                otel_editor_field("service_version", EditorFieldKind::String, &[], true),
+                otel_editor_field("instrumentation_scope", EditorFieldKind::String, &[], false),
+                otel_editor_field("max_queue_size", EditorFieldKind::Integer, &[], true),
+                otel_editor_field("max_export_batch_size", EditorFieldKind::Integer, &[], true),
+                otel_editor_field(
+                    "scheduled_delay_millis",
+                    EditorFieldKind::Integer,
+                    &[],
+                    true,
+                ),
+                otel_editor_field(
+                    "completed_span_context_ttl_millis",
+                    EditorFieldKind::Integer,
+                    &[],
+                    true,
+                ),
+                otel_editor_field(
+                    "resource_attributes",
+                    EditorFieldKind::StringMap,
+                    &[],
+                    false,
+                ),
+            ],
+        };
+        &SCHEMA
+    }
+}
+
 impl EditorConfig for OpenTelemetrySignalEndpointConfig {
     fn editor_schema() -> &'static EditorSchema {
         static SCHEMA: EditorSchema = EditorSchema {
@@ -948,6 +1027,26 @@ static OPENTELEMETRY_ENDPOINT_LIST: EditorListItemSpec = EditorListItemSpec {
     kind: EditorFieldKind::Section,
     schema: Some(<OpenTelemetryEndpointConfig as EditorConfig>::editor_schema),
     default: Some(default_opentelemetry_endpoint_editor_value),
+    tagged_union: None,
+    list_item: None,
+};
+
+fn default_opentelemetry_file_sink_editor_value() -> Json {
+    serde_json::json!({
+        "type": "full",
+        "output_directory": "",
+        "format": "json_lines",
+        "mode": "overwrite",
+        "service_name": "unknown_service",
+        "instrumentation_scope": "opentelemetry",
+        "resource_attributes": {},
+    })
+}
+
+static OPENTELEMETRY_FILE_SINK_LIST: EditorListItemSpec = EditorListItemSpec {
+    kind: EditorFieldKind::Section,
+    schema: Some(<OpenTelemetryFileSinkConfig as EditorConfig>::editor_schema),
+    default: Some(default_opentelemetry_file_sink_editor_value),
     tagged_union: None,
     list_item: None,
 };
@@ -4143,16 +4242,45 @@ fn validate_opentelemetry_section(
             .metrics
             .as_ref()
             .is_some_and(|signal| signal.enabled);
-    if section.enabled && section.endpoints.is_empty() && !has_enabled_signal {
+    if section.enabled
+        && section.endpoints.is_empty()
+        && section.file_sinks.is_empty()
+        && !has_enabled_signal
+    {
         push_policy_diag(
             diagnostics,
             policy.unsupported_value,
             "observability.unsupported_value",
             Some("opentelemetry".to_string()),
             Some("endpoints".to_string()),
-            "enabled OpenTelemetry section requires at least one endpoint or an enabled log/metric signal"
+            "enabled OpenTelemetry section requires at least one endpoint, one file sink, or an enabled log/metric signal"
                 .to_string(),
         );
+    }
+    for (index, file_sink) in section.file_sinks.iter().enumerate() {
+        if file_sink.output_directory.as_os_str().is_empty() {
+            push_policy_diag(
+                diagnostics,
+                policy.unsupported_value,
+                "observability.unsupported_value",
+                Some("opentelemetry".to_string()),
+                Some(format!("file_sinks[{index}].output_directory")),
+                "OpenTelemetry file sink output_directory must be a nonblank path".to_string(),
+            );
+        }
+        if !matches!(file_sink.mode.as_str(), "append" | "overwrite") {
+            push_policy_diag(
+                diagnostics,
+                policy.unsupported_value,
+                "observability.unsupported_value",
+                Some("opentelemetry".to_string()),
+                Some(format!("file_sinks[{index}].mode")),
+                format!(
+                    "OpenTelemetry file sink mode must be 'append' or 'overwrite', got {:?}",
+                    file_sink.mode
+                ),
+            );
+        }
     }
     for (index, endpoint) in section.endpoints.iter().enumerate() {
         if endpoint.endpoint.trim().is_empty() {

--- a/crates/core/src/observability/plugin_component.rs
+++ b/crates/core/src/observability/plugin_component.rs
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as Json};
 use uuid::Uuid;
 
+use super::otel_file::OtlpFileFormat;
 use super::private_file::atomic_private_write;
 use crate::api::event::{Event, LogSeverity, ScopeCategory, ValidatedMetricMeasurement};
 use crate::api::runtime::{EventSubscriberFn, current_scope_stack, global_context};
@@ -55,8 +56,8 @@ use crate::observability::atof::{
     AtofSinkConfig as CoreAtofSinkConfig, AtofStreamSinkConfig,
 };
 use crate::observability::otel::{
-    OpenTelemetryConfig as CoreOpenTelemetryConfig, OpenTelemetrySubscriber, OtlpTransport,
-    resolve_http_trace_endpoint,
+    OpenTelemetryConfig as CoreOpenTelemetryConfig, OpenTelemetrySubscriber, OtlpFileSinkSettings,
+    OtlpTransport, resolve_http_trace_endpoint,
 };
 use crate::observability::otel_logs::{
     OpenTelemetryLogConfig as CoreOpenTelemetryLogConfig, OpenTelemetryLogSubscriber,
@@ -81,6 +82,7 @@ use crate::plugin::{
     register_builtin_plugin,
 };
 use crate::plugin::{RuntimeDiagnostic, record_active_plugin_runtime_diagnostic};
+use chrono::Utc;
 
 /// The plugin kind registered by the core crate.
 pub const OBSERVABILITY_PLUGIN_KIND: &str = "observability";
@@ -182,6 +184,9 @@ pub struct OpenTelemetrySectionConfig {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub endpoints: Vec<OpenTelemetryEndpointConfig>,
+    /// Local file destinations that receive the same projected spans.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_sinks: Vec<OpenTelemetryFileSinkConfig>,
     /// Optional OTLP log pipeline sourced from non-metric marks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logs: Option<OpenTelemetryLogSectionConfig>,
@@ -373,6 +378,77 @@ pub struct OpenTelemetryEndpointConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_export_batch_size: Option<usize>,
     /// Maximum delay before exporting a non-full batch, in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_delay_millis: Option<u64>,
+    /// How long completed scopes retain trace context for late marks, in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_span_context_ttl_millis: Option<u64>,
+}
+
+/// One local file destination for projected OTLP spans.
+///
+/// A file sink writes the same `ExportTraceServiceRequest` an OTLP endpoint
+/// would receive, so a consumer that reads trajectories as artifacts needs no
+/// collector. It shares the projection and batching settings with
+/// [`OpenTelemetryEndpointConfig`] and drops the fields that only a network
+/// destination has: endpoint, transport, headers, and timeout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct OpenTelemetryFileSinkConfig {
+    /// Semantic projection written to this file.
+    #[serde(rename = "type", default)]
+    pub otel_type: OpenTelemetryType,
+    /// Directory containing the output file.
+    pub output_directory: PathBuf,
+    /// Output filename. Defaults to a timestamped name for the chosen format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// On-disk encoding: `json_lines` or `proto`.
+    #[serde(default)]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "otlp_file_format_schema"))]
+    pub format: OtlpFileFormat,
+    /// File open mode: `append` or `overwrite`.
+    #[serde(default = "default_otlp_file_sink_mode")]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "atof_mode_schema"))]
+    pub mode: String,
+    /// Representation used for point-in-time marks.
+    #[serde(default)]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "mark_projection_schema"))]
+    pub mark_projection: MarkProjection,
+    /// Mark names excluded from tool projection.
+    #[serde(default = "default_mark_exclude_names")]
+    pub mark_exclude_names: Vec<String>,
+    /// Projected attributes copied to aliases.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attribute_mappings: Vec<OtlpAttributeMapping>,
+    /// Literal Event metadata prefixes copied to top-level OTLP attributes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub promote_metadata_prefixes: Vec<String>,
+    /// Literal root-scope Event metadata prefixes copied to OTLP resource attributes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub promote_resource_metadata_prefixes: Vec<String>,
+    /// Extra resource attributes.
+    #[serde(default)]
+    pub resource_attributes: HashMap<String, String>,
+    /// `service.name` resource attribute.
+    #[serde(default = "default_otel_service_name")]
+    pub service_name: String,
+    /// Optional `service.namespace` resource attribute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_namespace: Option<String>,
+    /// Optional `service.version` resource attribute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_version: Option<String>,
+    /// Instrumentation scope name.
+    #[serde(default = "default_otel_instrumentation_scope")]
+    pub instrumentation_scope: String,
+    /// Maximum completed spans buffered before the sink drops new spans.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_queue_size: Option<usize>,
+    /// Maximum spans written in one batch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_export_batch_size: Option<usize>,
+    /// Maximum delay before writing a non-full batch, in milliseconds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scheduled_delay_millis: Option<u64>,
     /// How long completed scopes retain trace context for late marks, in milliseconds.
@@ -1125,6 +1201,13 @@ fn otlp_transport_schema(
 }
 
 #[cfg(feature = "schema")]
+fn otlp_file_format_schema(
+    generator: &mut schemars::r#gen::SchemaGenerator,
+) -> schemars::schema::Schema {
+    string_enum_schema(generator, &["json_lines", "proto"], Some("json_lines"))
+}
+
+#[cfg(feature = "schema")]
 fn mark_projection_schema(
     generator: &mut schemars::r#gen::SchemaGenerator,
 ) -> schemars::schema::Schema {
@@ -1504,19 +1587,21 @@ fn register_opentelemetry(
 ) -> PluginResult<()> {
     let OpenTelemetrySectionConfig {
         endpoints,
+        file_sinks,
         logs,
         metrics,
         ..
     } = section;
     let logs = logs.filter(|section| section.enabled);
     let metrics = metrics.filter(|section| section.enabled);
-    if endpoints.is_empty() && logs.is_none() && metrics.is_none() {
+    if endpoints.is_empty() && file_sinks.is_empty() && logs.is_none() && metrics.is_none() {
         return Err(PluginError::InvalidConfig(
-            "enabled OpenTelemetry section requires at least one endpoint or an enabled log/metric signal"
+            "enabled OpenTelemetry section requires at least one endpoint, one file sink, or an enabled log/metric signal"
                 .to_string(),
         ));
     }
     validate_distinct_opentelemetry_destinations(&endpoints)?;
+    validate_distinct_opentelemetry_file_sinks(&file_sinks)?;
     let log_resolution = logs
         .as_ref()
         .map(|section| resolve_signal_endpoints("logs", section.endpoints.as_ref(), &endpoints))
@@ -1531,7 +1616,11 @@ fn register_opentelemetry(
     if let Some(resolution) = &metric_resolution {
         warn_skipped_signal_endpoints("metrics", &resolution.endpoints);
     }
-    let trace_subscribers = build_opentelemetry_subscribers(endpoints)?;
+    let mut trace_subscribers = build_opentelemetry_subscribers(endpoints)?;
+    // File sinks join the trace fan-out: they receive the same projected spans
+    // an endpoint would, so logs and metrics derive from endpoints only.
+    let file_sink_subscribers =
+        build_opentelemetry_file_sink_subscribers(file_sinks, trace_subscribers.len())?;
     let signal_subscribers = build_opentelemetry_signal_subscribers(
         logs,
         log_resolution,
@@ -1539,6 +1628,8 @@ fn register_opentelemetry(
         metric_resolution,
         &trace_subscribers,
     )?;
+    trace_subscribers.extend(file_sink_subscribers);
+    let trace_subscribers = trace_subscribers;
     let log_subscribers = signal_subscribers.logs;
     let metric_subscribers = signal_subscribers.metrics;
     if !has_active_opentelemetry_resource(&trace_subscribers)
@@ -1874,6 +1965,43 @@ fn build_opentelemetry_subscribers(
                     resource_kind = "otlp_endpoint",
                     resource_index = index;
                     "OpenTelemetry endpoint was skipped during activation; delivery continues to valid endpoints: {error}"
+                );
+                subscribers.push(IndexedOpenTelemetryResource {
+                    index,
+                    value: OpenTelemetryResource::Skipped(error.to_string()),
+                });
+            }
+        }
+    }
+    Ok(subscribers)
+}
+
+fn build_opentelemetry_file_sink_subscribers(
+    file_sinks: Vec<OpenTelemetryFileSinkConfig>,
+    index_offset: usize,
+) -> PluginResult<Vec<IndexedOpenTelemetryResource<Arc<OpenTelemetrySubscriber>>>> {
+    let mut subscribers = Vec::with_capacity(file_sinks.len());
+    for (index, file_sink) in file_sinks.into_iter().enumerate() {
+        let subscriber = build_otel_file_config(index, file_sink).and_then(|config| {
+            OpenTelemetrySubscriber::new_for_plugin_file_sink(config, index)
+                .map_err(observability_registration_error)
+        });
+        // Offset so a file sink and an endpoint never share a fan-out index,
+        // while the diagnostic field above still reports the configured slot.
+        let index = index_offset + index;
+        match subscriber {
+            Ok(value) => subscribers.push(IndexedOpenTelemetryResource {
+                index,
+                value: OpenTelemetryResource::Active(Arc::new(value)),
+            }),
+            Err(error) => {
+                log::warn!(
+                    target: "nemo_relay.plugin",
+                    event = "opentelemetry_file_sink_skipped",
+                    plugin_kind = OBSERVABILITY_PLUGIN_KIND,
+                    resource_kind = "otlp_file_sink",
+                    resource_index = index;
+                    "OpenTelemetry file sink was skipped during activation; delivery continues to valid destinations: {error}"
                 );
                 subscribers.push(IndexedOpenTelemetryResource {
                     index,
@@ -3361,6 +3489,131 @@ fn build_otel_config(
     Ok(config)
 }
 
+fn build_otel_file_config(
+    index: usize,
+    section: OpenTelemetryFileSinkConfig,
+) -> PluginResult<CoreOpenTelemetryConfig> {
+    if section.output_directory.as_os_str().is_empty() {
+        return Err(PluginError::InvalidConfig(format!(
+            "OpenTelemetry file_sinks[{index}].output_directory must be a nonblank path"
+        )));
+    }
+    let append = match section.mode.as_str() {
+        "append" => true,
+        "overwrite" => false,
+        other => {
+            return Err(PluginError::InvalidConfig(format!(
+                "OpenTelemetry file_sinks[{index}].mode must be 'append' or 'overwrite', got {other:?}"
+            )));
+        }
+    };
+    validate_otel_file_sink_batch_config(index, &section)?;
+    let filename = match section.filename {
+        Some(filename) => {
+            validate_otel_file_sink_filename(index, &filename)?;
+            filename
+        }
+        None => default_otlp_file_sink_filename(section.format),
+    };
+
+    let settings = OtlpFileSinkSettings {
+        path: section.output_directory.join(&filename),
+        output_directory: section.output_directory,
+        format: section.format,
+        append,
+    };
+    let mut config = CoreOpenTelemetryConfig::new_file_sink(section.otel_type, settings)
+        .with_service_name(section.service_name)
+        .with_instrumentation_scope(section.instrumentation_scope)
+        .with_mark_projection(section.mark_projection)
+        .with_mark_exclude_names(section.mark_exclude_names)
+        .with_attribute_mappings(section.attribute_mappings)
+        .with_promote_metadata_prefixes(section.promote_metadata_prefixes)
+        .with_promote_resource_metadata_prefixes(section.promote_resource_metadata_prefixes);
+    if let Some(max_queue_size) = section.max_queue_size {
+        config = config.with_max_queue_size(max_queue_size);
+    }
+    if let Some(max_export_batch_size) = section.max_export_batch_size {
+        config = config.with_max_export_batch_size(max_export_batch_size);
+    }
+    if let Some(scheduled_delay_millis) = section.scheduled_delay_millis {
+        config = config.with_scheduled_delay(Duration::from_millis(scheduled_delay_millis));
+    }
+    if let Some(completed_span_context_ttl_millis) = section.completed_span_context_ttl_millis {
+        config = config.with_completed_span_context_ttl(Duration::from_millis(
+            completed_span_context_ttl_millis,
+        ));
+    }
+    if let Some(namespace) = section.service_namespace {
+        config = config.with_service_namespace(namespace);
+    }
+    if let Some(version) = section.service_version {
+        config = config.with_service_version(version);
+    }
+    for (key, value) in section.resource_attributes {
+        config = config.with_resource_attribute(key, value);
+    }
+    Ok(config)
+}
+
+/// Rejects a filename that would escape `output_directory`.
+///
+/// The exporter confines its writes as well, but a path component here is a
+/// configuration mistake worth naming rather than an I/O error at export time.
+fn validate_otel_file_sink_filename(index: usize, filename: &str) -> PluginResult<()> {
+    if filename.trim().is_empty() || filename.trim() != filename {
+        return Err(PluginError::InvalidConfig(format!(
+            "OpenTelemetry file_sinks[{index}].filename must be nonblank and unpadded"
+        )));
+    }
+    if Path::new(filename).components().count() != 1
+        || matches!(
+            Path::new(filename).components().next(),
+            Some(Component::ParentDir) | Some(Component::RootDir) | Some(Component::Prefix(_))
+        )
+    {
+        return Err(PluginError::InvalidConfig(format!(
+            "OpenTelemetry file_sinks[{index}].filename must be a single path component"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_otel_file_sink_batch_config(
+    index: usize,
+    section: &OpenTelemetryFileSinkConfig,
+) -> PluginResult<()> {
+    for (field, value) in [
+        ("max_queue_size", section.max_queue_size),
+        ("max_export_batch_size", section.max_export_batch_size),
+    ] {
+        if value == Some(0) {
+            return Err(PluginError::InvalidConfig(format!(
+                "OpenTelemetry file_sinks[{index}].{field} must be greater than 0"
+            )));
+        }
+    }
+    if section.scheduled_delay_millis == Some(0) {
+        return Err(PluginError::InvalidConfig(format!(
+            "OpenTelemetry file_sinks[{index}].scheduled_delay_millis must be greater than 0"
+        )));
+    }
+    if section.completed_span_context_ttl_millis == Some(0) {
+        return Err(PluginError::InvalidConfig(format!(
+            "OpenTelemetry file_sinks[{index}].completed_span_context_ttl_millis must be greater than 0"
+        )));
+    }
+    if matches!(
+        (section.max_export_batch_size, section.max_queue_size),
+        (Some(batch), Some(queue)) if batch > queue
+    ) {
+        return Err(PluginError::InvalidConfig(format!(
+            "OpenTelemetry file_sinks[{index}].max_export_batch_size must be less than or equal to max_queue_size"
+        )));
+    }
+    Ok(())
+}
+
 fn validate_otel_batch_config(
     index: usize,
     section: &OpenTelemetryEndpointConfig,
@@ -4326,6 +4579,30 @@ fn validate_distinct_opentelemetry_destinations(
     Ok(())
 }
 
+/// Rejects two file sinks writing the same path.
+///
+/// Two exporters appending to one file interleave their records; two
+/// overwriting it race. Either way the trace that survives is not the one
+/// either sink was configured to produce.
+fn validate_distinct_opentelemetry_file_sinks(
+    file_sinks: &[OpenTelemetryFileSinkConfig],
+) -> PluginResult<()> {
+    let mut seen: HashMap<PathBuf, usize> = HashMap::new();
+    for (index, file_sink) in file_sinks.iter().enumerate() {
+        let filename = file_sink
+            .filename
+            .clone()
+            .unwrap_or_else(|| default_otlp_file_sink_filename(file_sink.format));
+        let path = file_sink.output_directory.join(filename);
+        if let Some(other_index) = seen.insert(path.clone(), index) {
+            return Err(PluginError::InvalidConfig(format!(
+                "OpenTelemetry file_sinks[{other_index}] and file_sinks[{index}] write the same path {path:?}; each sink requires its own file"
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn opentelemetry_destination_collision_errors(
     endpoints: &[OpenTelemetryEndpointConfig],
 ) -> Vec<OpenTelemetryDestinationCollision> {
@@ -5264,6 +5541,18 @@ fn default_atif_filename_template() -> String {
 
 fn default_otlp_transport() -> String {
     "http_binary".to_string()
+}
+
+fn default_otlp_file_sink_mode() -> String {
+    "overwrite".to_string()
+}
+
+fn default_otlp_file_sink_filename(format: OtlpFileFormat) -> String {
+    format!(
+        "nemo-relay-otlp-{}.{}",
+        Utc::now().format("%Y-%m-%d-%H.%M.%S"),
+        format.extension()
+    )
 }
 
 fn default_otel_service_name() -> String {

--- a/crates/core/tests/unit/observability/otel_file_tests.rs
+++ b/crates/core/tests/unit/observability/otel_file_tests.rs
@@ -1,0 +1,442 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for the OTLP file exporter.
+//!
+//! The round-trip assertions decode with `prost` and `serde_json` directly
+//! rather than through this module's own encoder, so a writer and reader that
+//! agree only with each other cannot pass.
+
+use super::*;
+use opentelemetry::KeyValue;
+use opentelemetry::trace::{Tracer, TracerProvider};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+use serde_json::Value as Json;
+use std::fs;
+
+fn sample_spans(names: &[&str]) -> Vec<SpanData> {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("nemo-relay-otlp-file-tests");
+    for name in names {
+        tracer.in_span(name.to_string(), |_cx| {});
+    }
+    provider.force_flush().unwrap();
+    exporter.get_finished_spans().unwrap()
+}
+
+fn exporter_at(
+    directory: &Path,
+    filename: &str,
+    format: OtlpFileFormat,
+    append: bool,
+) -> OtlpFileSpanExporter {
+    OtlpFileSpanExporter::new(directory, &directory.join(filename), format, append).unwrap()
+}
+
+/// Reads length-delimited protobuf frames without using the exporter's encoder.
+fn read_proto_frames(path: &Path) -> Vec<ExportTraceServiceRequest> {
+    let bytes = fs::read(path).unwrap();
+    let mut requests = Vec::new();
+    let mut offset = 0usize;
+    while offset < bytes.len() {
+        let length = u32::from_be_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
+        offset += 4;
+        let frame = &bytes[offset..offset + length];
+        offset += length;
+        requests.push(ExportTraceServiceRequest::decode(frame).unwrap());
+    }
+    requests
+}
+
+fn read_json_lines(path: &Path) -> Vec<Json> {
+    fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+fn span_names(request: &ExportTraceServiceRequest) -> Vec<String> {
+    request
+        .resource_spans
+        .iter()
+        .flat_map(|resource| resource.scope_spans.iter())
+        .flat_map(|scope| scope.spans.iter())
+        .map(|span| span.name.clone())
+        .collect()
+}
+
+#[tokio::test]
+async fn proto_export_round_trips_through_an_independent_decoder() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.otlp.pb",
+        OtlpFileFormat::Proto,
+        false,
+    );
+    let spans = sample_spans(&["outer", "inner"]);
+
+    exporter.export(spans).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let requests = read_proto_frames(&directory.path().join("trace.otlp.pb"));
+    assert_eq!(requests.len(), 1, "one export is one frame");
+    let mut names = span_names(&requests[0]);
+    names.sort();
+    assert_eq!(names, vec!["inner".to_string(), "outer".to_string()]);
+}
+
+#[tokio::test]
+async fn proto_frames_are_length_prefixed_big_endian() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.otlp.pb",
+        OtlpFileFormat::Proto,
+        false,
+    );
+    exporter.export(sample_spans(&["only"])).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let bytes = fs::read(directory.path().join("trace.otlp.pb")).unwrap();
+    let declared = u32::from_be_bytes(bytes[..4].try_into().unwrap()) as usize;
+    assert_eq!(
+        declared,
+        bytes.len() - 4,
+        "the prefix must describe exactly the bytes that follow it"
+    );
+}
+
+#[tokio::test]
+async fn each_proto_export_appends_one_frame() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.otlp.pb",
+        OtlpFileFormat::Proto,
+        false,
+    );
+    exporter.export(sample_spans(&["first"])).await.unwrap();
+    exporter.export(sample_spans(&["second"])).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let requests = read_proto_frames(&directory.path().join("trace.otlp.pb"));
+    assert_eq!(requests.len(), 2);
+    assert_eq!(span_names(&requests[0]), vec!["first".to_string()]);
+    assert_eq!(span_names(&requests[1]), vec!["second".to_string()]);
+}
+
+#[tokio::test]
+async fn json_lines_export_is_one_json_object_per_export() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+    exporter.export(sample_spans(&["first"])).await.unwrap();
+    exporter.export(sample_spans(&["second"])).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let lines = read_json_lines(&directory.path().join("trace.jsonl"));
+    assert_eq!(
+        lines.len(),
+        2,
+        "one line per export, per the file-exporter spec"
+    );
+    assert!(lines.iter().all(|line| line.is_object()));
+}
+
+#[tokio::test]
+async fn json_lines_encode_span_identifiers_as_hex() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+    exporter.export(sample_spans(&["only"])).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let lines = read_json_lines(&directory.path().join("trace.jsonl"));
+    let span = lines[0]
+        .pointer("/resourceSpans/0/scopeSpans/0/spans/0")
+        .expect("OTLP/JSON uses camelCase member names");
+    let trace_id = span.pointer("/traceId").unwrap().as_str().unwrap();
+    let span_id = span.pointer("/spanId").unwrap().as_str().unwrap();
+    // OTLP/JSON encodes these two fields as hex rather than the base64 the
+    // protobuf JSON mapping would otherwise give a bytes field.
+    assert_eq!(trace_id.len(), 32);
+    assert_eq!(span_id.len(), 16);
+    assert!(trace_id.chars().all(|c| c.is_ascii_hexdigit()));
+    assert!(span_id.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[tokio::test]
+async fn json_lines_records_never_contain_an_embedded_newline() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+    // A span name carrying a newline would split the record if the encoder
+    // ever pretty-printed.
+    let exporter_spans = sample_spans(&["outer\nnewline"]);
+    exporter.export(exporter_spans).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let contents = fs::read_to_string(directory.path().join("trace.jsonl")).unwrap();
+    assert_eq!(contents.matches('\n').count(), 1);
+    assert!(contents.ends_with('\n'));
+}
+
+#[tokio::test]
+async fn an_empty_batch_writes_no_record() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+    exporter.export(Vec::new()).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let contents = fs::read_to_string(directory.path().join("trace.jsonl")).unwrap();
+    assert!(
+        contents.is_empty(),
+        "an empty record would be indistinguishable from a lost one"
+    );
+}
+
+#[tokio::test]
+async fn resource_attributes_reach_the_written_record() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut exporter = exporter_at(
+        directory.path(),
+        "trace.otlp.pb",
+        OtlpFileFormat::Proto,
+        false,
+    );
+    let resource = Resource::builder_empty()
+        .with_attributes(vec![KeyValue::new("service.name", "relay-file-sink")])
+        .build();
+    exporter.set_resource(&resource);
+    exporter.export(sample_spans(&["only"])).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let requests = read_proto_frames(&directory.path().join("trace.otlp.pb"));
+    let attributes = &requests[0].resource_spans[0]
+        .resource
+        .as_ref()
+        .unwrap()
+        .attributes;
+    assert!(
+        attributes
+            .iter()
+            .any(|attribute| attribute.key == "service.name"),
+        "set_resource must reach the encoded request"
+    );
+}
+
+#[tokio::test]
+async fn exporting_after_shutdown_is_rejected() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let error = exporter.export(sample_spans(&["late"])).await.unwrap_err();
+    assert!(matches!(error, OTelSdkError::AlreadyShutdown));
+}
+
+#[test]
+fn shutting_down_twice_is_rejected() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let error = exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap_err();
+    assert!(matches!(error, OTelSdkError::AlreadyShutdown));
+}
+
+#[test]
+fn flushing_after_shutdown_succeeds() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    // Everything the exporter accepted is already durable, so there is nothing
+    // left for a flush to fail on.
+    exporter.force_flush().unwrap();
+}
+
+#[tokio::test]
+async fn each_export_is_durable_before_it_returns() {
+    let directory = tempfile::tempdir().unwrap();
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.otlp.pb",
+        OtlpFileFormat::Proto,
+        false,
+    );
+    exporter.export(sample_spans(&["only"])).await.unwrap();
+
+    // Deliberately no shutdown: a run that dies between batches must still
+    // leave the batches it already delivered on disk.
+    let requests = read_proto_frames(&directory.path().join("trace.otlp.pb"));
+    assert_eq!(requests.len(), 1);
+}
+
+#[tokio::test]
+async fn overwrite_mode_replaces_an_existing_file() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("trace.jsonl");
+    fs::write(&path, b"stale\n").unwrap();
+
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+    exporter.export(sample_spans(&["fresh"])).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let contents = fs::read_to_string(&path).unwrap();
+    assert!(!contents.contains("stale"));
+    assert_eq!(contents.lines().count(), 1);
+}
+
+#[tokio::test]
+async fn append_mode_preserves_existing_records() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("trace.jsonl");
+    fs::write(&path, b"{\"resourceSpans\":[]}\n").unwrap();
+
+    let exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        true,
+    );
+    exporter.export(sample_spans(&["fresh"])).await.unwrap();
+    exporter
+        .shutdown_with_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    let lines = read_json_lines(&path);
+    assert_eq!(lines.len(), 2);
+}
+
+#[test]
+fn a_missing_output_directory_is_created() {
+    let directory = tempfile::tempdir().unwrap();
+    let nested = directory.path().join("nested").join("deeper");
+    let exporter = OtlpFileSpanExporter::new(
+        directory.path(),
+        &nested.join("trace.jsonl"),
+        OtlpFileFormat::JsonLines,
+        false,
+    )
+    .unwrap();
+
+    assert!(nested.is_dir());
+    assert_eq!(exporter.path(), nested.join("trace.jsonl"));
+}
+
+#[test]
+fn an_unwritable_directory_reports_the_path() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("trace.jsonl");
+    fs::create_dir(&path).unwrap();
+
+    let error =
+        OtlpFileSpanExporter::new(directory.path(), &path, OtlpFileFormat::JsonLines, false)
+            .unwrap_err();
+    assert!(
+        error.to_string().contains("trace.jsonl"),
+        "the error must name the path that failed: {error}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn the_output_file_is_readable_only_by_its_owner() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().unwrap();
+    let _exporter = exporter_at(
+        directory.path(),
+        "trace.jsonl",
+        OtlpFileFormat::JsonLines,
+        false,
+    );
+
+    let mode = fs::metadata(directory.path().join("trace.jsonl"))
+        .unwrap()
+        .permissions()
+        .mode();
+    // A trajectory carries prompt and response content, so it is created with
+    // the same owner-only permissions as the ATOF and ATIF sinks.
+    assert_eq!(
+        mode & 0o077,
+        0,
+        "unexpected group or other permissions: {mode:o}"
+    );
+}
+
+#[test]
+fn each_format_names_its_conventional_extension() {
+    assert_eq!(OtlpFileFormat::JsonLines.extension(), "jsonl");
+    assert_eq!(OtlpFileFormat::Proto.extension(), "otlp.pb");
+    assert_eq!(OtlpFileFormat::default(), OtlpFileFormat::JsonLines);
+}

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -832,6 +832,7 @@ fn default_config_and_component_conversion_cover_public_shape() {
 
     let otel = OpenTelemetrySectionConfig {
         enabled: true,
+        file_sinks: Vec::new(),
         endpoints: vec![OpenTelemetryEndpointConfig {
             otel_type: OpenTelemetryType::Full,
             endpoint: "http://localhost:4318/v1/traces".to_string(),
@@ -1248,6 +1249,7 @@ fn validate_opentelemetry_section_reports_empty_and_malformed_endpoints() {
         &policy,
         &OpenTelemetrySectionConfig {
             enabled: true,
+            file_sinks: Vec::new(),
             endpoints: Vec::new(),
             logs: None,
             metrics: None,
@@ -1273,6 +1275,7 @@ fn validate_opentelemetry_section_reports_empty_and_malformed_endpoints() {
         &policy,
         &OpenTelemetrySectionConfig {
             enabled: true,
+            file_sinks: Vec::new(),
             endpoints: vec![endpoint],
             logs: None,
             metrics: None,
@@ -1302,6 +1305,7 @@ fn validate_opentelemetry_section_reports_empty_and_malformed_endpoints() {
         &policy,
         &OpenTelemetrySectionConfig {
             enabled: true,
+            file_sinks: Vec::new(),
             endpoints: vec![endpoint],
             logs: None,
             metrics: None,
@@ -1411,6 +1415,7 @@ fn opentelemetry_registration_rejects_an_empty_endpoint_list() {
     let error = register_opentelemetry(
         OpenTelemetrySectionConfig {
             enabled: true,
+            file_sinks: Vec::new(),
             endpoints: Vec::new(),
             logs: None,
             metrics: None,
@@ -5642,4 +5647,245 @@ fn atif_filename_helpers_cover_metadata_resolution_and_rejection_paths() {
         )
         .is_err()
     );
+}
+
+// --- OpenTelemetry file sinks ----------------------------------------------
+
+fn file_sink_section(output_directory: &Path) -> OpenTelemetryFileSinkConfig {
+    OpenTelemetryFileSinkConfig {
+        otel_type: OpenTelemetryType::Full,
+        output_directory: output_directory.to_path_buf(),
+        filename: Some("trace.jsonl".to_string()),
+        format: OtlpFileFormat::JsonLines,
+        mode: default_otlp_file_sink_mode(),
+        mark_projection: MarkProjection::default(),
+        mark_exclude_names: default_mark_exclude_names(),
+        attribute_mappings: Vec::new(),
+        promote_metadata_prefixes: Vec::new(),
+        promote_resource_metadata_prefixes: Vec::new(),
+        resource_attributes: HashMap::new(),
+        service_name: default_otel_service_name(),
+        service_namespace: None,
+        service_version: None,
+        instrumentation_scope: default_otel_instrumentation_scope(),
+        max_queue_size: None,
+        max_export_batch_size: None,
+        scheduled_delay_millis: None,
+        completed_span_context_ttl_millis: None,
+    }
+}
+
+#[test]
+fn a_file_sink_section_parses_with_only_an_output_directory() {
+    let section: OpenTelemetryFileSinkConfig =
+        toml::from_str("output_directory = \"/tmp/relay-traces\"").unwrap();
+
+    assert_eq!(section.format, OtlpFileFormat::JsonLines);
+    assert_eq!(section.mode, "overwrite");
+    assert_eq!(section.otel_type, OpenTelemetryType::Full);
+    assert!(section.filename.is_none());
+}
+
+#[test]
+fn a_file_sink_section_parses_the_proto_format() {
+    let section: OpenTelemetryFileSinkConfig =
+        toml::from_str("output_directory = \"/tmp/relay-traces\"\nformat = \"proto\"").unwrap();
+
+    assert_eq!(section.format, OtlpFileFormat::Proto);
+}
+
+#[test]
+fn a_file_sink_config_resolves_its_path_under_the_output_directory() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = build_otel_file_config(0, file_sink_section(directory.path())).unwrap();
+
+    let settings = config.file_sink().expect("a file sink config has settings");
+    assert_eq!(settings.path, directory.path().join("trace.jsonl"));
+    assert_eq!(settings.output_directory, directory.path());
+    assert!(!settings.append, "overwrite mode must not append");
+}
+
+#[test]
+fn a_file_sink_without_a_filename_names_the_file_after_its_format() {
+    let directory = tempfile::tempdir().unwrap();
+    for (format, extension) in [
+        (OtlpFileFormat::JsonLines, ".jsonl"),
+        (OtlpFileFormat::Proto, ".otlp.pb"),
+    ] {
+        let mut section = file_sink_section(directory.path());
+        section.filename = None;
+        section.format = format;
+        let config = build_otel_file_config(0, section).unwrap();
+
+        let path = config.file_sink().unwrap().path.display().to_string();
+        assert!(
+            path.ends_with(extension),
+            "unexpected default filename {path}"
+        );
+    }
+}
+
+#[test]
+fn a_file_sink_rejects_a_blank_output_directory() {
+    let mut section = file_sink_section(Path::new(""));
+    section.filename = None;
+    let error = build_otel_file_config(3, section).unwrap_err();
+
+    assert!(error.to_string().contains("file_sinks[3].output_directory"));
+}
+
+#[test]
+fn a_file_sink_rejects_an_unknown_mode() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut section = file_sink_section(directory.path());
+    section.mode = "truncate".to_string();
+    let error = build_otel_file_config(1, section).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("must be 'append' or 'overwrite'")
+    );
+}
+
+#[test]
+fn a_file_sink_accepts_append_mode() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut section = file_sink_section(directory.path());
+    section.mode = "append".to_string();
+    let config = build_otel_file_config(0, section).unwrap();
+
+    assert!(config.file_sink().unwrap().append);
+}
+
+#[test]
+fn a_file_sink_rejects_a_filename_that_leaves_its_directory() {
+    let directory = tempfile::tempdir().unwrap();
+    for filename in ["../escape.jsonl", "nested/trace.jsonl", "/absolute.jsonl"] {
+        let mut section = file_sink_section(directory.path());
+        section.filename = Some(filename.to_string());
+        let error = build_otel_file_config(2, section).unwrap_err();
+
+        assert!(
+            error.to_string().contains("single path component"),
+            "{filename} should be rejected, got {error}"
+        );
+    }
+}
+
+#[test]
+fn a_file_sink_rejects_a_blank_or_padded_filename() {
+    let directory = tempfile::tempdir().unwrap();
+    for filename in ["", "   ", " trace.jsonl"] {
+        let mut section = file_sink_section(directory.path());
+        section.filename = Some(filename.to_string());
+        let error = build_otel_file_config(0, section).unwrap_err();
+
+        assert!(error.to_string().contains("nonblank and unpadded"));
+    }
+}
+
+#[test]
+fn a_file_sink_rejects_zero_and_inverted_batch_settings() {
+    let directory = tempfile::tempdir().unwrap();
+    type MutateFileSink = Box<dyn Fn(&mut OpenTelemetryFileSinkConfig)>;
+    let cases: Vec<(MutateFileSink, &str)> = vec![
+        (Box::new(|s| s.max_queue_size = Some(0)), "max_queue_size"),
+        (
+            Box::new(|s| s.max_export_batch_size = Some(0)),
+            "max_export_batch_size",
+        ),
+        (
+            Box::new(|s| s.scheduled_delay_millis = Some(0)),
+            "scheduled_delay_millis",
+        ),
+        (
+            Box::new(|s| s.completed_span_context_ttl_millis = Some(0)),
+            "completed_span_context_ttl_millis",
+        ),
+        (
+            Box::new(|s| {
+                s.max_queue_size = Some(1);
+                s.max_export_batch_size = Some(2);
+            }),
+            "must be less than or equal to max_queue_size",
+        ),
+    ];
+    for (mutate, expected) in cases {
+        let mut section = file_sink_section(directory.path());
+        mutate(&mut section);
+        let error = build_otel_file_config(0, section).unwrap_err();
+        assert!(error.to_string().contains(expected), "got {error}");
+    }
+}
+
+#[test]
+fn two_file_sinks_writing_one_path_are_rejected() {
+    let directory = tempfile::tempdir().unwrap();
+    let sinks = vec![
+        file_sink_section(directory.path()),
+        file_sink_section(directory.path()),
+    ];
+    let error = validate_distinct_opentelemetry_file_sinks(&sinks).unwrap_err();
+
+    assert!(error.to_string().contains("write the same path"));
+}
+
+#[test]
+fn file_sinks_writing_distinct_paths_are_accepted() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut second = file_sink_section(directory.path());
+    second.filename = Some("other.jsonl".to_string());
+    let sinks = vec![file_sink_section(directory.path()), second];
+
+    validate_distinct_opentelemetry_file_sinks(&sinks).unwrap();
+}
+
+#[test]
+fn a_file_sink_config_builds_a_subscriber_and_opens_its_file() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = build_otel_file_config(0, file_sink_section(directory.path())).unwrap();
+
+    // Endpoint validation must not apply: this destination has no endpoint.
+    let subscriber = crate::observability::otel::OpenTelemetrySubscriber::new(config).unwrap();
+    assert!(directory.path().join("trace.jsonl").is_file());
+    subscriber.shutdown().unwrap();
+}
+
+#[test]
+fn opentelemetry_registration_accepts_a_section_with_only_file_sinks() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut context = PluginRegistrationContext::new();
+
+    register_opentelemetry(
+        OpenTelemetrySectionConfig {
+            enabled: true,
+            file_sinks: vec![file_sink_section(directory.path())],
+            endpoints: Vec::new(),
+            logs: None,
+            metrics: None,
+        },
+        &mut context,
+    )
+    .unwrap();
+
+    assert!(directory.path().join("trace.jsonl").is_file());
+}
+
+#[test]
+fn opentelemetry_registration_rejects_an_empty_endpoint_and_file_sink_list() {
+    let mut context = PluginRegistrationContext::new();
+    let error = register_opentelemetry(
+        OpenTelemetrySectionConfig {
+            enabled: true,
+            file_sinks: Vec::new(),
+            endpoints: Vec::new(),
+            logs: None,
+            metrics: None,
+        },
+        &mut context,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("one file sink"));
 }

--- a/crates/core/tests/unit/observability/plugin_component_tests.rs
+++ b/crates/core/tests/unit/observability/plugin_component_tests.rs
@@ -5889,3 +5889,96 @@ fn opentelemetry_registration_rejects_an_empty_endpoint_and_file_sink_list() {
 
     assert!(error.to_string().contains("one file sink"));
 }
+
+#[test]
+fn file_sinks_are_offered_by_the_config_editor() {
+    let schema = OpenTelemetrySectionConfig::editor_schema();
+    let file_sinks = schema.field("file_sinks").expect("file_sinks editor field");
+    assert_eq!(file_sinks.kind, EditorFieldKind::List);
+
+    let item_schema = (file_sinks
+        .list_item
+        .expect("file_sinks list metadata")
+        .schema
+        .expect("file_sinks item schema"))();
+    let format = item_schema.field("format").expect("format editor field");
+    assert_eq!(format.enum_values, &["json_lines", "proto"]);
+    assert!(
+        item_schema.field("endpoint").is_none(),
+        "a file sink has no endpoint to configure"
+    );
+    assert!(
+        !item_schema
+            .field("output_directory")
+            .expect("output_directory editor field")
+            .optional,
+        "a file sink cannot default its output directory"
+    );
+}
+
+#[test]
+fn the_file_sink_editor_default_is_a_valid_section() {
+    let default = default_opentelemetry_file_sink_editor_value();
+    let section: OpenTelemetryFileSinkConfig = serde_json::from_value(default).unwrap();
+
+    assert_eq!(section.format, OtlpFileFormat::JsonLines);
+    assert_eq!(section.mode, "overwrite");
+}
+
+#[test]
+fn validate_opentelemetry_section_accepts_a_file_sink_as_the_only_destination() {
+    let directory = tempfile::tempdir().unwrap();
+    let policy = ConfigPolicy::default();
+    let mut diagnostics = Vec::new();
+
+    validate_opentelemetry_section(
+        &mut diagnostics,
+        &policy,
+        &OpenTelemetrySectionConfig {
+            enabled: true,
+            file_sinks: vec![file_sink_section(directory.path())],
+            endpoints: Vec::new(),
+            logs: None,
+            metrics: None,
+        },
+    );
+
+    // Static validation runs before activation, so a section it rejects never
+    // reaches `register_opentelemetry` at all.
+    assert!(
+        diagnostics.is_empty(),
+        "a file sink is a destination: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn validate_opentelemetry_section_reports_malformed_file_sinks() {
+    let directory = tempfile::tempdir().unwrap();
+    let policy = ConfigPolicy::default();
+    let mut blank_directory = file_sink_section(directory.path());
+    blank_directory.output_directory = PathBuf::new();
+    let mut bad_mode = file_sink_section(directory.path());
+    bad_mode.mode = "truncate".to_string();
+    let mut diagnostics = Vec::new();
+
+    validate_opentelemetry_section(
+        &mut diagnostics,
+        &policy,
+        &OpenTelemetrySectionConfig {
+            enabled: true,
+            file_sinks: vec![blank_directory, bad_mode],
+            endpoints: Vec::new(),
+            logs: None,
+            metrics: None,
+        },
+    );
+
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.field.as_deref() == Some("file_sinks[0].output_directory")
+    }));
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.field.as_deref() == Some("file_sinks[1].mode"))
+    );
+}

--- a/crates/ffi/nemo_relay.h
+++ b/crates/ffi/nemo_relay.h
@@ -1756,6 +1756,30 @@ NemoRelayStatus nemo_relay_otel_subscriber_create(const char *otel_type,
                                                   struct FfiOpenTelemetrySubscriber **out);
 
 /**
+ * Creates one typed OpenTelemetry exporter subscriber that writes OTLP to a file.
+ *
+ * `otel_type` must be `full`, `gen_ai`, or `openinference`. `output_directory` is
+ * required. `filename` may be null to use a default name for the format.
+ * `format` is `json_lines` (the OpenTelemetry file-exporter specification's
+ * serialization, and the default when null) or `proto`. `mode` is `overwrite`
+ * (the default when null) or `append`.
+ *
+ * # Safety
+ * Any non-null C strings must be valid and `out` must be non-null.
+ */
+NemoRelayStatus nemo_relay_otel_subscriber_create_file_sink(const char *otel_type,
+                                                            const char *output_directory,
+                                                            const char *filename,
+                                                            const char *format,
+                                                            const char *mode,
+                                                            const char *resource_attributes_json,
+                                                            const char *service_name,
+                                                            const char *service_namespace,
+                                                            const char *service_version,
+                                                            const char *instrumentation_scope,
+                                                            struct FfiOpenTelemetrySubscriber **out);
+
+/**
  * Creates one typed OpenTelemetry exporter subscriber with projection controls.
  *
  * The JSON arrays use `mark_exclude_names: ["llm.chunk"]` and

--- a/crates/ffi/src/api/observability.rs
+++ b/crates/ffi/src/api/observability.rs
@@ -875,6 +875,144 @@ pub unsafe extern "C" fn nemo_relay_otel_subscriber_create(
     NemoRelayStatus::Ok
 }
 
+/// Creates one typed OpenTelemetry exporter subscriber that writes OTLP to a file.
+///
+/// `otel_type` must be `full`, `gen_ai`, or `openinference`. `output_directory` is
+/// required. `filename` may be null to use a default name for the format.
+/// `format` is `json_lines` (the OpenTelemetry file-exporter specification's
+/// serialization, and the default when null) or `proto`. `mode` is `overwrite`
+/// (the default when null) or `append`.
+///
+/// # Safety
+/// Any non-null C strings must be valid and `out` must be non-null.
+#[allow(clippy::too_many_arguments)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nemo_relay_otel_subscriber_create_file_sink(
+    otel_type: *const c_char,
+    output_directory: *const c_char,
+    filename: *const c_char,
+    format: *const c_char,
+    mode: *const c_char,
+    resource_attributes_json: *const c_char,
+    service_name: *const c_char,
+    service_namespace: *const c_char,
+    service_version: *const c_char,
+    instrumentation_scope: *const c_char,
+    out: *mut *mut FfiOpenTelemetrySubscriber,
+) -> NemoRelayStatus {
+    clear_last_error();
+    if let Err(status) = required_out_ptr(out) {
+        return status;
+    }
+    let otel_type = match parse_otel_type(otel_type) {
+        Ok(value) => value,
+        Err(status) => return status,
+    };
+    let settings = match parse_ffi_file_sink_settings(output_directory, filename, format, mode) {
+        Ok(settings) => settings,
+        Err(status) => return status,
+    };
+    let mut config = OpenTelemetryConfig::new_file_sink(otel_type, settings);
+    config =
+        match apply_optional_string(config, service_name, OpenTelemetryConfig::with_service_name) {
+            Ok(config) => config,
+            Err(status) => return status,
+        };
+    config = match apply_optional_string(
+        config,
+        service_namespace,
+        OpenTelemetryConfig::with_service_namespace,
+    ) {
+        Ok(config) => config,
+        Err(status) => return status,
+    };
+    config = match apply_optional_string(
+        config,
+        service_version,
+        OpenTelemetryConfig::with_service_version,
+    ) {
+        Ok(config) => config,
+        Err(status) => return status,
+    };
+    config = match apply_optional_string(
+        config,
+        instrumentation_scope,
+        OpenTelemetryConfig::with_instrumentation_scope,
+    ) {
+        Ok(config) => config,
+        Err(status) => return status,
+    };
+    config = match apply_string_map(
+        config,
+        resource_attributes_json,
+        "resource_attributes",
+        OpenTelemetryConfig::with_resource_attribute,
+    ) {
+        Ok(config) => config,
+        Err(status) => return status,
+    };
+    let subscriber = match create_otel_subscriber(config) {
+        Ok(subscriber) => subscriber,
+        Err(status) => return status,
+    };
+    unsafe { *out = Box::into_raw(Box::new(FfiOpenTelemetrySubscriber(subscriber))) };
+    NemoRelayStatus::Ok
+}
+
+fn parse_ffi_file_sink_settings(
+    output_directory: *const c_char,
+    filename: *const c_char,
+    format: *const c_char,
+    mode: *const c_char,
+) -> Result<nemo_relay::observability::otel::OtlpFileSinkSettings, NemoRelayStatus> {
+    let output_directory = match parse_optional_string(output_directory)? {
+        Some(value) if !value.trim().is_empty() => value,
+        _ => {
+            set_last_error("output_directory is required");
+            return Err(NemoRelayStatus::InvalidArg);
+        }
+    };
+    let format = match parse_optional_string(format)?.as_deref() {
+        None | Some("json_lines") => {
+            nemo_relay::observability::otel_file::OtlpFileFormat::JsonLines
+        }
+        Some("proto") => nemo_relay::observability::otel_file::OtlpFileFormat::Proto,
+        Some(other) => {
+            set_last_error(&format!(
+                "format must be 'json_lines' or 'proto', got {other:?}"
+            ));
+            return Err(NemoRelayStatus::InvalidArg);
+        }
+    };
+    let append = match parse_optional_string(mode)?.as_deref() {
+        None | Some("overwrite") => false,
+        Some("append") => true,
+        Some(other) => {
+            set_last_error(&format!(
+                "mode must be 'append' or 'overwrite', got {other:?}"
+            ));
+            return Err(NemoRelayStatus::InvalidArg);
+        }
+    };
+    let filename = match parse_optional_string(filename)? {
+        Some(filename) => {
+            if std::path::Path::new(&filename).components().count() != 1 {
+                set_last_error("filename must be a single path component");
+                return Err(NemoRelayStatus::InvalidArg);
+            }
+            filename
+        }
+        None => format!("nemo-relay-otlp.{}", format.extension()),
+    };
+    let output_directory = std::path::PathBuf::from(output_directory);
+    Ok(nemo_relay::observability::otel::OtlpFileSinkSettings {
+        path: output_directory.join(filename),
+        output_directory,
+        format,
+        append,
+    })
+}
+
 /// Creates one typed OpenTelemetry exporter subscriber with projection controls.
 ///
 /// The JSON arrays use `mark_exclude_names: ["llm.chunk"]` and

--- a/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
+++ b/crates/ffi/tests/unit/api/coverage_sweeps_tests.rs
@@ -3821,3 +3821,100 @@ fn test_ffi_otel_signal_subscribers_apply_all_typed_options() {
         );
     }
 }
+
+#[test]
+fn otel_file_sink_subscriber_create_covers_success_and_rejection() {
+    let directory = tempfile::tempdir().unwrap();
+    let output_directory = cstring(&directory.path().display().to_string());
+    let otel_type = cstring("full");
+
+    unsafe {
+        let filename = cstring("ffi-trace.jsonl");
+        let mut subscriber = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_subscriber_create_file_sink(
+                otel_type.as_ptr(),
+                output_directory.as_ptr(),
+                filename.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut subscriber,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert!(directory.path().join("ffi-trace.jsonl").is_file());
+        assert_status!(
+            nemo_relay_otel_subscriber_shutdown(subscriber),
+            NemoRelayStatus::Ok
+        );
+        types::nemo_relay_otel_subscriber_free(subscriber);
+
+        // A null format defaults to the specification's JSON lines, and a null
+        // filename is derived from it.
+        let mut defaulted = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_subscriber_create_file_sink(
+                otel_type.as_ptr(),
+                output_directory.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut defaulted,
+            ),
+            NemoRelayStatus::Ok
+        );
+        assert!(directory.path().join("nemo-relay-otlp.jsonl").is_file());
+        assert_status!(
+            nemo_relay_otel_subscriber_shutdown(defaulted),
+            NemoRelayStatus::Ok
+        );
+        types::nemo_relay_otel_subscriber_free(defaulted);
+
+        let bad_format = cstring("yaml");
+        let mut rejected = ptr::null_mut();
+        assert_status!(
+            nemo_relay_otel_subscriber_create_file_sink(
+                otel_type.as_ptr(),
+                output_directory.as_ptr(),
+                ptr::null(),
+                bad_format.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut rejected,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+
+        let blank = cstring("");
+        assert_status!(
+            nemo_relay_otel_subscriber_create_file_sink(
+                otel_type.as_ptr(),
+                blank.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                &mut rejected,
+            ),
+            NemoRelayStatus::InvalidArg
+        );
+    }
+}

--- a/crates/node/observability.d.ts
+++ b/crates/node/observability.d.ts
@@ -120,9 +120,37 @@ export interface OpenTelemetryMetricSectionConfig {
   cardinality_limit?: number;
 }
 
+export interface OpenTelemetryFileSinkConfig {
+  type?: 'full' | 'gen_ai' | 'openinference';
+  output_directory: string;
+  filename?: string;
+  /**
+   * `json_lines` follows the OpenTelemetry Protocol File Exporter
+   * specification: one OTLP/JSON record per line. `proto` writes each record
+   * length-delimited.
+   */
+  format?: 'json_lines' | 'proto';
+  mode?: 'append' | 'overwrite';
+  mark_projection?: 'inherit' | 'event' | 'tool';
+  mark_exclude_names?: string[];
+  attribute_mappings?: Array<{ key: string; alias: string }>;
+  promote_metadata_prefixes?: string[];
+  promote_resource_metadata_prefixes?: string[];
+  resource_attributes?: Record<string, string>;
+  service_name?: string;
+  service_namespace?: string;
+  service_version?: string;
+  instrumentation_scope?: string;
+  max_queue_size?: number;
+  max_export_batch_size?: number;
+  scheduled_delay_millis?: number;
+  completed_span_context_ttl_millis?: number;
+}
+
 export interface OpenTelemetrySectionConfig {
   enabled?: boolean;
   endpoints?: OpenTelemetryEndpointConfig[];
+  file_sinks?: OpenTelemetryFileSinkConfig[];
   logs?: OpenTelemetryLogSectionConfig;
   metrics?: OpenTelemetryMetricSectionConfig;
 }
@@ -153,6 +181,7 @@ export declare function atofConfig(config?: AtofConfig): AtofConfig;
 export declare function atifConfig(config?: AtifConfig): AtifConfig;
 /** Create one typed OpenTelemetry endpoint. */
 export declare function openTelemetryEndpoint(config: OpenTelemetryEndpointConfig): OpenTelemetryEndpointConfig;
+export declare function openTelemetryFileSink(config: OpenTelemetryFileSinkConfig): OpenTelemetryFileSinkConfig;
 /** Create one signal-specific OpenTelemetry endpoint for logs or metrics. */
 export declare function openTelemetrySignalEndpoint(
   config: OpenTelemetrySignalEndpointConfig,

--- a/crates/node/observability.js
+++ b/crates/node/observability.js
@@ -80,6 +80,42 @@ function openTelemetryEndpoint(config) {
 }
 
 /**
+ * Create one local file destination for projected OTLP spans.
+ *
+ * `json_lines` is the OpenTelemetry file-exporter specification's serialization:
+ * one OTLP/JSON record per line. `proto` writes each record length-delimited.
+ *
+ * @param {object} config - File sink settings including required `output_directory`.
+ * @returns {object} A normalized OpenTelemetry file sink.
+ */
+function openTelemetryFileSink(config) {
+  if (!config || typeof config !== 'object') {
+    throw new TypeError('OpenTelemetry file sink config is required');
+  }
+  if (typeof config.output_directory !== 'string' || config.output_directory.trim() === '') {
+    throw new TypeError('OpenTelemetry file sink output_directory must be a nonblank string');
+  }
+  if (config.format !== undefined && !['json_lines', 'proto'].includes(config.format)) {
+    throw new TypeError('OpenTelemetry file sink format must be "json_lines" or "proto"');
+  }
+  if (config.mode !== undefined && !['append', 'overwrite'].includes(config.mode)) {
+    throw new TypeError('OpenTelemetry file sink mode must be "append" or "overwrite"');
+  }
+  return {
+    type: 'full',
+    format: 'json_lines',
+    mode: 'overwrite',
+    service_name: 'unknown_service',
+    instrumentation_scope: 'opentelemetry',
+    completed_span_context_ttl_millis: DEFAULT_COMPLETED_SPAN_CONTEXT_TTL_MILLIS,
+    resource_attributes: {},
+    promote_metadata_prefixes: [],
+    promote_resource_metadata_prefixes: [],
+    ...config,
+  };
+}
+
+/**
  * Create one signal-specific OpenTelemetry endpoint for logs or metrics.
  *
  * @param {object} config - Endpoint settings including required `endpoint`.
@@ -149,6 +185,7 @@ function openTelemetryConfig(config = {}) {
   return {
     enabled: false,
     endpoints: [],
+    file_sinks: [],
     ...config,
   };
 }
@@ -172,6 +209,7 @@ module.exports = {
   atofConfig,
   atifConfig,
   openTelemetryEndpoint,
+  openTelemetryFileSink,
   openTelemetrySignalEndpoint,
   openTelemetryLogConfig,
   openTelemetryMetricConfig,

--- a/crates/node/src/api/mod.rs
+++ b/crates/node/src/api/mod.rs
@@ -257,12 +257,70 @@ fn parse_attribute_mappings(
     Ok(mappings)
 }
 
+fn parse_otel_file_sink(
+    output_directory: &str,
+    filename: Option<&str>,
+    format: Option<&str>,
+    mode: Option<&str>,
+) -> napi::Result<nemo_relay::observability::otel::OtlpFileSinkSettings> {
+    let format = match format.unwrap_or("json_lines") {
+        "json_lines" => nemo_relay::observability::otel_file::OtlpFileFormat::JsonLines,
+        "proto" => nemo_relay::observability::otel_file::OtlpFileFormat::Proto,
+        other => {
+            return Err(napi::Error::from_reason(format!(
+                "format must be 'json_lines' or 'proto', got {other:?}"
+            )));
+        }
+    };
+    let append = match mode.unwrap_or("overwrite") {
+        "overwrite" => false,
+        "append" => true,
+        other => {
+            return Err(napi::Error::from_reason(format!(
+                "mode must be 'append' or 'overwrite', got {other:?}"
+            )));
+        }
+    };
+    let filename = match filename {
+        Some(filename) => {
+            if std::path::Path::new(filename).components().count() != 1 {
+                return Err(napi::Error::from_reason(
+                    "filename must be a single path component",
+                ));
+            }
+            filename.to_string()
+        }
+        None => format!("nemo-relay-otlp.{}", format.extension()),
+    };
+    let output_directory = std::path::PathBuf::from(output_directory);
+    Ok(nemo_relay::observability::otel::OtlpFileSinkSettings {
+        path: output_directory.join(filename),
+        output_directory,
+        format,
+        append,
+    })
+}
+
 fn build_otel_config(
     options: OpenTelemetryConfig,
 ) -> napi::Result<nemo_relay::observability::otel::OpenTelemetryConfig> {
     let otel_type = parse_otel_type(&options.r#type)?;
+    let file_sink = options
+        .output_directory
+        .as_deref()
+        .map(str::trim)
+        .filter(|directory| !directory.is_empty())
+        .map(|directory| {
+            parse_otel_file_sink(
+                directory,
+                options.filename.as_deref(),
+                options.format.as_deref(),
+                options.mode.as_deref(),
+            )
+        })
+        .transpose()?;
     let endpoint = options.endpoint.trim().to_string();
-    if endpoint.is_empty() {
+    if file_sink.is_none() && endpoint.is_empty() {
         return Err(napi::Error::from_reason(
             "endpoint must be a nonblank string",
         ));
@@ -299,14 +357,19 @@ fn build_otel_config(
             .expect("the default completed span context TTL fits in u64 milliseconds")
         });
 
-    let mut config = nemo_relay::observability::otel::OpenTelemetryConfig::new(otel_type, endpoint)
-        .with_transport(transport)
-        .with_service_name(service_name)
-        .with_instrumentation_scope(instrumentation_scope)
-        .with_timeout(std::time::Duration::from_millis(timeout_millis.into()))
-        .with_completed_span_context_ttl(std::time::Duration::from_millis(
-            completed_span_context_ttl_millis,
-        ));
+    let mut config = match file_sink {
+        Some(file_sink) => nemo_relay::observability::otel::OpenTelemetryConfig::new_file_sink(
+            otel_type, file_sink,
+        ),
+        None => nemo_relay::observability::otel::OpenTelemetryConfig::new(otel_type, endpoint)
+            .with_transport(transport),
+    }
+    .with_service_name(service_name)
+    .with_instrumentation_scope(instrumentation_scope)
+    .with_timeout(std::time::Duration::from_millis(timeout_millis.into()))
+    .with_completed_span_context_ttl(std::time::Duration::from_millis(
+        completed_span_context_ttl_millis,
+    ));
 
     if let Some(namespace) = options.service_namespace {
         config = config.with_service_namespace(namespace);
@@ -5172,8 +5235,20 @@ pub struct OpenTelemetryConfig {
     pub r#type: String,
     /// `"http_binary"` (default) or `"grpc"`.
     pub transport: Option<String>,
-    /// OTLP endpoint, such as `http://localhost:4318/v1/traces`.
+    /// OTLP endpoint, such as `http://localhost:4318/v1/traces`. Leave empty
+    /// when `outputDirectory` selects a file sink.
     pub endpoint: String,
+    /// Directory for a local file destination. When set, spans are written
+    /// there instead of exported to `endpoint`.
+    pub output_directory: Option<String>,
+    /// Output filename. Defaults to a name derived from `format`.
+    pub filename: Option<String>,
+    /// `"json_lines"` (default) or `"proto"`. Only used with `outputDirectory`.
+    #[napi(ts_type = "\"json_lines\" | \"proto\"")]
+    pub format: Option<String>,
+    /// `"overwrite"` (default) or `"append"`. Only used with `outputDirectory`.
+    #[napi(ts_type = "\"append\" | \"overwrite\"")]
+    pub mode: Option<String>,
     /// Extra exporter headers/metadata as string key/value pairs.
     pub headers: Option<Json>,
     /// Header names mapped to environment variables resolved during subscriber activation.

--- a/crates/node/tests/observability_plugin_tests.mjs
+++ b/crates/node/tests/observability_plugin_tests.mjs
@@ -35,6 +35,7 @@ describe('observability plugin helpers', () => {
     assert.deepEqual(observability.openTelemetryConfig(), {
       enabled: false,
       endpoints: [],
+      file_sinks: [],
     });
     assert.deepEqual(
       observability.openTelemetryEndpoint({
@@ -111,6 +112,7 @@ describe('observability plugin helpers', () => {
     assert.deepEqual(observability.openTelemetryConfig({ enabled: true, logs, metrics }), {
       enabled: true,
       endpoints: [],
+      file_sinks: [],
       logs,
       metrics,
     });
@@ -337,5 +339,57 @@ describe('observability plugin helpers', () => {
     assert.match(secondPayload, /node-second-agent/);
     assert.doesNotMatch(secondPayload, /node-first-agent/);
     assert.doesNotMatch(secondPayload, /node-nested-agent/);
+  });
+});
+
+describe('opentelemetry file sinks', () => {
+  it('normalizes a file sink and validates its fields', () => {
+    const directory = tempDir('otlp-file-sink');
+    const sink = observability.openTelemetryFileSink({ output_directory: directory });
+
+    assert.equal(sink.type, 'full');
+    assert.equal(sink.format, 'json_lines');
+    assert.equal(sink.mode, 'overwrite');
+    assert.equal(sink.output_directory, directory);
+    // A file sink has no network destination to configure.
+    assert.equal(sink.endpoint, undefined);
+    assert.equal(sink.transport, undefined);
+
+    assert.throws(() => observability.openTelemetryFileSink(), /config is required/);
+    assert.throws(() => observability.openTelemetryFileSink({ output_directory: ' ' }), /nonblank/);
+    assert.throws(
+      () => observability.openTelemetryFileSink({ output_directory: directory, format: 'yaml' }),
+      /"json_lines" or "proto"/,
+    );
+    assert.throws(
+      () => observability.openTelemetryFileSink({ output_directory: directory, mode: 'truncate' }),
+      /"append" or "overwrite"/,
+    );
+  });
+
+  it('writes a trace file for a file-sink-only section', async () => {
+    const directory = tempDir('otlp-file-sink-write');
+    const config = {
+      version: 4,
+      opentelemetry: observability.openTelemetryConfig({
+        enabled: true,
+        file_sinks: [
+          observability.openTelemetryFileSink({
+            output_directory: directory,
+            filename: 'node-trace.jsonl',
+          }),
+        ],
+      }),
+    };
+
+    await pluginHost.initialize({
+      version: 1,
+      components: [observability.ComponentSpec(config)],
+    });
+    try {
+      assert.deepEqual(readdirSync(directory), ['node-trace.jsonl']);
+    } finally {
+      await pluginHost.close();
+    }
   });
 });

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -36,3 +36,4 @@ chrono = "0.4"
 
 [dev-dependencies]
 nemo-relay = { workspace = true, features = ["__test-plugin-host"] }
+tempfile = "3"

--- a/crates/python/src/py_types/observability.rs
+++ b/crates/python/src/py_types/observability.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use pyo3::prelude::*;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::runtime::{Handle, Runtime};
 
 use super::{
@@ -497,6 +497,64 @@ pub struct PyOpenTelemetryConfig {
     pub(crate) promote_metadata_prefixes: Vec<String>,
     #[pyo3(get, set)]
     pub(crate) promote_resource_metadata_prefixes: Vec<String>,
+    /// Set by [`PyOpenTelemetryConfig::file_sink`]; when present the spans are
+    /// written to this file instead of exported to `endpoint`.
+    pub(crate) file_sink: Option<PyOtlpFileSink>,
+}
+
+/// A local file destination for a programmatically built OpenTelemetry config.
+#[derive(Clone)]
+pub(crate) struct PyOtlpFileSink {
+    pub(crate) output_directory: String,
+    pub(crate) filename: Option<String>,
+    pub(crate) format: String,
+    pub(crate) mode: String,
+}
+
+impl PyOtlpFileSink {
+    fn to_settings(&self) -> PyResult<nemo_relay::observability::otel::OtlpFileSinkSettings> {
+        let format = match self.format.as_str() {
+            "json_lines" => nemo_relay::observability::otel_file::OtlpFileFormat::JsonLines,
+            "proto" => nemo_relay::observability::otel_file::OtlpFileFormat::Proto,
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "format must be 'json_lines' or 'proto', got {other:?}"
+                )));
+            }
+        };
+        let append = match self.mode.as_str() {
+            "append" => true,
+            "overwrite" => false,
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "mode must be 'append' or 'overwrite', got {other:?}"
+                )));
+            }
+        };
+        if self.output_directory.trim().is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "output_directory must be a nonblank path",
+            ));
+        }
+        let output_directory = PathBuf::from(&self.output_directory);
+        let filename = match &self.filename {
+            Some(filename) => {
+                if Path::new(filename).components().count() != 1 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "filename must be a single path component",
+                    ));
+                }
+                filename.clone()
+            }
+            None => format!("nemo-relay-otlp.{}", format.extension()),
+        };
+        Ok(nemo_relay::observability::otel::OtlpFileSinkSettings {
+            path: output_directory.join(filename),
+            output_directory,
+            format,
+            append,
+        })
+    }
 }
 
 impl PyOpenTelemetryConfig {
@@ -513,19 +571,33 @@ impl PyOpenTelemetryConfig {
                 )));
             }
         };
-        validate_otel_signal_endpoint(&self.endpoint)?;
-        let transport = parse_otel_signal_transport(&self.transport)?;
-        let mut config = nemo_relay::observability::otel::OpenTelemetryConfig::new(
-            otel_type,
-            self.endpoint.clone(),
-        )
-        .with_transport(transport)
-        .with_service_name(self.service_name.clone())
-        .with_instrumentation_scope(self.instrumentation_scope.clone())
-        .with_timeout(Duration::from_millis(self.timeout_millis))
-        .with_completed_span_context_ttl(Duration::from_millis(
-            self.completed_span_context_ttl_millis,
-        ));
+        let mut config = match &self.file_sink {
+            Some(file_sink) => nemo_relay::observability::otel::OpenTelemetryConfig::new_file_sink(
+                otel_type,
+                file_sink.to_settings()?,
+            ),
+            None => {
+                validate_otel_signal_endpoint(&self.endpoint)?;
+                let transport = parse_otel_signal_transport(&self.transport)?;
+                nemo_relay::observability::otel::OpenTelemetryConfig::new(
+                    otel_type,
+                    self.endpoint.clone(),
+                )
+                .with_transport(transport)
+                .with_timeout(Duration::from_millis(self.timeout_millis))
+            }
+        };
+        if self.file_sink.is_some() && (!self.headers.is_empty() || !self.header_env.is_empty()) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "headers and header_env do not apply to a file sink",
+            ));
+        }
+        config = config
+            .with_service_name(self.service_name.clone())
+            .with_instrumentation_scope(self.instrumentation_scope.clone())
+            .with_completed_span_context_ttl(Duration::from_millis(
+                self.completed_span_context_ttl_millis,
+            ));
 
         if let Some(namespace) = &self.service_namespace {
             config = config.with_service_namespace(namespace.clone());
@@ -588,6 +660,38 @@ impl PyOpenTelemetryConfig {
             attribute_mappings: Vec::new(),
             promote_metadata_prefixes: Vec::new(),
             promote_resource_metadata_prefixes: Vec::new(),
+            file_sink: None,
+        }
+    }
+
+    /// Creates a config that writes OTLP to a local file rather than exporting
+    /// it to a collector.
+    ///
+    /// ``format`` is ``"json_lines"`` (the OpenTelemetry file-exporter
+    /// specification's serialization) or ``"proto"``. ``mode`` is ``"append"``
+    /// or ``"overwrite"``.
+    ///
+    /// Example:
+    /// ```python
+    /// config = OpenTelemetryConfig.file_sink("full", "/tmp/relay-traces")
+    /// ```
+    #[staticmethod]
+    #[pyo3(signature = (otel_type, output_directory, filename=None, format="json_lines".to_string(), mode="overwrite".to_string()))]
+    pub(crate) fn file_sink(
+        otel_type: String,
+        output_directory: String,
+        filename: Option<String>,
+        format: String,
+        mode: String,
+    ) -> Self {
+        Self {
+            file_sink: Some(PyOtlpFileSink {
+                output_directory,
+                filename,
+                format,
+                mode,
+            }),
+            ..Self::new(otel_type, String::new())
         }
     }
 

--- a/crates/python/tests/coverage/py_types_coverage_tests.rs
+++ b/crates/python/tests/coverage/py_types_coverage_tests.rs
@@ -498,6 +498,116 @@ fn test_open_telemetry_config_and_subscriber_cover_lifecycle() {
 }
 
 #[test]
+fn test_open_telemetry_file_sink_config_writes_a_trace_file() {
+    let _python = crate::test_support::init_python_test();
+    let directory = tempfile::tempdir().unwrap();
+    Python::attach(|py| {
+        let config = PyOpenTelemetryConfig::file_sink(
+            "full".into(),
+            directory.path().display().to_string(),
+            Some("py-trace.jsonl".into()),
+            "json_lines".into(),
+            "overwrite".into(),
+        );
+        // A file sink carries no endpoint, so endpoint validation must not run.
+        assert!(config.endpoint.is_empty());
+
+        let config = pyo3::Py::new(py, config).unwrap();
+        let subscriber = PyOpenTelemetrySubscriber::new(config.bind(py).borrow()).unwrap();
+        assert!(directory.path().join("py-trace.jsonl").is_file());
+        subscriber.shutdown(py).unwrap();
+    });
+}
+
+#[test]
+fn test_open_telemetry_file_sink_defaults_name_the_file_after_the_format() {
+    let _python = crate::test_support::init_python_test();
+    let directory = tempfile::tempdir().unwrap();
+    Python::attach(|py| {
+        let config = PyOpenTelemetryConfig::file_sink(
+            "full".into(),
+            directory.path().display().to_string(),
+            None,
+            "proto".into(),
+            "overwrite".into(),
+        );
+        let config = pyo3::Py::new(py, config).unwrap();
+        let subscriber = PyOpenTelemetrySubscriber::new(config.bind(py).borrow()).unwrap();
+        assert!(directory.path().join("nemo-relay-otlp.otlp.pb").is_file());
+        subscriber.shutdown(py).unwrap();
+    });
+}
+
+#[test]
+fn test_open_telemetry_file_sink_rejects_invalid_inputs() {
+    let _python = crate::test_support::init_python_test();
+    let directory = tempfile::tempdir().unwrap();
+    Python::attach(|py| {
+        for (filename, format, mode, expected) in [
+            (None, "yaml", "overwrite", "format must be"),
+            (None, "proto", "truncate", "mode must be"),
+            (
+                Some("../escape.jsonl"),
+                "proto",
+                "append",
+                "single path component",
+            ),
+        ] {
+            let config = PyOpenTelemetryConfig::file_sink(
+                "full".into(),
+                directory.path().display().to_string(),
+                filename.map(str::to_string),
+                format.into(),
+                mode.into(),
+            );
+            let config = pyo3::Py::new(py, config).unwrap();
+            let Err(error) = PyOpenTelemetrySubscriber::new(config.bind(py).borrow()) else {
+                panic!("expected {expected:?} to be rejected");
+            };
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?}, got {error}"
+            );
+        }
+
+        let config = PyOpenTelemetryConfig::file_sink(
+            "full".into(),
+            String::new(),
+            None,
+            "json_lines".into(),
+            "overwrite".into(),
+        );
+        let config = pyo3::Py::new(py, config).unwrap();
+        let Err(error) = PyOpenTelemetrySubscriber::new(config.bind(py).borrow()) else {
+            panic!("a blank output_directory must be rejected");
+        };
+        assert!(error.to_string().contains("output_directory"));
+    });
+}
+
+#[test]
+fn test_open_telemetry_file_sink_rejects_headers() {
+    let _python = crate::test_support::init_python_test();
+    let directory = tempfile::tempdir().unwrap();
+    Python::attach(|py| {
+        let mut config = PyOpenTelemetryConfig::file_sink(
+            "full".into(),
+            directory.path().display().to_string(),
+            Some("headers.jsonl".into()),
+            "json_lines".into(),
+            "overwrite".into(),
+        );
+        config.set_header("authorization".into(), "Bearer token".into());
+
+        let config = pyo3::Py::new(py, config).unwrap();
+        let Err(error) = PyOpenTelemetrySubscriber::new(config.bind(py).borrow()) else {
+            panic!("headers on a file sink must be rejected");
+        };
+        assert!(error.to_string().contains("do not apply to a file sink"));
+    });
+}
+
+#[test]
 fn test_open_telemetry_config_rejects_invalid_inputs() {
     let _python = crate::test_support::init_python_test();
     Python::attach(|py| {

--- a/docs/configure-plugins/observability/opentelemetry.mdx
+++ b/docs/configure-plugins/observability/opentelemetry.mdx
@@ -164,6 +164,64 @@ exporters are unchanged.
 | `promote_metadata_prefixes` | `[]` | Literal prefixes that select sanitized Event metadata to copy to top-level span attributes. |
 | `promote_resource_metadata_prefixes` | `[]` | Literal prefixes that select root Scope-start metadata to copy to OTLP resource attributes. Each unique effective resource retains an exporter pipeline for the subscriber lifetime. |
 
+## Trace File Sinks
+
+A file sink writes the same OTLP `ExportTraceServiceRequest` an endpoint would
+receive to a local file. Use one when a trajectory is an artifact rather than
+telemetry: an evaluation harness that scores the trace it just produced, an
+offline replay, or any environment with no collector to export to. File sinks
+and endpoints can be configured together; each destination receives the same
+projected spans.
+
+```toml
+[[components.config.opentelemetry.file_sinks]]
+type = "full"
+output_directory = "/var/log/nemo-relay"
+format = "json_lines"
+```
+
+`json_lines` is the serialization described by the OpenTelemetry Protocol File
+Exporter specification: one OTLP/JSON-encoded `ExportTraceServiceRequest` per
+line, with `traceId` and `spanId` hex-encoded. `proto` writes each request
+length-delimited -- a big-endian `u32` byte count followed by that many bytes of
+encoded request -- matching the OpenTelemetry Collector file exporter's
+`format: proto` layout.
+
+Each export is flushed before it is reported as delivered, so a run that exits
+between batches still leaves a readable prefix rather than an empty file. Output
+files are created with owner-only permissions and confined to
+`output_directory`, the same as the ATOF and ATIF file sinks, because a
+trajectory carries prompt and response content.
+
+Endpoint validation does not apply: a file sink has no endpoint, transport,
+headers, or request timeout, and configuring those fields on one is an error.
+
+| Field | Default | Notes |
+|---|---|---|
+| `type` | `full` | `full`, `gen_ai`, or `openinference`. |
+| `output_directory` | Required | Directory containing the output file. Created if absent. |
+| `filename` | Timestamped | Single path component. Defaults to `nemo-relay-otlp-<timestamp>.jsonl` or `.otlp.pb` for the chosen format. |
+| `format` | `json_lines` | `json_lines` or `proto`. |
+| `mode` | `overwrite` | `append` or `overwrite`. |
+| `service_name` | `unknown_service` | `service.name` resource attribute. |
+| `service_namespace` | Omitted | Optional `service.namespace`. |
+| `service_version` | Omitted | Optional `service.version`. |
+| `instrumentation_scope` | `opentelemetry` | Instrumentation scope name. |
+| `max_queue_size` | Environment or `2048` | Maximum completed spans buffered before this sink drops new spans. |
+| `max_export_batch_size` | Environment or `512` | Maximum spans written in one batch; capped at the effective queue size. |
+| `scheduled_delay_millis` | Environment or `5000` ms | Maximum delay before this sink writes a non-full batch. |
+| `completed_span_context_ttl_millis` | `60000` | Positive duration for retaining completed scopes' trace context for late marks. |
+| `resource_attributes` | `{}` | String-to-string resource attributes. |
+| `mark_projection` | `inherit` | Mark representation for `full` and `openinference`: `inherit`, `event`, or `tool`. |
+| `mark_exclude_names` | `["llm.chunk"]` | Mark names excluded from `full` and `openinference` projection. |
+| `attribute_mappings` | `[]` | `{ key, alias }` copies applied by `full` and `openinference` projection. |
+| `promote_metadata_prefixes` | `[]` | Literal prefixes that select sanitized Event metadata to copy to top-level span attributes. |
+| `promote_resource_metadata_prefixes` | `[]` | Literal prefixes that select root Scope-start metadata to copy to OTLP resource attributes. |
+
+Two file sinks cannot write the same path: appending sinks would interleave
+their records and overwriting sinks would race, so the configuration is
+rejected at activation.
+
 ## Event Metadata Promotion
 
 Set `promote_metadata_prefixes` on a trace endpoint to copy selected keys from

--- a/go/nemo_relay/observability_plugin.go
+++ b/go/nemo_relay/observability_plugin.go
@@ -23,8 +23,34 @@ type ObservabilityConfig struct {
 type ObservabilityOpenTelemetryConfig struct {
 	Enabled   bool                                       `json:"enabled,omitempty"`
 	Endpoints []ObservabilityOpenTelemetryEndpointConfig `json:"endpoints,omitempty"`
+	FileSinks []ObservabilityOpenTelemetryFileSinkConfig `json:"file_sinks,omitempty"`
 	Logs      *ObservabilityOpenTelemetryLogConfig       `json:"logs,omitempty"`
 	Metrics   *ObservabilityOpenTelemetryMetricConfig    `json:"metrics,omitempty"`
+}
+
+// ObservabilityOpenTelemetryFileSinkConfig configures one local file destination for
+// projected OTLP spans. Format "json_lines" follows the OpenTelemetry Protocol File
+// Exporter specification: one OTLP/JSON record per line. Format "proto" writes each
+// record length-delimited.
+type ObservabilityOpenTelemetryFileSinkConfig struct {
+	Type                          OpenTelemetryType      `json:"type,omitempty"`
+	OutputDirectory               string                 `json:"output_directory"`
+	Filename                      string                 `json:"filename,omitempty"`
+	Format                        string                 `json:"format,omitempty"`
+	Mode                          string                 `json:"mode,omitempty"`
+	MarkProjection                string                 `json:"mark_projection,omitempty"`
+	MarkExcludeNames              []string               `json:"mark_exclude_names,omitempty"`
+	AttributeMappings             []OtlpAttributeMapping `json:"attribute_mappings,omitempty"`
+	PromoteMetadataPrefixes       []string               `json:"promote_metadata_prefixes,omitempty"`
+	ResourceAttributes            map[string]string      `json:"resource_attributes,omitempty"`
+	ServiceName                   string                 `json:"service_name,omitempty"`
+	ServiceNamespace              string                 `json:"service_namespace,omitempty"`
+	ServiceVersion                string                 `json:"service_version,omitempty"`
+	InstrumentationScope          string                 `json:"instrumentation_scope,omitempty"`
+	MaxQueueSize                  *uint64                `json:"max_queue_size,omitempty"`
+	MaxExportBatchSize            *uint64                `json:"max_export_batch_size,omitempty"`
+	ScheduledDelayMillis          *uint64                `json:"scheduled_delay_millis,omitempty"`
+	CompletedSpanContextTTLMillis *uint64                `json:"completed_span_context_ttl_millis,omitempty"`
 }
 
 // ObservabilityOpenTelemetrySignalEndpointConfig configures one log or metric OTLP destination.

--- a/go/nemo_relay/otel_test.go
+++ b/go/nemo_relay/otel_test.go
@@ -375,3 +375,48 @@ func TestOpenTelemetrySubscriberExportsGenAIAgentProjection(t *testing.T) {
 		t.Fatal("timed out waiting for OTLP request")
 	}
 }
+
+// TestObservabilityOpenTelemetryFileSinkConfigSerializes checks the file-sink section
+// marshals to the keys the Rust plugin config deserializes, and that optional fields
+// stay absent so core defaults apply.
+func TestObservabilityOpenTelemetryFileSinkConfigSerializes(t *testing.T) {
+	config := ObservabilityOpenTelemetryConfig{
+		Enabled: true,
+		FileSinks: []ObservabilityOpenTelemetryFileSinkConfig{{
+			Type:            OpenTelemetryTypeFull,
+			OutputDirectory: "/var/log/nemo-relay",
+			Format:          "proto",
+		}},
+	}
+
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal file sink config: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal file sink config: %v", err)
+	}
+	sinks, ok := decoded["file_sinks"].([]any)
+	if !ok || len(sinks) != 1 {
+		t.Fatalf("expected one file_sinks entry, got %v", decoded["file_sinks"])
+	}
+	sink, ok := sinks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a file sink object, got %T", sinks[0])
+	}
+	if sink["output_directory"] != "/var/log/nemo-relay" {
+		t.Errorf("unexpected output_directory %v", sink["output_directory"])
+	}
+	if sink["format"] != "proto" {
+		t.Errorf("unexpected format %v", sink["format"])
+	}
+	// A file sink has no endpoint, and unset optionals must not be emitted:
+	// an empty mode would otherwise override the core default.
+	for _, absent := range []string{"endpoint", "transport", "filename", "mode"} {
+		if _, present := sink[absent]; present {
+			t.Errorf("unexpected %q in a file sink section", absent)
+		}
+	}
+}

--- a/python/nemo_relay/_native.pyi
+++ b/python/nemo_relay/_native.pyi
@@ -1178,6 +1178,21 @@ class OpenTelemetryConfig:
     ) -> None:
         """Create a typed OpenTelemetry config for the required endpoint."""
         ...
+    @staticmethod
+    def file_sink(
+        otel_type: Literal["full", "gen_ai", "openinference"],
+        output_directory: str,
+        filename: Optional[str] = None,
+        format: Literal["json_lines", "proto"] = "json_lines",
+        mode: Literal["append", "overwrite"] = "overwrite",
+    ) -> "OpenTelemetryConfig":
+        """Create a config that writes OTLP to a local file.
+
+        ``json_lines`` is the OpenTelemetry file-exporter specification's
+        serialization: one OTLP/JSON record per line. ``proto`` writes each
+        record length-delimited.
+        """
+        ...
     @property
     def headers(self) -> dict[str, str]:
         """Return additional exporter headers."""

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -803,6 +803,46 @@ class TestOpenTelemetryTypes:
         assert config.promote_resource_metadata_prefixes == ["deployment."]
         assert "OpenTelemetryConfig" in repr(config)
 
+    def test_file_sink_config_writes_a_trace_file(self, tmp_path):
+        config = OpenTelemetryConfig.file_sink("full", str(tmp_path), "py-trace.jsonl")
+
+        # A file sink has no endpoint, so endpoint validation does not apply.
+        assert config.endpoint == ""
+
+        subscriber = OpenTelemetrySubscriber(config)
+        try:
+            assert (tmp_path / "py-trace.jsonl").is_file()
+        finally:
+            subscriber.shutdown()
+
+    def test_file_sink_defaults_name_the_file_after_the_format(self, tmp_path):
+        subscriber = OpenTelemetrySubscriber(OpenTelemetryConfig.file_sink("full", str(tmp_path), format="proto"))
+        try:
+            assert (tmp_path / "nemo-relay-otlp.otlp.pb").is_file()
+        finally:
+            subscriber.shutdown()
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            ({"format": "yaml"}, "format must be"),
+            ({"mode": "truncate"}, "mode must be"),
+            ({"filename": "../escape.jsonl"}, "single path component"),
+        ],
+    )
+    def test_file_sink_rejects_invalid_inputs(self, tmp_path, kwargs, expected):
+        config = OpenTelemetryConfig.file_sink("full", str(tmp_path), **kwargs)
+
+        with pytest.raises(ValueError, match=expected):
+            OpenTelemetrySubscriber(config)
+
+    def test_file_sink_rejects_headers(self, tmp_path):
+        config = OpenTelemetryConfig.file_sink("full", str(tmp_path))
+        config.set_header("authorization", "Bearer token")
+
+        with pytest.raises(ValueError, match="do not apply to a file sink"):
+            OpenTelemetrySubscriber(config)
+
     def test_config_rejects_invalid_map_values(self):
         config = OpenTelemetryConfig("full", "http://localhost:4318/v1/traces")
 


### PR DESCRIPTION
#### Overview

Relay's OpenTelemetry plugin can only ship spans to a collector. ATIF and ATOF both write to disk, so a consumer that treats a trajectory as an *artifact* rather than as telemetry has no OTLP option at all. This adds `[[components.config.opentelemetry.file_sinks]]`, which writes the same `ExportTraceServiceRequest` an endpoint would receive to a local file.

The argument for a sink here rather than a collector is that it removes a routable address and an egress rule for isolated sandboxes. Additionally, some users using Fabric+Relay for evaluation, may not have provision the infrastructure required to collect traces.

- [X] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [X] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Note for reviewers: a companion change is needed in NeMo-Fabric

This change is necessary but not sufficient for the evaluation use case.

Callers that reach Relay through Fabric use `nemo_fabric.RelayOpenTelemetryConfig`, which has two fields (`enabled`, `endpoints`) and a hand-written validator in its own `models.py`:

```python
if self.enabled and not self.endpoints:
    raise ValueError("enabled NeMo Relay OpenTelemetry requires at least one endpoint")
```

Checked against `nemo-fabric` 0.3.0b1:

- **Multiple endpoints** already work and need nothing from anyone.
- **A file sink alongside at least one endpoint** works with this PR alone: the model sets `extra="allow"`, so `file_sinks` survives serialization and reaches Relay untouched.
- **A file sink as the only destination** — the configuration an eval actually wants — is rejected by Fabric before Relay sees the config.

Fabric needs `file_sinks` on the model and the validator relaxed to accept a file sink as a destination, which is the same shape as the `validate_opentelemetry_section` change in the second commit here.

#### Details

**The destination is a sum type.** `endpoint`, `transport`, `headers`, `header_env`, and `timeout` live inside `TraceDestination::Otlp`, so a config holding both an endpoint and a file sink cannot be built:

```rust
pub enum TraceDestination {
    Otlp(OtlpEndpointSettings),   // endpoint, transport, headers, header_env, timeout
    File(OtlpFileSinkSettings),   // output_directory, path, format, append
}
```

Endpoint and header validation moved into that variant, which removed the conditional that gated it on the absence of a file sink. Configuration mirrors the existing ATOF file sink (`output_directory`, `filename`, `mode`) instead of overloading `endpoint` with a path.

**No silent ignore.** The builders stay infallible, so an endpoint-only option set on a file sink is recorded and refused at construction: `endpoint, headers, transport do not apply to a file sink destination`, deduplicated and sorted. Each binding enforces the same rule at its own boundary. Python turns the three endpoint-only attributes into setters that raise; Node rejects them alongside `outputDirectory`, which it had been applying to file sinks all along, since it passed `timeoutMillis` and the header map through unconditionally.

Everything above the exporter (projection, id generation, batching, resource attributes, shutdown) is shared, so a span means the same thing whichever destination it goes to. `SpanExporter::export` returns `impl Future`, so the trait is not dyn-compatible and dispatch is a concrete enum.

**Conversion is upstream.** `group_spans_by_resource_and_scope` and the `SpanData` → protobuf `From` impls come from `opentelemetry-proto`, the crate `opentelemetry-otlp` already uses to build its wire payload. Both `opentelemetry-proto` and `prost` were already in `crates/core/Cargo.toml` under `[dev-dependencies]`; they move to `[dependencies]` with the `trace` and `with-serde` features. No new crates and no version changes.

**Durability and permissions.** Each export is flushed before it is reported as delivered, so a run that exits between batches leaves a readable prefix rather than an empty file. Output is created with the same owner-only permissions and directory confinement as the ATOF and ATIF sinks, because a trajectory carries prompt and response content. Two sinks writing one path are rejected at activation.

**Surfaces.** `nemo-relay configure` lists file sinks beside trace endpoints; Python, Node, Go, and the FFI each gain the destination.

#### Where should the reviewer start?

`crates/core/src/observability/otel_file.rs` — the exporter is ~200 lines and the whole design is visible there. Then `crates/core/tests/unit/observability/otel_file_tests.rs`: the round-trips decode with `prost` and `serde_json` directly rather than through this module's own encoder, so a writer and reader that agree only with each other cannot pass. `json_lines_encode_span_identifiers_as_hex` is the OTLP/JSON conformance check.

`endpoint_options_on_a_file_sink_are_refused_by_name` and `several_refused_options_are_reported_together` cover the exclusivity rule.

The design decision worth arguing about is `file_sinks` as a separate array versus a `transport = "file"` variant on `endpoints`. I chose the former because `endpoint` is required and URL-validated, and conditional validation on a field that sometimes holds a path seemed worse than a second array.

#### Testing

- `cargo test --workspace` — 1660 core lib tests pass. 46 new tests: exporter round-trip and framing, config validation, destination exclusivity, editor schema, and per-binding coverage.
  - Pre-existing unrelated failure: `native_plugin_integration` needs `just build-test-plugin-fixtures`, which I could not run locally.
- `cargo clippy --workspace --all-targets` and `cargo fmt --all` clean.
- Node: `node --test crates/node/tests/observability_plugin_tests.mjs` — 10/10. One test drives a file-sink-only section through the plugin host and asserts the trace file appears.
- Python: `pytest python/tests/test_types.py` — 63/63, `ruff` clean, `ty` clean (9 pre-existing unused-ignore warnings).
- Go: `go test` on `otel_test.go` passes; `gofmt` and `go vet` clean.
- Not run locally: `cargo deny` (not installed) and the fixture-dependent native plugin integration tests.

#### Breaking changes

None. `file_sinks` defaults to empty and every existing configuration behaves identically.

#### Related Issues:

Relates to #1089


