### PR TITLE
fix: log gateway shutdown when it begins

### DIFF
--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -335,12 +335,7 @@ async fn serve_listener_with_dynamic_inner(
         };
     let shutdown = server_shutdown_future(shutdown_mode, idle_shutdown);
     let shutdown = combine_shutdown_futures(shutdown, bootstrap_shutdown_rx);
-    log::info!(
-        target: "nemo_relay.server",
-        event = "server_shutdown_started",
-        instance_id = instance_id.as_str();
-        "Gateway server shutdown started"
-    );
+    let shutdown = shutdown.map(|shutdown| log_shutdown_started(shutdown, instance_id.clone()));
     let serve_result = match shutdown {
         Some(shutdown) => {
             axum::serve(listener, app)
@@ -372,6 +367,18 @@ fn server_shutdown_future(
         })),
         None => idle_shutdown,
     }
+}
+
+fn log_shutdown_started(shutdown: ShutdownFuture, instance_id: String) -> ShutdownFuture {
+    Box::pin(async move {
+        shutdown.await;
+        log::info!(
+            target: "nemo_relay.server",
+            event = "server_shutdown_started",
+            instance_id = instance_id.as_str();
+            "Gateway server shutdown started"
+        );
+    })
 }
 
 fn combine_shutdown_futures(


### PR DESCRIPTION
#### Overview

Delay the gateway `server_shutdown_started` lifecycle record until graceful shutdown is actually triggered.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Wrap the resolved gateway shutdown future so it emits `server_shutdown_started` only when a signal, idle timeout, bootstrap shutdown, or receiver resolves it.
- Preserve the existing `server_stopped` record after server teardown completes.
- This prevents the shutdown-start marker from sharing the startup/listening timestamp while the gateway is still accepting requests.

#### Where should the reviewer start?

Start with `crates/cli/src/server/mod.rs`, where `log_shutdown_started` now wraps the shutdown future passed to Axum.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown event timing so shutdown-start notifications are emitted when the server actually begins shutting down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->