### PR TITLE
fix(plugin): defer worker registration until static components activate

### DIFF
--- a/crates/core/src/plugin/dynamic/host.rs
+++ b/crates/core/src/plugin/dynamic/host.rs
@@ -29,13 +29,16 @@ use super::{
 };
 
 #[cfg(feature = "worker-grpc")]
-use super::{WorkerPluginActivation, WorkerPluginLoadSpec, load_worker_plugins};
+use super::{WorkerPluginActivation, WorkerPluginLoadSpec, prepare_worker_plugins};
 
 /// Initializes the process-wide static and dynamic plugin host.
 ///
 /// The returned handle must remain alive while any plugin-provided callback can
 /// run. Closing or dropping it unregisters components before unloading dynamic
 /// runtimes.
+/// Workers are authenticated and validated before component initialization.
+/// Their `Register` RPC runs when the worker component activates, after earlier
+/// static components have installed their runtime registrations.
 pub async fn initialize(
     config: PluginConfig,
     additional_plugins_toml: Option<PathBuf>,
@@ -198,6 +201,8 @@ impl PluginHostActivation {
 
         #[cfg(feature = "worker-grpc")]
         let worker = {
+            // Register can discover and gate preceding static subscribers. Only
+            // prepare workers here; their adapters register during initialization.
             let worker_specs = dynamic_plugins
                 .iter()
                 .filter(|plugin| plugin.kind == DynamicPluginKind::Worker)
@@ -210,7 +215,7 @@ impl PluginHostActivation {
                 .collect::<Vec<_>>();
             (!worker_specs.is_empty())
                 .then(|| {
-                    load_worker_plugins(worker_specs)
+                    prepare_worker_plugins(worker_specs)
                         .map_err(|error| plugin_error_context("worker plugin load failed", error))
                 })
                 .transpose()?

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -1116,6 +1116,21 @@ impl WorkerPluginInstance {
         }
         validate_registration_plan(&self.plugin_kind, &register)?;
         let registrations = register.registrations;
+        if registrations.iter().any(|registration| {
+            RegistrationSurface::try_from(registration.surface)
+                .is_ok_and(|surface| surface == RegistrationSurface::LlmRequestIntercept)
+        }) {
+            validate_annotated_request_consumer_compatibility(
+                &self.relay_compat,
+                &self.plugin_kind,
+            )?;
+        }
+        if registrations.iter().any(|registration| {
+            RegistrationSurface::try_from(registration.surface)
+                .is_ok_and(|surface| surface == RegistrationSurface::ToolExecutionIntercept)
+        }) {
+            validate_tool_execution_context_compatibility(&self.relay_compat, &self.plugin_kind)?;
+        }
         let initial_gates = register.conditional_middleware_guardrails;
         for gate in initial_gates {
             let kinds = gate
@@ -1151,21 +1166,6 @@ impl WorkerPluginInstance {
                     "worker initial conditional middleware guardrail failed: {error}"
                 )));
             }
-        }
-        if registrations.iter().any(|registration| {
-            RegistrationSurface::try_from(registration.surface)
-                .is_ok_and(|surface| surface == RegistrationSurface::LlmRequestIntercept)
-        }) {
-            validate_annotated_request_consumer_compatibility(
-                &self.relay_compat,
-                &self.plugin_kind,
-            )?;
-        }
-        if registrations.iter().any(|registration| {
-            RegistrationSurface::try_from(registration.surface)
-                .is_ok_and(|surface| surface == RegistrationSurface::ToolExecutionIntercept)
-        }) {
-            validate_tool_execution_context_compatibility(&self.relay_compat, &self.plugin_kind)?;
         }
 
         log::info!(

--- a/crates/core/src/plugin/dynamic/worker.rs
+++ b/crates/core/src/plugin/dynamic/worker.rs
@@ -195,12 +195,30 @@ pub fn load_worker_plugins<I>(specs: I) -> crate::plugin::Result<WorkerPluginAct
 where
     I: IntoIterator<Item = WorkerPluginLoadSpec>,
 {
+    load_worker_plugins_inner(specs, false)
+}
+
+/// Prepare workers without calling Register until their host component activates.
+pub(super) fn prepare_worker_plugins<I>(specs: I) -> crate::plugin::Result<WorkerPluginActivation>
+where
+    I: IntoIterator<Item = WorkerPluginLoadSpec>,
+{
+    load_worker_plugins_inner(specs, true)
+}
+
+fn load_worker_plugins_inner<I>(
+    specs: I,
+    defer_registration: bool,
+) -> crate::plugin::Result<WorkerPluginActivation>
+where
+    I: IntoIterator<Item = WorkerPluginLoadSpec>,
+{
     let mut activation = WorkerPluginActivation {
         plugins: Vec::new(),
         plugin_registrations: Vec::new(),
     };
     for spec in specs {
-        let instance = load_one_worker_plugin(&spec)?;
+        let instance = load_one_worker_plugin(&spec, defer_registration)?;
         let plugin_kind = instance.plugin_kind.clone();
         let registration_id = register_plugin_tracked(Arc::new(WorkerPluginAdapter {
             plugin_kind: plugin_kind.clone(),
@@ -254,6 +272,7 @@ impl Plugin for WorkerPluginAdapter {
                         .into(),
                 ));
             }
+            self.instance.prepare_registrations().await?;
             self.instance.install_registrations(ctx)
         })
     }
@@ -264,7 +283,8 @@ struct WorkerPluginInstance {
     allows_multiple_components: bool,
     config: Map<String, Json>,
     validation_diagnostics: Vec<ConfigDiagnostic>,
-    registrations: Vec<Registration>,
+    relay_compat: String,
+    registrations: tokio::sync::OnceCell<Vec<Registration>>,
     runtime: OwnedWorkerRuntime,
     client: PluginWorkerClient<Channel>,
     host_state: Arc<WorkerHostRuntimeState>,
@@ -464,6 +484,7 @@ fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> &str {
 
 fn load_one_worker_plugin(
     spec: &WorkerPluginLoadSpec,
+    defer_registration: bool,
 ) -> crate::plugin::Result<Arc<WorkerPluginInstance>> {
     log::info!(
         target: "nemo_relay.worker",
@@ -621,88 +642,13 @@ fn load_one_worker_plugin(
         None => Vec::new(),
     };
 
-    let (registrations, initial_gates) = if diagnostics_have_errors(&validation_diagnostics) {
-        (Vec::new(), Vec::new())
-    } else {
-        let register = block_on_runtime(
-            runtime_handle.runtime(),
-            worker_rpc(client.register(worker_rpc_request(RegisterRequest {
-                activation_id: activation_id.clone(),
-                plugin_id: spec.plugin_id.clone(),
-                auth_token: auth_token.clone(),
-                config: Some(json_envelope(JSON_SCHEMA, &config)?),
-            }))),
-        )
-        .map_err(|err| {
-            PluginError::RegistrationFailed(format!("worker registration RPC failed: {err}"))
-        })?;
-        let register = register.into_inner();
-        if let Some(error) = register.error {
-            return Err(worker_error_to_plugin(error, "worker registration failed"));
-        }
-        validate_registration_plan(&spec.plugin_id, &register)?;
-        (
-            register.registrations,
-            register.conditional_middleware_guardrails,
-        )
-    };
-    for gate in initial_gates {
-        let kinds = gate
-            .kinds
-            .into_iter()
-            .map(|kind| {
-                RegistrationSurface::try_from(kind)
-                    .map_err(|_| {
-                        PluginError::RegistrationFailed(format!(
-                            "worker plugin '{}' returned an unknown conditional middleware guardrail kind",
-                            spec.plugin_id
-                        ))
-                    })
-                    .and_then(|surface| {
-                        runtime_registration_kind_from_surface(surface).map_err(|status| {
-                            PluginError::RegistrationFailed(status.message().to_string())
-                        })
-                    })
-            })
-            .collect::<crate::plugin::Result<BTreeSet<_>>>()?;
-        if let Err(error) = host_state.register_owned_conditional_middleware_guardrail(
-            gate.name,
-            kinds,
-            gate.registration_name,
-            gate.reason,
-            gate.callback,
-        ) {
-            host_state.cleanup_conditional_middleware_guardrails();
-            return Err(PluginError::RegistrationFailed(format!(
-                "worker initial conditional middleware guardrail failed: {error}"
-            )));
-        }
-    }
-    if registrations.iter().any(|registration| {
-        RegistrationSurface::try_from(registration.surface)
-            .is_ok_and(|surface| surface == RegistrationSurface::LlmRequestIntercept)
-    }) {
-        validate_annotated_request_consumer_compatibility(&relay_compat, &spec.plugin_id)?;
-    }
-    if registrations.iter().any(|registration| {
-        RegistrationSurface::try_from(registration.surface)
-            .is_ok_and(|surface| surface == RegistrationSurface::ToolExecutionIntercept)
-    }) {
-        validate_tool_execution_context_compatibility(&relay_compat, &spec.plugin_id)?;
-    }
-
-    log::info!(
-        target: "nemo_relay.worker",
-        event = "worker_connected",
-        plugin_id = spec.plugin_id.as_str();
-        "Worker plugin connected and registered"
-    );
-    Ok(Arc::new(WorkerPluginInstance {
+    let instance = Arc::new(WorkerPluginInstance {
         plugin_kind: spec.plugin_id.clone(),
         allows_multiple_components: handshake.allows_multiple_components,
         config: spec.config.clone(),
         validation_diagnostics,
-        registrations,
+        relay_compat,
+        registrations: tokio::sync::OnceCell::new(),
         runtime: runtime_handle,
         client,
         host_state,
@@ -710,7 +656,11 @@ fn load_one_worker_plugin(
         process: Mutex::new(Some(child.take())),
         activation_dir: activation_dir_guard.keep(),
         teardown_started: AtomicBool::new(false),
-    }))
+    });
+    if !defer_registration && !diagnostics_have_errors(&instance.validation_diagnostics) {
+        block_on_runtime(instance.runtime.runtime(), instance.prepare_registrations())?;
+    }
+    Ok(instance)
 }
 
 enum HostRuntimeServer {
@@ -1136,11 +1086,104 @@ fn clear_host_python_environment(command: &mut Command) {
 }
 
 impl WorkerPluginInstance {
+    // Register needs the preceding components' live runtime registrations.
+    // Cache its plan once per worker so multiple components do not repeat setup.
+    async fn prepare_registrations(&self) -> crate::plugin::Result<()> {
+        self.registrations
+            .get_or_try_init(|| self.request_registration_plan())
+            .await?;
+        Ok(())
+    }
+
+    async fn request_registration_plan(&self) -> crate::plugin::Result<Vec<Registration>> {
+        let mut client = self.client.clone();
+        let register = worker_rpc(client.register(worker_rpc_request(RegisterRequest {
+            activation_id: self.host_state.activation_id.clone(),
+            plugin_id: self.plugin_kind.clone(),
+            auth_token: self.host_state.auth_token.clone(),
+            config: Some(json_envelope(
+                JSON_SCHEMA,
+                &Json::Object(self.config.clone()),
+            )?),
+        })))
+        .await
+        .map_err(|err| {
+            PluginError::RegistrationFailed(format!("worker registration RPC failed: {err}"))
+        })?
+        .into_inner();
+        if let Some(error) = register.error {
+            return Err(worker_error_to_plugin(error, "worker registration failed"));
+        }
+        validate_registration_plan(&self.plugin_kind, &register)?;
+        let registrations = register.registrations;
+        let initial_gates = register.conditional_middleware_guardrails;
+        for gate in initial_gates {
+            let kinds = gate
+                .kinds
+                .into_iter()
+                .map(|kind| {
+                    RegistrationSurface::try_from(kind)
+                        .map_err(|_| {
+                            PluginError::RegistrationFailed(format!(
+                                "worker plugin '{}' returned an unknown conditional middleware guardrail kind",
+                                self.plugin_kind
+                            ))
+                        })
+                        .and_then(|surface| {
+                            runtime_registration_kind_from_surface(surface).map_err(|status| {
+                                PluginError::RegistrationFailed(status.message().to_string())
+                            })
+                        })
+                })
+                .collect::<crate::plugin::Result<BTreeSet<_>>>()?;
+            if let Err(error) = self
+                .host_state
+                .register_owned_conditional_middleware_guardrail(
+                    gate.name,
+                    kinds,
+                    gate.registration_name,
+                    gate.reason,
+                    gate.callback,
+                )
+            {
+                self.host_state.cleanup_conditional_middleware_guardrails();
+                return Err(PluginError::RegistrationFailed(format!(
+                    "worker initial conditional middleware guardrail failed: {error}"
+                )));
+            }
+        }
+        if registrations.iter().any(|registration| {
+            RegistrationSurface::try_from(registration.surface)
+                .is_ok_and(|surface| surface == RegistrationSurface::LlmRequestIntercept)
+        }) {
+            validate_annotated_request_consumer_compatibility(
+                &self.relay_compat,
+                &self.plugin_kind,
+            )?;
+        }
+        if registrations.iter().any(|registration| {
+            RegistrationSurface::try_from(registration.surface)
+                .is_ok_and(|surface| surface == RegistrationSurface::ToolExecutionIntercept)
+        }) {
+            validate_tool_execution_context_compatibility(&self.relay_compat, &self.plugin_kind)?;
+        }
+
+        log::info!(
+            target: "nemo_relay.worker",
+            event = "worker_connected",
+            plugin_id = self.plugin_kind.as_str();
+            "Worker plugin connected and registered"
+        );
+        Ok(registrations)
+    }
+
     fn install_registrations(
         &self,
         ctx: &mut PluginRegistrationContext,
     ) -> crate::plugin::Result<()> {
-        for registration in &self.registrations {
+        for registration in self.registrations.get().ok_or_else(|| {
+            PluginError::Internal("worker registration plan is not prepared".into())
+        })? {
             let surface = RegistrationSurface::try_from(registration.surface).map_err(|_| {
                 PluginError::RegistrationFailed(format!(
                     "worker plugin '{}' returned unsupported registration surface {}",

--- a/crates/core/tests/fixtures/native_plugin/src/lib.rs
+++ b/crates/core/tests/fixtures/native_plugin/src/lib.rs
@@ -77,11 +77,30 @@ impl NativePlugin for FixtureNativePlugin {
             return Ok(());
         }
         let runtime = ctx.runtime();
+        let subscriber_kinds = BTreeSet::from([RuntimeRegistrationKind::Subscriber]);
+        if plugin_config
+            .get("discover_observability")
+            .and_then(Json::as_bool)
+            .unwrap_or(false)
+        {
+            let observability_subscribers = runtime
+                .list_runtime_registrations(Some(&subscriber_kinds))?
+                .into_iter()
+                .filter(|registration| {
+                    registration.local_name == "opentelemetry"
+                        && registration.owner.plugin_kind.as_deref() == Some("observability")
+                })
+                .count();
+            if observability_subscribers != 1 {
+                return Err(format!(
+                    "expected one observability subscriber during registration; found {observability_subscribers}"
+                ));
+            }
+        }
         ctx.register_subscriber("fixture_subscriber", {
             let runtime = runtime.clone();
             move |event| subscriber_mark(&runtime, event)
         })?;
-        let subscriber_kinds = BTreeSet::from([RuntimeRegistrationKind::Subscriber]);
         if !runtime
             .list_runtime_registrations(Some(&subscriber_kinds))?
             .iter()

--- a/crates/core/tests/fixtures/worker_plugin/src/main.rs
+++ b/crates/core/tests/fixtures/worker_plugin/src/main.rs
@@ -46,6 +46,36 @@ impl WorkerPlugin for FixtureWorkerPlugin {
     }
 
     fn register(&self, ctx: &mut PluginContext, config: &Json) -> nemo_relay_worker::Result<()> {
+        if fixture_flag(config, "discover_observability") {
+            let runtime = ctx.runtime().expect("host runtime should be available");
+            let registrations = std::thread::spawn(move || {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("discovery runtime")
+                    .block_on(runtime.list_runtime_registrations(Some(BTreeSet::from([
+                        RuntimeRegistrationKind::Subscriber,
+                    ]))))
+            })
+            .join()
+            .expect("discovery thread")?;
+            let targets = registrations.into_iter().filter(|registration| {
+                registration.local_name == "opentelemetry"
+                    && registration.owner.plugin_kind.as_deref() == Some("observability")
+            }).collect::<Vec<_>>();
+            if targets.len() != 1 {
+                return Err(WorkerSdkError::Callback(format!(
+                    "expected one observability subscriber during registration; found {}",
+                    targets.len()
+                )));
+            }
+            ctx.register_conditional_middleware_guardrail(
+                "discovered_observability_gate",
+                BTreeSet::from([RuntimeRegistrationKind::Subscriber]),
+                &targets[0].effective_name,
+                |_, _| async { Ok(Some("fixture export policy".into())) },
+            );
+        }
         if fixture_flag(config, "exit_in_register") {
             std::process::exit(43);
         }

--- a/crates/core/tests/fixtures/worker_plugin/src/main.rs
+++ b/crates/core/tests/fixtures/worker_plugin/src/main.rs
@@ -48,17 +48,14 @@ impl WorkerPlugin for FixtureWorkerPlugin {
     fn register(&self, ctx: &mut PluginContext, config: &Json) -> nemo_relay_worker::Result<()> {
         if fixture_flag(config, "discover_observability") {
             let runtime = ctx.runtime().expect("host runtime should be available");
-            let registrations = std::thread::spawn(move || {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("discovery runtime")
-                    .block_on(runtime.list_runtime_registrations(Some(BTreeSet::from([
+            let registrations = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async move {
+                    runtime.list_runtime_registrations(Some(BTreeSet::from([
                         RuntimeRegistrationKind::Subscriber,
-                    ]))))
+                    ]))).await
+                })
             })
-            .join()
-            .expect("discovery thread")?;
+            ?;
             let targets = registrations.into_iter().filter(|registration| {
                 registration.local_name == "opentelemetry"
                     && registration.owner.plugin_kind.as_deref() == Some("observability")

--- a/crates/core/tests/integration/native_plugin_tests.rs
+++ b/crates/core/tests/integration/native_plugin_tests.rs
@@ -1533,6 +1533,39 @@ async fn plugin_host_activation_owns_configuration_until_close() {
 }
 
 #[tokio::test]
+async fn native_registration_discovers_static_observability() {
+    let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_plugin();
+    let manifest_ref = write_manifest(&fixture);
+    let collector = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let endpoint = format!("http://{}/v1/traces", collector.local_addr().unwrap());
+    let config: PluginConfig = serde_json::from_value(json!({
+        "components": [{"kind": "observability", "enabled": true, "config": {
+            "opentelemetry": {"enabled": true, "endpoints": [{
+                "type": "gen_ai", "endpoint": endpoint
+            }]}
+        }}]
+    }))
+    .unwrap();
+    let mut spec = host_spec("fixture_native", &manifest_ref);
+    spec.config = Map::from_iter([("discover_observability".into(), json!(true))]);
+
+    let (mut activation, report) =
+        PluginHostActivation::initialize_with_verified_specs(config, [spec])
+            .await
+            .expect("native registration must discover static OpenTelemetry subscribers");
+    assert!(!report.has_errors());
+    activation
+        .close()
+        .expect("native host should close cleanly");
+    assert!(
+        nemo_relay::api::registry::list_runtime_registrations(None)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn native_conditional_callbacks_block_allow_fail_open_and_clear() {
     let _guard = NATIVE_PLUGIN_TEST_LOCK.lock().await;
     let fixture = build_fixture_plugin();

--- a/crates/core/tests/integration/worker_plugin_tests.rs
+++ b/crates/core/tests/integration/worker_plugin_tests.rs
@@ -119,6 +119,84 @@ fn worker_activation_with_no_specs_is_empty() {
 }
 
 #[tokio::test]
+async fn worker_registration_discovers_static_observability() {
+    let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
+    let fixture = build_fixture_worker();
+    let (_manifest_dir, manifest_ref) = write_manifest(fixture.binary_path());
+    let collector = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    collector.set_nonblocking(true).unwrap();
+    let endpoint = format!("http://{}/v1/traces", collector.local_addr().unwrap());
+    let config: PluginConfig = serde_json::from_value(json!({
+        "components": [{"kind": "observability", "enabled": true, "config": {
+            "opentelemetry": {"enabled": true, "endpoints": [{
+                "type": "gen_ai", "endpoint": endpoint
+            }]}
+        }}]
+    }))
+    .unwrap();
+    let spec = VerifiedDynamicPluginSpec {
+        plugin_id: "fixture_worker".into(),
+        kind: DynamicPluginKind::Worker,
+        manifest_ref: manifest_ref.to_string_lossy().into_owned(),
+        environment_ref: None,
+        config: Map::from_iter([("discover_observability".into(), json!(true))]),
+    };
+    let mut failing_spec = spec.clone();
+    failing_spec
+        .config
+        .insert("register_error".into(), json!(true));
+    let error =
+        PluginHostActivation::initialize_with_verified_specs(config.clone(), [failing_spec])
+            .await
+            .err()
+            .expect("registration failure must abort activation");
+    assert!(
+        error
+            .to_string()
+            .contains("fixture registration error requested"),
+        "{error}"
+    );
+    assert!(
+        nemo_relay::api::registry::list_runtime_registrations(None)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        !list_plugin_kinds()
+            .iter()
+            .any(|kind| kind == "fixture_worker")
+    );
+
+    let (mut activation, _) = PluginHostActivation::initialize_with_verified_specs(config, [spec])
+        .await
+        .expect("worker must discover static subscribers during Register after rollback");
+    TASK_SCOPE_STACK
+        .scope(create_scope_stack(), async {
+            let scope = push_scope(
+                PushScopeParams::builder()
+                    .scope_type(ScopeType::Agent)
+                    .name("gated-worker-registration")
+                    .build(),
+            )
+            .unwrap();
+            pop_scope(PopScopeParams::builder().handle_uuid(&scope.uuid).build()).unwrap();
+        })
+        .await;
+    flush_subscribers().expect("gated events should finish delivery");
+    activation.close().expect("host should close cleanly");
+    assert_eq!(
+        collector.accept().unwrap_err().kind(),
+        std::io::ErrorKind::WouldBlock,
+        "the discovered gate must prevent OTLP export"
+    );
+    assert!(
+        nemo_relay::api::registry::list_runtime_registrations(None)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn plugin_host_activation_owns_worker_lifecycle() {
     let _guard = WORKER_PLUGIN_TEST_LOCK.lock().await;
     let fixture = build_fixture_worker();

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -2871,7 +2871,8 @@ async fn fake_worker_instance(
             allows_multiple_components: false,
             config: serde_json::Map::new(),
             validation_diagnostics: Vec::new(),
-            registrations,
+            relay_compat: ">=0.9,<1.0".into(),
+            registrations: tokio::sync::OnceCell::new_with(Some(registrations)),
             runtime: OwnedWorkerRuntime::new(
                 RuntimeBuilder::new_multi_thread()
                     .enable_all()

--- a/crates/core/tests/unit/dynamic_worker_tests.rs
+++ b/crates/core/tests/unit/dynamic_worker_tests.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 #[cfg(unix)]
@@ -1970,6 +1971,61 @@ async fn adapter_register_rejects_config_drift_even_without_validation_call() {
 }
 
 #[tokio::test]
+async fn install_registrations_requires_a_prepared_plan() {
+    enable_operational_logs();
+    let (mut instance, _shutdown) = fake_worker_instance(Vec::new()).await;
+    instance.registrations = tokio::sync::OnceCell::new();
+    let mut ctx = PluginRegistrationContext::new();
+
+    let error = instance
+        .install_registrations(&mut ctx)
+        .expect_err("an unprepared worker registration plan must fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("worker registration plan is not prepared"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn adapter_registration_requests_the_deferred_plan_once() {
+    enable_operational_logs();
+    let (client, _worker_shutdown, _cancel_rx, register_calls) = fake_worker_client_with_handlers(
+        |_| {
+            Box::pin(async {
+                InvokeResponse {
+                    result: Some(InvokeResult::Empty(EmptyResult {})),
+                }
+            })
+        },
+        |_| Box::pin(tokio_stream::empty()) as FakeInvokeStream,
+    )
+    .await;
+    let (mut instance, _instance_shutdown) = fake_worker_instance(Vec::new()).await;
+    instance.client = client;
+    instance.registrations = tokio::sync::OnceCell::new();
+    let adapter = WorkerPluginAdapter {
+        plugin_kind: "fixture_worker".into(),
+        allows_multiple_components: true,
+        instance: Arc::new(instance),
+    };
+    let config = serde_json::Map::new();
+
+    assert_eq!(register_calls.load(Ordering::Relaxed), 0);
+    adapter
+        .register(&config, &mut PluginRegistrationContext::new())
+        .await
+        .expect("the first component registration should request the plan");
+    adapter
+        .register(&config, &mut PluginRegistrationContext::new())
+        .await
+        .expect("the second component registration should reuse the plan");
+    assert_eq!(register_calls.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
 async fn host_runtime_service_covers_auth_scope_and_ack_errors() {
     enable_operational_logs();
     let state = Arc::new(WorkerHostRuntimeState::new(
@@ -2829,7 +2885,7 @@ async fn fake_callback_service_with_handlers(
     oneshot::Sender<()>,
     mpsc::UnboundedReceiver<CancelInvocationRequest>,
 ) {
-    let (client, shutdown_tx, cancel_rx) =
+    let (client, shutdown_tx, cancel_rx, _register_calls) =
         fake_worker_client_with_handlers(invoke, invoke_stream).await;
     let (callback, shutdown_tx) = callback_for_client(client, shutdown_tx);
     (callback, shutdown_tx, cancel_rx)
@@ -2909,7 +2965,7 @@ async fn fake_worker_client_with_stream(
     invoke_stream: impl Fn(InvokeRequest) -> FakeInvokeStream + Send + Sync + 'static,
 ) -> (PluginWorkerClient<Channel>, oneshot::Sender<()>) {
     let invoke = Arc::new(invoke);
-    let (client, shutdown_tx, _cancel_rx) = fake_worker_client_with_handlers(
+    let (client, shutdown_tx, _cancel_rx, _register_calls) = fake_worker_client_with_handlers(
         move |request| {
             let invoke = invoke.clone();
             Box::pin(async move { invoke(request) })
@@ -2927,6 +2983,7 @@ async fn fake_worker_client_with_handlers(
     PluginWorkerClient<Channel>,
     oneshot::Sender<()>,
     mpsc::UnboundedReceiver<CancelInvocationRequest>,
+    Arc<AtomicUsize>,
 ) {
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
         .await
@@ -2936,12 +2993,14 @@ async fn fake_worker_client_with_handlers(
         .expect("fake worker listener address should be available");
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (cancel_tx, cancel_rx) = mpsc::unbounded_channel();
+    let register_calls = Arc::new(AtomicUsize::new(0));
     tokio::spawn(
         Server::builder()
             .add_service(PluginWorkerServer::new(FakePluginWorker {
                 invoke: Arc::new(invoke),
                 invoke_stream: Arc::new(invoke_stream),
                 cancel_tx,
+                register_calls: register_calls.clone(),
             }))
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                 let _ = shutdown_rx.await;
@@ -2950,7 +3009,7 @@ async fn fake_worker_client_with_handlers(
     let client = PluginWorkerClient::connect(format!("http://{addr}"))
         .await
         .expect("fake worker client should connect");
-    (client, shutdown_tx, cancel_rx)
+    (client, shutdown_tx, cancel_rx, register_calls)
 }
 
 fn registration(surface: RegistrationSurface, local_name: &str) -> Registration {
@@ -2977,6 +3036,7 @@ struct FakePluginWorker {
     invoke: Arc<dyn Fn(InvokeRequest) -> FakeInvokeFuture + Send + Sync>,
     invoke_stream: Arc<dyn Fn(InvokeRequest) -> FakeInvokeStream + Send + Sync>,
     cancel_tx: mpsc::UnboundedSender<CancelInvocationRequest>,
+    register_calls: Arc<AtomicUsize>,
 }
 
 type FakeInvokeFuture = Pin<Box<dyn Future<Output = InvokeResponse> + Send>>;
@@ -3071,6 +3131,7 @@ impl PluginWorker for FakePluginWorker {
         &self,
         _request: Request<RegisterRequest>,
     ) -> std::result::Result<tonic::Response<RegisterResponse>, tonic::Status> {
+        self.register_calls.fetch_add(1, Ordering::Relaxed);
         Ok(tonic::Response::new(RegisterResponse {
             registrations: Vec::new(),
             error: None,


### PR DESCRIPTION
#### Overview

Fix dynamic gRPC worker activation when a worker needs to discover or gate registrations installed by an earlier static component. In the 0.9 unified plugin host, worker startup performed the gRPC Register RPC before static components initialized. A worker that queries for the OpenTelemetry subscriber during registration therefore received an empty result and failed activation.

This restores the intended lifecycle relationship: validate and prepare the worker before host activation, but invoke its Register RPC only when the worker component activates after the configured static components.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

##### Worker lifecycle

- Split worker activation into preparation and registration. Preparation still starts the worker, authenticates it, performs the handshake, and validates its manifest, compatibility, and plugin configuration. It deliberately does not call Register.
- Defer the gRPC Register RPC until the worker adapter is initialized as a configured component. Static components are initialized first, and dynamic components are appended afterwards, so worker registration can reliably discover static subscribers and middleware.
- Cache the registration plan returned by the first successful Register RPC, validate it, and install it only after registration succeeds. Activation errors still roll back host-owned registrations and release the worker so a later activation can succeed.
- Keep the public direct worker-loader API eager. This preserves its existing behavior for callers that intentionally load and register workers outside the dynamic plugin host.

##### Native dynamic plugins

Rust native dynamic plugins already defer their register callback until component initialization. No native-loader behavior changes in this PR. The added regression explicitly verifies that a native plugin can discover the static OpenTelemetry subscriber during registration, protecting the shared lifecycle guarantee across both plugin lanes.

##### Validation

- Reproduced the original worker failure without the fix: the registration callback found zero OpenTelemetry subscribers.
- Added worker coverage for static OpenTelemetry discovery, export gating, rollback after registration failure, and successful reactivation.
- Added native dynamic-plugin coverage for OpenTelemetry discovery during the native register callback.
- Passed the focused worker/core suite: 1,690 tests.
- Passed the native dynamic-plugin integration suite: 38 tests.
- Passed repository pre-commit hooks.
- Manually verified the patched CLI starts the configured Claude worker plugin that previously failed with found 0.

#### Where should the reviewer start?

Start with crates/core/src/plugin/dynamic/worker.rs, specifically prepare_worker_plugins and WorkerPluginAdapter::register. The key design choice is to retain early process and protocol validation while moving only the registration RPC behind static component activation. Then review crates/core/src/plugin/dynamic/host.rs for the host ordering, followed by the worker and native integration regressions.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Worker plugins are now validated and authenticated before component initialization.
  * Worker registration is coordinated during activation, improving support for plugins with multiple components.
  * Observability configuration can be discovered and validated for native and worker plugins.
  * Invalid observability registrations now prevent activation with clear validation errors.
  * Successful observability setup applies the appropriate tracing safeguards during runtime.

* **Tests**
  * Added coverage for worker registration reuse, activation failures, cleanup, and observability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->